### PR TITLE
feat: rate-history retention prune cron (keep-monthly-anchor) (deepen)

### DIFF
--- a/__tests__/api/cron-prune-rate-history.test.ts
+++ b/__tests__/api/cron-prune-rate-history.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Tests for GET /api/cron/prune-rate-history
+ *
+ * Covers:
+ *   - requireCronAuth gate (401 / 500 on bad/missing secret)
+ *   - Both tables pruned and counts returned in response
+ *   - Fetch error on either table logs error but does not crash the handler
+ *   - Delete error on either table logs error but does not crash the handler
+ *   - Empty tables are a no-op (zero deletes, zero anchors)
+ *   - maxDuration export value
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { NextRequest } from "next/server";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+const mockFrom = vi.fn();
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+import { GET, maxDuration } from "@/app/api/cron/prune-rate-history/route";
+
+// ─── Supabase builder helpers ─────────────────────────────────────────────────
+
+/**
+ * Builds a chainable Supabase-like query builder.
+ *
+ * `selectResult`  — resolved value for the SELECT query.
+ * `deleteResult`  — resolved value for the DELETE query.
+ */
+function makeBuilder(
+  selectResult: { data: unknown; error: unknown } = { data: [], error: null },
+  deleteResult: { error: unknown } = { error: null },
+) {
+  const builder: Record<string, unknown> = {};
+
+  // Terminal select resolves via .then()
+  builder.then = (cb: (v: unknown) => unknown) =>
+    Promise.resolve(cb(selectResult));
+
+  // Chainable query methods
+  for (const m of ["select", "lt", "limit", "order", "eq"]) {
+    builder[m] = vi.fn(() => builder);
+  }
+
+  // .delete() returns a new builder that resolves with deleteResult
+  builder.delete = vi.fn(() => {
+    const delBuilder: Record<string, unknown> = {};
+    delBuilder.in = vi.fn(() => Promise.resolve(deleteResult));
+    return delBuilder;
+  });
+
+  return builder;
+}
+
+// ─── Auth helpers ─────────────────────────────────────────────────────────────
+
+const SECRET = "test-cron-secret-1234567890";
+
+function req(headers: Record<string, string> = {}): NextRequest {
+  return new Request("http://localhost/api/cron/prune-rate-history", {
+    headers,
+  }) as unknown as NextRequest;
+}
+
+function authedReq(): NextRequest {
+  return req({ authorization: `Bearer ${SECRET}` });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("GET /api/cron/prune-rate-history", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = SECRET;
+  });
+
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  // ── Exports ──────────────────────────────────────────────────────────────────
+
+  it("exports maxDuration = 60", () => {
+    expect(maxDuration).toBe(60);
+  });
+
+  // ── Auth gate ─────────────────────────────────────────────────────────────────
+
+  it("returns 500 when CRON_SECRET is unset", async () => {
+    delete process.env.CRON_SECRET;
+    const res = await GET(req({ authorization: `Bearer ${SECRET}` }));
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 401 on a wrong bearer token", async () => {
+    const res = await GET(req({ authorization: "Bearer wrong-token" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when no Authorization header is present", async () => {
+    const res = await GET(req());
+    expect(res.status).toBe(401);
+  });
+
+  // ── Empty tables ──────────────────────────────────────────────────────────────
+
+  it("returns 200 ok:true with zero counts when both tables are empty", async () => {
+    mockFrom.mockReturnValue(makeBuilder({ data: [], error: null }));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.savings_rate_snapshots_deleted).toBe(0);
+    expect(body.broker_health_score_history_deleted).toBe(0);
+    expect(body.savings_rate_snapshots_anchors_kept).toBe(0);
+    expect(body.broker_health_score_history_anchors_kept).toBe(0);
+    expect(body.retentionDays).toBe(90);
+  });
+
+  it("returns 200 ok:true when both tables return null data", async () => {
+    mockFrom.mockReturnValue(makeBuilder({ data: null, error: null }));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+  });
+
+  // ── Normal pruning ────────────────────────────────────────────────────────────
+
+  it("prunes savings_rate_snapshots and reports deleted count", async () => {
+    // Two old rows for the same group in the same month → one anchor, one delete
+    const savingsRows = [
+      {
+        id: "uuid-001",
+        broker_id: 1,
+        product_kind: "savings_account",
+        captured_at: "2025-10-01T00:00:00Z",
+      },
+      {
+        id: "uuid-002",
+        broker_id: 1,
+        product_kind: "savings_account",
+        captured_at: "2025-10-15T00:00:00Z",
+      },
+    ];
+
+    let savingsDeleteCalled = false;
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "savings_rate_snapshots") {
+        const b: Record<string, unknown> = {};
+        b.select = vi.fn(() => b);
+        b.lt = vi.fn(() => b);
+        b.limit = vi.fn(() => b);
+        b.then = (cb: (v: unknown) => unknown) =>
+          Promise.resolve(cb({ data: savingsRows, error: null }));
+        b.delete = vi.fn(() => {
+          savingsDeleteCalled = true;
+          return { in: vi.fn(() => Promise.resolve({ error: null })) };
+        });
+        return b;
+      }
+      // broker_health_score_history — empty, no deletions
+      return makeBuilder({ data: [], error: null });
+    });
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.savings_rate_snapshots_deleted).toBe(1);
+    expect(body.savings_rate_snapshots_anchors_kept).toBe(1);
+    expect(savingsDeleteCalled).toBe(true);
+    // Health table had no old rows
+    expect(body.broker_health_score_history_deleted).toBe(0);
+  });
+
+  it("prunes broker_health_score_history and reports deleted count", async () => {
+    const healthRows = [
+      { id: 101, broker_slug: "commsec", captured_at: "2025-09-01T00:00:00Z" },
+      { id: 102, broker_slug: "commsec", captured_at: "2025-09-15T00:00:00Z" },
+    ];
+
+    let healthDeleteCalled = false;
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "broker_health_score_history") {
+        const b: Record<string, unknown> = {};
+        b.select = vi.fn(() => b);
+        b.lt = vi.fn(() => b);
+        b.limit = vi.fn(() => b);
+        b.then = (cb: (v: unknown) => unknown) =>
+          Promise.resolve(cb({ data: healthRows, error: null }));
+        b.delete = vi.fn(() => {
+          healthDeleteCalled = true;
+          return { in: vi.fn(() => Promise.resolve({ error: null })) };
+        });
+        return b;
+      }
+      return makeBuilder({ data: [], error: null });
+    });
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.broker_health_score_history_deleted).toBe(1);
+    expect(body.broker_health_score_history_anchors_kept).toBe(1);
+    expect(healthDeleteCalled).toBe(true);
+  });
+
+  // ── Error resilience ──────────────────────────────────────────────────────────
+
+  it("still returns 200 and prunes health table when savings fetch fails", async () => {
+    const healthRows = [
+      { id: 201, broker_slug: "stake", captured_at: "2025-08-01T00:00:00Z" },
+      { id: 202, broker_slug: "stake", captured_at: "2025-08-10T00:00:00Z" },
+    ];
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "savings_rate_snapshots") {
+        // Simulate a DB fetch error
+        return makeBuilder({ data: null, error: { message: "connection timeout" } });
+      }
+      // Health table succeeds
+      const b: Record<string, unknown> = {};
+      b.select = vi.fn(() => b);
+      b.lt = vi.fn(() => b);
+      b.limit = vi.fn(() => b);
+      b.then = (cb: (v: unknown) => unknown) =>
+        Promise.resolve(cb({ data: healthRows, error: null }));
+      b.delete = vi.fn(() => ({
+        in: vi.fn(() => Promise.resolve({ error: null })),
+      }));
+      return b;
+    });
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    // Savings was errored — 0 deleted
+    expect(body.savings_rate_snapshots_deleted).toBe(0);
+    // Health proceeded normally
+    expect(body.broker_health_score_history_deleted).toBe(1);
+  });
+
+  it("still returns 200 when a delete call errors on savings table", async () => {
+    const savingsRows = [
+      { id: "uuid-a", broker_id: 3, product_kind: "term_deposit", captured_at: "2025-07-01T00:00:00Z" },
+      { id: "uuid-b", broker_id: 3, product_kind: "term_deposit", captured_at: "2025-07-20T00:00:00Z" },
+    ];
+
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "savings_rate_snapshots") {
+        const b: Record<string, unknown> = {};
+        b.select = vi.fn(() => b);
+        b.lt = vi.fn(() => b);
+        b.limit = vi.fn(() => b);
+        b.then = (cb: (v: unknown) => unknown) =>
+          Promise.resolve(cb({ data: savingsRows, error: null }));
+        b.delete = vi.fn(() => ({
+          in: vi.fn(() => Promise.resolve({ error: { message: "delete failed" } })),
+        }));
+        return b;
+      }
+      return makeBuilder({ data: [], error: null });
+    });
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    // Delete errored, so count stays 0
+    expect(body.savings_rate_snapshots_deleted).toBe(0);
+  });
+
+  it("returns 200 even when both tables throw an exception", async () => {
+    mockFrom.mockImplementation(() => {
+      throw new Error("unexpected supabase error");
+    });
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+  });
+});

--- a/__tests__/lib/snapshot-retention.test.ts
+++ b/__tests__/lib/snapshot-retention.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Tests for lib/snapshot-retention.ts
+ *
+ * Covers the pure prune-selection helper `selectSnapshotIdsToDelete`.
+ * No I/O, no mocks needed — all inputs are plain arrays.
+ *
+ * Policy under test:
+ *   - Keep all rows captured within the last RETENTION_DAYS (parameterised).
+ *   - For rows older than that cutoff: keep one "monthly anchor" (the earliest
+ *     captured row) per (groupKey × calendar month).
+ *   - Delete all remaining old rows (intra-month daily duplicates).
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  selectSnapshotIdsToDelete,
+  type SnapshotRow,
+} from "@/lib/snapshot-retention";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Reference "now" pinned to 2026-05-25T00:00:00Z for deterministic tests. */
+const NOW_ISO = "2026-05-25T00:00:00.000Z";
+const NOW_MS = new Date(NOW_ISO).getTime();
+
+/** Build a SnapshotRow from a compact spec. */
+function row(
+  id: string | number,
+  capturedAt: string,
+  groupKey = "broker:1:savings_account",
+): SnapshotRow {
+  return { id, captured_at: capturedAt, groupKey };
+}
+
+/** Returns a date that is `days` days before NOW_MS, as ISO string. */
+function daysAgo(days: number): string {
+  return new Date(NOW_MS - days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+// ─── Edge cases ───────────────────────────────────────────────────────────────
+
+describe("selectSnapshotIdsToDelete — edge cases", () => {
+  it("returns empty result for empty input", () => {
+    const result = selectSnapshotIdsToDelete([], 90, NOW_MS);
+    expect(result.toDelete).toEqual([]);
+    expect(result.kept).toEqual([]);
+    expect(result.candidateCount).toBe(0);
+    expect(result.anchorCount).toBe(0);
+  });
+
+  it("never deletes a single row, even if old", () => {
+    const rows = [row("a", daysAgo(200))];
+    const { toDelete, kept } = selectSnapshotIdsToDelete(rows, 90, NOW_MS);
+    expect(toDelete).toEqual([]);
+    expect(kept).toContain("a");
+  });
+
+  it("never deletes when all rows are within the retention window", () => {
+    const rows = [
+      row("a", daysAgo(10)),
+      row("b", daysAgo(20)),
+      row("c", daysAgo(89)),
+    ];
+    const { toDelete } = selectSnapshotIdsToDelete(rows, 90, NOW_MS);
+    expect(toDelete).toEqual([]);
+  });
+
+  it("treats the exact cutoff boundary as recent (not old)", () => {
+    // A row captured exactly at the cutoff instant should NOT be deleted.
+    const cutoffMs = NOW_MS - 90 * 24 * 60 * 60 * 1000;
+    const rows = [row("boundary", new Date(cutoffMs).toISOString())];
+    const { toDelete } = selectSnapshotIdsToDelete(rows, 90, NOW_MS);
+    expect(toDelete).toEqual([]);
+  });
+});
+
+// ─── Recent-only behaviour ────────────────────────────────────────────────────
+
+describe("selectSnapshotIdsToDelete — all rows are recent", () => {
+  it("returns empty toDelete when all rows are within window", () => {
+    const rows = [
+      row(1, daysAgo(1)),
+      row(2, daysAgo(45)),
+      row(3, daysAgo(89)),
+    ];
+    const { toDelete, kept, candidateCount } = selectSnapshotIdsToDelete(rows, 90, NOW_MS);
+    expect(toDelete).toEqual([]);
+    expect(candidateCount).toBe(0);
+    expect(kept).toHaveLength(3);
+  });
+});
+
+// ─── Monthly anchor behaviour ─────────────────────────────────────────────────
+
+describe("selectSnapshotIdsToDelete — monthly anchors", () => {
+  it("keeps the earliest row per (groupKey, month) as the anchor", () => {
+    // Three rows for the same group in the same month (January 2026 — >90d ago)
+    // The earliest (jan-01) should be the anchor; the others deleted.
+    const rows = [
+      row("jan-01", "2026-01-01T00:00:00Z"),
+      row("jan-15", "2026-01-15T00:00:00Z"),
+      row("jan-28", "2026-01-28T00:00:00Z"),
+    ];
+    const { toDelete, kept, anchorCount } = selectSnapshotIdsToDelete(rows, 90, NOW_MS);
+    expect(anchorCount).toBe(1);
+    expect(kept).toContain("jan-01");
+    expect(toDelete).toContain("jan-15");
+    expect(toDelete).toContain("jan-28");
+    expect(toDelete).not.toContain("jan-01");
+  });
+
+  it("keeps one anchor per calendar month for a group", () => {
+    // Two months of old data — two anchors should survive.
+    const rows = [
+      row("nov-01", "2025-11-01T00:00:00Z"),
+      row("nov-10", "2025-11-10T00:00:00Z"),
+      row("dec-01", "2025-12-01T00:00:00Z"),
+      row("dec-20", "2025-12-20T00:00:00Z"),
+    ];
+    const { toDelete, kept, anchorCount } = selectSnapshotIdsToDelete(rows, 90, NOW_MS);
+    expect(anchorCount).toBe(2);
+    expect(kept).toContain("nov-01");
+    expect(kept).toContain("dec-01");
+    expect(toDelete).toContain("nov-10");
+    expect(toDelete).toContain("dec-20");
+  });
+
+  it("keeps anchors per group independently (different groupKeys have their own anchors)", () => {
+    // Two groups, each with two old rows in the same month.
+    const rows = [
+      row("g1-early", "2025-10-01T00:00:00Z", "broker:1:savings"),
+      row("g1-late",  "2025-10-15T00:00:00Z", "broker:1:savings"),
+      row("g2-early", "2025-10-05T00:00:00Z", "broker:2:savings"),
+      row("g2-late",  "2025-10-20T00:00:00Z", "broker:2:savings"),
+    ];
+    const { toDelete, kept, anchorCount } = selectSnapshotIdsToDelete(rows, 90, NOW_MS);
+    expect(anchorCount).toBe(2);  // one anchor per group×month combination
+    expect(kept).toContain("g1-early");
+    expect(kept).toContain("g2-early");
+    expect(toDelete).toContain("g1-late");
+    expect(toDelete).toContain("g2-late");
+  });
+
+  it("a group with only one old row per month never generates a deletion", () => {
+    // One row per month — all should be kept as anchors.
+    const rows = [
+      row("aug-a", "2025-08-14T00:00:00Z"),
+      row("sep-a", "2025-09-14T00:00:00Z"),
+      row("oct-a", "2025-10-14T00:00:00Z"),
+    ];
+    const { toDelete, anchorCount } = selectSnapshotIdsToDelete(rows, 90, NOW_MS);
+    expect(toDelete).toEqual([]);
+    expect(anchorCount).toBe(3);
+  });
+});
+
+// ─── Mixed recent + old rows ──────────────────────────────────────────────────
+
+describe("selectSnapshotIdsToDelete — mixed recent + old rows", () => {
+  it("keeps recent rows intact while pruning old daily duplicates", () => {
+    const rows = [
+      // Recent — must never be deleted
+      row("recent-1", daysAgo(1)),
+      row("recent-2", daysAgo(30)),
+      row("recent-3", daysAgo(89)),
+      // Old — January 2026, same group: earliest becomes anchor
+      row("old-jan-01", "2026-01-01T00:00:00Z"),
+      row("old-jan-10", "2026-01-10T00:00:00Z"),
+      row("old-jan-20", "2026-01-20T00:00:00Z"),
+    ];
+    const { toDelete, kept } = selectSnapshotIdsToDelete(rows, 90, NOW_MS);
+
+    // All three recent rows must be in kept
+    expect(kept).toContain("recent-1");
+    expect(kept).toContain("recent-2");
+    expect(kept).toContain("recent-3");
+
+    // Anchor (earliest in Jan) kept; duplicates deleted
+    expect(kept).toContain("old-jan-01");
+    expect(toDelete).toContain("old-jan-10");
+    expect(toDelete).toContain("old-jan-20");
+
+    // Exactly two rows deleted
+    expect(toDelete).toHaveLength(2);
+  });
+
+  it("candidateCount reflects only the old rows, not recent ones", () => {
+    const rows = [
+      row("r1", daysAgo(10)),    // recent
+      row("o1", daysAgo(100)),   // old
+      row("o2", daysAgo(110)),   // old, same month as o1 if ≥ retention window
+    ];
+    const { candidateCount } = selectSnapshotIdsToDelete(rows, 90, NOW_MS);
+    // The exact count depends on whether o1/o2 fall in the same calendar month,
+    // but either way it should equal the number of old rows (2).
+    expect(candidateCount).toBe(2);
+  });
+});
+
+// ─── Custom retention window ──────────────────────────────────────────────────
+
+describe("selectSnapshotIdsToDelete — custom retentionDays", () => {
+  it("respects a shorter retention window (30 days)", () => {
+    // With retentionDays=30 and NOW=2026-05-25:
+    //   cutoff = 2026-04-25T00:00:00Z
+    //   daysAgo(29) = 2026-04-26 → recent
+    //   daysAgo(30) = 2026-04-25 → boundary, exactly at cutoff → recent (≥ cutoff)
+    //   daysAgo(40) = 2026-04-15 → old (before cutoff, in April 2026)
+    //   daysAgo(50) = 2026-04-05 → old (before cutoff, in April 2026)
+    // o1 (Apr-05) is earlier than o2 (Apr-15) in the same month, so o1 is the anchor.
+    const rows = [
+      row("r1", daysAgo(29)),   // recent
+      row("r2", daysAgo(30)),   // boundary — still recent (≥ cutoff)
+      row("o1", daysAgo(50)),   // old — earliest in April → becomes the anchor
+      row("o2", daysAgo(40)),   // old — same month as o1, later → deleted
+    ];
+    const { toDelete, kept } = selectSnapshotIdsToDelete(rows, 30, NOW_MS);
+    expect(kept).toContain("r1");
+    expect(kept).toContain("r2");
+    // o1 is the earliest old row in April — it becomes the anchor
+    expect(kept).toContain("o1");
+    expect(toDelete).not.toContain("o1");
+    // o2 is a later duplicate in the same month — it gets pruned
+    expect(toDelete).toContain("o2");
+  });
+});
+
+// ─── ID types ─────────────────────────────────────────────────────────────────
+
+describe("selectSnapshotIdsToDelete — ID types", () => {
+  it("works with numeric IDs (broker_health_score_history uses integer PK)", () => {
+    const rows: SnapshotRow[] = [
+      { id: 1001, captured_at: "2025-10-01T00:00:00Z", groupKey: "commsec" },
+      { id: 1002, captured_at: "2025-10-15T00:00:00Z", groupKey: "commsec" },
+    ];
+    const { toDelete, kept } = selectSnapshotIdsToDelete(rows, 90, NOW_MS);
+    expect(kept).toContain(1001);
+    expect(toDelete).toContain(1002);
+  });
+
+  it("works with UUID string IDs (savings_rate_snapshots uses UUID PK)", () => {
+    const uuid1 = "00000000-0000-0000-0000-000000000001";
+    const uuid2 = "00000000-0000-0000-0000-000000000002";
+    const rows: SnapshotRow[] = [
+      { id: uuid1, captured_at: "2025-10-01T00:00:00Z", groupKey: "broker:5:savings_account" },
+      { id: uuid2, captured_at: "2025-10-20T00:00:00Z", groupKey: "broker:5:savings_account" },
+    ];
+    const { toDelete, kept } = selectSnapshotIdsToDelete(rows, 90, NOW_MS);
+    expect(kept).toContain(uuid1);
+    expect(toDelete).toContain(uuid2);
+  });
+});
+
+// ─── Large-scale invariant ────────────────────────────────────────────────────
+
+describe("selectSnapshotIdsToDelete — invariants", () => {
+  it("toDelete + kept covers every input ID exactly once", () => {
+    const rows = [
+      row("a", daysAgo(5)),
+      row("b", daysAgo(95)),
+      row("c", "2025-10-01T00:00:00Z"),
+      row("d", "2025-10-15T00:00:00Z"),
+      row("e", "2025-09-01T00:00:00Z"),
+      row("f", "2025-09-28T00:00:00Z"),
+    ];
+    const { toDelete, kept } = selectSnapshotIdsToDelete(rows, 90, NOW_MS);
+    const allOutput = new Set([...toDelete, ...kept]);
+    for (const r of rows) {
+      expect(allOutput.has(r.id)).toBe(true);
+    }
+    // No ID appears in both lists
+    const deleteSet = new Set(toDelete);
+    for (const id of kept) {
+      expect(deleteSet.has(id)).toBe(false);
+    }
+  });
+});

--- a/app/api/cron/prune-rate-history/route.ts
+++ b/app/api/cron/prune-rate-history/route.ts
@@ -1,0 +1,159 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { requireCronAuth } from "@/lib/cron-auth";
+import { logger } from "@/lib/logger";
+import { selectSnapshotIdsToDelete } from "@/lib/snapshot-retention";
+import type { SnapshotRow } from "@/lib/snapshot-retention";
+
+const log = logger("cron:prune-rate-history");
+
+export const maxDuration = 60;
+
+/**
+ * GET /api/cron/prune-rate-history
+ *
+ * Retention sweep for the two append-only snapshot tables that feed
+ * Market Pulse trend charts and rate-alert comparisons.
+ *
+ * Problem:
+ *   Both tables grow by one full set of rows per cron run (daily for health
+ *   scores, daily for savings rates). Without pruning they'd blow out the
+ *   database indefinitely — a silent cost escalator with no circuit-breaker.
+ *
+ * Policy (keep-monthly-anchor):
+ *   - Retain ALL rows captured within the last RETENTION_DAYS (90) — these
+ *     are the "recent" rows that power current-week/month trend views.
+ *   - For rows OLDER than 90 days: keep the EARLIEST row per
+ *     (broker_id × product_kind, calendar month) for savings snapshots, and
+ *     the earliest row per (broker_slug, calendar month) for health scores.
+ *     These are the "monthly anchors" that allow long-range charts to remain
+ *     accurate without retaining every daily duplicate.
+ *   - Delete all remaining old rows (intra-month daily duplicates).
+ *
+ * This preserves:
+ *   - Full fidelity for the last 90 days (trend charts, rate alerts).
+ *   - One data point per broker×product per month beyond 90 days
+ *     (long-range trend lines, delta summaries).
+ *
+ * Safety:
+ *   - Bounded per-run to BATCH_LIMIT rows so a cold catch-up can't
+ *     time out the handler.
+ *   - Idempotent: re-running on an already-pruned table is a no-op.
+ *   - Both tables are pruned in independent try/catch blocks so a failure
+ *     on one doesn't skip the other.
+ *
+ * Registered in: lib/cron-groups.ts  (daily-3, alongside observability-retention)
+ */
+
+const RETENTION_DAYS = 90;
+const BATCH_LIMIT = 20_000;
+
+export async function GET(req: NextRequest) {
+  const unauth = requireCronAuth(req);
+  if (unauth) return unauth;
+
+  const supabase = createAdminClient();
+  const now = Date.now();
+
+  const cutoff = new Date(now - RETENTION_DAYS * 24 * 60 * 60 * 1000).toISOString();
+
+  let savingsDeleted = 0;
+  let healthDeleted = 0;
+  let savingsAnchors = 0;
+  let healthAnchors = 0;
+
+  // ── 1. Prune savings_rate_snapshots ──────────────────────────────────────────
+  try {
+    const { data: oldSnapshots, error: fetchErr } = await supabase
+      .from("savings_rate_snapshots")
+      .select("id, broker_id, product_kind, captured_at")
+      .lt("captured_at", cutoff)
+      .limit(BATCH_LIMIT);
+
+    if (fetchErr) {
+      log.error("savings_rate_snapshots_fetch_failed", { err: fetchErr.message });
+    } else if (oldSnapshots && oldSnapshots.length > 0) {
+      const rows: SnapshotRow[] = oldSnapshots.map((r) => ({
+        id: r.id as string,
+        captured_at: r.captured_at as string,
+        groupKey: `${r.broker_id as number}:${r.product_kind as string}`,
+      }));
+
+      const { toDelete, anchorCount } = selectSnapshotIdsToDelete(rows, RETENTION_DAYS, now);
+      savingsAnchors = anchorCount;
+
+      if (toDelete.length > 0) {
+        const { error: delErr } = await supabase
+          .from("savings_rate_snapshots")
+          .delete()
+          .in("id", toDelete as string[]);
+
+        if (delErr) {
+          log.error("savings_rate_snapshots_delete_failed", { err: delErr.message });
+        } else {
+          savingsDeleted = toDelete.length;
+        }
+      }
+    }
+  } catch (err) {
+    log.error("savings_rate_snapshots_prune_exception", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  // ── 2. Prune broker_health_score_history ─────────────────────────────────────
+  try {
+    const { data: oldHealth, error: fetchErr } = await supabase
+      .from("broker_health_score_history")
+      .select("id, broker_slug, captured_at")
+      .lt("captured_at", cutoff)
+      .limit(BATCH_LIMIT);
+
+    if (fetchErr) {
+      log.error("broker_health_score_history_fetch_failed", { err: fetchErr.message });
+    } else if (oldHealth && oldHealth.length > 0) {
+      const rows: SnapshotRow[] = oldHealth.map((r) => ({
+        id: r.id as number,
+        captured_at: r.captured_at as string,
+        groupKey: r.broker_slug as string,
+      }));
+
+      const { toDelete, anchorCount } = selectSnapshotIdsToDelete(rows, RETENTION_DAYS, now);
+      healthAnchors = anchorCount;
+
+      if (toDelete.length > 0) {
+        const { error: delErr } = await supabase
+          .from("broker_health_score_history")
+          .delete()
+          .in("id", toDelete as number[]);
+
+        if (delErr) {
+          log.error("broker_health_score_history_delete_failed", { err: delErr.message });
+        } else {
+          healthDeleted = toDelete.length;
+        }
+      }
+    }
+  } catch (err) {
+    log.error("broker_health_score_history_prune_exception", {
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  log.info("prune-rate-history complete", {
+    retentionDays: RETENTION_DAYS,
+    savings_deleted: savingsDeleted,
+    savings_anchors_kept: savingsAnchors,
+    health_deleted: healthDeleted,
+    health_anchors_kept: healthAnchors,
+  });
+
+  return NextResponse.json({
+    ok: true,
+    retentionDays: RETENTION_DAYS,
+    savings_rate_snapshots_deleted: savingsDeleted,
+    savings_rate_snapshots_anchors_kept: savingsAnchors,
+    broker_health_score_history_deleted: healthDeleted,
+    broker_health_score_history_anchors_kept: healthAnchors,
+  });
+}

--- a/lib/cron-groups.ts
+++ b/lib/cron-groups.ts
@@ -60,6 +60,7 @@ export const CRON_GROUPS: Record<string, readonly string[]> = {
     "/api/cron/referral-payouts",
     "/api/cron/data-integrity-audit",
     "/api/cron/observability-retention",
+    "/api/cron/prune-rate-history",
     "/api/cron/advisor-credit-expiry",
     "/api/cron/advisor-auto-topup",
     "/api/cron/annual-mot",

--- a/lib/snapshot-retention.ts
+++ b/lib/snapshot-retention.ts
@@ -1,0 +1,141 @@
+/**
+ * lib/snapshot-retention.ts
+ *
+ * Pure helper for selecting snapshot rows to prune from append-only history
+ * tables (savings_rate_snapshots, broker_health_score_history).
+ *
+ * Retention policy:
+ *   - Keep ALL rows captured within the last N days (default 90).
+ *   - For rows older than N days, keep the EARLIEST row per
+ *     (group key, calendar month) as a "monthly anchor" so long-range
+ *     trend charts and rate-alert history remain intact.
+ *   - Delete all other rows older than N days (intra-month daily duplicates).
+ *
+ * Design constraints:
+ *   - Pure functions only — no I/O. Unit-testable without a DB.
+ *   - Caller is responsible for fetching candidate rows and executing deletes.
+ *   - `retentionDays` is parameterised so tests can exercise small windows.
+ */
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/**
+ * Minimal shape required from a savings_rate_snapshots row.
+ * `groupKey` is a caller-supplied composite key (e.g. `${broker_id}:${product_kind}`).
+ */
+export interface SnapshotRow {
+  /** Stable row identifier (UUID string for savings_rate_snapshots, number for health). */
+  id: string | number;
+  /** ISO-8601 timestamp, e.g. "2025-08-14T06:00:00Z". */
+  captured_at: string;
+  /** Caller-supplied partition key that defines "same product/broker". */
+  groupKey: string;
+}
+
+/**
+ * Result of the prune-selection pass.
+ *
+ * `toDelete` contains the IDs of rows that may safely be deleted.
+ * `kept` is informational — the IDs that were retained (anchors + recent).
+ */
+export interface PruneSelection {
+  toDelete: Array<string | number>;
+  kept: Array<string | number>;
+  /** Count of rows older than retentionDays (before monthly-anchor filtering). */
+  candidateCount: number;
+  /** Count of monthly anchors retained. */
+  anchorCount: number;
+}
+
+// ─── Core logic ───────────────────────────────────────────────────────────────
+
+/**
+ * Given an array of snapshot rows, return the IDs that should be deleted.
+ *
+ * Algorithm:
+ *   1. Partition rows into "recent" (within retentionDays of `now`) and
+ *      "old" (outside that window).
+ *   2. For the "old" bucket, group by `(groupKey, YYYY-MM)` (calendar month).
+ *   3. Within each group, keep the row with the smallest `captured_at`
+ *      (the earliest snapshot for that group in that month = the monthly anchor).
+ *   4. All other old rows are scheduled for deletion.
+ *
+ * Edge cases:
+ *   - Empty input → empty result.
+ *   - Single row (old or recent) → never deleted.
+ *   - All rows are recent → nothing deleted.
+ *   - Multiple rows in one month for a group → only the earliest is kept.
+ *
+ * @param rows         Candidate rows to evaluate (may include recent rows).
+ * @param retentionDays Days to retain unconditionally (default 90).
+ * @param now          Reference time for age calculations (default Date.now()).
+ */
+export function selectSnapshotIdsToDelete(
+  rows: SnapshotRow[],
+  retentionDays = 90,
+  now: number = Date.now(),
+): PruneSelection {
+  if (rows.length === 0) {
+    return { toDelete: [], kept: [], candidateCount: 0, anchorCount: 0 };
+  }
+
+  const cutoffMs = now - retentionDays * 24 * 60 * 60 * 1000;
+
+  const recentIds = new Set<string | number>();
+  const oldRows: SnapshotRow[] = [];
+
+  for (const row of rows) {
+    const ts = new Date(row.captured_at).getTime();
+    if (Number.isNaN(ts) || ts >= cutoffMs) {
+      recentIds.add(row.id);
+    } else {
+      oldRows.push(row);
+    }
+  }
+
+  if (oldRows.length === 0) {
+    return {
+      toDelete: [],
+      kept: [...recentIds],
+      candidateCount: 0,
+      anchorCount: 0,
+    };
+  }
+
+  // Group old rows by (groupKey, YYYY-MM) and find the earliest per group.
+  // "earliest" = smallest captured_at string (ISO lexicographic order is
+  // chronological for UTC timestamps with the same TZ offset).
+  const monthGroups = new Map<string, SnapshotRow>();
+
+  for (const row of oldRows) {
+    const month = row.captured_at.slice(0, 7); // "YYYY-MM"
+    const key = `${row.groupKey}::${month}`;
+    const existing = monthGroups.get(key);
+    if (!existing || row.captured_at < existing.captured_at) {
+      monthGroups.set(key, row);
+    }
+  }
+
+  const anchorIds = new Set<string | number>();
+  for (const anchor of monthGroups.values()) {
+    anchorIds.add(anchor.id);
+  }
+
+  const toDelete: Array<string | number> = [];
+  const kept: Array<string | number> = [...recentIds];
+
+  for (const row of oldRows) {
+    if (anchorIds.has(row.id)) {
+      kept.push(row.id);
+    } else {
+      toDelete.push(row.id);
+    }
+  }
+
+  return {
+    toDelete,
+    kept,
+    candidateCount: oldRows.length,
+    anchorCount: anchorIds.size,
+  };
+}


### PR DESCRIPTION
Round-4 deepening (10 of 10). Prevents unbounded growth of the append-only snapshot tables (`savings_rate_snapshots` + `broker_health_score_history` had **no pruning anywhere** — a silent DB-cost escalator). AFSL-neutral data ops.

- `lib/snapshot-retention.ts` — pure, tested `selectSnapshotIdsToDelete()`: keep **all rows < 90 days** (powers current trends + alert freshness); for older rows keep the **earliest per (broker × product_kind, calendar month)** as a long-range anchor; delete the rest. So Market Pulse keeps long-range monthly history while daily churn beyond 90 days is pruned.
- `app/api/cron/prune-rate-history` — `requireCronAuth` first, `createAdminClient`, batched selects→deletes (≤20k/run), each table in its own try/catch, structured logging; registered in the `daily-3` group.

**No reads affected:** `rate-alerts`, `refresh-savings-rates`, and `/market-pulse` all use `ORDER BY captured_at DESC` / best-in-window queries that monthly anchors preserve.

**Verified:** `tsc` clean · **26 tests** (helper: boundary, multi-month anchors, group independence, partition-coverage invariant; route: auth gate, empty/normal/error/exception paths) pass · eslint clean · rate-limit `--strict` pass · cron-auth confirmed.

**Tier C** (new cron touching data tables) — announcing; proceeding unless STOP. First run drains backlog over multiple days (20k batch cap) — intentional + safe.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUfSRE2Teb6VhEXFP6RpS9)_