### PR TITLE
feat(geo): AI-traffic measurement — classifier + PostHog capture + /admin/geo

### DIFF
--- a/__tests__/lib/geo/ai-referrer.test.ts
+++ b/__tests__/lib/geo/ai-referrer.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { classifyAiReferrer, classifyAiCrawler } from "@/lib/geo/ai-referrer";
+import {
+  classifyAiReferrer,
+  classifyAiCrawler,
+  aiReferralEventProps,
+  listAiReferrerSources,
+  listAiCrawlers,
+} from "@/lib/geo/ai-referrer";
 
 describe("classifyAiReferrer", () => {
   it("matches ChatGPT from a full URL", () => {
@@ -87,5 +93,38 @@ describe("classifyAiCrawler", () => {
     expect(classifyAiCrawler("")).toBeNull();
     expect(classifyAiCrawler(null)).toBeNull();
     expect(classifyAiCrawler(undefined)).toBeNull();
+  });
+});
+
+describe("aiReferralEventProps", () => {
+  it("attaches the landing path to a matched source", () => {
+    expect(aiReferralEventProps("https://chatgpt.com/c/x", "/glossary/etf")).toEqual({
+      source: "chatgpt",
+      label: "ChatGPT",
+      vendor: "OpenAI",
+      kind: "assistant",
+      landing_path: "/glossary/etf",
+    });
+  });
+
+  it("returns null for non-AI referrers", () => {
+    expect(aiReferralEventProps("https://www.google.com/search", "/x")).toBeNull();
+    expect(aiReferralEventProps(null, "/x")).toBeNull();
+  });
+});
+
+describe("coverage lists", () => {
+  it("lists distinct referrer sources with no duplicate source keys", () => {
+    const keys = listAiReferrerSources().map((s) => s.source);
+    expect(new Set(keys).size).toBe(keys.length);
+    expect(keys).toContain("chatgpt");
+    expect(keys).toContain("perplexity");
+  });
+
+  it("lists the crawler tokens we detect", () => {
+    const bots = listAiCrawlers().map((c) => c.bot);
+    expect(bots).toContain("GPTBot");
+    expect(bots).toContain("ClaudeBot");
+    expect(bots).toContain("PerplexityBot");
   });
 });

--- a/__tests__/lib/geo/ai-referrer.test.ts
+++ b/__tests__/lib/geo/ai-referrer.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { classifyAiReferrer, classifyAiCrawler } from "@/lib/geo/ai-referrer";
+
+describe("classifyAiReferrer", () => {
+  it("matches ChatGPT from a full URL", () => {
+    expect(classifyAiReferrer("https://chatgpt.com/c/abc123")).toEqual({
+      source: "chatgpt",
+      label: "ChatGPT",
+      vendor: "OpenAI",
+      kind: "assistant",
+    });
+  });
+
+  it("matches a bare host with no scheme", () => {
+    expect(classifyAiReferrer("perplexity.ai")?.source).toBe("perplexity");
+  });
+
+  it("matches a subdomain via the host-suffix rule", () => {
+    expect(classifyAiReferrer("https://www.perplexity.ai/search?q=etf")?.source).toBe("perplexity");
+    expect(classifyAiReferrer("https://www.chatgpt.com/")?.source).toBe("chatgpt");
+  });
+
+  it("lowercases the host before matching", () => {
+    expect(classifyAiReferrer("https://ChatGPT.com")?.source).toBe("chatgpt");
+  });
+
+  it("maps Bard and Gemini to the same source", () => {
+    expect(classifyAiReferrer("https://gemini.google.com/app")?.source).toBe("gemini");
+    expect(classifyAiReferrer("https://bard.google.com/")?.source).toBe("gemini");
+  });
+
+  it("maps both xAI hosts to grok", () => {
+    expect(classifyAiReferrer("https://grok.com")?.source).toBe("grok");
+    expect(classifyAiReferrer("https://x.ai")?.source).toBe("grok");
+  });
+
+  it("tags answer engines distinctly from assistants", () => {
+    expect(classifyAiReferrer("https://perplexity.ai")?.kind).toBe("answer_engine");
+    expect(classifyAiReferrer("https://claude.ai")?.kind).toBe("assistant");
+  });
+
+  it("does not match plain Google or Bing (AI Overviews / Bing chat share the search host)", () => {
+    expect(classifyAiReferrer("https://www.google.com/search?q=best+etf")).toBeNull();
+    expect(classifyAiReferrer("https://www.bing.com/search?q=etf")).toBeNull();
+  });
+
+  it("does not false-positive on a host that merely ends with a known name", () => {
+    expect(classifyAiReferrer("https://notchatgpt.com")).toBeNull();
+  });
+
+  it("returns null for same-origin, empty, and malformed referrers", () => {
+    expect(classifyAiReferrer("https://invest.com.au/glossary/etf")).toBeNull();
+    expect(classifyAiReferrer("")).toBeNull();
+    expect(classifyAiReferrer(null)).toBeNull();
+    expect(classifyAiReferrer(undefined)).toBeNull();
+    expect(classifyAiReferrer("not a url ###")).toBeNull();
+  });
+});
+
+describe("classifyAiCrawler", () => {
+  it("identifies GPTBot as training traffic", () => {
+    const ua =
+      "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; GPTBot/1.2; +https://openai.com/gptbot";
+    expect(classifyAiCrawler(ua)).toEqual({ bot: "GPTBot", vendor: "OpenAI", purpose: "training" });
+  });
+
+  it("distinguishes user-fetch bots from training crawlers for the same vendor", () => {
+    expect(classifyAiCrawler("Mozilla/5.0 ... ChatGPT-User/1.0; +https://openai.com/bot")?.purpose).toBe(
+      "user_fetch",
+    );
+    expect(classifyAiCrawler("Mozilla/5.0 (compatible; ClaudeBot/1.0; +claudebot@anthropic.com)")?.purpose).toBe(
+      "training",
+    );
+    expect(classifyAiCrawler("Mozilla/5.0 (compatible; Claude-User/1.0)")?.bot).toBe("Claude-User");
+  });
+
+  it("identifies the major search/answer crawlers", () => {
+    expect(classifyAiCrawler("Mozilla/5.0 (compatible; PerplexityBot/1.0; +https://perplexity.ai/perplexitybot)")?.vendor).toBe("Perplexity");
+    expect(classifyAiCrawler("Mozilla/5.0 (compatible; Google-Extended)")?.vendor).toBe("Google");
+    expect(classifyAiCrawler("CCBot/2.0 (https://commoncrawl.org/faq/)")?.vendor).toBe("Common Crawl");
+  });
+
+  it("returns null for ordinary browsers and empty input", () => {
+    const chrome =
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+    expect(classifyAiCrawler(chrome)).toBeNull();
+    expect(classifyAiCrawler("")).toBeNull();
+    expect(classifyAiCrawler(null)).toBeNull();
+    expect(classifyAiCrawler(undefined)).toBeNull();
+  });
+});

--- a/app/admin/geo/page.tsx
+++ b/app/admin/geo/page.tsx
@@ -1,3 +1,4 @@
+import AdminShell from "@/components/AdminShell";
 import { listAiReferrerSources, listAiCrawlers } from "@/lib/geo/ai-referrer";
 
 export const dynamic = "force-dynamic";
@@ -24,8 +25,11 @@ export default function GeoMeasurementPage() {
   const crawlers = listAiCrawlers();
 
   return (
-    <div className="p-6">
-      <h1 className="mb-1 text-2xl font-bold">GEO / AI Traffic</h1>
+    <AdminShell
+      title="GEO / AI Traffic"
+      subtitle="Whether generative-AI engines cite us and send traffic"
+    >
+      <div className="p-6">
       <p className="mb-6 max-w-3xl text-sm text-gray-600">
         Measures whether generative-AI engines send us traffic. When a visitor
         arrives from an AI assistant or answer engine we capture an{" "}
@@ -133,6 +137,7 @@ export default function GeoMeasurementPage() {
           </li>
         </ul>
       </section>
-    </div>
+      </div>
+    </AdminShell>
   );
 }

--- a/app/admin/geo/page.tsx
+++ b/app/admin/geo/page.tsx
@@ -1,0 +1,138 @@
+import { listAiReferrerSources, listAiCrawlers } from "@/lib/geo/ai-referrer";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GEO / AI-traffic measurement page. Renders what we detect (from the
+ * classifier, the single source of truth) plus how to read the live numbers.
+ * The detection coverage is live; the live counts live in PostHog (the
+ * `ai_referral` event), with the HogQL below as a ready-made insight.
+ */
+
+const HOGQL_QUERY = `SELECT
+  properties.source AS ai_source,
+  properties.kind   AS kind,
+  count()           AS visits
+FROM events
+WHERE event = 'ai_referral'
+  AND timestamp > now() - INTERVAL 30 DAY
+GROUP BY ai_source, kind
+ORDER BY visits DESC`;
+
+export default function GeoMeasurementPage() {
+  const sources = listAiReferrerSources();
+  const crawlers = listAiCrawlers();
+
+  return (
+    <div className="p-6">
+      <h1 className="mb-1 text-2xl font-bold">GEO / AI Traffic</h1>
+      <p className="mb-6 max-w-3xl text-sm text-gray-600">
+        Measures whether generative-AI engines send us traffic. When a visitor
+        arrives from an AI assistant or answer engine we capture an{" "}
+        <code className="rounded bg-gray-100 px-1">ai_referral</code> event
+        (consent-gated, once per session). Plain Google and Bing are deliberately
+        excluded — AI Overviews and Bing chat share the ordinary search hostname,
+        so they can&apos;t be told apart from a blue-link click by referrer alone;
+        those are measured via the Search Console impressions-vs-clicks gap (see
+        roadmap).
+      </p>
+
+      <section className="mb-8">
+        <h2 className="mb-2 text-lg font-semibold">
+          AI referrers we detect ({sources.length})
+        </h2>
+        <div className="overflow-x-auto rounded border border-gray-200">
+          <table className="min-w-full text-sm">
+            <thead className="bg-gray-50 text-left text-gray-500">
+              <tr>
+                <th className="px-3 py-2 font-medium">Source</th>
+                <th className="px-3 py-2 font-medium">Vendor</th>
+                <th className="px-3 py-2 font-medium">Type</th>
+                <th className="px-3 py-2 font-medium">Event key</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sources.map((s) => (
+                <tr key={s.source} className="border-t border-gray-100">
+                  <td className="px-3 py-2">{s.label}</td>
+                  <td className="px-3 py-2 text-gray-600">{s.vendor}</td>
+                  <td className="px-3 py-2 text-gray-600">
+                    {s.kind === "assistant" ? "Assistant" : "Answer engine"}
+                  </td>
+                  <td className="px-3 py-2 font-mono text-xs text-gray-500">{s.source}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="mb-8">
+        <h2 className="mb-2 text-lg font-semibold">
+          AI crawlers we can detect ({crawlers.length})
+        </h2>
+        <p className="mb-2 max-w-3xl text-sm text-gray-600">
+          User-Agent tokens for AI vendor bots. The detection table is wired;
+          server-side crawler capture (in{" "}
+          <code className="rounded bg-gray-100 px-1">proxy.ts</code>) is the next
+          step — see roadmap.
+        </p>
+        <div className="overflow-x-auto rounded border border-gray-200">
+          <table className="min-w-full text-sm">
+            <thead className="bg-gray-50 text-left text-gray-500">
+              <tr>
+                <th className="px-3 py-2 font-medium">Bot</th>
+                <th className="px-3 py-2 font-medium">Vendor</th>
+                <th className="px-3 py-2 font-medium">Purpose</th>
+              </tr>
+            </thead>
+            <tbody>
+              {crawlers.map((c) => (
+                <tr key={c.bot} className="border-t border-gray-100">
+                  <td className="px-3 py-2 font-mono text-xs">{c.bot}</td>
+                  <td className="px-3 py-2 text-gray-600">{c.vendor}</td>
+                  <td className="px-3 py-2 text-gray-600">{c.purpose.replace("_", " ")}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="mb-8">
+        <h2 className="mb-2 text-lg font-semibold">See live numbers in PostHog</h2>
+        <p className="mb-2 max-w-3xl text-sm text-gray-600">
+          The <code className="rounded bg-gray-100 px-1">ai_referral</code> event
+          carries <code className="rounded bg-gray-100 px-1">source</code>,{" "}
+          <code className="rounded bg-gray-100 px-1">vendor</code>,{" "}
+          <code className="rounded bg-gray-100 px-1">kind</code> and{" "}
+          <code className="rounded bg-gray-100 px-1">landing_path</code>. Paste
+          this HogQL into a PostHog insight for a 30-day breakdown:
+        </p>
+        <pre className="overflow-x-auto rounded bg-gray-900 p-3 text-xs text-gray-100">
+          <code>{HOGQL_QUERY}</code>
+        </pre>
+      </section>
+
+      <section>
+        <h2 className="mb-2 text-lg font-semibold">Roadmap</h2>
+        <ul className="ml-5 list-disc space-y-1 text-sm text-gray-600">
+          <li>
+            Server-side crawler capture in{" "}
+            <code className="rounded bg-gray-100 px-1">proxy.ts</code> (fire-and-forget
+            edge event) — a Tier-C change, needs founder sign-off.
+          </li>
+          <li>
+            Search Console ingestion to measure the AI-Overview
+            impressions-vs-clicks gap (the part referrers can&apos;t see).
+          </li>
+          <li>
+            Optional: persist <code className="rounded bg-gray-100 px-1">ai_referral</code>{" "}
+            to a Supabase table for in-app charts — deferred until the existing
+            Supabase types-drift check is green, to avoid compounding it.
+          </li>
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/components/AdminSidebar.tsx
+++ b/components/AdminSidebar.tsx
@@ -18,7 +18,7 @@ const NAV_GROUPS = [
       { href: "/admin/finance", icon: "wallet", label: "Finance" },
       { href: "/admin/funnel", icon: "filter", label: "Funnel" },
       { href: "/admin/analytics", icon: "trending-up", label: "Traffic" },
-      { href: "/admin/geo", icon: "bot", label: "GEO / AI Traffic" },
+      { href: "/admin/geo", icon: "zap", label: "GEO / AI Traffic" },
     ],
   },
   {

--- a/components/AdminSidebar.tsx
+++ b/components/AdminSidebar.tsx
@@ -18,6 +18,7 @@ const NAV_GROUPS = [
       { href: "/admin/finance", icon: "wallet", label: "Finance" },
       { href: "/admin/funnel", icon: "filter", label: "Funnel" },
       { href: "/admin/analytics", icon: "trending-up", label: "Traffic" },
+      { href: "/admin/geo", icon: "bot", label: "GEO / AI Traffic" },
     ],
   },
   {

--- a/components/PostHogProvider.tsx
+++ b/components/PostHogProvider.tsx
@@ -4,6 +4,8 @@ import { usePathname, useSearchParams } from 'next/navigation'
 import { Suspense, useEffect, useState } from 'react'
 import { initClientPostHog, getClientPostHog } from '@/lib/posthog/client'
 import { hasAnalyticsConsent } from '@/lib/consent'
+import { trackEvent } from '@/lib/posthog/events'
+import { aiReferralEventProps } from '@/lib/geo/ai-referrer'
 
 function PostHogPageviewTracker() {
   const pathname = usePathname()
@@ -54,6 +56,21 @@ function PostHogPageviewTracker() {
       : pathname
     ph.capture('$pageview', { $current_url: url })
   }, [ready, pathname, searchParams])
+
+  // Record arrivals from AI assistants / answer engines exactly once per
+  // session. Rides PostHog's consent + init gate (only fires once `ready`),
+  // and reads the arrival referrer, which SPA navigations don't overwrite.
+  useEffect(() => {
+    if (!ready || typeof window === 'undefined') return
+    try {
+      if (window.sessionStorage.getItem('ai_referral_captured')) return
+      const props = aiReferralEventProps(document.referrer, window.location.pathname)
+      if (props) trackEvent('ai_referral', props)
+      window.sessionStorage.setItem('ai_referral_captured', '1')
+    } catch {
+      // sessionStorage / referrer access can throw under strict privacy modes.
+    }
+  }, [ready])
 
   return null
 }

--- a/docs/strategy/FIN_NOTEBOOK.md
+++ b/docs/strategy/FIN_NOTEBOOK.md
@@ -14,6 +14,55 @@
 
 ## Active strategic decisions log
 
+### 2026-05-29 — GEO measurement built; GEO "supply floor" found already-shipped
+
+Picked up the GEO thread to build the **measurement** side (the one piece the
+2026-05-21 GEO entry left unbuilt). Grounding the codebase first changed the
+picture twice — logging both as corrections so future sessions don't re-scope
+from stale notes:
+
+**Correction 1 — the GEO "to-do" list is mostly already shipped.** Contrary to
+the 2026-05-21 open items: `public/llms.txt` + `public/llms-full.txt` exist
+(served, curated, compliance-aware); `public/robots.txt` was dropped so
+`app/robots.ts` is the single robots source (caveat (a) resolved); `Speakable`
++ answer-first schema now extend to articles, `/questions/[slug]`, and versus
+(not just glossary); articles emit a real `dateModified` from `updated_at`; FAQ
+schema is on the calculators (commit `c918cd7` "answer-engine v2"). The cheap
+structural GEO floor is **done** — don't rebuild it.
+
+**Correction 2 — golden-flow E2E already exists.** `T-TESTS-02` was tracked as
+"`__tests__/e2e/` doesn't exist". True about that path but misleading: the
+suite lives in `e2e/` (15 specs incl. `critical-path-get-matched-to-brief`,
+`smoke`, `pre-launch-qa`). Golden flows are covered; don't duplicate.
+
+**What was genuinely missing → built (PR #1274, branch `claude/sleepy-dirac-gTZXz`):**
+measurement — there was zero AI-referrer/crawler instrumentation.
+- `lib/geo/ai-referrer.ts` — pure, tested classifier for AI referrers
+  (ChatGPT/Perplexity/Gemini/Claude/Copilot/…) + AI crawlers
+  (GPTBot/ClaudeBot/PerplexityBot/…). google.com/bing.com excluded on purpose
+  (AI Overviews / Bing chat share the search host — that's a GSC signal).
+- `ai_referral` PostHog event, fired once/session, consent-gated.
+- `/admin/geo` page: live detection coverage + a ready-to-paste HogQL insight.
+
+**Decision — schema-markup.ts / seo.ts consolidation: NOT doing it.** The
+2026-05-21 deep-dive item #1 mused about merging the two JSON-LD modules.
+Rejected: `CLAUDE.md` documents `breadcrumbJsonLd` + SEO helpers as living in
+`seo.ts` and schema.org builders in `schema-markup.ts`, so "one module"
+contradicts documented ownership; it's hundreds of import sites for low payoff;
+bundling a big refactor with a feature hurts reviewability. The only real smell
+is `qaPageJsonLd` + `howToJsonLd` being defined in **both** files — worth a
+small, separate dedup PR if/when someone touches them.
+
+**Flagged next steps (deliberately deferred):** server-side crawler capture in
+`proxy.ts` (Tier C); Search Console ingestion for the AI-Overview
+impressions-vs-clicks gap (the part referrers can't see); optional Supabase
+table for in-app charts (deferred until the pre-existing "Supabase types drift"
+CI check is green, to avoid compounding it).
+
+**Revisit:** 2026-06-29 — are `ai_referral` events actually landing in PostHog,
+and which AI sources dominate? If volume is real, do crawler capture + the GSC
+gap next.
+
 ### 2026-05-21 — Platform Expansion (PX stream) shipped
 
 Seven features that turn the platform from comparison directory into practice management tool for advisors and financial dashboard for investors.

--- a/lib/geo/ai-referrer.ts
+++ b/lib/geo/ai-referrer.ts
@@ -1,0 +1,127 @@
+/**
+ * Detection of generative-AI traffic for GEO (generative-engine optimisation)
+ * measurement.
+ *
+ * Two distinct surfaces:
+ *  - `classifyAiReferrer` — a human who clicked a citation inside an AI
+ *    assistant / answer engine, detected from `document.referrer`.
+ *  - `classifyAiCrawler` — an AI vendor's bot fetching a page, detected from
+ *    the request `User-Agent`.
+ *
+ * Kept pure and dependency-free so it runs unchanged in the browser, an edge
+ * route, or a Node route, and can be unit-tested in isolation.
+ */
+
+export interface AiReferrerMatch {
+  /** Stable machine key, safe to use directly as an analytics property. */
+  source: string;
+  /** Human-readable label for dashboards. */
+  label: string;
+  vendor: string;
+  /** Conversational assistant vs answer/search engine. */
+  kind: "assistant" | "answer_engine";
+}
+
+interface ReferrerRule extends AiReferrerMatch {
+  /** Matched against the extracted hostname. */
+  host: RegExp;
+}
+
+// `(^|\.)x$` matches the bare apex and any subdomain of `x`, but never a host
+// that merely ends in `x` (e.g. `notchatgpt.com`). Ordered most-specific first.
+//
+// google.com and bing.com are intentionally absent: AI Overviews and Bing chat
+// answers share the hostname of ordinary search, so the referrer can't
+// distinguish an AI citation from a blue-link click. Those are measured via the
+// GSC impressions-vs-clicks divergence, not here.
+const REFERRER_RULES: ReferrerRule[] = [
+  { host: /(^|\.)chatgpt\.com$/, source: "chatgpt", label: "ChatGPT", vendor: "OpenAI", kind: "assistant" },
+  { host: /(^|\.)chat\.openai\.com$/, source: "chatgpt", label: "ChatGPT", vendor: "OpenAI", kind: "assistant" },
+  { host: /(^|\.)perplexity\.ai$/, source: "perplexity", label: "Perplexity", vendor: "Perplexity", kind: "answer_engine" },
+  { host: /(^|\.)gemini\.google\.com$/, source: "gemini", label: "Gemini", vendor: "Google", kind: "assistant" },
+  { host: /(^|\.)bard\.google\.com$/, source: "gemini", label: "Gemini (Bard)", vendor: "Google", kind: "assistant" },
+  { host: /(^|\.)claude\.ai$/, source: "claude", label: "Claude", vendor: "Anthropic", kind: "assistant" },
+  { host: /(^|\.)copilot\.microsoft\.com$/, source: "copilot", label: "Microsoft Copilot", vendor: "Microsoft", kind: "assistant" },
+  { host: /(^|\.)you\.com$/, source: "you", label: "You.com", vendor: "You.com", kind: "answer_engine" },
+  { host: /(^|\.)poe\.com$/, source: "poe", label: "Poe", vendor: "Quora", kind: "assistant" },
+  { host: /(^|\.)phind\.com$/, source: "phind", label: "Phind", vendor: "Phind", kind: "answer_engine" },
+  { host: /(^|\.)meta\.ai$/, source: "meta_ai", label: "Meta AI", vendor: "Meta", kind: "assistant" },
+  { host: /(^|\.)deepseek\.com$/, source: "deepseek", label: "DeepSeek", vendor: "DeepSeek", kind: "assistant" },
+  { host: /(^|\.)mistral\.ai$/, source: "mistral", label: "Le Chat (Mistral)", vendor: "Mistral", kind: "assistant" },
+  { host: /(^|\.)grok\.com$/, source: "grok", label: "Grok", vendor: "xAI", kind: "assistant" },
+  { host: /(^|\.)x\.ai$/, source: "grok", label: "Grok", vendor: "xAI", kind: "assistant" },
+];
+
+function extractHost(referrer: string): string | null {
+  const raw = referrer.trim();
+  if (!raw) return null;
+  try {
+    return new URL(raw).hostname.toLowerCase();
+  } catch {
+    // Bare host with no scheme, e.g. "chatgpt.com" or "chatgpt.com/foo?x=1".
+    const host = raw.replace(/^\/\//, "").split("/")[0]?.split("?")[0]?.toLowerCase();
+    return host && host.includes(".") ? host : null;
+  }
+}
+
+export function classifyAiReferrer(referrer: string | null | undefined): AiReferrerMatch | null {
+  if (!referrer) return null;
+  const host = extractHost(referrer);
+  if (!host) return null;
+  for (const rule of REFERRER_RULES) {
+    if (rule.host.test(host)) {
+      return { source: rule.source, label: rule.label, vendor: rule.vendor, kind: rule.kind };
+    }
+  }
+  return null;
+}
+
+export interface AiCrawlerMatch {
+  bot: string;
+  vendor: string;
+  /** Operator's declared use of the fetch, per each vendor's published docs. */
+  purpose: "training" | "search" | "user_fetch" | "unknown";
+}
+
+interface CrawlerRule extends AiCrawlerMatch {
+  /** Matched case-insensitively against the raw User-Agent. */
+  token: RegExp;
+}
+
+// Token order matters where one bot's name is a substring of another's; the
+// distinct OpenAI/Anthropic/Perplexity tokens below don't overlap, but keep
+// the most-specific token first if you add an overlapping one.
+const CRAWLER_RULES: CrawlerRule[] = [
+  { token: /GPTBot/i, bot: "GPTBot", vendor: "OpenAI", purpose: "training" },
+  { token: /OAI-SearchBot/i, bot: "OAI-SearchBot", vendor: "OpenAI", purpose: "search" },
+  { token: /ChatGPT-User/i, bot: "ChatGPT-User", vendor: "OpenAI", purpose: "user_fetch" },
+  { token: /ClaudeBot/i, bot: "ClaudeBot", vendor: "Anthropic", purpose: "training" },
+  { token: /Claude-SearchBot/i, bot: "Claude-SearchBot", vendor: "Anthropic", purpose: "search" },
+  { token: /Claude-User/i, bot: "Claude-User", vendor: "Anthropic", purpose: "user_fetch" },
+  { token: /anthropic-ai/i, bot: "anthropic-ai", vendor: "Anthropic", purpose: "training" },
+  { token: /PerplexityBot/i, bot: "PerplexityBot", vendor: "Perplexity", purpose: "search" },
+  { token: /Perplexity-User/i, bot: "Perplexity-User", vendor: "Perplexity", purpose: "user_fetch" },
+  { token: /Google-Extended/i, bot: "Google-Extended", vendor: "Google", purpose: "training" },
+  { token: /GoogleOther/i, bot: "GoogleOther", vendor: "Google", purpose: "unknown" },
+  { token: /Applebot-Extended/i, bot: "Applebot-Extended", vendor: "Apple", purpose: "training" },
+  { token: /Bytespider/i, bot: "Bytespider", vendor: "ByteDance", purpose: "training" },
+  { token: /Amazonbot/i, bot: "Amazonbot", vendor: "Amazon", purpose: "unknown" },
+  { token: /Meta-ExternalAgent/i, bot: "Meta-ExternalAgent", vendor: "Meta", purpose: "training" },
+  { token: /CCBot/i, bot: "CCBot", vendor: "Common Crawl", purpose: "training" },
+  { token: /cohere-(ai|training-data-crawler)/i, bot: "cohere-ai", vendor: "Cohere", purpose: "training" },
+  { token: /DuckAssistBot/i, bot: "DuckAssistBot", vendor: "DuckDuckGo", purpose: "search" },
+  { token: /YouBot/i, bot: "YouBot", vendor: "You.com", purpose: "search" },
+  { token: /Diffbot/i, bot: "Diffbot", vendor: "Diffbot", purpose: "training" },
+  { token: /Timpibot/i, bot: "Timpibot", vendor: "Timpi", purpose: "search" },
+  { token: /ImagesiftBot/i, bot: "ImagesiftBot", vendor: "ImageSift", purpose: "training" },
+];
+
+export function classifyAiCrawler(userAgent: string | null | undefined): AiCrawlerMatch | null {
+  if (!userAgent) return null;
+  for (const rule of CRAWLER_RULES) {
+    if (rule.token.test(userAgent)) {
+      return { bot: rule.bot, vendor: rule.vendor, purpose: rule.purpose };
+    }
+  }
+  return null;
+}

--- a/lib/geo/ai-referrer.ts
+++ b/lib/geo/ai-referrer.ts
@@ -125,3 +125,49 @@ export function classifyAiCrawler(userAgent: string | null | undefined): AiCrawl
   }
   return null;
 }
+
+export interface AiReferralEventProps {
+  source: string;
+  label: string;
+  vendor: string;
+  kind: AiReferrerMatch["kind"];
+  landing_path: string;
+}
+
+/**
+ * Build the analytics payload for an AI-sourced visit, or null when the
+ * referrer is not a known AI source. Keeps the "should we record this, and
+ * with what" decision in one tested place so the client tracker stays thin.
+ */
+export function aiReferralEventProps(
+  referrer: string | null | undefined,
+  landingPath: string,
+): AiReferralEventProps | null {
+  const match = classifyAiReferrer(referrer);
+  if (!match) return null;
+  return { ...match, landing_path: landingPath };
+}
+
+export interface AiReferrerSourceInfo {
+  source: string;
+  label: string;
+  vendor: string;
+  kind: AiReferrerMatch["kind"];
+}
+
+/** Distinct AI referrer sources we detect — powers the admin coverage view. */
+export function listAiReferrerSources(): AiReferrerSourceInfo[] {
+  const seen = new Set<string>();
+  const out: AiReferrerSourceInfo[] = [];
+  for (const rule of REFERRER_RULES) {
+    if (seen.has(rule.source)) continue;
+    seen.add(rule.source);
+    out.push({ source: rule.source, label: rule.label, vendor: rule.vendor, kind: rule.kind });
+  }
+  return out;
+}
+
+/** Every AI crawler token we detect — powers the admin coverage view. */
+export function listAiCrawlers(): AiCrawlerMatch[] {
+  return CRAWLER_RULES.map((rule) => ({ bot: rule.bot, vendor: rule.vendor, purpose: rule.purpose }));
+}

--- a/lib/posthog/events.ts
+++ b/lib/posthog/events.ts
@@ -6,6 +6,7 @@ export type EventName =
   | 'lead_submitted'
   | 'advisor_response'
   | 'lead_outcome'
+  | 'ai_referral'
 
 export interface EventProps {
   quiz_started: {
@@ -61,6 +62,14 @@ export interface EventProps {
     advisor_id: number
     outcome: 'converted' | 'lost' | 'no_response'
     lead_source: string | null
+  }
+  /** A visit that arrived from a generative-AI assistant / answer engine. */
+  ai_referral: {
+    source: string
+    label: string
+    vendor: string
+    kind: 'assistant' | 'answer_engine'
+    landing_path: string
   }
 }
 


### PR DESCRIPTION
## Why

The GEO pivot (see `docs/strategy/FIN_NOTEBOOK.md`) shipped the *supply* side — `llms.txt`, `Speakable`/`DefinedTerm`/FAQ schema, answer-first content — but there was **no way to measure whether AI engines actually cite us or refer traffic**. A grep for any AI-referrer / AI-Overview instrumentation (`gptbot`, `perplexity`, `chatgpt`, `ai_overview`, …) returned nothing. Measurement was the one genuinely-unbuilt GEO lever — this PR builds it end to end.

## What's here

**1. Detection library — `lib/geo/ai-referrer.ts`** (pure, dependency-free, runs in browser / edge / Node):
- `classifyAiReferrer(referrer)` — a human arriving from an AI assistant / answer engine (ChatGPT, Perplexity, Gemini, Claude, Copilot, You, Poe, Phind, Meta AI, DeepSeek, Le Chat, Grok) via `document.referrer`.
- `classifyAiCrawler(userAgent)` — an AI vendor bot (GPTBot, OAI-SearchBot, ChatGPT-User, ClaudeBot, PerplexityBot, Google-Extended, CCBot, Bytespider, …), tagged by `purpose` (training / search / user_fetch).
- `aiReferralEventProps` / `listAiReferrerSources` / `listAiCrawlers` helpers for the tracker + admin page.

**2. PostHog capture** — a typed `ai_referral` event (`lib/posthog/events.ts`) fired once per session from the existing pageview tracker (`components/PostHogProvider.tsx`). It rides the existing analytics-consent + PostHog-init gate, so it respects the cookie banner and does nothing for non-consenting visitors. Carries `source`, `vendor`, `kind`, `landing_path`.

**3. `/admin/geo` panel** — "GEO / AI Traffic", wrapped in `AdminShell` and registered in the sidebar. Renders live detection coverage straight from the classifier (single source of truth) plus a ready-to-paste HogQL insight for the 30-day breakdown.

`google.com` / `bing.com` are **deliberately excluded** — AI Overviews and Bing chat share the ordinary search hostname, so the referrer can't distinguish an AI citation from a blue-link click. Those need the Search Console impressions-vs-clicks divergence (on the roadmap), not referrer strings.

## Why PostHog and not a Supabase table

Measurement rides PostHog rather than a new table on purpose: the repo's pre-existing **"Supabase types drift"** check is already red on `main` (live schema vs `lib/database.types.ts`; this branch touches **zero** migrations / DB types), and a DB-backed panel can't be preview-verified while Vercel deploys are account-blocked. A table is deferred (see the page roadmap) to avoid compounding either.

## Verification

- `npm test -- __tests__/lib/geo/ai-referrer.test.ts` → **18/18 green**
- `npm run type-check` → **exit 0** (full strict project, `noUncheckedIndexedAccess`)
- `eslint` clean on all changed files (lint-staged `--max-warnings 0` enforced per-commit)

## Known-red CI (both pre-existing, not from this diff)

- **Vercel — "Account is blocked"**: account/billing block, affects all deploys; also why preview-smoke can't run. Needs founder action on Vercel.
- **Supabase types drift**: live-schema vs committed-types drift that predates this branch (baseline `M05_migration_drift = 437`). Not fixable from this PR.

## Roadmap (deliberately deferred)

- Server-side crawler capture in `proxy.ts` (Tier C — needs founder sign-off).
- Search Console ingestion for the AI-Overview impressions-vs-clicks gap.
- Optional Supabase table for in-app charts, once the types-drift check is green.

https://claude.ai/code/session_01Y5x18qjabp4JxhLr7cLx91