### PR TITLE
feat(account): unified My Saves hub (deepen)

### DIFF
--- a/__tests__/lib/my-saves-hub.test.ts
+++ b/__tests__/lib/my-saves-hub.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Unit tests for lib/my-saves-hub.ts — buildMySavesHubViewModel.
+ *
+ * All tests are pure: no DB, no mocks, no async. The helper takes five
+ * in-memory arrays and returns a view-model.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  buildMySavesHubViewModel,
+  RECENT_COUNT,
+  type MySavesHubInputs,
+} from "@/lib/my-saves-hub";
+import type { BookmarkRow } from "@/lib/bookmarks";
+
+// ── Fixtures ───────────────────────────────────────────────────────────────────
+
+function makeBookmark(n: number): BookmarkRow {
+  return {
+    id: n,
+    user_id: "user-1",
+    bookmark_type: "article",
+    ref: `article-${n}`,
+    label: `Article ${n}`,
+    note: null,
+    created_at: new Date(2026, 0, n).toISOString(),
+  };
+}
+
+function makeWatchlistItem(n: number) {
+  return {
+    id: n,
+    item_type: "broker",
+    item_slug: `broker-${n}`,
+    display_name: `Broker ${n}`,
+    added_at: new Date(2026, 0, n).toISOString(),
+  };
+}
+
+function makeComparison(n: number) {
+  return {
+    id: `comp-${n}`,
+    name: `Comparison ${n}`,
+    broker_slugs: ["commsec", "stake"],
+    created_at: new Date(2026, 0, n).toISOString(),
+  };
+}
+
+function makeSavedSearch(n: number) {
+  return {
+    id: n,
+    kind: "advisors" as const,
+    label: `Search ${n}`,
+    email_frequency: "weekly",
+    created_at: new Date(2026, 0, n).toISOString(),
+  };
+}
+
+function makeAlert(n: number) {
+  return {
+    id: `alert-${n}`,
+    metric_kind: "savings_rate",
+    product_kind: "savings_account",
+    threshold_bps: 500,
+    direction: "above",
+    broker_slug: null,
+    verified: true,
+    created_at: new Date(2026, 0, n).toISOString(),
+  };
+}
+
+const emptyInputs: MySavesHubInputs = {
+  bookmarks: [],
+  watchlistItems: [],
+  comparisons: [],
+  savedSearches: [],
+  rateAlerts: [],
+};
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("buildMySavesHubViewModel — all-empty input", () => {
+  it("returns isEmpty = true when all five sets are empty", () => {
+    const vm = buildMySavesHubViewModel(emptyInputs);
+    expect(vm.isEmpty).toBe(true);
+  });
+
+  it("returns count = 0 and recent = [] for every section", () => {
+    const vm = buildMySavesHubViewModel(emptyInputs);
+    expect(vm.bookmarks.count).toBe(0);
+    expect(vm.bookmarks.recent).toHaveLength(0);
+    expect(vm.watchlist.count).toBe(0);
+    expect(vm.watchlist.recent).toHaveLength(0);
+    expect(vm.comparisons.count).toBe(0);
+    expect(vm.comparisons.recent).toHaveLength(0);
+    expect(vm.savedSearches.count).toBe(0);
+    expect(vm.savedSearches.recent).toHaveLength(0);
+    expect(vm.rateAlerts.count).toBe(0);
+    expect(vm.rateAlerts.recent).toHaveLength(0);
+  });
+});
+
+describe("buildMySavesHubViewModel — counts", () => {
+  it("reflects the full length of each data set in count", () => {
+    const vm = buildMySavesHubViewModel({
+      bookmarks: [makeBookmark(1), makeBookmark(2), makeBookmark(3), makeBookmark(4), makeBookmark(5)],
+      watchlistItems: [makeWatchlistItem(1), makeWatchlistItem(2)],
+      comparisons: [makeComparison(1)],
+      savedSearches: [makeSavedSearch(1), makeSavedSearch(2), makeSavedSearch(3), makeSavedSearch(4)],
+      rateAlerts: [makeAlert(1), makeAlert(2), makeAlert(3), makeAlert(4), makeAlert(5), makeAlert(6)],
+    });
+    expect(vm.bookmarks.count).toBe(5);
+    expect(vm.watchlist.count).toBe(2);
+    expect(vm.comparisons.count).toBe(1);
+    expect(vm.savedSearches.count).toBe(4);
+    expect(vm.rateAlerts.count).toBe(6);
+  });
+});
+
+describe("buildMySavesHubViewModel — recent slicing", () => {
+  it(`returns at most RECENT_COUNT (${RECENT_COUNT}) items in each recent array`, () => {
+    const many = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    const vm = buildMySavesHubViewModel({
+      bookmarks: many.map(makeBookmark),
+      watchlistItems: many.map(makeWatchlistItem),
+      comparisons: many.map(makeComparison),
+      savedSearches: many.map(makeSavedSearch),
+      rateAlerts: many.map(makeAlert),
+    });
+    expect(vm.bookmarks.recent.length).toBeLessThanOrEqual(RECENT_COUNT);
+    expect(vm.watchlist.recent.length).toBeLessThanOrEqual(RECENT_COUNT);
+    expect(vm.comparisons.recent.length).toBeLessThanOrEqual(RECENT_COUNT);
+    expect(vm.savedSearches.recent.length).toBeLessThanOrEqual(RECENT_COUNT);
+    expect(vm.rateAlerts.recent.length).toBeLessThanOrEqual(RECENT_COUNT);
+  });
+
+  it("preserves input order in the recent slice (first-in = most recent)", () => {
+    // Inputs arrive newest-first from the helpers; slice should keep that order.
+    const bookmarks = [makeBookmark(10), makeBookmark(9), makeBookmark(8), makeBookmark(7)];
+    const vm = buildMySavesHubViewModel({ ...emptyInputs, bookmarks });
+    expect(vm.bookmarks.recent[0]?.id).toBe(10);
+    expect(vm.bookmarks.recent[1]?.id).toBe(9);
+    expect(vm.bookmarks.recent[2]?.id).toBe(8);
+  });
+
+  it("returns exactly N items when input length equals RECENT_COUNT", () => {
+    const bookmarks = Array.from({ length: RECENT_COUNT }, (_, i) => makeBookmark(i + 1));
+    const vm = buildMySavesHubViewModel({ ...emptyInputs, bookmarks });
+    expect(vm.bookmarks.recent).toHaveLength(RECENT_COUNT);
+    expect(vm.bookmarks.count).toBe(RECENT_COUNT);
+  });
+
+  it("does not duplicate items between recent and count", () => {
+    const bookmarks = [makeBookmark(1), makeBookmark(2)];
+    const vm = buildMySavesHubViewModel({ ...emptyInputs, bookmarks });
+    // recent is a strict subset, not a separate list
+    expect(vm.bookmarks.count).toBe(2);
+    expect(vm.bookmarks.recent).toHaveLength(2);
+  });
+});
+
+describe("buildMySavesHubViewModel — partial fill (isEmpty = false)", () => {
+  it("is not empty when only bookmarks are present", () => {
+    const vm = buildMySavesHubViewModel({
+      ...emptyInputs,
+      bookmarks: [makeBookmark(1)],
+    });
+    expect(vm.isEmpty).toBe(false);
+  });
+
+  it("is not empty when only rate alerts are present", () => {
+    const vm = buildMySavesHubViewModel({
+      ...emptyInputs,
+      rateAlerts: [makeAlert(1)],
+    });
+    expect(vm.isEmpty).toBe(false);
+  });
+
+  it("is not empty when only watchlist is present", () => {
+    const vm = buildMySavesHubViewModel({
+      ...emptyInputs,
+      watchlistItems: [makeWatchlistItem(1)],
+    });
+    expect(vm.isEmpty).toBe(false);
+  });
+
+  it("is not empty when only saved searches are present", () => {
+    const vm = buildMySavesHubViewModel({
+      ...emptyInputs,
+      savedSearches: [makeSavedSearch(1)],
+    });
+    expect(vm.isEmpty).toBe(false);
+  });
+
+  it("is not empty when only comparisons are present", () => {
+    const vm = buildMySavesHubViewModel({
+      ...emptyInputs,
+      comparisons: [makeComparison(1)],
+    });
+    expect(vm.isEmpty).toBe(false);
+  });
+
+  it("other sections stay at count=0 when only one section has data", () => {
+    const vm = buildMySavesHubViewModel({
+      ...emptyInputs,
+      watchlistItems: [makeWatchlistItem(1), makeWatchlistItem(2)],
+    });
+    expect(vm.bookmarks.count).toBe(0);
+    expect(vm.comparisons.count).toBe(0);
+    expect(vm.savedSearches.count).toBe(0);
+    expect(vm.rateAlerts.count).toBe(0);
+    expect(vm.watchlist.count).toBe(2);
+  });
+});
+
+describe("buildMySavesHubViewModel — bookmark shape projection", () => {
+  it("projects only the fields needed by the hub view", () => {
+    const bm = makeBookmark(1);
+    const vm = buildMySavesHubViewModel({ ...emptyInputs, bookmarks: [bm] });
+    const projected = vm.bookmarks.recent[0];
+    expect(projected).toBeDefined();
+    if (!projected) return;
+    // Required hub fields
+    expect(projected.id).toBe(bm.id);
+    expect(projected.bookmark_type).toBe(bm.bookmark_type);
+    expect(projected.ref).toBe(bm.ref);
+    expect(projected.label).toBe(bm.label);
+    expect(projected.created_at).toBe(bm.created_at);
+    // user_id is NOT included in the projection — hub doesn't need it
+    expect("user_id" in projected).toBe(false);
+  });
+});
+
+describe("buildMySavesHubViewModel — watchlist / comparison / search / alert passthrough", () => {
+  it("passes watchlist items through unchanged", () => {
+    const w = makeWatchlistItem(5);
+    const vm = buildMySavesHubViewModel({ ...emptyInputs, watchlistItems: [w] });
+    expect(vm.watchlist.recent[0]).toEqual(w);
+  });
+
+  it("passes comparison items through unchanged", () => {
+    const c = makeComparison(3);
+    const vm = buildMySavesHubViewModel({ ...emptyInputs, comparisons: [c] });
+    expect(vm.comparisons.recent[0]).toEqual(c);
+  });
+
+  it("passes saved search items through unchanged", () => {
+    const s = makeSavedSearch(2);
+    const vm = buildMySavesHubViewModel({ ...emptyInputs, savedSearches: [s] });
+    expect(vm.savedSearches.recent[0]).toEqual(s);
+  });
+
+  it("passes rate alert items through unchanged", () => {
+    const a = makeAlert(4);
+    const vm = buildMySavesHubViewModel({ ...emptyInputs, rateAlerts: [a] });
+    expect(vm.rateAlerts.recent[0]).toEqual(a);
+  });
+});

--- a/app/account/AccountClient.tsx
+++ b/app/account/AccountClient.tsx
@@ -515,6 +515,27 @@ export default function AccountClient() {
           <NotificationPreferences isPro={isPro} />
         </div>
 
+        {/* My Saves hub — prominent card linking to the aggregated saves view */}
+        <div className="bg-white border border-slate-200 rounded-xl p-5 mb-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-base font-bold text-slate-900">My Saves</h2>
+              <p className="text-xs text-slate-500 mt-0.5">
+                Reading list, watchlist, comparisons, searches &amp; alerts
+              </p>
+            </div>
+            <Link
+              href="/account/my-saves"
+              className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-semibold text-slate-700 bg-slate-50 rounded-xl hover:bg-slate-100 transition-colors"
+            >
+              View all
+              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+              </svg>
+            </Link>
+          </div>
+        </div>
+
         {/* Quick Links */}
         <div className="bg-white border border-slate-200 rounded-xl p-5 mb-4">
           <h2 className="text-base font-bold text-slate-900 mb-3">Quick Links</h2>
@@ -537,8 +558,8 @@ export default function AccountClient() {
             <Link href="/account/notifications" className="flex items-center gap-2 px-3 py-2 text-sm text-slate-700 bg-slate-50 rounded-lg hover:bg-slate-100 transition-colors">
               <span>🔔</span> Notifications
             </Link>
-            <Link href="/account/bookmarks" className="flex items-center gap-2 px-3 py-2 text-sm text-slate-700 bg-slate-50 rounded-lg hover:bg-slate-100 transition-colors">
-              <span>🔖</span> Reading List
+            <Link href="/account/my-saves" className="flex items-center gap-2 px-3 py-2 text-sm text-slate-700 bg-slate-50 rounded-lg hover:bg-slate-100 transition-colors">
+              <span>🔖</span> My Saves
             </Link>
             <Link href="/account/quizzes" className="flex items-center gap-2 px-3 py-2 text-sm text-slate-700 bg-slate-50 rounded-lg hover:bg-slate-100 transition-colors">
               <span>📝</span> Quiz History

--- a/app/account/my-saves/page.tsx
+++ b/app/account/my-saves/page.tsx
@@ -1,0 +1,429 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { listBookmarks } from "@/lib/bookmarks";
+import { listForUser as listSavedSearches } from "@/lib/saved-searches";
+import {
+  buildMySavesHubViewModel,
+  type WatchlistItem,
+  type SavedComparisonItem,
+  type SavedSearchItem,
+  type RateAlertItem,
+} from "@/lib/my-saves-hub";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "My Saves — My Account",
+  robots: "noindex, nofollow",
+};
+
+// ── Small formatting helpers ───────────────────────────────────────────────────
+
+function fmtDate(iso: string | null | undefined): string {
+  if (!iso) return "";
+  return new Date(iso).toLocaleDateString("en-AU", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+function bpsToPercent(bps: number): string {
+  return (bps / 100).toFixed(2);
+}
+
+// ── Section wrapper ────────────────────────────────────────────────────────────
+
+function Section({
+  title,
+  count,
+  viewAllHref,
+  addHref,
+  addLabel,
+  children,
+  emptyMessage,
+  emptyCtaHref,
+  emptyCtaLabel,
+}: {
+  title: string;
+  count: number;
+  viewAllHref: string;
+  addHref?: string;
+  addLabel?: string;
+  children?: React.ReactNode;
+  emptyMessage: string;
+  emptyCtaHref: string;
+  emptyCtaLabel: string;
+}) {
+  return (
+    <section className="bg-white border border-slate-200 rounded-xl overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center justify-between px-5 py-4 border-b border-slate-100">
+        <div className="flex items-baseline gap-2">
+          <h2 className="text-base font-bold text-slate-900">{title}</h2>
+          {count > 0 && (
+            <span className="text-xs font-semibold text-slate-400 tabular-nums">
+              {count}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-3">
+          {addHref && addLabel && (
+            <Link
+              href={addHref}
+              className="text-xs font-semibold text-emerald-600 hover:text-emerald-700"
+            >
+              + {addLabel}
+            </Link>
+          )}
+          {count > 0 && (
+            <Link
+              href={viewAllHref}
+              className="text-xs font-semibold text-slate-500 hover:text-slate-700"
+            >
+              View all
+            </Link>
+          )}
+        </div>
+      </div>
+
+      {/* Body */}
+      {count === 0 ? (
+        <div className="px-5 py-8 text-center">
+          <p className="text-sm text-slate-500 mb-3">{emptyMessage}</p>
+          <Link
+            href={emptyCtaHref}
+            className="inline-block px-4 py-2 bg-slate-900 text-white text-xs font-semibold rounded-lg hover:bg-slate-800 transition-colors"
+          >
+            {emptyCtaLabel}
+          </Link>
+        </div>
+      ) : (
+        <div className="divide-y divide-slate-100">{children}</div>
+      )}
+    </section>
+  );
+}
+
+// ── Main page ──────────────────────────────────────────────────────────────────
+
+export default async function MySavesPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/account/login?redirect=/account/my-saves");
+  }
+
+  const admin = createAdminClient();
+
+  // Fetch all five data sets in parallel. Each call is already guarded
+  // against throwing by its lib helper (returns [] on failure). The
+  // watchlist and rate alerts don't have standalone lib helpers that return
+  // the right shape, so we query here directly — matching the existing
+  // patterns in /account/watchlist/page.tsx and /account/alerts/page.tsx.
+  const [
+    bookmarks,
+    savedSearchRows,
+    comparisonsRes,
+    watchlistRes,
+    alertsRes,
+  ] = await Promise.all([
+    listBookmarks(user.id),
+    listSavedSearches(user.id),
+    // Saved comparisons: same fetch as SavedComparisonsClient uses via
+    // /api/saved-comparisons, but here we query directly (RSC context).
+    supabase
+      .from("user_saved_comparisons")
+      .select("id, name, broker_slugs, created_at")
+      .eq("user_id", user.id)
+      .order("created_at", { ascending: false }),
+    // Watchlist items: mirrors /account/watchlist/page.tsx
+    supabase
+      .from("user_watchlist_items")
+      .select("id, item_type, item_slug, display_name, added_at")
+      .eq("user_id", user.id)
+      .order("added_at", { ascending: false }),
+    // Rate alerts: mirrors /account/alerts/page.tsx (service-role for
+    // the or() cross-column query the same way the full alerts page does).
+    admin
+      .from("rate_alert_subscriptions")
+      .select(
+        "id, metric_kind, product_kind, threshold_bps, direction, broker_slug, verified, created_at",
+      )
+      .or(`user_id.eq.${user.id},email.eq.${(user.email ?? "").toLowerCase()}`)
+      .order("created_at", { ascending: false }),
+  ]);
+
+  const watchlistItems: WatchlistItem[] = (watchlistRes.data ?? []).map(
+    (row) => ({
+      id: row.id as number,
+      item_type: row.item_type as string,
+      item_slug: row.item_slug as string,
+      display_name: row.display_name as string | null,
+      added_at: row.added_at as string,
+    }),
+  );
+
+  const comparisons: SavedComparisonItem[] = (
+    comparisonsRes.data ?? []
+  ).map((row) => ({
+    id: row.id as string,
+    name: row.name as string,
+    broker_slugs: (row.broker_slugs as string[]) ?? [],
+    created_at: row.created_at as string,
+  }));
+
+  const savedSearches: SavedSearchItem[] = savedSearchRows.map((r) => ({
+    id: r.id,
+    kind: r.kind,
+    label: r.label,
+    email_frequency: r.email_frequency,
+    created_at: r.created_at,
+  }));
+
+  const rateAlerts: RateAlertItem[] = (alertsRes.data ?? []).map((row) => ({
+    id: row.id as string,
+    metric_kind: row.metric_kind as string | null,
+    product_kind: row.product_kind as string,
+    threshold_bps: row.threshold_bps as number,
+    direction: row.direction as string,
+    broker_slug: row.broker_slug as string | null,
+    verified: row.verified as boolean,
+    created_at: row.created_at as string | null,
+  }));
+
+  const vm = buildMySavesHubViewModel({
+    bookmarks,
+    watchlistItems,
+    comparisons,
+    savedSearches,
+    rateAlerts,
+  });
+
+  const METRIC_LABELS: Record<string, string> = {
+    savings_rate: "Savings Rate",
+    term_deposit: "Term Deposit",
+    loan_rate: "Loan Rate",
+    broker_fee: "Brokerage Fee",
+    savings_account: "Savings Rate",
+  };
+
+  const SEARCH_KIND_LABELS: Record<string, string> = {
+    advisors: "Advisors",
+    teams: "Teams",
+    invest: "Invest",
+  };
+
+  return (
+    <div className="py-6 md:py-10">
+      <div className="container-custom max-w-3xl">
+        {/* Breadcrumb */}
+        <nav className="text-xs text-slate-500 mb-3">
+          <Link href="/account" className="hover:text-slate-900">
+            ← My account
+          </Link>
+        </nav>
+
+        <div className="mb-6">
+          <h1 className="text-2xl font-extrabold text-slate-900">My Saves</h1>
+          <p className="text-sm text-slate-500 mt-1">
+            Everything you&rsquo;ve saved in one place.
+          </p>
+        </div>
+
+        {/* All-empty state */}
+        {vm.isEmpty && (
+          <div className="bg-white border border-slate-200 rounded-xl p-10 text-center mb-6">
+            <div className="text-4xl mb-3" aria-hidden>
+              🔖
+            </div>
+            <h2 className="text-lg font-bold text-slate-900 mb-1">
+              Nothing saved yet
+            </h2>
+            <p className="text-sm text-slate-500 mb-5">
+              Start comparing brokers, save articles you want to read later, or
+              set up a rate alert and they&rsquo;ll all show up here.
+            </p>
+            <div className="flex flex-wrap gap-2 justify-center">
+              <Link
+                href="/compare"
+                className="px-5 py-2.5 bg-slate-900 text-white text-sm font-semibold rounded-xl hover:bg-slate-800 transition-colors"
+              >
+                Compare brokers
+              </Link>
+              <Link
+                href="/rate-alerts"
+                className="px-5 py-2.5 border border-slate-200 text-slate-700 text-sm font-semibold rounded-xl hover:bg-slate-50 transition-colors"
+              >
+                Set a rate alert
+              </Link>
+            </div>
+          </div>
+        )}
+
+        <div className="space-y-4">
+          {/* ── Bookmarks ─────────────────────────────────────────────────── */}
+          <Section
+            title="Reading List"
+            count={vm.bookmarks.count}
+            viewAllHref="/account/bookmarks"
+            emptyMessage="Save articles, brokers and advisors to read or revisit later."
+            emptyCtaHref="/compare"
+            emptyCtaLabel="Browse brokers"
+          >
+            {vm.bookmarks.recent.map((b) => (
+              <div key={b.id} className="flex items-center gap-3 px-5 py-3">
+                <span className="text-xs font-medium text-slate-400 w-16 shrink-0 capitalize">
+                  {b.bookmark_type}
+                </span>
+                <Link
+                  href={
+                    b.bookmark_type === "article"
+                      ? `/article/${b.ref}`
+                      : b.bookmark_type === "broker"
+                        ? `/broker/${b.ref}`
+                        : b.bookmark_type === "advisor"
+                          ? `/advisor/${b.ref}`
+                          : b.bookmark_type === "calculator"
+                            ? `/calculators/${b.ref}`
+                            : `#`
+                  }
+                  className="flex-1 text-sm font-medium text-slate-900 hover:text-primary truncate"
+                >
+                  {b.label ?? b.ref}
+                </Link>
+                <span className="text-xs text-slate-400 shrink-0">
+                  {fmtDate(b.created_at)}
+                </span>
+              </div>
+            ))}
+          </Section>
+
+          {/* ── Watchlist ─────────────────────────────────────────────────── */}
+          <Section
+            title="Watchlist"
+            count={vm.watchlist.count}
+            viewAllHref="/account/watchlist"
+            emptyMessage="Add brokers, savings accounts and term deposits to your watchlist to track them."
+            emptyCtaHref="/compare"
+            emptyCtaLabel="Browse brokers"
+          >
+            {vm.watchlist.recent.map((w) => (
+              <div key={w.id} className="flex items-center gap-3 px-5 py-3">
+                <span className="text-xs font-medium text-slate-400 w-16 shrink-0 capitalize">
+                  {w.item_type}
+                </span>
+                <Link
+                  href={`/broker/${w.item_slug}`}
+                  className="flex-1 text-sm font-medium text-slate-900 hover:text-primary truncate"
+                >
+                  {w.display_name ?? w.item_slug}
+                </Link>
+                <span className="text-xs text-slate-400 shrink-0">
+                  {fmtDate(w.added_at)}
+                </span>
+              </div>
+            ))}
+          </Section>
+
+          {/* ── Saved Comparisons ─────────────────────────────────────────── */}
+          <Section
+            title="Saved Comparisons"
+            count={vm.comparisons.count}
+            viewAllHref="/account/saved"
+            addHref="/compare"
+            addLabel="New comparison"
+            emptyMessage="Compare brokers side by side and save your shortlists for later."
+            emptyCtaHref="/compare"
+            emptyCtaLabel="Start comparing"
+          >
+            {vm.comparisons.recent.map((c) => (
+              <div key={c.id} className="flex items-center gap-3 px-5 py-3">
+                <Link
+                  href={`/compare?brokers=${c.broker_slugs.join(",")}`}
+                  className="flex-1 text-sm font-medium text-slate-900 hover:text-primary truncate"
+                >
+                  {c.name}
+                </Link>
+                <span className="text-xs text-slate-400 shrink-0">
+                  {c.broker_slugs.length} broker
+                  {c.broker_slugs.length !== 1 ? "s" : ""}
+                </span>
+                <span className="text-xs text-slate-400 shrink-0">
+                  {fmtDate(c.created_at)}
+                </span>
+              </div>
+            ))}
+          </Section>
+
+          {/* ── Saved Searches ────────────────────────────────────────────── */}
+          <Section
+            title="Saved Searches"
+            count={vm.savedSearches.count}
+            viewAllHref="/account/saved-searches"
+            emptyMessage="Save an advisor or team search and get a digest when new providers match."
+            emptyCtaHref="/advisors"
+            emptyCtaLabel="Browse advisors"
+          >
+            {vm.savedSearches.recent.map((s) => (
+              <div key={s.id} className="flex items-center gap-3 px-5 py-3">
+                <span className="text-xs font-medium text-slate-400 w-16 shrink-0">
+                  {SEARCH_KIND_LABELS[s.kind] ?? s.kind}
+                </span>
+                <span className="flex-1 text-sm font-medium text-slate-900 truncate">
+                  {s.label}
+                </span>
+                <span className="text-xs text-slate-400 shrink-0 capitalize">
+                  {s.email_frequency === "off" ? "Alerts off" : s.email_frequency}
+                </span>
+              </div>
+            ))}
+          </Section>
+
+          {/* ── Rate Alerts ───────────────────────────────────────────────── */}
+          <Section
+            title="Rate Alerts"
+            count={vm.rateAlerts.count}
+            viewAllHref="/account/alerts"
+            addHref="/rate-alerts"
+            addLabel="New alert"
+            emptyMessage="Get notified when savings rates, term deposits or brokerage fees hit your threshold."
+            emptyCtaHref="/rate-alerts"
+            emptyCtaLabel="Set an alert"
+          >
+            {vm.rateAlerts.recent.map((a) => {
+              const kind = a.metric_kind ?? a.product_kind;
+              const label = METRIC_LABELS[kind] ?? kind;
+              const direction = a.direction === "above" ? "rises above" : "drops below";
+              const threshold = a.threshold_bps > 0 ? ` ${bpsToPercent(a.threshold_bps)}%` : "";
+              return (
+                <div key={a.id} className="flex items-center gap-3 px-5 py-3">
+                  <span className="flex-1 text-sm font-medium text-slate-900 truncate">
+                    {label} {direction}{threshold}
+                    {a.broker_slug ? ` — ${a.broker_slug}` : ""}
+                  </span>
+                  {a.verified ? (
+                    <span className="text-xs font-semibold text-emerald-600 shrink-0">
+                      Active
+                    </span>
+                  ) : (
+                    <span className="text-xs font-semibold text-amber-600 shrink-0">
+                      Unverified
+                    </span>
+                  )}
+                </div>
+              );
+            })}
+          </Section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/my-saves-hub.ts
+++ b/lib/my-saves-hub.ts
@@ -1,0 +1,141 @@
+/**
+ * My Saves Hub — assembly helper.
+ *
+ * Pure function: takes the five raw data sets fetched by the hub page
+ * and returns a typed view-model ready for rendering. No DB calls, no
+ * side-effects — everything is unit-testable without a mock surface.
+ *
+ * The five save types:
+ *   1. Bookmarks     — articles, brokers, advisors, scenarios, calculators
+ *   2. Watchlist     — watched broker / product items
+ *   3. Comparisons   — named saved broker comparisons
+ *   4. Saved searches — filter snapshots with email-alert frequencies
+ *   5. Rate alerts   — threshold-based notifications from rate_alert_subscriptions
+ */
+
+import type { BookmarkRow } from "@/lib/bookmarks";
+
+// ── Minimal shapes pulled from each per-type page ─────────────────────────────
+
+export interface WatchlistItem {
+  id: number;
+  item_type: string;
+  item_slug: string;
+  display_name: string | null;
+  added_at: string;
+}
+
+export interface SavedComparisonItem {
+  id: string;
+  name: string;
+  broker_slugs: string[];
+  created_at: string;
+}
+
+export interface SavedSearchItem {
+  id: number;
+  kind: string;
+  label: string;
+  email_frequency: string;
+  created_at: string;
+}
+
+export interface RateAlertItem {
+  id: string;
+  metric_kind: string | null;
+  product_kind: string;
+  threshold_bps: number;
+  direction: string;
+  broker_slug: string | null;
+  verified: boolean;
+  created_at: string | null;
+}
+
+// ── Hub view-model ─────────────────────────────────────────────────────────────
+
+/** One section in the hub, generic over the item shape. */
+export interface HubSection<T> {
+  /** Total items the user has for this type. */
+  count: number;
+  /** Most-recent N items (controlled by RECENT_COUNT). */
+  recent: T[];
+}
+
+/** The shape the hub page renders. */
+export interface MySavesHubViewModel {
+  bookmarks: HubSection<Pick<BookmarkRow, "id" | "bookmark_type" | "ref" | "label" | "created_at">>;
+  watchlist: HubSection<WatchlistItem>;
+  comparisons: HubSection<SavedComparisonItem>;
+  savedSearches: HubSection<SavedSearchItem>;
+  rateAlerts: HubSection<RateAlertItem>;
+  /** True when every section has count === 0. */
+  isEmpty: boolean;
+}
+
+/** How many items to surface in each section's preview strip. */
+export const RECENT_COUNT = 3;
+
+// ── Raw inputs ─────────────────────────────────────────────────────────────────
+
+export interface MySavesHubInputs {
+  bookmarks: BookmarkRow[];
+  watchlistItems: WatchlistItem[];
+  comparisons: SavedComparisonItem[];
+  savedSearches: SavedSearchItem[];
+  rateAlerts: RateAlertItem[];
+}
+
+// ── Assembly ───────────────────────────────────────────────────────────────────
+
+/**
+ * Assemble the hub view-model from five pre-fetched data sets.
+ *
+ * Each data set is assumed to arrive newest-first from its respective
+ * fetch helper (all five existing helpers already order by created_at
+ * descending). The helper slices the first RECENT_COUNT items — it does
+ * NOT re-sort, so the caller must pass already-sorted arrays for the
+ * "most-recent" guarantee to hold.
+ */
+export function buildMySavesHubViewModel(
+  inputs: MySavesHubInputs,
+): MySavesHubViewModel {
+  const bookmarks: MySavesHubViewModel["bookmarks"] = {
+    count: inputs.bookmarks.length,
+    recent: inputs.bookmarks.slice(0, RECENT_COUNT).map((b) => ({
+      id: b.id,
+      bookmark_type: b.bookmark_type,
+      ref: b.ref,
+      label: b.label,
+      created_at: b.created_at,
+    })),
+  };
+
+  const watchlist: MySavesHubViewModel["watchlist"] = {
+    count: inputs.watchlistItems.length,
+    recent: inputs.watchlistItems.slice(0, RECENT_COUNT),
+  };
+
+  const comparisons: MySavesHubViewModel["comparisons"] = {
+    count: inputs.comparisons.length,
+    recent: inputs.comparisons.slice(0, RECENT_COUNT),
+  };
+
+  const savedSearches: MySavesHubViewModel["savedSearches"] = {
+    count: inputs.savedSearches.length,
+    recent: inputs.savedSearches.slice(0, RECENT_COUNT),
+  };
+
+  const rateAlerts: MySavesHubViewModel["rateAlerts"] = {
+    count: inputs.rateAlerts.length,
+    recent: inputs.rateAlerts.slice(0, RECENT_COUNT),
+  };
+
+  const isEmpty =
+    bookmarks.count === 0 &&
+    watchlist.count === 0 &&
+    comparisons.count === 0 &&
+    savedSearches.count === 0 &&
+    rateAlerts.count === 0;
+
+  return { bookmarks, watchlist, comparisons, savedSearches, rateAlerts, isEmpty };
+}


### PR DESCRIPTION
Round-5 deepening (1 of 10), user-facing. A single unified **"My Saves" hub** — bookmarks, watchlist, saved comparisons, saved searches, and alerts were scattered across five separate `/account/*` pages. AFSL-safe (the member's own data).

- `app/account/my-saves` — new RSC hub: five sections, each with a count, a recent-items preview, a "view all" link, and an honest empty state + CTA. Fetches all five sources in one `Promise.all`; auth-gated.
- `lib/my-saves-hub.ts` — pure, tested assembly helper (counts + recent-3 slice + `isEmpty`), no DB dependency.
- Account dashboard gains a prominent "My Saves" card + Quick-Links entry.

**Reuses existing fetches** (`listBookmarks`, `listForUser` for saved-searches; user-client queries for watchlist/comparisons matching their current pages; admin client for the email-keyed rate-alerts — same documented pattern as `/account/alerts`).

**Verified:** `tsc` clean · **18 tests** (counts, recent-slicing ceiling/order, per-section `isEmpty`, bookmark shape excludes `user_id`, passthrough fidelity) pass · eslint clean. Tier A (account UI + lib + tests; no schema/auth change).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUfSRE2Teb6VhEXFP6RpS9)_