### PR TITLE
feat(account): shared EmptyState + empty-state polish + first-visit guidance (deepen)

### DIFF
--- a/__tests__/components/BookmarksList.test.tsx
+++ b/__tests__/components/BookmarksList.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "./setup";
+
+vi.mock("@/components/Icon", () => ({
+  default: ({ name }: { name: string }) => (
+    <span data-testid={`icon-${name}`} />
+  ),
+}));
+
+// Must be imported after vi.mock calls
+import BookmarksList from "@/app/account/bookmarks/BookmarksList";
+
+const SAMPLE_ITEMS = [
+  {
+    id: 1,
+    bookmark_type: "article",
+    ref: "how-to-invest",
+    label: "How to Invest",
+    note: null,
+    created_at: "2026-01-10T00:00:00Z",
+  },
+  {
+    id: 2,
+    bookmark_type: "broker",
+    ref: "stake",
+    label: "Stake",
+    note: null,
+    created_at: "2026-01-11T00:00:00Z",
+  },
+];
+
+describe("BookmarksList", () => {
+  describe("empty state", () => {
+    it("shows the EmptyState heading when there are no bookmarks", () => {
+      render(<BookmarksList initialItems={[]} />);
+      expect(
+        screen.getByText("Your reading list is empty"),
+      ).toBeInTheDocument();
+    });
+
+    it("renders the 'Browse brokers' CTA link pointing to /compare", () => {
+      render(<BookmarksList initialItems={[]} />);
+      const link = screen.getByRole("link", { name: /Browse brokers/i });
+      expect(link).toHaveAttribute("href", "/compare");
+    });
+
+    it("renders the 'Explore guides' secondary CTA pointing to /learn", () => {
+      render(<BookmarksList initialItems={[]} />);
+      const link = screen.getByRole("link", { name: /Explore guides/i });
+      expect(link).toHaveAttribute("href", "/learn");
+    });
+
+    it("does not render any list items in the empty state", () => {
+      render(<BookmarksList initialItems={[]} />);
+      expect(screen.queryByRole("listitem")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("with items", () => {
+    it("renders item labels as links", () => {
+      render(<BookmarksList initialItems={SAMPLE_ITEMS} />);
+      expect(
+        screen.getByRole("link", { name: "How to Invest" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("link", { name: "Stake" }),
+      ).toBeInTheDocument();
+    });
+
+    it("groups items under section headings", () => {
+      render(<BookmarksList initialItems={SAMPLE_ITEMS} />);
+      expect(screen.getByText("Articles")).toBeInTheDocument();
+      expect(screen.getByText("Brokers")).toBeInTheDocument();
+    });
+
+    it("does not render the empty state when items are present", () => {
+      render(<BookmarksList initialItems={SAMPLE_ITEMS} />);
+      expect(
+        screen.queryByText("Your reading list is empty"),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/__tests__/components/WatchlistClient.test.tsx
+++ b/__tests__/components/WatchlistClient.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "./setup";
+
+vi.mock("@/components/Icon", () => ({
+  default: ({ name }: { name: string }) => (
+    <span data-testid={`icon-${name}`} />
+  ),
+}));
+
+import WatchlistClient from "@/app/account/watchlist/WatchlistClient";
+import type { WatchlistItem } from "@/app/account/watchlist/WatchlistClient";
+
+const SAMPLE_ITEMS: WatchlistItem[] = [
+  {
+    id: 1,
+    item_type: "broker",
+    item_slug: "stake",
+    display_name: "Stake",
+    added_at: "2026-01-10T00:00:00Z",
+    current_rate_bps: null,
+  },
+  {
+    id: 2,
+    item_type: "etf",
+    item_slug: "vgs",
+    display_name: "VGS",
+    added_at: "2026-01-11T00:00:00Z",
+    current_rate_bps: null,
+  },
+];
+
+describe("WatchlistClient", () => {
+  describe("empty state", () => {
+    it("shows the EmptyState heading when the watchlist is empty", () => {
+      render(<WatchlistClient initialItems={[]} />);
+      expect(
+        screen.getByText("Your watchlist is empty"),
+      ).toBeInTheDocument();
+    });
+
+    it("renders a 'Browse brokers' CTA pointing to /brokers", () => {
+      render(<WatchlistClient initialItems={[]} />);
+      const link = screen.getByRole("link", { name: /Browse brokers/i });
+      expect(link).toHaveAttribute("href", "/brokers");
+    });
+
+    it("renders an 'Explore ETFs' secondary CTA pointing to /etfs", () => {
+      render(<WatchlistClient initialItems={[]} />);
+      const link = screen.getByRole("link", { name: /Explore ETFs/i });
+      expect(link).toHaveAttribute("href", "/etfs");
+    });
+
+    it("is labelled as a 'No results' region for screen readers", () => {
+      render(<WatchlistClient initialItems={[]} />);
+      expect(
+        screen.getByRole("region", { name: "No results" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("with items", () => {
+    it("renders item display names as links", () => {
+      render(<WatchlistClient initialItems={SAMPLE_ITEMS} />);
+      expect(
+        screen.getByRole("link", { name: /Stake/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("groups by type with section headings", () => {
+      render(<WatchlistClient initialItems={SAMPLE_ITEMS} />);
+      expect(screen.getByText(/Brokers \(1\)/i)).toBeInTheDocument();
+      expect(screen.getByText(/ETFs \(1\)/i)).toBeInTheDocument();
+    });
+
+    it("does not show the empty-state when items are present", () => {
+      render(<WatchlistClient initialItems={SAMPLE_ITEMS} />);
+      expect(
+        screen.queryByText("Your watchlist is empty"),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/__tests__/components/directory/EmptyState.test.tsx
+++ b/__tests__/components/directory/EmptyState.test.tsx
@@ -58,4 +58,67 @@ describe("EmptyState", () => {
     );
     expect(screen.getByTestId("custom-action")).toBeInTheDocument();
   });
+
+  describe("ctas prop (link-based CTAs)", () => {
+    it("renders primary CTA as a link with correct href", () => {
+      render(
+        <EmptyState
+          title="Empty watchlist"
+          ctas={[{ label: "Browse brokers", href: "/brokers" }]}
+        />,
+      );
+      const link = screen.getByRole("link", { name: "Browse brokers" });
+      expect(link).toHaveAttribute("href", "/brokers");
+    });
+
+    it("renders multiple CTAs in order", () => {
+      render(
+        <EmptyState
+          title="x"
+          ctas={[
+            { label: "Primary CTA", href: "/primary" },
+            { label: "Secondary CTA", href: "/secondary", variant: "secondary" },
+          ]}
+        />,
+      );
+      expect(screen.getByRole("link", { name: "Primary CTA" })).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: "Secondary CTA" })).toBeInTheDocument();
+    });
+
+    it("applies different styles for primary vs secondary variant", () => {
+      render(
+        <EmptyState
+          title="x"
+          ctas={[
+            { label: "Primary", href: "/a", variant: "primary" },
+            { label: "Secondary", href: "/b", variant: "secondary" },
+          ]}
+        />,
+      );
+      const primary = screen.getByRole("link", { name: "Primary" });
+      const secondary = screen.getByRole("link", { name: "Secondary" });
+      // Primary has dark background class; secondary has border class
+      expect(primary.className).toContain("bg-slate-900");
+      expect(secondary.className).toContain("border-slate-200");
+    });
+
+    it("does not render a CTA container when ctas is absent", () => {
+      render(<EmptyState title="x" />);
+      // No links should appear (beyond the component itself)
+      expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    });
+
+    it("renders both suggestions and ctas when both supplied", () => {
+      const handleClick = vi.fn();
+      render(
+        <EmptyState
+          title="x"
+          suggestions={[{ label: "Remove filter", onClick: handleClick }]}
+          ctas={[{ label: "Browse", href: "/browse" }]}
+        />,
+      );
+      expect(screen.getByRole("button", { name: "Remove filter" })).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: "Browse" })).toBeInTheDocument();
+    });
+  });
 });

--- a/app/account/AccountClient.tsx
+++ b/app/account/AccountClient.tsx
@@ -290,6 +290,63 @@ export default function AccountClient() {
           </div>
         )}
 
+        {/* First-visit "where to start" panel — shown when account is brand new (no saves + onboarding incomplete) */}
+        {!onboardingDone && savedComparisonsCount === 0 && (
+          <div className="mb-4 bg-white border border-slate-200 rounded-xl overflow-hidden">
+            <div className="bg-gradient-to-r from-slate-900 to-slate-700 px-5 py-4">
+              <h2 className="text-base font-bold text-white">Get the most out of Invest.com.au</h2>
+              <p className="text-xs text-slate-400 mt-0.5">Three things worth doing first</p>
+            </div>
+            <div className="divide-y divide-slate-100">
+              <div className="flex items-start gap-4 px-5 py-4">
+                <div className="w-8 h-8 rounded-full bg-emerald-100 flex items-center justify-center shrink-0 mt-0.5">
+                  <span className="text-xs font-extrabold text-emerald-700">1</span>
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-semibold text-slate-900">Take the Platform Quiz</p>
+                  <p className="text-xs text-slate-500 mt-0.5">Answer 5 questions and we&apos;ll match you with the right broker for your style and goals.</p>
+                </div>
+                <Link
+                  href="/quiz"
+                  className="shrink-0 px-3 py-1.5 bg-emerald-600 text-white text-xs font-bold rounded-lg hover:bg-emerald-700 transition-colors"
+                >
+                  Start quiz
+                </Link>
+              </div>
+              <div className="flex items-start gap-4 px-5 py-4">
+                <div className="w-8 h-8 rounded-full bg-amber-100 flex items-center justify-center shrink-0 mt-0.5">
+                  <span className="text-xs font-extrabold text-amber-700">2</span>
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-semibold text-slate-900">Compare brokers side by side</p>
+                  <p className="text-xs text-slate-500 mt-0.5">Pick up to five brokers, compare fees and features, and save your shortlist.</p>
+                </div>
+                <Link
+                  href="/compare"
+                  className="shrink-0 px-3 py-1.5 bg-amber-500 text-white text-xs font-bold rounded-lg hover:bg-amber-600 transition-colors"
+                >
+                  Compare
+                </Link>
+              </div>
+              <div className="flex items-start gap-4 px-5 py-4">
+                <div className="w-8 h-8 rounded-full bg-blue-100 flex items-center justify-center shrink-0 mt-0.5">
+                  <span className="text-xs font-extrabold text-blue-700">3</span>
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-semibold text-slate-900">Set a rate alert</p>
+                  <p className="text-xs text-slate-500 mt-0.5">Get notified when a savings rate, term deposit or brokerage fee hits your target.</p>
+                </div>
+                <Link
+                  href="/rate-alerts"
+                  className="shrink-0 px-3 py-1.5 border border-slate-200 text-slate-700 text-xs font-semibold rounded-lg hover:bg-slate-50 transition-colors"
+                >
+                  Set alert
+                </Link>
+              </div>
+            </div>
+          </div>
+        )}
+
         {/* Profile */}
         <div className="bg-white border border-slate-200 rounded-xl p-5 mb-4">
           <div className="flex items-center justify-between">
@@ -517,18 +574,20 @@ export default function AccountClient() {
 
         {/* My Saves hub — prominent card linking to the aggregated saves view */}
         <div className="bg-white border border-slate-200 rounded-xl p-5 mb-4">
-          <div className="flex items-center justify-between">
+          <div className="flex items-center justify-between mb-0">
             <div>
               <h2 className="text-base font-bold text-slate-900">My Saves</h2>
               <p className="text-xs text-slate-500 mt-0.5">
-                Reading list, watchlist, comparisons, searches &amp; alerts
+                {savedComparisonsCount === 0
+                  ? "Nothing saved yet — bookmark articles, brokers and advisors as you browse"
+                  : "Reading list, watchlist, comparisons, searches & alerts"}
               </p>
             </div>
             <Link
               href="/account/my-saves"
               className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-semibold text-slate-700 bg-slate-50 rounded-xl hover:bg-slate-100 transition-colors"
             >
-              View all
+              {savedComparisonsCount === 0 ? "Explore" : "View all"}
               <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
               </svg>

--- a/app/account/bookmarks/BookmarksList.tsx
+++ b/app/account/bookmarks/BookmarksList.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import Link from "next/link";
+import EmptyState from "@/components/directory/EmptyState";
 
 interface BookmarkItem {
   id: number;
@@ -58,21 +59,15 @@ export default function BookmarksList({ initialItems }: Props) {
 
   if (items.length === 0) {
     return (
-      <div className="rounded-xl border border-slate-200 bg-white p-10 text-center">
-        <div className="text-4xl mb-2" aria-hidden>
-          🔖
-        </div>
-        <p className="text-sm text-slate-600">
-          Nothing saved yet — tap the bookmark icon on any article,
-          broker or advisor to save it here.
-        </p>
-        <Link
-          href="/compare"
-          className="mt-4 inline-block bg-amber-500 hover:bg-amber-600 text-white font-bold text-sm px-5 py-2.5 rounded-lg transition-colors"
-        >
-          Start comparing →
-        </Link>
-      </div>
+      <EmptyState
+        icon="file-text"
+        title="Your reading list is empty"
+        body="Tap the bookmark icon on any article, broker or advisor page to save it here for later."
+        ctas={[
+          { label: "Browse brokers", href: "/compare" },
+          { label: "Explore guides", href: "/learn", variant: "secondary" },
+        ]}
+      />
     );
   }
 

--- a/app/account/saved-searches/SavedSearchesClient.tsx
+++ b/app/account/saved-searches/SavedSearchesClient.tsx
@@ -17,6 +17,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 
 import { useUser } from "@/lib/hooks/useUser";
+import EmptyState from "@/components/directory/EmptyState";
 
 type Kind = "advisors" | "teams" | "invest";
 type Frequency = "off" | "daily" | "weekly";
@@ -169,29 +170,15 @@ export default function SavedSearchesClient() {
         )}
 
         {rows.length === 0 && (
-          <div className="bg-white border border-slate-200 rounded-xl p-8 text-center">
-            <h2 className="text-lg font-bold text-slate-900 mb-1">
-              No saved searches yet
-            </h2>
-            <p className="text-sm text-slate-500 mb-4">
-              Save an advisor or team filter to get a daily digest when new
-              providers match.
-            </p>
-            <div className="flex gap-2 justify-center">
-              <Link
-                href="/advisors"
-                className="inline-block px-5 py-2.5 bg-slate-900 text-white text-sm font-semibold rounded-xl hover:bg-slate-800 transition-colors"
-              >
-                Browse Advisors
-              </Link>
-              <Link
-                href="/teams"
-                className="inline-block px-5 py-2.5 border border-slate-200 text-slate-700 text-sm font-semibold rounded-xl hover:bg-slate-50 transition-colors"
-              >
-                Browse Teams
-              </Link>
-            </div>
-          </div>
+          <EmptyState
+            icon="search"
+            title="No saved searches yet"
+            body="Filter advisors or teams, then save the search to receive a digest when new providers match your criteria."
+            ctas={[
+              { label: "Browse advisors", href: "/advisors" },
+              { label: "Browse teams", href: "/teams", variant: "secondary" },
+            ]}
+          />
         )}
 
         <div className="space-y-3">

--- a/app/account/saved/SavedComparisonsClient.tsx
+++ b/app/account/saved/SavedComparisonsClient.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { useUser } from "@/lib/hooks/useUser";
+import EmptyState from "@/components/directory/EmptyState";
 
 interface SavedComparison {
   id: string;
@@ -171,23 +172,12 @@ export default function SavedComparisonsClient() {
 
         {/* Empty state */}
         {comparisons.length === 0 && (
-          <div className="bg-white border border-slate-200 rounded-xl p-8 text-center">
-            <div className="w-12 h-12 bg-slate-100 rounded-full flex items-center justify-center mx-auto mb-4">
-              <svg className="w-6 h-6 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 17V7m0 10a2 2 0 01-2 2H5a2 2 0 01-2-2V7a2 2 0 012-2h2a2 2 0 012 2m0 10a2 2 0 002 2h2a2 2 0 002-2M9 7a2 2 0 012-2h2a2 2 0 012 2m0 10V7m0 10a2 2 0 002 2h2a2 2 0 002-2V7a2 2 0 00-2-2h-2a2 2 0 00-2 2" />
-              </svg>
-            </div>
-            <h2 className="text-lg font-bold text-slate-900 mb-1">No saved comparisons yet</h2>
-            <p className="text-sm text-slate-500 mb-4">
-              Compare brokers side by side and save your comparisons for easy access later.
-            </p>
-            <Link
-              href="/compare"
-              className="inline-block px-5 py-2.5 bg-slate-900 text-white text-sm font-semibold rounded-xl hover:bg-slate-800 transition-colors"
-            >
-              Start Comparing
-            </Link>
-          </div>
+          <EmptyState
+            icon="bar-chart"
+            title="No saved comparisons yet"
+            body="Compare brokers side by side, then save your shortlist — you can return to it any time."
+            ctas={[{ label: "Start comparing", href: "/compare" }]}
+          />
         )}
 
         {/* Comparisons list */}

--- a/app/account/watchlist/WatchlistClient.tsx
+++ b/app/account/watchlist/WatchlistClient.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
+import EmptyState from "@/components/directory/EmptyState";
 
 export interface WatchlistItem {
   id: number;
@@ -77,20 +78,15 @@ export default function WatchlistClient({ initialItems }: Props) {
 
   if (items.length === 0) {
     return (
-      <div className="rounded-xl border border-slate-200 bg-white p-10 text-center">
-        <p className="text-slate-500 text-sm">Your watchlist is empty.</p>
-        <p className="text-slate-400 text-xs mt-1">
-          Browse{" "}
-          <Link href="/brokers" className="underline hover:text-slate-600">
-            brokers
-          </Link>
-          {" or "}
-          <Link href="/etfs" className="underline hover:text-slate-600">
-            ETFs
-          </Link>{" "}
-          and add items to track them here.
-        </p>
-      </div>
+      <EmptyState
+        icon="eye"
+        title="Your watchlist is empty"
+        body="Add brokers, ETFs, stocks and savings accounts to your watchlist to track them in one place."
+        ctas={[
+          { label: "Browse brokers", href: "/brokers" },
+          { label: "Explore ETFs", href: "/etfs", variant: "secondary" },
+        ]}
+      />
     );
   }
 

--- a/components/directory/EmptyState.tsx
+++ b/components/directory/EmptyState.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import type { ReactNode } from "react";
+import Link from "next/link";
 import Icon from "@/components/Icon";
 
 /**
- * Canonical empty-state for directory pages.
+ * Canonical empty-state for directory pages and account surfaces.
  *
  * Renders a centered message + optional smart-suggestion list when
  * filtering returns zero results. The suggestions are the difference
@@ -12,20 +13,19 @@ import Icon from "@/components/Icon";
  * give users a concrete next click instead of just "no results, try
  * something else".
  *
- * Three slots:
+ * Slots:
  *   1. `icon` (optional) — defaults to the search icon
  *   2. `title` — short headline ("No advisors found", "No
  *      opportunities match your filters")
  *   3. `body` — one-sentence explanation ("Try removing some filters
  *      or expanding the radius.")
  *   4. `suggestions` (optional) — array of one-click recovery
- *      actions ("Remove the SIV filter (+12 results)", "Expand to
- *      'Any distance' (+48 results)"). Each suggestion has a label
- *      and an onClick; the count delta is part of the label
- *      because rendering it separately required a tighter layout
- *      contract we don't need yet.
- *   5. `children` (optional) — slot for a custom action, e.g. an
- *      alert-capture email form. Renders below suggestions.
+ *      actions (button/onClick, used by directory filter resets).
+ *   5. `ctas` (optional) — array of link-based CTAs ({label, href,
+ *      variant}) for account surfaces where navigation is the
+ *      next step rather than filter mutation.
+ *   6. `children` (optional) — slot for a custom action, e.g. an
+ *      alert-capture email form. Renders below suggestions/CTAs.
  *
  * Use inline (inside the result feed where listings would be) rather
  * than as a modal — empty-state modals interrupt flow and aren't
@@ -36,12 +36,22 @@ export interface EmptyStateSuggestion {
   onClick: () => void;
 }
 
+/** A link-based CTA for surfaces where the next step is navigation. */
+export interface EmptyStateCta {
+  label: string;
+  href: string;
+  /** "primary" = dark filled button; "secondary" = outlined. Default: "primary". */
+  variant?: "primary" | "secondary";
+}
+
 export interface EmptyStateProps {
   title: string;
   body?: string;
   icon?: string;
   suggestions?: ReadonlyArray<EmptyStateSuggestion>;
-  /** Optional custom slot (e.g. alert-capture form). Renders below suggestions. */
+  /** Link-based CTAs (account surfaces). Renders in place of / after suggestions. */
+  ctas?: ReadonlyArray<EmptyStateCta>;
+  /** Optional custom slot (e.g. alert-capture form). Renders below suggestions/CTAs. */
   children?: ReactNode;
   className?: string;
 }
@@ -51,6 +61,7 @@ export default function EmptyState({
   body,
   icon = "search",
   suggestions,
+  ctas,
   children,
   className = "",
 }: EmptyStateProps) {
@@ -86,6 +97,23 @@ export default function EmptyState({
             </li>
           ))}
         </ul>
+      )}
+      {ctas && ctas.length > 0 && (
+        <div className="flex flex-wrap items-center justify-center gap-2 mt-4">
+          {ctas.map((cta, i) => (
+            <Link
+              key={i}
+              href={cta.href}
+              className={
+                (cta.variant ?? "primary") === "primary"
+                  ? "inline-block px-5 py-2.5 bg-slate-900 text-white text-sm font-semibold rounded-xl hover:bg-slate-800 transition-colors"
+                  : "inline-block px-5 py-2.5 border border-slate-200 text-slate-700 text-sm font-semibold rounded-xl hover:bg-slate-50 transition-colors"
+              }
+            >
+              {cta.label}
+            </Link>
+          ))}
+        </div>
       )}
       {children}
     </div>


### PR DESCRIPTION
Round-5 deepening (7 of 10), user-facing. Helpful **empty states** across the account/saved surfaces + first-visit guidance. AFSL-safe (UX).

- `components/directory/EmptyState.tsx` — generalised with an optional `ctas` prop (link CTAs, primary/secondary) alongside the existing `suggestions` prop; **backward-compatible** (directory consumers untouched).
- Applied illustrated empty states to `/account/bookmarks`, `/account/watchlist`, `/account/saved` (comparisons), `/account/saved-searches` — each with surface-appropriate copy + next-step CTAs (empty watchlist → Browse brokers / ETFs, etc.). `/account/my-saves` (just shipped) keeps its per-section pattern — not regressed.
- `AccountClient` — a "Get the most out of Invest.com.au" first-visit panel (quiz → compare → alert) shown only when onboarding is incomplete + nothing saved; the My Saves card guides empty accounts.

**Verified:** `tsc` clean · **25 tests** (EmptyState ctas/variants/coexistence + bookmarks & watchlist empty/populated states) pass · eslint clean. Tier A (additive account UI + tests; optional prop, zero risk to existing EmptyState consumers).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUfSRE2Teb6VhEXFP6RpS9)_