### PR TITLE
feat: homepage personalization + persistent mobile bottom nav (deepen)

### DIFF
--- a/__tests__/components/MobileBottomNav.test.tsx
+++ b/__tests__/components/MobileBottomNav.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * Tests for MobileBottomNav.
+ *
+ * Covers:
+ *   1. The component renders its nav tabs after mount.
+ *   2. Hidden on HIDDEN_PREFIXES routes (/admin, /auth, /quiz, /broker-portal).
+ *   3. Active tab highlighted when pathname matches a tab prefix.
+ *   4. Double-mount guard — verifies app/page.tsx no longer imports
+ *      MobileBottomNav directly, so the nav is only mounted once via LayoutShell.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+
+// ── Mock next/navigation so we can control usePathname ───────────────────────
+
+const { mockUsePathname } = vi.hoisted(() => ({
+  mockUsePathname: vi.fn<() => string>(() => "/"),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn(), prefetch: vi.fn() }),
+  usePathname: mockUsePathname,
+  useSearchParams: () => new URLSearchParams(),
+  useParams: () => ({}),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+import MobileBottomNav from "@/components/MobileBottomNav";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function renderNav(pathname = "/") {
+  mockUsePathname.mockReturnValue(pathname);
+  return render(<MobileBottomNav />);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("MobileBottomNav — render", () => {
+  it("renders nothing before mount (no SSR mismatch)", () => {
+    // Before useEffect fires, setMounted(true) hasn't run yet.
+    // We can't easily test pre-hydration in jsdom, but we can confirm the
+    // component renders into the DOM after mounting.
+    const { container } = renderNav("/");
+    // After mount (effect runs synchronously in test env)
+    expect(container.firstElementChild).not.toBeNull();
+  });
+
+  it("renders all four navigation tabs", () => {
+    renderNav("/");
+    expect(screen.getByText("Compare")).toBeInTheDocument();
+    expect(screen.getByText("Opportunities")).toBeInTheDocument();
+    expect(screen.getByText("Experts")).toBeInTheDocument();
+    expect(screen.getByText("Get Matched")).toBeInTheDocument();
+  });
+
+  it("has the correct links for each tab", () => {
+    renderNav("/");
+    expect(screen.getByRole("link", { name: /compare/i })).toHaveAttribute("href", "/compare");
+    expect(screen.getByRole("link", { name: /opportunities/i })).toHaveAttribute("href", "/invest");
+    expect(screen.getByRole("link", { name: /experts/i })).toHaveAttribute("href", "/advisors");
+    expect(screen.getByRole("link", { name: /get matched/i })).toHaveAttribute("href", "/quiz");
+  });
+});
+
+describe("MobileBottomNav — hidden routes", () => {
+  it.each([
+    ["/admin"],
+    ["/admin/some-page"],
+    ["/auth"],
+    ["/auth/signin"],
+    ["/quiz"],
+    ["/quiz/results"],
+    ["/broker-portal"],
+    ["/broker-portal/dashboard"],
+  ])("returns null on hidden route %s", (pathname) => {
+    const { container } = renderNav(pathname);
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe("MobileBottomNav — active tab", () => {
+  it("marks Compare tab as active on /compare", () => {
+    renderNav("/compare");
+    const link = screen.getByRole("link", { name: /compare/i });
+    // active tab has text-amber-600 class
+    expect(link.className).toMatch(/text-amber-600/);
+  });
+
+  it("marks Opportunities tab as active on /invest", () => {
+    renderNav("/invest/some-listing");
+    const link = screen.getByRole("link", { name: /opportunities/i });
+    expect(link.className).toMatch(/text-amber-600/);
+  });
+
+  it("marks Experts tab as active on /advisors", () => {
+    renderNav("/advisors/some-advisor");
+    const link = screen.getByRole("link", { name: /experts/i });
+    expect(link.className).toMatch(/text-amber-600/);
+  });
+
+  it("does not mark Compare as active on a different route", () => {
+    renderNav("/invest");
+    const link = screen.getByRole("link", { name: /compare/i });
+    expect(link.className).not.toMatch(/text-amber-600/);
+  });
+});
+
+describe("MobileBottomNav — double-mount guard", () => {
+  it("app/page.tsx does not import MobileBottomNav directly", async () => {
+    // Read the source of app/page.tsx and assert MobileBottomNav is not imported.
+    // This is a static analysis guard — if someone adds it back to page.tsx the
+    // test will fail and remind them to remove it (nav is now in LayoutShell).
+    const fs = await import("fs");
+    const path = await import("path");
+    const pageSource = fs.readFileSync(
+      path.resolve(process.cwd(), "app/page.tsx"),
+      "utf8",
+    );
+    expect(pageSource).not.toContain("MobileBottomNav");
+  });
+
+  it("LayoutShell.tsx imports MobileBottomNav", async () => {
+    const fs = await import("fs");
+    const path = await import("path");
+    const shellSource = fs.readFileSync(
+      path.resolve(process.cwd(), "components/LayoutShell.tsx"),
+      "utf8",
+    );
+    expect(shellSource).toContain("MobileBottomNav");
+  });
+});

--- a/__tests__/components/MobileBottomNav.test.tsx
+++ b/__tests__/components/MobileBottomNav.test.tsx
@@ -10,7 +10,7 @@
  */
 
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, act } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
 
 // ── Mock next/navigation so we can control usePathname ───────────────────────

--- a/__tests__/lib/homepage-personalisation.test.ts
+++ b/__tests__/lib/homepage-personalisation.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Unit tests for lib/homepage-personalisation.ts
+ *
+ * Covers: classifyVisitor (all three buckets + edge cases) and
+ * buildWelcomeGreeting (per bucket + with/without displayName).
+ * Pure functions — no mocks needed.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  classifyVisitor,
+  buildWelcomeGreeting,
+  type PersonalisationSignals,
+  type VisitorKind,
+} from "@/lib/homepage-personalisation";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function signals(
+  overrides: Partial<PersonalisationSignals> = {},
+): PersonalisationSignals {
+  return {
+    isSignedIn: false,
+    quizCompleted: false,
+    hasIntentCountry: false,
+    displayName: null,
+    ...overrides,
+  };
+}
+
+// ── classifyVisitor ───────────────────────────────────────────────────────────
+
+describe("classifyVisitor", () => {
+  describe("anonymous", () => {
+    it("returns 'anonymous' when no signals are present", () => {
+      expect(classifyVisitor(signals())).toBe("anonymous");
+    });
+
+    it("returns 'anonymous' when quiz started but not completed and no country", () => {
+      expect(
+        classifyVisitor(signals({ quizCompleted: false, hasIntentCountry: false })),
+      ).toBe("anonymous");
+    });
+  });
+
+  describe("returning", () => {
+    it("returns 'returning' when quiz is completed (no auth)", () => {
+      expect(
+        classifyVisitor(signals({ quizCompleted: true })),
+      ).toBe("returning");
+    });
+
+    it("returns 'returning' when intent country is set (no auth)", () => {
+      expect(
+        classifyVisitor(signals({ hasIntentCountry: true })),
+      ).toBe("returning");
+    });
+
+    it("returns 'returning' when both quiz and country are set (no auth)", () => {
+      expect(
+        classifyVisitor(signals({ quizCompleted: true, hasIntentCountry: true })),
+      ).toBe("returning");
+    });
+  });
+
+  describe("signed-in", () => {
+    it("returns 'signed-in' when user is authenticated", () => {
+      expect(
+        classifyVisitor(signals({ isSignedIn: true })),
+      ).toBe("signed-in");
+    });
+
+    it("returns 'signed-in' even when quiz and country are absent", () => {
+      expect(
+        classifyVisitor(
+          signals({ isSignedIn: true, quizCompleted: false, hasIntentCountry: false }),
+        ),
+      ).toBe("signed-in");
+    });
+
+    it("signed-in takes priority over returning signals", () => {
+      // Auth session + quiz + country → still "signed-in"
+      const result = classifyVisitor(
+        signals({ isSignedIn: true, quizCompleted: true, hasIntentCountry: true }),
+      );
+      expect(result).toBe("signed-in");
+    });
+  });
+});
+
+// ── buildWelcomeGreeting ──────────────────────────────────────────────────────
+
+describe("buildWelcomeGreeting", () => {
+  it("returns null for anonymous visitors", () => {
+    expect(buildWelcomeGreeting("anonymous", null)).toBeNull();
+    expect(buildWelcomeGreeting("anonymous", "Alice")).toBeNull();
+  });
+
+  it("returns generic greeting for returning visitors (no name)", () => {
+    expect(buildWelcomeGreeting("returning", null)).toBe("Welcome back");
+  });
+
+  it("returns generic greeting for returning visitors even when name is supplied (no auth = no trust)", () => {
+    // The returning bucket has no auth session; we don't have a verified name
+    expect(buildWelcomeGreeting("returning", "Alice")).toBe("Welcome back");
+  });
+
+  it("returns generic greeting for signed-in user without a display name", () => {
+    expect(buildWelcomeGreeting("signed-in", null)).toBe("Welcome back");
+  });
+
+  it("uses the first name only for signed-in users", () => {
+    expect(buildWelcomeGreeting("signed-in", "Alice Smith")).toBe("Welcome back, Alice");
+  });
+
+  it("handles single-word display names", () => {
+    expect(buildWelcomeGreeting("signed-in", "Alice")).toBe("Welcome back, Alice");
+  });
+
+  it("handles extra whitespace in display name", () => {
+    expect(buildWelcomeGreeting("signed-in", "  Alice  ")).toBe("Welcome back, Alice");
+  });
+
+  it("handles empty-string display name as absent", () => {
+    expect(buildWelcomeGreeting("signed-in", "")).toBe("Welcome back");
+  });
+});
+
+// ── Integration: round-trip ───────────────────────────────────────────────────
+
+describe("classifyVisitor + buildWelcomeGreeting round-trip", () => {
+  it("anonymous user always gets null greeting", () => {
+    const kind: VisitorKind = classifyVisitor(signals());
+    expect(buildWelcomeGreeting(kind, "Finn")).toBeNull();
+  });
+
+  it("returning user gets generic welcome back", () => {
+    const kind: VisitorKind = classifyVisitor(
+      signals({ quizCompleted: true }),
+    );
+    expect(buildWelcomeGreeting(kind, null)).toBe("Welcome back");
+  });
+
+  it("signed-in user with a name gets personalised greeting", () => {
+    const kind: VisitorKind = classifyVisitor(signals({ isSignedIn: true }));
+    expect(buildWelcomeGreeting(kind, "Finn Dunn")).toBe("Welcome back, Finn");
+  });
+});

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,8 +20,8 @@ import CountryExpertsPreview from "@/components/country-mode/CountryExpertsPrevi
 import CountryComparePreview from "@/components/country-mode/CountryComparePreview";
 import CountryPopularLinks from "@/components/country-mode/CountryPopularLinks";
 import ScrollFadeIn from "@/components/ScrollFadeIn";
-import MobileBottomNav from "@/components/MobileBottomNav";
 import HomeActivitySection from "@/components/HomeActivitySection";
+import HomepagePersonalisedStrip from "@/components/HomepagePersonalisedStrip";
 import HomeHowItWorks from "@/components/HomeHowItWorks";
 import { ORGANIZATION_JSONLD, SITE_URL } from "@/lib/seo";
 
@@ -245,6 +245,12 @@ export default async function HomePage() {
         }}
       />
 
+      {/* Personalised strip — visible to signed-in and returning visitors;
+          renders null for anonymous / first-time visitors. Wrapped in its
+          own Suspense so the async auth read never blocks the ISR-cached
+          static content below. See components/HomepagePersonalisedStrip.tsx. */}
+      <HomepagePersonalisedStrip />
+
       <HomeActivitySection />
 
       <HomeHero
@@ -340,8 +346,6 @@ export default async function HomePage() {
       <ScrollFadeIn>
         <CountryToolsStripWrapper />
       </ScrollFadeIn>
-
-      <MobileBottomNav />
     </div>
   );
 }

--- a/components/HomepagePersonalisedStrip.tsx
+++ b/components/HomepagePersonalisedStrip.tsx
@@ -1,0 +1,297 @@
+/**
+ * Homepage personalised strip (W-HOMEPAGE-PERSONAL).
+ *
+ * Server component. Renders above the static marketing content for
+ * signed-in and returning visitors. Anonymous / first-time visitors see
+ * nothing — the existing ResumeBanner (sessionStorage-backed) and static
+ * page already handle that case.
+ *
+ * Architecture:
+ *   - Resolves auth + quiz signals in parallel (one supabase round-trip,
+ *     deduplicated by React cache() in getQuizProfile / getInvestorProfile).
+ *   - Delegates classification to the pure `classifyVisitor` helper in
+ *     lib/homepage-personalisation.ts (testable without mocking Next.js).
+ *   - Reuses SmartRecommendationsStrip for the recs row (already handles
+ *     vertical-routing and country-eligibility).
+ *   - Reuses buildNextActions from lib/next-action for the next-step card.
+ *   - Falls back to null (renders nothing) on any error — never breaks the
+ *     homepage render.
+ *
+ * AFSL compliance: every action that surfaces product comparisons or advisor
+ * referrals wraps GENERAL_ADVICE_WARNING from lib/compliance.ts. Copy is
+ * factual ("Compare platforms", "Browse advisors") — not personal advice.
+ *
+ * ISR note: this component calls supabase.auth.getUser() which reads the
+ * request cookie — it is implicitly dynamic. The rest of app/page.tsx
+ * is ISR-cached; this strip is intentionally outside that cache boundary
+ * (it is rendered in its own React subtree via Suspense in the page).
+ */
+
+import { Suspense } from "react";
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { getQuizProfile } from "@/lib/quiz-profile";
+import { getInvestorProfile } from "@/lib/investor-profiles";
+import { getIntentCountry } from "@/lib/intent-context-server";
+import {
+  classifyVisitor,
+  buildWelcomeGreeting,
+} from "@/lib/homepage-personalisation";
+import { buildNextActions, type NextActionSignals } from "@/lib/next-action";
+import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
+import SmartRecommendationsStrip from "@/components/SmartRecommendationsStrip";
+
+// ─── Saved-items count helper ────────────────────────────────────────────────
+
+interface SavedCounts {
+  shortlistedBrokers: number;
+  savedAdvisors: number;
+  savedComparisons: number;
+}
+
+async function loadSavedCounts(userId: string): Promise<SavedCounts> {
+  const [serverClient, adminClient] = [await createClient(), createAdminClient()];
+
+  const [shortlistRes, advisorRes, comparisonRes] = await Promise.allSettled([
+    serverClient
+      .from("user_shortlisted_brokers")
+      .select("broker_slug", { count: "exact", head: true })
+      .eq("user_id", userId),
+    adminClient
+      .from("user_bookmarks")
+      .select("id", { count: "exact", head: true })
+      .eq("user_id", userId)
+      .eq("bookmark_type", "advisor"),
+    adminClient
+      .from("saved_broker_comparisons")
+      .select("id", { count: "exact", head: true })
+      .eq("user_id", userId),
+  ]);
+
+  return {
+    shortlistedBrokers:
+      shortlistRes.status === "fulfilled"
+        ? ((shortlistRes.value as { count: number | null }).count ?? 0)
+        : 0,
+    savedAdvisors:
+      advisorRes.status === "fulfilled"
+        ? ((advisorRes.value as { count: number | null }).count ?? 0)
+        : 0,
+    savedComparisons:
+      comparisonRes.status === "fulfilled"
+        ? ((comparisonRes.value as { count: number | null }).count ?? 0)
+        : 0,
+  };
+}
+
+// ─── Inner async component ────────────────────────────────────────────────────
+
+async function PersonalisedStripInner() {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    // Fetch signals in parallel. investor_profiles only fetched for authed users
+    // (admin-client read; costly to call on every anonymous visit).
+    const [quizProfile, intentCountry, investorProfile] = await Promise.all([
+      getQuizProfile(),
+      getIntentCountry(),
+      user ? getInvestorProfile(user.id) : Promise.resolve(null),
+    ]);
+
+    const kind = classifyVisitor({
+      isSignedIn: !!user,
+      quizCompleted: !!quizProfile?.completedAt,
+      hasIntentCountry: !!intentCountry,
+      displayName: investorProfile?.displayName ?? null,
+    });
+
+    if (kind === "anonymous") return null;
+
+    const greeting = buildWelcomeGreeting(
+      kind,
+      investorProfile?.displayName ?? null,
+    );
+
+    // Build next-action signals from merged profile
+    const vertical =
+      investorProfile?.primaryVertical ?? quizProfile?.vertical ?? null;
+    const signals: NextActionSignals = {
+      profile: investorProfile
+        ? {
+            primaryVertical: investorProfile.primaryVertical,
+            budgetBand: investorProfile.budgetBand,
+            experienceLevel: investorProfile.experienceLevel,
+            isFhb: investorProfile.isFhb,
+            isPreRetiree: investorProfile.isPreRetiree,
+            isCrossBorder: investorProfile.isCrossBorder,
+            isHnw: investorProfile.isHnw,
+            isBusinessOwner: investorProfile.isBusinessOwner,
+          }
+        : null,
+      quizVertical: quizProfile?.vertical ?? null,
+      quizCompleted: !!quizProfile?.completedAt,
+      topMatchSlug: quizProfile?.topMatchSlug ?? null,
+      intentCountry: investorProfile?.intentCountrySnapshot ?? intentCountry,
+      surface: "other",
+    };
+
+    const nextActions = buildNextActions(signals).slice(0, 3);
+    const primaryAction = nextActions[0];
+
+    // Saved-item counts (signed-in only)
+    const savedCounts =
+      kind === "signed-in" && user
+        ? await loadSavedCounts(user.id)
+        : null;
+
+    const hasSavedActivity =
+      savedCounts &&
+      (savedCounts.shortlistedBrokers > 0 ||
+        savedCounts.savedAdvisors > 0 ||
+        savedCounts.savedComparisons > 0);
+
+    return (
+      <div
+        className="bg-gradient-to-br from-slate-50 via-white to-emerald-50/40 border-b border-slate-100"
+        aria-label="Your personalised dashboard"
+        data-testid="homepage-personalised-strip"
+      >
+        {/* ── Welcome row ─────────────────────────────────────────── */}
+        <div className="container-custom pt-5 pb-3">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              {greeting && (
+                <p className="text-base font-bold text-slate-900 sm:text-lg">
+                  {greeting}
+                </p>
+              )}
+              {vertical && (
+                <p className="text-sm text-slate-500 mt-0.5">
+                  {verticalLabel(vertical)}
+                </p>
+              )}
+            </div>
+
+            {/* ── Saved-activity pills (signed-in) ─────────────── */}
+            {hasSavedActivity && savedCounts && (
+              <ul className="flex flex-wrap gap-2">
+                {savedCounts.shortlistedBrokers > 0 && (
+                  <li>
+                    <Link
+                      href="/shortlist"
+                      className="inline-flex items-center gap-1.5 rounded-full bg-emerald-50 border border-emerald-200 px-3 py-1 text-xs font-semibold text-emerald-800 hover:bg-emerald-100 transition-colors"
+                    >
+                      <span aria-hidden>📊</span>
+                      {savedCounts.shortlistedBrokers} shortlisted broker
+                      {savedCounts.shortlistedBrokers !== 1 ? "s" : ""}
+                    </Link>
+                  </li>
+                )}
+                {savedCounts.savedAdvisors > 0 && (
+                  <li>
+                    <Link
+                      href="/account/bookmarks"
+                      className="inline-flex items-center gap-1.5 rounded-full bg-amber-50 border border-amber-200 px-3 py-1 text-xs font-semibold text-amber-800 hover:bg-amber-100 transition-colors"
+                    >
+                      <span aria-hidden>🧑‍💼</span>
+                      {savedCounts.savedAdvisors} saved advisor
+                      {savedCounts.savedAdvisors !== 1 ? "s" : ""}
+                    </Link>
+                  </li>
+                )}
+                {savedCounts.savedComparisons > 0 && (
+                  <li>
+                    <Link
+                      href="/account/saved"
+                      className="inline-flex items-center gap-1.5 rounded-full bg-slate-100 border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-700 hover:bg-slate-200 transition-colors"
+                    >
+                      <span aria-hidden>🔖</span>
+                      {savedCounts.savedComparisons} saved comparison
+                      {savedCounts.savedComparisons !== 1 ? "s" : ""}
+                    </Link>
+                  </li>
+                )}
+              </ul>
+            )}
+          </div>
+
+          {/* ── Primary next-action card ─────────────────────────── */}
+          {primaryAction && (
+            <div className="mt-4 mb-2">
+              <div className="flex flex-col sm:flex-row sm:items-center gap-3 bg-white border border-slate-200 rounded-xl px-4 py-3 shadow-sm">
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-semibold text-slate-900">
+                    {primaryAction.title}
+                  </p>
+                  <p className="text-xs text-slate-500 mt-0.5 line-clamp-2">
+                    {primaryAction.description}
+                  </p>
+                </div>
+                <Link
+                  href={primaryAction.href}
+                  className="shrink-0 inline-flex items-center justify-center gap-1.5 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white font-semibold text-sm px-4 py-2 transition-colors"
+                >
+                  {primaryAction.cta}
+                  <span aria-hidden>→</span>
+                </Link>
+              </div>
+              {primaryAction.showAdviceWarning && (
+                <p className="mt-2 text-[0.65rem] text-slate-400 leading-relaxed">
+                  {GENERAL_ADVICE_WARNING}
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* ── SmartRecommendationsStrip — reuses the existing engine ── */}
+        <SmartRecommendationsStrip />
+      </div>
+    );
+  } catch {
+    // Fail-soft: never break the homepage
+    return null;
+  }
+}
+
+// ─── Public component with Suspense boundary ──────────────────────────────────
+
+/**
+ * Homepage personalised strip — wraps in Suspense so the async auth
+ * read doesn't block the (ISR-cached) static page below it.
+ */
+export default function HomepagePersonalisedStrip() {
+  return (
+    <Suspense fallback={null}>
+      <PersonalisedStripInner />
+    </Suspense>
+  );
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function verticalLabel(vertical: string): string {
+  const LABELS: Record<string, string> = {
+    trade: "Your focus: trading platforms",
+    automate: "Your focus: automated investing",
+    fees: "Your focus: minimising brokerage fees",
+    tools: "Your focus: research & tools",
+    safety: "Your focus: capital protection",
+    crypto: "Your focus: crypto platforms",
+    broker_diy: "Your focus: DIY investing",
+    advisor_match: "Your focus: finding an advisor",
+    complex: "Your focus: complex wealth",
+    wealth: "Your focus: wealth management",
+    super: "Your focus: superannuation",
+    smsf: "Your focus: self-managed super",
+    property: "Your focus: property investing",
+    first_home: "Your focus: buying your first home",
+    international: "Your focus: international investing",
+  };
+  return LABELS[vertical] ?? "Personalised for you";
+}
+

--- a/components/LayoutShell.tsx
+++ b/components/LayoutShell.tsx
@@ -3,6 +3,7 @@
 import { usePathname } from "next/navigation";
 import dynamic from "next/dynamic";
 import { SiteFooter } from "@/components/layout/SiteFooter";
+import MobileBottomNav from "@/components/MobileBottomNav";
 
 // Navigation is large (738 lines incl. mega-menu data) — code-split into
 // its own chunk so it doesn't block the main page bundle. Keeps SSR so
@@ -62,6 +63,11 @@ export default function LayoutShell({ children, countryModeBanner }: LayoutShell
       {countryModeBanner}
       <main id="main-content" className="min-h-screen pb-14 sm:pb-0">{children}</main>
       <SiteFooter />
+      {/* MobileBottomNav — persistent across all non-admin routes.
+          The component itself handles hiding on /admin, /auth, /quiz etc.
+          via its HIDDEN_PREFIXES list. Placed after the footer so it
+          paints above it in the stacking order (z-40). */}
+      <MobileBottomNav />
       <CookieBanner />
       <BackToTop />
       <QuizPromptBar />

--- a/lib/homepage-personalisation.ts
+++ b/lib/homepage-personalisation.ts
@@ -73,7 +73,7 @@ export function buildWelcomeGreeting(
 ): string | null {
   if (kind === "anonymous") return null;
   if (kind === "signed-in") {
-    const first = displayName?.split(" ")[0]?.trim() ?? null;
+    const first = displayName?.trim().split(/\s+/)[0] || null;
     return first ? `Welcome back, ${first}` : "Welcome back";
   }
   // "returning" — quiz-signal visitor without a session

--- a/lib/homepage-personalisation.ts
+++ b/lib/homepage-personalisation.ts
@@ -1,0 +1,81 @@
+/**
+ * Homepage personalisation decision helper.
+ *
+ * Pure function: given resolved auth + quiz signals, classify the visitor
+ * into one of three buckets so the homepage can choose what to render
+ * above the fold.
+ *
+ * Three states:
+ *   "signed-in"  — Supabase user session is present (may or may not have a
+ *                  quiz profile; investor_profiles row is optional).
+ *   "returning"  — No active auth session, but the visitor has a completed
+ *                  quiz session cookie (iv_quiz_session + completedAt set)
+ *                  or a recognised intent-country cookie, so we have a
+ *                  personalisation signal without requiring login.
+ *   "anonymous"  — First-time or cookieless visitor. No signal available.
+ *                  Render the default static homepage without the strip.
+ *
+ * AFSL compliance: this function controls WHICH strip renders, not WHAT it
+ * says. The strip itself only surfaces factual "next step" links. Copy that
+ * implies a personal recommendation must include GENERAL_ADVICE_WARNING
+ * (see lib/compliance.ts). No personalised advice copy lives here.
+ *
+ * Designed to be called once per homepage render, then passed as props into
+ * server sub-components. React cache() deduplication is applied at the
+ * call-site in the page component (shared with SmartRecommendationsStrip).
+ */
+
+export type VisitorKind = "signed-in" | "returning" | "anonymous";
+
+export interface PersonalisationSignals {
+  /** Whether a Supabase auth session exists for the current request. */
+  isSignedIn: boolean;
+  /**
+   * Whether the visitor completed the quiz at some point in the past
+   * (the iv_quiz_session cookie resolves to a row with completedAt set).
+   */
+  quizCompleted: boolean;
+  /**
+   * Whether the visitor has any intent-country signal (from the quiz or the
+   * iv_intent_country cookie). Used as a fallback "returning" signal when the
+   * quiz is incomplete.
+   */
+  hasIntentCountry: boolean;
+  /**
+   * Display name from the investor_profiles row (signed-in path only).
+   * Null when absent or when the row doesn't exist yet.
+   */
+  displayName: string | null;
+}
+
+/**
+ * Classify the visitor into a bucket for homepage personalisation.
+ *
+ * Bucket resolution order:
+ *   1. isSignedIn → "signed-in" (always, even without a quiz profile)
+ *   2. quizCompleted || hasIntentCountry → "returning"
+ *   3. else → "anonymous"
+ */
+export function classifyVisitor(signals: PersonalisationSignals): VisitorKind {
+  if (signals.isSignedIn) return "signed-in";
+  if (signals.quizCompleted || signals.hasIntentCountry) return "returning";
+  return "anonymous";
+}
+
+/**
+ * Build a short welcome greeting for the personalised strip header.
+ * Factual and friendly — does NOT imply a recommendation or financial advice.
+ * Returns null for anonymous visitors (no strip is rendered in that case).
+ */
+export function buildWelcomeGreeting(
+  kind: VisitorKind,
+  displayName: string | null,
+): string | null {
+  if (kind === "anonymous") return null;
+  if (kind === "signed-in") {
+    const first = displayName?.split(" ")[0]?.trim() ?? null;
+    return first ? `Welcome back, ${first}` : "Welcome back";
+  }
+  // "returning" — quiz-signal visitor without a session
+  return "Welcome back";
+}


### PR DESCRIPTION
Round-5 deepening (4 of 10), user-facing. Two shell upgrades: **personalise the homepage** for signed-in/returning visitors, and make the **mobile bottom nav persistent**. AFSL-safe (factual personalisation).

- `lib/homepage-personalisation.ts` — pure `classifyVisitor` (signed-in / returning / anonymous, auth-first priority) + `buildWelcomeGreeting`.
- `components/HomepagePersonalisedStrip.tsx` — `<Suspense>`-wrapped (never blocks the ISR-cached marketing content below): welcome greeting + vertical focus + saved-item count pills + a primary next-action from the existing `buildNextActions` engine + `SmartRecommendationsStrip`. Returning (cookie-only) visitors get a lighter version; anonymous → `null`. Fail-soft. Mounted first in `app/page.tsx`; static page untouched below.
- `MobileBottomNav` moved from the homepage-only mount into `LayoutShell` (after the footer) so it's **persistent** across pages; its own `HIDDEN_PREFIXES` guard handles admin/auth/quiz; existing `pb-14` clears it. Static-analysis test guards against double-mount.

**Fixes on verification:** `buildWelcomeGreeting` now trims before splitting (a leading-space name like "  Alice  " was dropping the first name — its own test caught it); removed an unused `act` import.

**Verified:** `tsc` clean · **36 tests** (visitor classification + greeting edge cases + nav render/hidden-routes/double-mount guard) pass · eslint clean · jsonld gate green. Tier B (homepage/layout affect all pages; no backend/migration). Reuses existing engines (admin-client for saved counts matches `HomeActivitySection`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUfSRE2Teb6VhEXFP6RpS9)_