### PR TITLE
fix(migrations): idempotent policy creation in v1-API migrations + backlog audit

### DIFF
--- a/supabase/migrations/20260825030000_api_billing_tiers.sql
+++ b/supabase/migrations/20260825030000_api_billing_tiers.sql
@@ -57,5 +57,6 @@ CREATE INDEX IF NOT EXISTS idx_api_key_subs_key_id
 
 ALTER TABLE api_key_subscriptions ENABLE ROW LEVEL SECURITY;
 -- Service-role only — no authenticated-user policy needed (admin/webhook use)
+DROP POLICY IF EXISTS "Service manage api_key_subscriptions" ON api_key_subscriptions;
 CREATE POLICY "Service manage api_key_subscriptions"
   ON api_key_subscriptions FOR ALL USING (true);

--- a/supabase/migrations/20260825050000_api_consumer_webhooks.sql
+++ b/supabase/migrations/20260825050000_api_consumer_webhooks.sql
@@ -26,5 +26,6 @@ CREATE INDEX IF NOT EXISTS idx_api_consumer_webhooks_key
 
 ALTER TABLE api_consumer_webhooks ENABLE ROW LEVEL SECURITY;
 -- Service-role only (admin/cron use the service key)
+DROP POLICY IF EXISTS "Service manage api_consumer_webhooks" ON api_consumer_webhooks;
 CREATE POLICY "Service manage api_consumer_webhooks"
   ON api_consumer_webhooks FOR ALL USING (true);

--- a/supabase/migrations/20260825060000_consumer_webhook_deliveries.sql
+++ b/supabase/migrations/20260825060000_consumer_webhook_deliveries.sql
@@ -61,5 +61,6 @@ ALTER TABLE consumer_webhook_deliveries ENABLE ROW LEVEL SECURITY;
 -- Service-role only — dispatch worker uses admin client (legitimate cron/service caller).
 -- No anon or authenticated-role access is permitted: the deliveries table contains
 -- potentially-sensitive response bodies and attempt metadata.
+DROP POLICY IF EXISTS "Service manage consumer_webhook_deliveries" ON consumer_webhook_deliveries;
 CREATE POLICY "Service manage consumer_webhook_deliveries"
   ON consumer_webhook_deliveries FOR ALL USING (true);


### PR DESCRIPTION
Follow-up to the deploy-backlog runbook (#1266): a **full quality audit of all 118 pending migrations** + the one real fix found.

**Fix:** three v1-API service-role policies used bare `CREATE POLICY` (Postgres has no `CREATE POLICY IF NOT EXISTS`), so a partial-failure re-run of `supabase db push` would error on the already-created policy. Each now gets a `DROP POLICY IF EXISTS … ;` first — idempotent, per the migration convention. (`api_key_subscriptions`, `api_consumer_webhooks`, `consumer_webhook_deliveries`.)

**Audit result — the backlog is otherwise clean** (no other changes needed; nothing deleted):
- **No executed destructive ops** — every `DROP TABLE/COLUMN/DELETE/TRUNCATE` is in a `-- Rollback:` comment, never run. Every `UPDATE` is `WHERE`-guarded or an intended new-column backfill (verified `fx_providers`, `add_listing_kind`, the `api_keys` array-appends, `verified_engagement` — all safe).
- **Full RLS coverage** — every `CREATE TABLE` enables RLS.
- **Idempotent** table/index/column/function creation (`IF NOT EXISTS`, `OR REPLACE`, or `information_schema`/`pg_policy` existence guards — the two `verified_engagement` `ADD COLUMN`s and the `ux_onboarding` policy were false positives, already guarded → left untouched).
- `SET search_path` present on all new functions; **no `CONCURRENTLY`/`VACUUM`** (transaction-unsafe) statements.

These files aren't applied anywhere yet, so this is the right time to fix them; pure idempotency hardening, no DDL behaviour change on first apply. Tier B.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUfSRE2Teb6VhEXFP6RpS9)_