### PR TITLE
feat: content-discovery Related rails (article/broker/advisor) (deepen)

### DIFF
--- a/__tests__/lib/related-content.test.ts
+++ b/__tests__/lib/related-content.test.ts
@@ -203,9 +203,9 @@ describe("getRelatedForArticle", () => {
   describe("articles — empty cases", () => {
     it("returns empty arrays when pool is empty", () => {
       const current = makeArticle({ id: 1, slug: "c", category: "ETFs" });
-      const { articles, tools } = getRelatedForArticle(current, []);
+      const { articles } = getRelatedForArticle(current, []);
       expect(articles).toEqual([]);
-      // tools may still have calculator hints from category
+      // tools may still have calculator hints from category, so not asserted here
     });
 
     it("returns empty articles when no article shares category or tags", () => {
@@ -365,6 +365,22 @@ describe("getRelatedForBroker", () => {
 
       const { brokers } = getRelatedForBroker(current, pool, []);
       expect(brokers.length).toBeLessThanOrEqual(4);
+    });
+  });
+
+  describe("brokers — guides", () => {
+    it("returns a platform-type guide hint", () => {
+      const current = makeBroker({ id: 1, slug: "c", platform_type: "share_broker" });
+      const { guides } = getRelatedForBroker(current, [], []);
+      expect(guides.length).toBe(1);
+      expect(guides[0]?.title).toBe("How to Choose a Share Broker");
+      expect(guides[0]?.badgeText).toBe("Guide");
+    });
+
+    it("returns no guide for an unknown platform type", () => {
+      const current = makeBroker({ id: 1, slug: "c", platform_type: "unknown_xyz" as never });
+      const { guides } = getRelatedForBroker(current, [], []);
+      expect(guides).toEqual([]);
     });
   });
 

--- a/__tests__/lib/related-content.test.ts
+++ b/__tests__/lib/related-content.test.ts
@@ -1,0 +1,551 @@
+import { describe, it, expect } from "vitest";
+import {
+  getRelatedForArticle,
+  getRelatedForBroker,
+  getRelatedForAdvisor,
+} from "@/lib/related-content";
+import type { Article, Broker, Professional } from "@/lib/types";
+
+// ─── Fixtures ──────────────────────────────────────────────────
+
+function makeArticle(
+  overrides: Partial<Article> = {},
+): Pick<Article, "id" | "slug" | "title" | "category" | "tags" | "read_time" | "published_at"> {
+  return {
+    id: 1,
+    slug: "test-article",
+    title: "Test Article",
+    category: "Investing Basics",
+    tags: ["beginners", "etf"],
+    read_time: 5,
+    published_at: "2026-01-01",
+    ...overrides,
+  };
+}
+
+function makeBroker(overrides: Partial<Broker> = {}): Pick<
+  Broker,
+  | "id"
+  | "slug"
+  | "name"
+  | "platform_type"
+  | "is_crypto"
+  | "chess_sponsored"
+  | "smsf_support"
+  | "markets"
+  | "rating"
+  | "asx_fee_value"
+> {
+  return {
+    id: 1,
+    slug: "test-broker",
+    name: "Test Broker",
+    platform_type: "share_broker",
+    is_crypto: false,
+    chess_sponsored: false,
+    smsf_support: false,
+    markets: ["ASX", "US"],
+    rating: 4.0,
+    asx_fee_value: 9.5,
+    ...overrides,
+  };
+}
+
+function makeAdvisor(
+  overrides: Partial<Professional> = {},
+): Pick<
+  Professional,
+  | "id"
+  | "slug"
+  | "name"
+  | "type"
+  | "specialties"
+  | "location_state"
+  | "location_display"
+  | "rating"
+  | "verified"
+  | "firm_name"
+> {
+  return {
+    id: 1,
+    slug: "test-advisor",
+    name: "Test Advisor",
+    type: "financial_planner",
+    specialties: ["super", "investments"],
+    location_state: "VIC",
+    location_display: "Melbourne, VIC",
+    rating: 4.5,
+    verified: true,
+    firm_name: undefined,
+    ...overrides,
+  };
+}
+
+// ─── getRelatedForArticle ───────────────────────────────────────
+
+describe("getRelatedForArticle", () => {
+  describe("articles — relatedness", () => {
+    it("returns articles in the same category", () => {
+      const current = makeArticle({ id: 1, slug: "current", category: "ETFs" });
+      const related = makeArticle({
+        id: 2,
+        slug: "related",
+        category: "ETFs",
+        title: "ETF Guide",
+        tags: [],
+      });
+      const unrelated = makeArticle({
+        id: 3,
+        slug: "unrelated",
+        category: "Property",
+        tags: [],
+        title: "Property Tips",
+      });
+
+      const { articles } = getRelatedForArticle(current, [related, unrelated]);
+      const slugs = articles.map((a) => a.href);
+      expect(slugs).toContain("/article/related");
+      expect(slugs).not.toContain("/article/unrelated");
+    });
+
+    it("returns articles with shared tags even in a different category", () => {
+      const current = makeArticle({
+        id: 1,
+        slug: "current",
+        category: "ETFs",
+        tags: ["etf", "passive"],
+      });
+      const crossCat = makeArticle({
+        id: 2,
+        slug: "cross",
+        category: "Property",
+        tags: ["etf"],
+        title: "Cross Category",
+      });
+
+      const { articles } = getRelatedForArticle(current, [crossCat]);
+      expect(articles[0]?.href).toBe("/article/cross");
+    });
+
+    it("ranks same-category above same-tag-only articles", () => {
+      const current = makeArticle({
+        id: 1,
+        slug: "current",
+        category: "ETFs",
+        tags: ["etf"],
+      });
+      const sameCat = makeArticle({
+        id: 2,
+        slug: "same-cat",
+        category: "ETFs",
+        tags: [],
+        title: "Same Cat",
+      });
+      const sameTag = makeArticle({
+        id: 3,
+        slug: "same-tag",
+        category: "Property",
+        tags: ["etf"],
+        title: "Same Tag",
+      });
+
+      const { articles } = getRelatedForArticle(current, [sameTag, sameCat]);
+      expect(articles[0]?.href).toBe("/article/same-cat");
+    });
+
+    it("uses recency as tiebreaker for equal scores", () => {
+      const current = makeArticle({ id: 1, slug: "c", category: "Tax" });
+      const older = makeArticle({
+        id: 2,
+        slug: "older",
+        category: "Tax",
+        title: "Older",
+        published_at: "2025-01-01",
+      });
+      const newer = makeArticle({
+        id: 3,
+        slug: "newer",
+        category: "Tax",
+        title: "Newer",
+        published_at: "2026-03-01",
+      });
+
+      const { articles } = getRelatedForArticle(current, [older, newer]);
+      expect(articles[0]?.href).toBe("/article/newer");
+    });
+  });
+
+  describe("articles — self-exclusion", () => {
+    it("never includes the current article", () => {
+      const current = makeArticle({ id: 1, slug: "self", category: "ETFs" });
+      const pool = [
+        makeArticle({ id: 1, slug: "self", title: "Same Article", category: "ETFs" }),
+        makeArticle({ id: 2, slug: "other", title: "Other", category: "ETFs" }),
+      ];
+
+      const { articles } = getRelatedForArticle(current, pool);
+      expect(articles.every((a) => a.href !== "/article/self")).toBe(true);
+    });
+  });
+
+  describe("articles — caps", () => {
+    it("caps results at 6", () => {
+      const current = makeArticle({ id: 0, slug: "c", category: "ETFs" });
+      const pool = Array.from({ length: 10 }, (_, i) =>
+        makeArticle({ id: i + 1, slug: `a${i}`, category: "ETFs", title: `A ${i}` }),
+      );
+
+      const { articles } = getRelatedForArticle(current, pool);
+      expect(articles.length).toBeLessThanOrEqual(6);
+    });
+  });
+
+  describe("articles — empty cases", () => {
+    it("returns empty arrays when pool is empty", () => {
+      const current = makeArticle({ id: 1, slug: "c", category: "ETFs" });
+      const { articles, tools } = getRelatedForArticle(current, []);
+      expect(articles).toEqual([]);
+      // tools may still have calculator hints from category
+    });
+
+    it("returns empty articles when no article shares category or tags", () => {
+      const current = makeArticle({ id: 1, slug: "c", category: "ETFs", tags: [] });
+      const pool = [
+        makeArticle({ id: 2, slug: "other", category: "Crypto", tags: [], title: "Crypto" }),
+      ];
+      const { articles } = getRelatedForArticle(current, pool);
+      expect(articles).toEqual([]);
+    });
+  });
+
+  describe("tools — calculator hints", () => {
+    it("uses explicit related_calc field first", () => {
+      const current = makeArticle({
+        id: 1,
+        slug: "c",
+        category: "ETFs",
+        tags: [],
+        related_calc: "calc-franking",
+      } as Pick<Article, "id" | "slug" | "category" | "tags" | "related_calc">);
+
+      const { tools } = getRelatedForArticle(current as Parameters<typeof getRelatedForArticle>[0], []);
+      expect(tools[0]?.href).toContain("calc-franking");
+      expect(tools[0]?.badgeText).toBe("Calculator");
+    });
+
+    it("derives a calculator from the category string when no related_calc", () => {
+      const current = makeArticle({
+        id: 1,
+        slug: "c",
+        category: "Tax & Strategy",
+        tags: ["cgt"],
+      });
+
+      const { tools } = getRelatedForArticle(current, []);
+      const hrefs = tools.map((t) => t.href);
+      expect(hrefs.some((h) => h.includes("calc-cgt"))).toBe(true);
+    });
+
+    it("derives a guide link when no calculator matches", () => {
+      const current = makeArticle({
+        id: 1,
+        slug: "c",
+        category: "mortgage",
+        tags: ["home loan"],
+      });
+
+      const { tools } = getRelatedForArticle(current, []);
+      const hrefs = tools.map((t) => t.href);
+      expect(hrefs.some((h) => h.includes("mortgage-broker"))).toBe(true);
+    });
+
+    it("caps tools at 2", () => {
+      const current = makeArticle({
+        id: 1,
+        slug: "c",
+        category: "Tax & Strategy",
+        tags: ["franking", "cgt", "fx", "chess", "switch", "mortgage"],
+      });
+
+      const { tools } = getRelatedForArticle(current, []);
+      expect(tools.length).toBeLessThanOrEqual(2);
+    });
+
+    it("returns no tools when no signals are present", () => {
+      const current = makeArticle({
+        id: 1,
+        slug: "c",
+        category: "Miscellaneous",
+        tags: [],
+      });
+
+      const { tools } = getRelatedForArticle(current, []);
+      expect(tools).toEqual([]);
+    });
+  });
+});
+
+// ─── getRelatedForBroker ────────────────────────────────────────
+
+describe("getRelatedForBroker", () => {
+  describe("brokers — relatedness", () => {
+    it("returns brokers of the same platform_type", () => {
+      const current = makeBroker({ id: 1, slug: "curr", platform_type: "share_broker" });
+      const same = makeBroker({ id: 2, slug: "same", platform_type: "share_broker", name: "Same" });
+      const different = makeBroker({ id: 3, slug: "diff", platform_type: "crypto_exchange", name: "Diff" });
+
+      const { brokers } = getRelatedForBroker(current, [same, different], []);
+      const slugs = brokers.map((b) => b.href);
+      expect(slugs).toContain("/broker/same");
+      expect(slugs).not.toContain("/broker/diff");
+    });
+
+    it("excludes crypto brokers when current is non-crypto", () => {
+      const current = makeBroker({ id: 1, slug: "curr", is_crypto: false });
+      const cryptoBroker = makeBroker({
+        id: 2,
+        slug: "crypto",
+        is_crypto: true,
+        name: "Crypto",
+        platform_type: "share_broker",
+      });
+
+      const { brokers } = getRelatedForBroker(current, [cryptoBroker], []);
+      expect(brokers).toEqual([]);
+    });
+
+    it("respects crypto type match for crypto brokers", () => {
+      const current = makeBroker({
+        id: 1,
+        slug: "curr",
+        is_crypto: true,
+        platform_type: "crypto_exchange",
+      });
+      const sameCrypto = makeBroker({
+        id: 2,
+        slug: "c2",
+        is_crypto: true,
+        platform_type: "crypto_exchange",
+        name: "Crypto 2",
+      });
+
+      const { brokers } = getRelatedForBroker(current, [sameCrypto], []);
+      expect(brokers[0]?.href).toBe("/broker/c2");
+    });
+
+    it("uses market overlap as a secondary signal", () => {
+      const current = makeBroker({ id: 1, slug: "c", markets: ["ASX", "US", "HK"] });
+      const manyMarkets = makeBroker({ id: 2, slug: "m", markets: ["ASX", "US", "HK"], name: "Many" });
+      const fewMarkets = makeBroker({ id: 3, slug: "f", markets: ["ASX"], name: "Few" });
+
+      const { brokers } = getRelatedForBroker(current, [fewMarkets, manyMarkets], []);
+      expect(brokers[0]?.href).toBe("/broker/m");
+    });
+  });
+
+  describe("brokers — self-exclusion", () => {
+    it("never includes the current broker", () => {
+      const current = makeBroker({ id: 1, slug: "self" });
+      const pool = [
+        makeBroker({ id: 1, slug: "self", name: "Self" }),
+        makeBroker({ id: 2, slug: "other", name: "Other" }),
+      ];
+
+      const { brokers } = getRelatedForBroker(current, pool, []);
+      expect(brokers.every((b) => b.href !== "/broker/self")).toBe(true);
+    });
+  });
+
+  describe("brokers — caps", () => {
+    it("caps broker results at 4", () => {
+      const current = makeBroker({ id: 0, slug: "c" });
+      const pool = Array.from({ length: 10 }, (_, i) =>
+        makeBroker({ id: i + 1, slug: `b${i}`, name: `B${i}` }),
+      );
+
+      const { brokers } = getRelatedForBroker(current, pool, []);
+      expect(brokers.length).toBeLessThanOrEqual(4);
+    });
+  });
+
+  describe("brokers — articles", () => {
+    it("returns related articles", () => {
+      const current = makeBroker({ id: 1, slug: "curr" });
+      const articles = [makeArticle({ id: 10, slug: "art", title: "Art" })];
+
+      const { articles: result } = getRelatedForBroker(current, [], articles);
+      expect(result[0]?.href).toBe("/article/art");
+    });
+
+    it("caps articles at 3", () => {
+      const current = makeBroker({ id: 1, slug: "curr" });
+      const articles = Array.from({ length: 6 }, (_, i) =>
+        makeArticle({ id: i, slug: `a${i}`, title: `A${i}` }),
+      );
+
+      const { articles: result } = getRelatedForBroker(current, [], articles);
+      expect(result.length).toBeLessThanOrEqual(3);
+    });
+  });
+
+  describe("brokers — empty cases", () => {
+    it("returns empty arrays when pool is empty", () => {
+      const current = makeBroker({ id: 1, slug: "c" });
+      const { brokers, articles } = getRelatedForBroker(current, [], []);
+      expect(brokers).toEqual([]);
+      expect(articles).toEqual([]);
+    });
+  });
+});
+
+// ─── getRelatedForAdvisor ───────────────────────────────────────
+
+describe("getRelatedForAdvisor", () => {
+  describe("advisors — relatedness", () => {
+    it("returns advisors of the same type only", () => {
+      const current = makeAdvisor({ id: 1, slug: "c", type: "financial_planner" });
+      const sameType = makeAdvisor({ id: 2, slug: "same", type: "financial_planner", name: "FP2", specialties: ["super"] });
+      const diffType = makeAdvisor({ id: 3, slug: "diff", type: "tax_agent", name: "Tax", specialties: [] });
+
+      const { advisors } = getRelatedForAdvisor(current, [sameType, diffType]);
+      const slugs = advisors.map((a) => a.href);
+      expect(slugs).toContain("/advisor/same");
+      expect(slugs).not.toContain("/advisor/diff");
+    });
+
+    it("ranks advisors with more shared specialties higher", () => {
+      const current = makeAdvisor({
+        id: 1,
+        slug: "c",
+        specialties: ["super", "investments", "retirement"],
+      });
+      const highOverlap = makeAdvisor({
+        id: 2,
+        slug: "high",
+        specialties: ["super", "investments", "retirement"],
+        name: "High",
+      });
+      const lowOverlap = makeAdvisor({
+        id: 3,
+        slug: "low",
+        specialties: ["super"],
+        name: "Low",
+      });
+
+      const { advisors } = getRelatedForAdvisor(current, [lowOverlap, highOverlap]);
+      expect(advisors[0]?.href).toBe("/advisor/high");
+    });
+
+    it("gives a bonus to advisors in the same state", () => {
+      const current = makeAdvisor({ id: 1, slug: "c", location_state: "VIC", specialties: [] });
+      const sameState = makeAdvisor({
+        id: 2,
+        slug: "vic",
+        location_state: "VIC",
+        specialties: [],
+        name: "VIC",
+        verified: false,
+      });
+      const diffState = makeAdvisor({
+        id: 3,
+        slug: "nsw",
+        location_state: "NSW",
+        specialties: [],
+        name: "NSW",
+        verified: false,
+      });
+
+      const { advisors } = getRelatedForAdvisor(current, [diffState, sameState]);
+      expect(advisors[0]?.href).toBe("/advisor/vic");
+    });
+
+    it("gives a bonus to verified advisors", () => {
+      const current = makeAdvisor({ id: 1, slug: "c", location_state: "WA", specialties: [] });
+      const notVerified = makeAdvisor({
+        id: 2,
+        slug: "unv",
+        location_state: "WA",
+        specialties: [],
+        verified: false,
+        name: "Unverified",
+      });
+      const verified = makeAdvisor({
+        id: 3,
+        slug: "ver",
+        location_state: "WA",
+        specialties: [],
+        verified: true,
+        name: "Verified",
+      });
+
+      const { advisors } = getRelatedForAdvisor(current, [notVerified, verified]);
+      expect(advisors[0]?.href).toBe("/advisor/ver");
+    });
+  });
+
+  describe("advisors — self-exclusion", () => {
+    it("never includes the current advisor", () => {
+      const current = makeAdvisor({ id: 1, slug: "self" });
+      const pool = [
+        makeAdvisor({ id: 1, slug: "self", name: "Self" }),
+        makeAdvisor({ id: 2, slug: "other", name: "Other", specialties: ["super"] }),
+      ];
+
+      const { advisors } = getRelatedForAdvisor(current, pool);
+      expect(advisors.every((a) => a.href !== "/advisor/self")).toBe(true);
+    });
+  });
+
+  describe("advisors — caps", () => {
+    it("caps advisor results at 3", () => {
+      const current = makeAdvisor({ id: 0, slug: "c" });
+      const pool = Array.from({ length: 8 }, (_, i) =>
+        makeAdvisor({ id: i + 1, slug: `a${i}`, name: `A${i}`, specialties: ["super"] }),
+      );
+
+      const { advisors } = getRelatedForAdvisor(current, pool);
+      expect(advisors.length).toBeLessThanOrEqual(3);
+    });
+  });
+
+  describe("advisors — guides", () => {
+    it("returns a guide link for known advisor types", () => {
+      const current = makeAdvisor({ id: 1, slug: "c", type: "financial_planner" });
+      const { guides } = getRelatedForAdvisor(current, []);
+      expect(guides.length).toBeGreaterThan(0);
+      expect(guides[0]?.href).toContain("financial-planner");
+    });
+
+    it("returns a directory link for advisor types without a specific guide", () => {
+      const current = makeAdvisor({ id: 1, slug: "c", type: "aged_care_advisor" });
+      const { guides } = getRelatedForAdvisor(current, []);
+      const hrefs = guides.map((g) => g.href);
+      expect(hrefs.some((h) => h.includes("aged-care-advisors"))).toBe(true);
+    });
+
+    it("caps guides at 2", () => {
+      const current = makeAdvisor({ id: 1, slug: "c", type: "mortgage_broker" });
+      const { guides } = getRelatedForAdvisor(current, []);
+      expect(guides.length).toBeLessThanOrEqual(2);
+    });
+  });
+
+  describe("advisors — empty cases", () => {
+    it("returns empty advisors array when no candidates match", () => {
+      const current = makeAdvisor({
+        id: 1,
+        slug: "c",
+        type: "financial_planner",
+        specialties: [],
+        location_state: undefined,
+      });
+      const pool = [
+        makeAdvisor({ id: 2, slug: "o", type: "financial_planner", specialties: [], location_state: undefined, name: "Other", verified: false }),
+      ];
+
+      // The other advisor has zero score (no specialty overlap, no state match, not verified)
+      const { advisors } = getRelatedForAdvisor(current, pool);
+      expect(advisors).toEqual([]);
+    });
+  });
+});

--- a/app/advisor/[slug]/page.tsx
+++ b/app/advisor/[slug]/page.tsx
@@ -20,6 +20,8 @@ import { computeAdvisorReputation } from "@/lib/advisor-reputation";
 import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
 import AdvisorTrustScoreSection from "./components/AdvisorTrustScoreSection";
 import AdvisorReputationSummary from "./components/AdvisorReputationSummary";
+import { getRelatedForAdvisor } from "@/lib/related-content";
+import RelatedRail from "@/components/RelatedRail";
 
 export const revalidate = 1800;
 
@@ -547,6 +549,44 @@ export default async function AdvisorProfilePage({ params }: { params: Promise<{
           isLoggedIn={!!sessionUser}
         />
       </div>
+      {/* Related advisors + guide rail — factual discovery, not advice.
+          Uses the same-type advisors already fetched above; no extra DB call. */}
+      {(() => {
+        const { advisors: relAdvisors, guides: relGuides } = getRelatedForAdvisor(
+          { id: pro.id, slug: pro.slug, type: pro.type, specialties: pro.specialties ?? [], location_state: pro.location_state },
+          similar.map((s) => ({
+            id: s.id,
+            slug: s.slug,
+            name: s.name,
+            type: s.type,
+            specialties: s.specialties ?? [],
+            location_state: s.location_state,
+            location_display: s.location_display,
+            rating: s.rating,
+            verified: s.verified,
+            firm_name: s.firm_name,
+          })),
+        );
+        if (relAdvisors.length === 0 && relGuides.length === 0) return null;
+        return (
+          <div className="container-custom max-w-4xl mt-6">
+            {relAdvisors.length > 0 && (
+              <RelatedRail
+                heading={`Similar ${PROFESSIONAL_TYPE_LABELS[pro.type as keyof typeof PROFESSIONAL_TYPE_LABELS] ?? "Advisors"}`}
+                items={relAdvisors}
+              />
+            )}
+            {relGuides.length > 0 && (
+              <RelatedRail
+                heading="Useful Guides"
+                items={[]}
+                secondaryItems={relGuides}
+                className="mt-4"
+              />
+            )}
+          </div>
+        );
+      })()}
       <ClaimListingButton
         claimType="advisor"
         targetSlug={pro.slug}

--- a/app/article/[slug]/page.tsx
+++ b/app/article/[slug]/page.tsx
@@ -24,6 +24,8 @@ import ClusterNav from "@/components/ClusterNav";
 import ArticleComments from "@/components/ArticleComments";
 import Icon from "@/components/Icon";
 import RelatedContentGrid from "@/components/RelatedContentGrid";
+import RelatedRail from "@/components/RelatedRail";
+import { getRelatedForArticle } from "@/lib/related-content";
 import AdSlot from "@/components/AdSlot";
 import AdvisorPrompt from "@/components/AdvisorPrompt";
 import LinkifiedText from "@/components/LinkifiedText";
@@ -708,6 +710,24 @@ export default async function ArticlePage({
                   meta: ra.read_time ? `${ra.read_time} min read` : undefined,
                 }))}
               />
+
+              {/* Calculators & Guides — derived from article category + tags.
+                  Pure: no extra DB fetch, computed from existing article fields. */}
+              {(() => {
+                const { tools } = getRelatedForArticle(
+                  { id: a.id, slug: a.slug, category: a.category, tags: a.tags, related_calc: a.related_calc },
+                  [], // articles already shown above; only need tools here
+                );
+                if (tools.length === 0) return null;
+                return (
+                  <RelatedRail
+                    heading="Calculators & Guides"
+                    items={[]}
+                    secondaryItems={tools}
+                    secondaryHeading="Free tools"
+                  />
+                );
+              })()}
 
               {/* Best Broker Guide Links */}
               {(() => {

--- a/app/broker/[slug]/page.tsx
+++ b/app/broker/[slug]/page.tsx
@@ -20,6 +20,9 @@ import {
   CURRENT_YEAR,
 } from "@/lib/seo";
 import { scoreBrokerSimilarity } from "@/lib/internal-links";
+import { getRelatedForBroker } from "@/lib/related-content";
+import { itemListJsonLd } from "@/lib/schema-markup";
+import RelatedRail from "@/components/RelatedRail";
 import QASection from "@/components/QASection";
 import AskQuestionForm from "@/components/AskQuestionForm";
 import ComplianceFooter from "@/components/ComplianceFooter";
@@ -365,6 +368,48 @@ export default async function BrokerPage({ params }: { params: Promise<{ slug: s
           <BrokerHistoryChart slug={b.slug} metric="asx_fee_value" daysBack={30} />
         </Suspense>
       </div>
+
+      {/* Related content rail — similar brokers + related articles.
+          Complements the "vs Alternatives" tab (BrokerReviewClient) which
+          is tab-scoped. This rail sits below the main review so both
+          surfaces are visible without duplication. */}
+      {(() => {
+        const { brokers: relBrokers, articles: relArts } = getRelatedForBroker(
+          b,
+          allOtherBrokers,
+          (brokerArticles || []) as { id: number; slug: string; title: string; category?: string; read_time?: number }[],
+        );
+        if (relBrokers.length === 0 && relArts.length === 0) return null;
+        const listItems = [
+          ...relBrokers.map((item, i) => ({
+            position: i + 1,
+            name: item.title,
+            url: item.href,
+            description: item.badgeText,
+          })),
+        ];
+        const jsonLd = listItems.length > 0
+          ? itemListJsonLd(`Similar platforms to ${b.name}`, listItems)
+          : null;
+        return (
+          <div className="container-custom max-w-4xl mt-8">
+            {relBrokers.length > 0 && (
+              <RelatedRail
+                heading={`Similar to ${b.name}`}
+                items={relBrokers}
+                jsonLd={jsonLd}
+              />
+            )}
+            {relArts.length > 0 && (
+              <RelatedRail
+                heading="Related Guides"
+                items={relArts}
+                className="mt-6"
+              />
+            )}
+          </div>
+        );
+      })()}
 
       {/* DDO compliance — render the current TMD link prominently
           next to the product footer. DDO (Corporations Act s994A–C)

--- a/app/broker/[slug]/page.tsx
+++ b/app/broker/[slug]/page.tsx
@@ -374,12 +374,12 @@ export default async function BrokerPage({ params }: { params: Promise<{ slug: s
           is tab-scoped. This rail sits below the main review so both
           surfaces are visible without duplication. */}
       {(() => {
-        const { brokers: relBrokers, articles: relArts } = getRelatedForBroker(
+        const { brokers: relBrokers, articles: relArts, guides: relGuides } = getRelatedForBroker(
           b,
           allOtherBrokers,
           (brokerArticles || []) as { id: number; slug: string; title: string; category?: string; read_time?: number }[],
         );
-        if (relBrokers.length === 0 && relArts.length === 0) return null;
+        if (relBrokers.length === 0 && relArts.length === 0 && relGuides.length === 0) return null;
         const listItems = [
           ...relBrokers.map((item, i) => ({
             position: i + 1,
@@ -400,10 +400,12 @@ export default async function BrokerPage({ params }: { params: Promise<{ slug: s
                 jsonLd={jsonLd}
               />
             )}
-            {relArts.length > 0 && (
+            {(relArts.length > 0 || relGuides.length > 0) && (
               <RelatedRail
                 heading="Related Guides"
                 items={relArts}
+                secondaryItems={relGuides.length > 0 ? relGuides : undefined}
+                secondaryHeading={relGuides.length > 0 ? "Helpful guide" : undefined}
                 className="mt-6"
               />
             )}

--- a/components/RelatedRail.tsx
+++ b/components/RelatedRail.tsx
@@ -1,0 +1,133 @@
+/**
+ * RelatedRail — content-discovery rail for article, broker, and advisor pages.
+ *
+ * Renders a responsive grid of related items drawn from existing data.
+ * Accepts an optional `jsonLd` block (ItemList JSON-LD) emitted as a
+ * <script type="application/ld+json"> block alongside the visual rail.
+ *
+ * AFSL note: all copy is factual-discovery framing ("Related content",
+ * "Similar brokers") — never advice framing ("Recommended for you").
+ */
+
+import Link from "next/link";
+import type { RelatedItem } from "@/lib/related-content";
+
+interface Props {
+  /** Section heading displayed above the grid. */
+  heading: string;
+  /**
+   * Primary items (articles, brokers, or advisors).
+   * The rail renders nothing when this array is empty.
+   */
+  items: RelatedItem[];
+  /**
+   * Optional secondary items shown in a separate sub-section below.
+   * Typically calculator/guide links (articles page) or directory links
+   * (advisor page). Hidden when the array is empty.
+   */
+  secondaryItems?: RelatedItem[];
+  /** Label for the secondary items sub-section. */
+  secondaryHeading?: string;
+  /**
+   * Optional pre-serialised JSON-LD block (ItemList). When provided
+   * it is emitted as a <script type="application/ld+json"> alongside
+   * the visual rail.
+   */
+  jsonLd?: object | null;
+  /** Tailwind utility classes added to the section wrapper. */
+  className?: string;
+}
+
+/**
+ * A single card in the rail.
+ */
+function RailCard({ item }: { item: RelatedItem }) {
+  return (
+    <Link
+      href={item.href}
+      className="group flex flex-col border border-slate-200 rounded-xl p-4 bg-white hover:shadow-md hover:border-slate-300 transition-all"
+    >
+      {item.badgeText && (
+        <span
+          className={`self-start text-[0.69rem] font-semibold px-2 py-0.5 rounded-full mb-2 ${item.badgeClass ?? "bg-slate-100 text-slate-700"}`}
+        >
+          {item.badgeText}
+        </span>
+      )}
+      <span className="text-sm font-bold text-slate-900 leading-snug line-clamp-2 flex-1 group-hover:text-slate-700 transition-colors">
+        {item.title}
+      </span>
+      {item.meta && (
+        <span className="mt-2 text-[0.69rem] text-slate-400">{item.meta}</span>
+      )}
+    </Link>
+  );
+}
+
+export default function RelatedRail({
+  heading,
+  items,
+  secondaryItems,
+  secondaryHeading,
+  jsonLd,
+  className = "",
+}: Props) {
+  if (items.length === 0 && (!secondaryItems || secondaryItems.length === 0)) {
+    return null;
+  }
+
+  return (
+    <section
+      aria-labelledby="related-rail-heading"
+      className={`mt-8 md:mt-12 ${className}`}
+    >
+      {jsonLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
+      )}
+
+      <h3
+        id="related-rail-heading"
+        className="text-lg md:text-xl font-bold mb-4"
+      >
+        {heading}
+      </h3>
+
+      {items.length > 0 && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3">
+          {items.map((item) => (
+            <RailCard key={item.id} item={item} />
+          ))}
+        </div>
+      )}
+
+      {secondaryItems && secondaryItems.length > 0 && (
+        <div className="mt-5">
+          {secondaryHeading && (
+            <p className="text-xs font-semibold text-slate-500 uppercase tracking-wider mb-2">
+              {secondaryHeading}
+            </p>
+          )}
+          <div className="flex flex-wrap gap-2">
+            {secondaryItems.map((item) => (
+              <Link
+                key={item.id}
+                href={item.href}
+                className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full border text-sm font-medium transition-colors ${item.badgeClass ? `${item.badgeClass} border-transparent` : "border-slate-200 text-slate-700 hover:border-slate-400 bg-white"}`}
+              >
+                {item.badgeText && (
+                  <span className="text-[0.69rem] font-bold opacity-70">
+                    {item.badgeText}
+                  </span>
+                )}
+                {item.title}
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/lib/related-content.ts
+++ b/lib/related-content.ts
@@ -42,6 +42,7 @@ export interface ArticleRelatedResult {
 export interface BrokerRelatedResult {
   brokers: RelatedItem[];
   articles: RelatedItem[];
+  guides: RelatedItem[];
 }
 
 /** Structured result for the advisor-page rail. */
@@ -366,7 +367,23 @@ export function getRelatedForBroker(
     meta: a.read_time ? `${a.read_time} min read` : undefined,
   }));
 
-  return { brokers, articles };
+  // --- Guides --- (platform-type → relevant guide; mirrors the advisor rail)
+  const guides: RelatedItem[] = [];
+  const guideHint = current.platform_type
+    ? PLATFORM_GUIDE_HINTS[current.platform_type]
+    : undefined;
+  if (guideHint) {
+    guides.push({
+      id: `guide:${guideHint.href}`,
+      href: guideHint.href,
+      title: guideHint.name,
+      badgeText: "Guide",
+      badgeClass: "bg-violet-100 text-violet-700",
+      meta: "Free guide",
+    });
+  }
+
+  return { brokers, articles, guides };
 }
 
 // ─── Advisor rail ───────────────────────────────────────────────

--- a/lib/related-content.ts
+++ b/lib/related-content.ts
@@ -1,0 +1,598 @@
+/**
+ * related-content.ts — pure helpers for content discovery rails.
+ *
+ * Given the current entity (article, broker, or advisor), returns ranked
+ * lists of related items from existing data for display in the "Related"
+ * rail component.
+ *
+ * Design principles:
+ *   - Deterministic ranking: no random order, no personalisation.
+ *   - AFSL-safe: factual discovery only ("similar brokers", "same category
+ *     articles") — never "recommended for you to buy" or advice framing.
+ *   - Pure: no I/O. All inputs must be pre-fetched by the caller (RSC page).
+ *   - Self-exclusion: the current entity is always excluded from results.
+ *   - Capped results: each helper enforces a max count.
+ */
+
+import type { Article, Broker, Professional } from "@/lib/types";
+
+// ─── Shared types ──────────────────────────────────────────────
+
+/** A single item in any related-content rail. */
+export interface RelatedItem {
+  id: string | number;
+  href: string;
+  title: string;
+  /** Short contextual label (e.g. article category, broker platform type). */
+  badgeText?: string;
+  /** Tailwind classes for the badge background + text colour. */
+  badgeClass?: string;
+  /** Optional meta line (e.g. "5 min read", "Financial Planner"). */
+  meta?: string;
+}
+
+/** Structured result for the article-page rail. */
+export interface ArticleRelatedResult {
+  articles: RelatedItem[];
+  /** Up to 2 calculator/guide links surfaced based on category+tags. */
+  tools: RelatedItem[];
+}
+
+/** Structured result for the broker-page rail. */
+export interface BrokerRelatedResult {
+  brokers: RelatedItem[];
+  articles: RelatedItem[];
+}
+
+/** Structured result for the advisor-page rail. */
+export interface AdvisorRelatedResult {
+  advisors: RelatedItem[];
+  guides: RelatedItem[];
+}
+
+// ─── Constants ──────────────────────────────────────────────────
+
+const MAX_RELATED_ARTICLES = 6;
+const MAX_RELATED_BROKERS = 4;
+const MAX_RELATED_ADVISORS = 3;
+const MAX_TOOLS = 2;
+
+/** Calculators surfaced on the article rail, keyed by the article's
+ *  `related_calc` slug value or derived from category/tags. */
+const CALC_MAP: Record<
+  string,
+  { name: string; href: string; meta?: string }
+> = {
+  "calc-franking": {
+    name: "Franking Credits Calculator",
+    href: "/calculators?calc=calc-franking",
+    meta: "Free tool",
+  },
+  "calc-switching": {
+    name: "Switching Cost Simulator",
+    href: "/calculators?calc=calc-switching",
+    meta: "Free tool",
+  },
+  "calc-fx": {
+    name: "FX Fee Calculator",
+    href: "/calculators?calc=calc-fx",
+    meta: "Free tool",
+  },
+  "calc-cgt": {
+    name: "CGT Estimator",
+    href: "/calculators?calc=calc-cgt",
+    meta: "Free tool",
+  },
+  "calc-chess": {
+    name: "CHESS Lookup Tool",
+    href: "/calculators?calc=calc-chess",
+    meta: "Free tool",
+  },
+};
+
+/** Category/tag → calculator hint (best match only, deterministic). */
+const CATEGORY_CALC_HINTS: { pattern: RegExp; calc: string }[] = [
+  { pattern: /\bfranking\b|\bdividend\b|\bfranked\b/i, calc: "calc-franking" },
+  { pattern: /\btax\b|\bcgt\b|\bcapital.gain\b|\beofy\b/i, calc: "calc-cgt" },
+  { pattern: /\bfx\b|\bcurrency\b|\binternational\b|\bforex\b|\bremitt/i, calc: "calc-fx" },
+  { pattern: /\bchess\b|\bcustody\b/i, calc: "calc-chess" },
+  { pattern: /\bswitch\b|\btransfer\b/i, calc: "calc-switching" },
+];
+
+/** Category → advisor-guide hint for the article rail. */
+const CATEGORY_GUIDE_HINTS: {
+  pattern: RegExp;
+  name: string;
+  href: string;
+}[] = [
+  {
+    pattern: /\bmortgage\b|\bhome.loan\b|\brefinanc\b/i,
+    name: "Mortgage Broker Guide",
+    href: "/advisor-guides/mortgage-broker",
+  },
+  {
+    pattern: /\bsmsf\b|\bself.managed\b/i,
+    name: "SMSF Accountant Guide",
+    href: "/advisor-guides/smsf-accountant",
+  },
+  {
+    pattern: /\btax\b|\bcapital.gain\b|\beofy\b|\bdeduction\b/i,
+    name: "Tax Agent Guide",
+    href: "/advisor-guides/tax-agent",
+  },
+  {
+    pattern: /\bproperty\b|\bnegative.gear\b|\binvestment.property\b/i,
+    name: "Property Advisor Guide",
+    href: "/advisor-guides/property-advisor",
+  },
+  {
+    pattern: /\bsuper\b|\bretirement\b|\bpension\b/i,
+    name: "Financial Planner Guide",
+    href: "/advisor-guides/financial-planner",
+  },
+  {
+    pattern: /\binsurance\b|\bcover\b|\bincome.protection\b/i,
+    name: "Insurance Broker Guide",
+    href: "/advisor-guides/insurance-broker",
+  },
+];
+
+/** Platform type → advisor guide hint for the broker rail. */
+const PLATFORM_GUIDE_HINTS: Record<
+  string,
+  { name: string; href: string }
+> = {
+  share_broker: {
+    name: "How to Choose a Share Broker",
+    href: "/advisor-guides/financial-planner",
+  },
+  crypto_exchange: {
+    name: "Crypto Tax Guide",
+    href: "/advisor-guides/tax-agent",
+  },
+  super_fund: {
+    name: "SMSF vs Managed Super",
+    href: "/advisor-guides/smsf-accountant",
+  },
+  robo_advisor: {
+    name: "Robo-Advisor vs Financial Planner",
+    href: "/advisor-guides/financial-planner",
+  },
+  property_platform: {
+    name: "Property Investment Guide",
+    href: "/advisor-guides/property-advisor",
+  },
+  cfd_forex: {
+    name: "CFD & Forex Tax Explained",
+    href: "/advisor-guides/tax-agent",
+  },
+  savings_account: {
+    name: "Savings vs Investing Guide",
+    href: "/advisor-guides/financial-planner",
+  },
+  term_deposit: {
+    name: "Term Deposit vs Shares Guide",
+    href: "/advisor-guides/financial-planner",
+  },
+};
+
+/** Advisor type → relevant guide hint. */
+const ADVISOR_GUIDE_HINTS: Record<
+  string,
+  { name: string; href: string }
+> = {
+  financial_planner: {
+    name: "Financial Planner vs Robo-Advisor",
+    href: "/advisor-guides/financial-planner-vs-robo-advisor",
+  },
+  mortgage_broker: {
+    name: "Mortgage Broker vs Bank",
+    href: "/advisor-guides/mortgage-broker-vs-bank",
+  },
+  smsf_accountant: {
+    name: "SMSF Accountant vs DIY",
+    href: "/advisor-guides/smsf-accountant-vs-diy",
+  },
+  tax_agent: {
+    name: "Tax Agent vs Accountant",
+    href: "/advisor-guides/tax-agent-vs-accountant",
+  },
+  buyers_agent: {
+    name: "Buyer's Agent vs DIY",
+    href: "/advisor-guides/buyers-agent-vs-diy",
+  },
+};
+
+// ─── Article rail ───────────────────────────────────────────────
+
+/**
+ * For an article page, returns:
+ *   - Up to `MAX_RELATED_ARTICLES` related articles (prioritised by same-category
+ *     + tag overlap, recency-tiebreaker).
+ *   - Up to `MAX_TOOLS` calculator/guide tools derived from the article's
+ *     `related_calc`, category, and tags — in that priority order.
+ *
+ * @param current  The current article (used for exclusion + attributes).
+ * @param allArticles  Published articles to draw from (excluding the current).
+ */
+export function getRelatedForArticle(
+  current: Pick<Article, "id" | "slug" | "category" | "tags" | "related_calc">,
+  allArticles: Pick<Article, "id" | "slug" | "title" | "category" | "tags" | "read_time" | "published_at">[],
+): ArticleRelatedResult {
+  // --- Articles ---
+  const candidates = allArticles.filter((a) => a.slug !== current.slug);
+
+  const scored = candidates.map((a) => ({
+    article: a,
+    score: scoreArticleSimilarity(current, a),
+  }));
+
+  // Sort: descending score, then descending recency
+  scored.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    const dateA = a.article.published_at ?? "";
+    const dateB = b.article.published_at ?? "";
+    return dateB.localeCompare(dateA);
+  });
+
+  const articles: RelatedItem[] = scored
+    .filter(({ score }) => score > 0)
+    .slice(0, MAX_RELATED_ARTICLES)
+    .map(({ article: a }) => ({
+      id: a.id,
+      href: `/article/${a.slug}`,
+      title: a.title,
+      badgeText: a.category ?? undefined,
+      badgeClass: undefined, // caller can inject colour from CATEGORY_COLORS
+      meta: a.read_time ? `${a.read_time} min read` : undefined,
+    }));
+
+  // --- Tools ---
+  const tools: RelatedItem[] = [];
+
+  // 1. Explicit related_calc field takes priority
+  if (current.related_calc && CALC_MAP[current.related_calc]) {
+    const calc = CALC_MAP[current.related_calc]!;
+    tools.push({
+      id: `calc:${current.related_calc}`,
+      href: calc.href,
+      title: calc.name,
+      badgeText: "Calculator",
+      badgeClass: "bg-amber-100 text-amber-700",
+      meta: calc.meta,
+    });
+  }
+
+  // 2. Derive from category + tags if still under cap
+  if (tools.length < MAX_TOOLS) {
+    const combined = [current.category ?? "", ...(current.tags ?? [])].join(" ");
+    const addedCalcs = new Set(tools.map((t) => t.href));
+
+    for (const hint of CATEGORY_CALC_HINTS) {
+      if (tools.length >= MAX_TOOLS) break;
+      if (hint.pattern.test(combined)) {
+        const calc = CALC_MAP[hint.calc];
+        if (calc && !addedCalcs.has(calc.href)) {
+          tools.push({
+            id: `calc:${hint.calc}`,
+            href: calc.href,
+            title: calc.name,
+            badgeText: "Calculator",
+            badgeClass: "bg-amber-100 text-amber-700",
+            meta: calc.meta,
+          });
+          addedCalcs.add(calc.href);
+        }
+      }
+    }
+
+    // Then advisor guide hints
+    for (const hint of CATEGORY_GUIDE_HINTS) {
+      if (tools.length >= MAX_TOOLS) break;
+      if (hint.pattern.test(combined) && !addedCalcs.has(hint.href)) {
+        tools.push({
+          id: `guide:${hint.href}`,
+          href: hint.href,
+          title: hint.name,
+          badgeText: "Guide",
+          badgeClass: "bg-violet-100 text-violet-700",
+          meta: "Free guide",
+        });
+        addedCalcs.add(hint.href);
+      }
+    }
+  }
+
+  return { articles, tools };
+}
+
+// ─── Broker rail ────────────────────────────────────────────────
+
+/**
+ * For a broker review page, returns:
+ *   - Up to `MAX_RELATED_BROKERS` similar brokers (scored by feature overlap).
+ *   - Up to 3 related articles from `brokerArticles`.
+ *
+ * NOTE: "similar brokers" should COMPLEMENT — not duplicate — the
+ * existing "vs Alternatives" section in BrokerReviewClient which
+ * already uses `scoreBrokerSimilarity` from `lib/internal-links.ts`.
+ * This helper is intended for a separate rail placed below the main
+ * review body, distinct from the tab-based alternatives section.
+ *
+ * @param current       The broker being reviewed.
+ * @param allBrokers    Active brokers to draw from (excluding current).
+ * @param brokerArticles Pre-fetched articles that mention this broker.
+ */
+export function getRelatedForBroker(
+  current: Pick<
+    Broker,
+    "id" | "slug" | "platform_type" | "is_crypto" | "chess_sponsored" | "smsf_support" | "markets" | "rating"
+  >,
+  allBrokers: Pick<
+    Broker,
+    "id" | "slug" | "name" | "platform_type" | "is_crypto" | "chess_sponsored" | "smsf_support" | "markets" | "rating" | "asx_fee_value"
+  >[],
+  brokerArticles: Pick<Article, "id" | "slug" | "title" | "category" | "read_time">[],
+): BrokerRelatedResult {
+  // --- Brokers ---
+  const candidates = allBrokers.filter((b) => b.slug !== current.slug);
+
+  const scored = candidates.map((b) => ({
+    broker: b,
+    score: scoreBrokerFeatureOverlap(current, b),
+  }));
+
+  scored.sort((a, b) => b.score - a.score);
+
+  const brokers: RelatedItem[] = scored
+    .filter(({ score }) => score > 0)
+    .slice(0, MAX_RELATED_BROKERS)
+    .map(({ broker: b }) => ({
+      id: b.id,
+      href: `/broker/${b.slug}`,
+      title: b.name,
+      badgeText: platformTypeLabel(b.platform_type),
+      badgeClass: "bg-slate-100 text-slate-700",
+      meta: b.rating ? `${b.rating.toFixed(1)} / 5` : undefined,
+    }));
+
+  // --- Articles ---
+  const articles: RelatedItem[] = brokerArticles.slice(0, 3).map((a) => ({
+    id: a.id,
+    href: `/article/${a.slug}`,
+    title: a.title,
+    badgeText: a.category ?? undefined,
+    badgeClass: "bg-slate-100 text-slate-700",
+    meta: a.read_time ? `${a.read_time} min read` : undefined,
+  }));
+
+  return { brokers, articles };
+}
+
+// ─── Advisor rail ───────────────────────────────────────────────
+
+/**
+ * For an advisor profile page, returns:
+ *   - Up to `MAX_RELATED_ADVISORS` advisors sharing the same type + at least
+ *     one overlapping specialty or same state (whichever yields more matches),
+ *     ranked by rating.
+ *   - Up to 2 guide links relevant to the advisor type.
+ *
+ * @param current    The advisor whose profile is being viewed.
+ * @param allAdvisors Active advisors of the same type, excluding current.
+ */
+export function getRelatedForAdvisor(
+  current: Pick<
+    Professional,
+    "id" | "slug" | "type" | "specialties" | "location_state"
+  >,
+  allAdvisors: Pick<
+    Professional,
+    "id" | "slug" | "name" | "type" | "specialties" | "location_state" | "location_display" | "rating" | "verified" | "firm_name"
+  >[],
+): AdvisorRelatedResult {
+  // --- Advisors ---
+  const candidates = allAdvisors.filter(
+    (a) => a.slug !== current.slug && a.type === current.type,
+  );
+
+  const scored = candidates.map((a) => ({
+    advisor: a,
+    score: scoreAdvisorSimilarity(current, a),
+  }));
+
+  scored.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    // Tiebreak: higher rating first
+    return (b.advisor.rating ?? 0) - (a.advisor.rating ?? 0);
+  });
+
+  const advisors: RelatedItem[] = scored
+    .filter(({ score }) => score > 0)
+    .slice(0, MAX_RELATED_ADVISORS)
+    .map(({ advisor: a }) => ({
+      id: a.id,
+      href: `/advisor/${a.slug}`,
+      title: a.name,
+      badgeText: a.location_display ?? a.location_state ?? undefined,
+      badgeClass: "bg-slate-100 text-slate-700",
+      meta: a.verified ? "Verified" : undefined,
+    }));
+
+  // --- Guides ---
+  const guides: RelatedItem[] = [];
+  const guideHint = ADVISOR_GUIDE_HINTS[current.type];
+  if (guideHint) {
+    guides.push({
+      id: `guide:${guideHint.href}`,
+      href: guideHint.href,
+      title: guideHint.name,
+      badgeText: "Guide",
+      badgeClass: "bg-violet-100 text-violet-700",
+      meta: "Free guide",
+    });
+  }
+
+  // Add the advisor directory link as a second guide entry
+  const dirSlug = current.type.replace(/_/g, "-") + "s";
+  const dirLabel = ADVISOR_TYPE_LABELS[current.type] ?? current.type.replace(/_/g, " ");
+  guides.push({
+    id: `dir:${dirSlug}`,
+    href: `/advisors/${dirSlug}`,
+    title: `Find a ${dirLabel}`,
+    badgeText: "Directory",
+    badgeClass: "bg-teal-100 text-teal-700",
+    meta: "Browse all",
+  });
+
+  return { advisors, guides: guides.slice(0, MAX_TOOLS) };
+}
+
+// ─── Internal scoring helpers ───────────────────────────────────
+
+/**
+ * Score how related two articles are. Returns 0 when there is no overlap
+ * (so the caller can filter these out).
+ *
+ * Scoring:
+ *   Same category  → +4
+ *   Each shared tag → +2 (capped at 6 pts)
+ */
+function scoreArticleSimilarity(
+  current: Pick<Article, "category" | "tags">,
+  candidate: Pick<Article, "category" | "tags">,
+): number {
+  let score = 0;
+  if (current.category && candidate.category === current.category) score += 4;
+  const currentTags = new Set(current.tags ?? []);
+  for (const tag of candidate.tags ?? []) {
+    if (currentTags.has(tag)) score += 2;
+    if (score >= 4 + 6) break; // cap tag contribution at 6
+  }
+  return score;
+}
+
+/**
+ * Score how similar two brokers are for the related rail.
+ *
+ * Distinct from `scoreBrokerSimilarity` in `lib/internal-links.ts` which
+ * drives the "vs Alternatives" tab. This version weights platform_type more
+ * heavily (same type = must match) and uses markets + feature flags as
+ * secondary signals. crypto must match (same as parent scorer).
+ */
+function scoreBrokerFeatureOverlap(
+  current: Pick<
+    Broker,
+    "platform_type" | "is_crypto" | "chess_sponsored" | "smsf_support" | "markets" | "rating"
+  >,
+  candidate: Pick<
+    Broker,
+    "platform_type" | "is_crypto" | "chess_sponsored" | "smsf_support" | "markets" | "rating" | "asx_fee_value"
+  >,
+): number {
+  // Crypto type must match (same rule as parent scorer)
+  if (current.is_crypto !== candidate.is_crypto) return 0;
+
+  // Platform type must match for the rail to show a broker — we want
+  // same-category discovery, not cross-category noise. Brokers of a
+  // different platform_type are excluded from the rail entirely.
+  if (candidate.platform_type !== current.platform_type) return 0;
+
+  let score = 0;
+
+  // Same platform_type is the primary signal (+5)
+  if (candidate.platform_type === current.platform_type) score += 5;
+
+  // Feature flag matches
+  if (current.chess_sponsored === candidate.chess_sponsored) score += 2;
+  if (current.smsf_support === candidate.smsf_support) score += 1;
+
+  // Market overlap (each shared market = +1, cap at 3)
+  const currentMarkets = new Set(current.markets ?? []);
+  let marketOverlap = 0;
+  for (const m of candidate.markets ?? []) {
+    if (currentMarkets.has(m)) marketOverlap++;
+    if (marketOverlap >= 3) break;
+  }
+  score += marketOverlap;
+
+  // Rating proximity tiebreaker (within 0.5 → small bonus)
+  const ratingDiff = Math.abs((current.rating ?? 0) - (candidate.rating ?? 0));
+  if (ratingDiff <= 0.5) score += 1;
+
+  return score;
+}
+
+/**
+ * Score how similar two advisors are for the related rail.
+ *
+ * Scoring:
+ *   Same type is a pre-filter (only same-type candidates reach this fn).
+ *   Each shared specialty → +2 (cap at 6)
+ *   Same state → +3
+ *   Verified → +1
+ */
+function scoreAdvisorSimilarity(
+  current: Pick<Professional, "specialties" | "location_state">,
+  candidate: Pick<Professional, "specialties" | "location_state" | "verified">,
+): number {
+  let score = 0;
+
+  // Specialty overlap
+  const currentSpecialties = new Set(current.specialties ?? []);
+  let specialtyPts = 0;
+  for (const s of candidate.specialties ?? []) {
+    if (currentSpecialties.has(s)) specialtyPts += 2;
+    if (specialtyPts >= 6) break;
+  }
+  score += specialtyPts;
+
+  // Same state
+  if (
+    current.location_state &&
+    candidate.location_state === current.location_state
+  ) {
+    score += 3;
+  }
+
+  // Verified bonus
+  if (candidate.verified) score += 1;
+
+  return score;
+}
+
+// ─── Utility ────────────────────────────────────────────────────
+
+function platformTypeLabel(type: string): string {
+  const LABELS: Record<string, string> = {
+    share_broker: "Share Broker",
+    crypto_exchange: "Crypto Exchange",
+    robo_advisor: "Robo-Advisor",
+    research_tool: "Research Tool",
+    super_fund: "Super Fund",
+    property_platform: "Property",
+    cfd_forex: "CFD & Forex",
+    savings_account: "Savings Account",
+    term_deposit: "Term Deposit",
+    fx_provider: "FX Provider",
+    business_lender: "Business Lender",
+  };
+  return LABELS[type] ?? type;
+}
+
+const ADVISOR_TYPE_LABELS: Record<string, string> = {
+  financial_planner: "Financial Planner",
+  mortgage_broker: "Mortgage Broker",
+  smsf_accountant: "SMSF Accountant",
+  tax_agent: "Tax Agent",
+  buyers_agent: "Buyer's Agent",
+  property_advisor: "Property Advisor",
+  insurance_broker: "Insurance Broker",
+  estate_planner: "Estate Planner",
+  wealth_manager: "Wealth Manager",
+  crypto_advisor: "Crypto Advisor",
+  stockbroker_firm: "Stockbroker",
+  private_wealth_manager: "Private Wealth Manager",
+  aged_care_advisor: "Aged Care Advisor",
+  debt_counsellor: "Debt Counsellor",
+};


### PR DESCRIPTION
Round-5 deepening (6 of 10), user-facing. **Content-discovery "Related" rails** on article + broker + advisor pages so visitors keep moving. AFSL-safe (factual related content, not "recommended for you to buy").

- `lib/related-content.ts` — pure, tested: `getRelatedForArticle` (category +4 / shared-tag +2, recency tiebreak, + tool links), `getRelatedForBroker` (same platform_type/is_crypto gate, feature/market/rating scoring, + a **platform-type guide hint**), `getRelatedForAdvisor` (specialty overlap + state/verified bonuses, + guide/directory links). Self-exclusion + caps throughout.
- `components/RelatedRail.tsx` — primary grid + optional secondary pills + optional `ItemList` JSON-LD; renders `null` when empty.
- Rails wired onto the three page types (complements the broker "vs Alternatives" tab, doesn't duplicate it). All from data already in scope — no new DB queries.

**Completed what the agent left half-done:** the `PLATFORM_GUIDE_HINTS` map (8 platform→guide entries) was built but **never wired** — I wired it into `getRelatedForBroker` so the broker rail surfaces a relevant guide (parity with the advisor rail's guide links), added type + render + tests; also dropped an unused test var.

**Verified:** `tsc` clean · **34 tests** (relatedness scoring, self-exclusion, caps, empty cases for all 3 types + new broker-guide cases) pass · eslint clean · jsonld gate green. Tier A (content pages + lib + tests).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUfSRE2Teb6VhEXFP6RpS9)_