### PR TITLE
feat(bots): AI bot-fleet testing harness (Phase 0 foundation)

### DIFF
--- a/.github/workflows/bots.yml
+++ b/.github/workflows/bots.yml
@@ -1,0 +1,149 @@
+# 🤖 Bot fleet — runs the synthetic-user QA fleet on demand or nightly.
+#
+# Deliberately NOT triggered on push/pull_request: this is a standalone QA
+# sweep, not a merge gate, so it never blocks PRs. It runs when you click
+# "Run workflow" (workflow_dispatch) or on the nightly schedule.
+#
+# Results are delivered two ways, with zero terminal use:
+#   1. The full visual report (report.html) is uploaded as a downloadable
+#      artifact on the run.
+#   2. A single rolling issue, "🤖 Bot fleet — latest results", is created/
+#      updated with a plain-English summary of what the bots found.
+#
+# Target: set the repo variable BOTS_TARGET_URL (Settings → Secrets and
+# variables → Actions → Variables) to your preview/staging URL, or paste a
+# URL when you click "Run workflow". If neither is set, the run is a friendly
+# no-op that tells you what to do.
+name: Bot fleet
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_url:
+        description: "URL to test (defaults to the BOTS_TARGET_URL repo variable)"
+        required: false
+        type: string
+      concurrency:
+        description: "How many bots run at once"
+        required: false
+        default: "4"
+        type: string
+  schedule:
+    # 14:00 UTC ≈ midnight AEST — a nightly sweep.
+    - cron: "0 14 * * *"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  fleet:
+    name: Run bot fleet
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Resolve target
+        id: target
+        run: |
+          URL="${{ github.event.inputs.target_url }}"
+          if [ -z "$URL" ]; then URL="${{ vars.BOTS_TARGET_URL }}"; fi
+          if [ -z "$URL" ]; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No target URL. Set the BOTS_TARGET_URL repo variable, or paste a URL when running this workflow."
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "url=$URL" >> "$GITHUB_OUTPUT"
+            echo "::notice::Bot fleet target: $URL"
+          fi
+
+      - uses: actions/checkout@v6
+        if: steps.target.outputs.run == 'true'
+
+      - uses: actions/setup-node@v6
+        if: steps.target.outputs.run == 'true'
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        if: steps.target.outputs.run == 'true'
+        run: npm ci
+
+      - name: Install Chromium
+        if: steps.target.outputs.run == 'true'
+        run: npx playwright install --with-deps chromium
+
+      - name: Run the fleet
+        if: steps.target.outputs.run == 'true'
+        # The fleet never fails the job — it collects findings, it doesn't assert.
+        continue-on-error: true
+        env:
+          BOTS_BASE_URL: ${{ steps.target.outputs.url }}
+          BOTS_SKIP_WEBSERVER: "1"
+          BOTS_CONCURRENCY: ${{ github.event.inputs.concurrency || '4' }}
+          # AI bots are off by default here; turn on by setting a budget + key.
+          BOTS_AI_TOKEN_BUDGET: ${{ vars.BOTS_AI_TOKEN_BUDGET || '0' }}
+          BOTS_AI_COST_BUDGET_USD: ${{ vars.BOTS_AI_COST_BUDGET_USD || '20' }}
+          BOTS_ANTHROPIC_API_KEY: ${{ secrets.BOTS_ANTHROPIC_API_KEY }}
+        run: npm run bots
+
+      - name: Upload report
+        if: steps.target.outputs.run == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: bot-report
+          path: |
+            bots/.runs/*/report.html
+            bots/.runs/*/summary.md
+            bots/.runs/*/findings.json
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Update results issue
+        if: steps.target.outputs.run == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+            const path = require("path");
+            const title = "🤖 Bot fleet — latest results";
+
+            // Find the newest run dir and read its plain-English summary.
+            let body = "⚠️ The bot fleet run did not produce a summary this time.";
+            try {
+              const runsDir = "bots/.runs";
+              const dirs = fs.readdirSync(runsDir)
+                .map((d) => path.join(runsDir, d))
+                .filter((p) => fs.statSync(p).isDirectory())
+                .sort((a, b) => fs.statSync(b).mtimeMs - fs.statSync(a).mtimeMs);
+              if (dirs.length > 0) {
+                body = fs.readFileSync(path.join(dirs[0], "summary.md"), "utf8");
+              }
+            } catch (e) {
+              core.warning("Could not read summary.md: " + e.message);
+            }
+
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            body += `\n\n📎 **Full visual report:** download the **bot-report** artifact from [this run](${runUrl}).`;
+
+            const q = `repo:${context.repo.owner}/${context.repo.repo} in:title type:issue state:open "${title}"`;
+            const found = await github.rest.search.issuesAndPullRequests({ q });
+            const existing = found.data.items.find((i) => i.title === title);
+
+            if (existing) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body,
+              });
+              core.notice(`Updated results issue #${existing.number}`);
+            } else {
+              const created = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+              });
+              core.notice(`Created results issue #${created.data.number}`);
+            }

--- a/.github/workflows/bots.yml
+++ b/.github/workflows/bots.yml
@@ -47,6 +47,10 @@ jobs:
         run: |
           URL="${{ github.event.inputs.target_url }}"
           if [ -z "$URL" ]; then URL="${{ vars.BOTS_TARGET_URL }}"; fi
+          # Default target: the current Netlify preview, so the fleet works with
+          # zero setup. Override any time by setting the BOTS_TARGET_URL repo
+          # variable — switch it to the Vercel production URL at launch.
+          if [ -z "$URL" ]; then URL="https://lambent-sawine-17c3dd.netlify.app"; fi
           if [ -z "$URL" ]; then
             echo "run=false" >> "$GITHUB_OUTPUT"
             echo "::notice::No target URL. Set the BOTS_TARGET_URL repo variable, or paste a URL when running this workflow."

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ supabase/.temp/
 # Visual screenshot pipeline (e2e/visual)
 /e2e/visual/snapshots/
 /e2e/visual/.auth/
+
+# Bot fleet run artifacts (bots/)
+/bots/.runs/

--- a/__tests__/bots/actions.test.ts
+++ b/__tests__/bots/actions.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { parseAction, REPORTABLE_CATEGORIES } from "../../bots/ai/actions";
+
+describe("parseAction — valid actions", () => {
+  it("accepts click with a ref", () => {
+    const r = parseAction({ type: "click", ref: "e12", note: "the CTA" });
+    expect(r).toEqual({ ok: true, action: { type: "click", ref: "e12", note: "the CTA" } });
+  });
+  it("accepts type and truncates very long text", () => {
+    const r = parseAction({ type: "type", ref: "e1", text: "x".repeat(5000) });
+    expect(r.ok).toBe(true);
+    if (r.ok && r.action.type === "type") expect(r.action.text.length).toBe(2000);
+  });
+  it("accepts a same-site navigate path", () => {
+    const r = parseAction({ type: "navigate", path: "/compare" });
+    expect(r.ok).toBe(true);
+  });
+  it("accepts scroll up/down", () => {
+    expect(parseAction({ type: "scroll", direction: "down" }).ok).toBe(true);
+    expect(parseAction({ type: "scroll", direction: "up" }).ok).toBe(true);
+  });
+  it("accepts a report_issue in an allowed category", () => {
+    const r = parseAction({
+      type: "report_issue",
+      severity: "high",
+      category: "ux",
+      title: "Confusing CTA",
+      detail: "Two buttons say Continue",
+    });
+    expect(r.ok).toBe(true);
+  });
+  it("accepts finish and defaults outcome to success", () => {
+    const r = parseAction({ type: "finish" });
+    expect(r.ok).toBe(true);
+    if (r.ok && r.action.type === "finish") expect(r.action.outcome).toBe("success");
+  });
+});
+
+describe("parseAction — rejects bad input (safety boundary)", () => {
+  it("rejects non-objects", () => {
+    expect(parseAction("click").ok).toBe(false);
+    expect(parseAction(null).ok).toBe(false);
+    expect(parseAction(["click"]).ok).toBe(false);
+  });
+  it("rejects a missing type", () => {
+    expect(parseAction({ ref: "e1" }).ok).toBe(false);
+  });
+  it("rejects unknown action types", () => {
+    expect(parseAction({ type: "eval", code: "alert(1)" }).ok).toBe(false);
+  });
+  it("rejects click without a ref", () => {
+    expect(parseAction({ type: "click" }).ok).toBe(false);
+  });
+  it("rejects type without text", () => {
+    expect(parseAction({ type: "type", ref: "e1" }).ok).toBe(false);
+  });
+  it("rejects off-site or protocol-relative navigation", () => {
+    expect(parseAction({ type: "navigate", path: "https://evil.example" }).ok).toBe(false);
+    expect(parseAction({ type: "navigate", path: "//evil.example" }).ok).toBe(false);
+    expect(parseAction({ type: "navigate", path: "compare" }).ok).toBe(false);
+  });
+  it("rejects an out-of-set report_issue category", () => {
+    // mechanical categories are owned by the automated checks, not the AI
+    expect(
+      parseAction({ type: "report_issue", severity: "high", category: "http-error", title: "x" }).ok,
+    ).toBe(false);
+    expect(REPORTABLE_CATEGORIES).not.toContain("http-error");
+  });
+  it("rejects a bad severity", () => {
+    expect(
+      parseAction({ type: "report_issue", severity: "boom", category: "ux", title: "x" }).ok,
+    ).toBe(false);
+  });
+  it("rejects report_issue without a title", () => {
+    expect(parseAction({ type: "report_issue", severity: "low", category: "ux" }).ok).toBe(false);
+  });
+  it("rejects a bad finish outcome", () => {
+    expect(parseAction({ type: "finish", outcome: "exploded" }).ok).toBe(false);
+  });
+});

--- a/__tests__/bots/ai-driver.test.ts
+++ b/__tests__/bots/ai-driver.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import { runAiSession } from "../../bots/ai/driver";
+import type { LlmClient, PageDriver, PageObservation, LlmDecision } from "../../bots/ai/types";
+import { FindingStore } from "../../bots/findings/store";
+import { CostLedger } from "../../bots/ai/cost";
+
+class FakeDriver implements PageDriver {
+  calls: string[] = [];
+  obs: PageObservation;
+  failNavigate: boolean;
+  constructor(obs?: PageObservation, failNavigate = false) {
+    this.obs = obs ?? { url: "/x", title: "X", elements: [{ ref: "e1", role: "button", name: "Go" }] };
+    this.failNavigate = failNavigate;
+  }
+  async observe(): Promise<PageObservation> {
+    return this.obs;
+  }
+  async click(ref: string): Promise<void> {
+    this.calls.push("click:" + ref);
+  }
+  async fill(ref: string, text: string): Promise<void> {
+    this.calls.push("fill:" + ref + ":" + text);
+  }
+  async scroll(direction: "up" | "down"): Promise<void> {
+    this.calls.push("scroll:" + direction);
+  }
+  async navigate(path: string): Promise<void> {
+    if (this.failNavigate) throw new Error("nav boom");
+    this.calls.push("nav:" + path);
+  }
+}
+
+function fakeLlm(
+  queue: Array<{ rawAction: unknown; usage?: { inputTokens: number; outputTokens: number } }>,
+): LlmClient {
+  let i = 0;
+  return async (): Promise<LlmDecision> => {
+    const item = queue[Math.min(i, queue.length - 1)];
+    i++;
+    if (!item) throw new Error("no llm response queued");
+    return {
+      rawAction: item.rawAction,
+      usage: item.usage ?? { inputTokens: 10, outputTokens: 5 },
+      model: "claude-haiku-4-5",
+    };
+  };
+}
+
+const base = {
+  persona: "tester",
+  goal: "do the thing",
+  startPath: "/start",
+  maxSteps: 10,
+};
+
+describe("runAiSession", () => {
+  it("walks click → report_issue → finish and logs the reported issue", async () => {
+    const driver = new FakeDriver();
+    const store = new FindingStore();
+    const llm = fakeLlm([
+      { rawAction: { type: "click", ref: "e1" } },
+      {
+        rawAction: {
+          type: "report_issue",
+          severity: "high",
+          category: "ux",
+          title: "Confusing CTA",
+          detail: "Two buttons say Continue",
+        },
+      },
+      { rawAction: { type: "finish", outcome: "success" } },
+    ]);
+
+    const res = await runAiSession({ ...base, driver, llm, store, ledger: new CostLedger(0) });
+
+    expect(res.stopReason).toBe("finished");
+    expect(res.outcome).toBe("success");
+    expect(res.issuesReported).toBe(1);
+    expect(store.size).toBe(1);
+    expect(store.all()[0]?.category).toBe("ux");
+    expect(driver.calls).toContain("nav:/start");
+    expect(driver.calls).toContain("click:e1");
+  });
+
+  it("stops when the spend budget is exhausted", async () => {
+    const driver = new FakeDriver();
+    const store = new FindingStore();
+    // Tiny budget; one big call blows it.
+    const ledger = new CostLedger(0.0000001);
+    const llm = fakeLlm([
+      { rawAction: { type: "scroll", direction: "down" }, usage: { inputTokens: 1_000_000, outputTokens: 1000 } },
+    ]);
+
+    const res = await runAiSession({ ...base, driver, llm, store, ledger });
+    expect(res.stopReason).toBe("budget");
+  });
+
+  it("feeds invalid actions back and recovers", async () => {
+    const driver = new FakeDriver();
+    const store = new FindingStore();
+    const llm = fakeLlm([
+      { rawAction: { type: "eval", code: "hack()" } }, // invalid
+      { rawAction: { type: "finish", outcome: "success" } },
+    ]);
+    const res = await runAiSession({ ...base, driver, llm, store, ledger: new CostLedger(0) });
+    expect(res.stopReason).toBe("finished");
+    expect(store.size).toBe(0); // invalid action logged nothing
+  });
+
+  it("stops at the step limit", async () => {
+    const driver = new FakeDriver();
+    const store = new FindingStore();
+    const llm = fakeLlm([{ rawAction: { type: "scroll", direction: "down" } }]); // never finishes
+    const res = await runAiSession({ ...base, maxSteps: 3, driver, llm, store, ledger: new CostLedger(0) });
+    expect(res.stopReason).toBe("max_steps");
+    expect(res.steps).toBe(3);
+  });
+
+  it("records a flow-failure when the start page won't open", async () => {
+    const driver = new FakeDriver(undefined, true); // navigate throws
+    const store = new FindingStore();
+    const llm = fakeLlm([{ rawAction: { type: "finish", outcome: "success" } }]);
+    const res = await runAiSession({ ...base, driver, llm, store, ledger: new CostLedger(0) });
+    expect(res.stopReason).toBe("error");
+    expect(store.all()[0]?.category).toBe("flow-failure");
+  });
+});

--- a/__tests__/bots/anthropic-client.test.ts
+++ b/__tests__/bots/anthropic-client.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { coalesceTurns, extractJsonObject } from "../../bots/ai/anthropic-client";
+import type { ConversationTurn } from "../../bots/ai/types";
+
+describe("coalesceTurns", () => {
+  it("merges consecutive same-role turns", () => {
+    const turns: ConversationTurn[] = [
+      { role: "user", content: "a" },
+      { role: "user", content: "b" },
+      { role: "assistant", content: "c" },
+    ];
+    expect(coalesceTurns(turns)).toEqual([
+      { role: "user", content: "a\n\nb" },
+      { role: "assistant", content: "c" },
+    ]);
+  });
+
+  it("drops a leading assistant turn (API must start with user)", () => {
+    const turns: ConversationTurn[] = [
+      { role: "assistant", content: "x" },
+      { role: "user", content: "y" },
+    ];
+    expect(coalesceTurns(turns)).toEqual([{ role: "user", content: "y" }]);
+  });
+
+  it("preserves a valid alternating sequence", () => {
+    const turns: ConversationTurn[] = [
+      { role: "user", content: "a" },
+      { role: "assistant", content: "b" },
+      { role: "user", content: "c" },
+    ];
+    expect(coalesceTurns(turns)).toHaveLength(3);
+  });
+});
+
+describe("extractJsonObject", () => {
+  it("pulls a JSON object out of surrounding prose", () => {
+    expect(extractJsonObject('Sure! {"type":"click","ref":"e1"} done')).toBe(
+      '{"type":"click","ref":"e1"}',
+    );
+  });
+  it("returns null when there is no object", () => {
+    expect(extractJsonObject("no json here")).toBeNull();
+  });
+});

--- a/__tests__/bots/config.test.ts
+++ b/__tests__/bots/config.test.ts
@@ -41,6 +41,7 @@ describe("loadConfig", () => {
     expect(cfg.targetClass).toBe("sandbox");
     expect(cfg.runDir.startsWith("bots/.runs/")).toBe(true);
     expect(cfg.aiCostBudgetUsd).toBeGreaterThanOrEqual(0);
+    expect(cfg.ignoreHttpsErrors).toBe(false);
   });
   it("derives a deterministic runId from the clock", () => {
     const cfg = loadConfig({ baseUrl: "http://localhost:3000" }, new Date("2026-05-29T12:34:56Z"));

--- a/__tests__/bots/config.test.ts
+++ b/__tests__/bots/config.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import {
+  isProdHost,
+  resolveTargetClass,
+  loadConfig,
+  assertTargetAllowed,
+} from "../../bots/config";
+
+describe("isProdHost", () => {
+  it.each([
+    ["invest.com.au", true],
+    ["www.invest.com.au", true],
+    ["staging.invest.com.au", true],
+    ["invest.com.au:443", true],
+    ["my-preview.vercel.app", false],
+    ["localhost", false],
+    ["localhost:3000", false],
+  ])("%s -> %s", (host, expected) => {
+    expect(isProdHost(host)).toBe(expected);
+  });
+});
+
+describe("resolveTargetClass", () => {
+  it("treats localhost as sandbox", () => {
+    expect(resolveTargetClass("localhost:3000")).toBe("sandbox");
+    expect(resolveTargetClass("127.0.0.1:3000")).toBe("sandbox");
+  });
+  it("treats remote hosts as protected by default", () => {
+    expect(resolveTargetClass("my-preview.vercel.app")).toBe("protected");
+  });
+  it("honours an explicit override", () => {
+    expect(resolveTargetClass("localhost", "protected")).toBe("protected");
+    expect(resolveTargetClass("my-preview.vercel.app", "sandbox")).toBe("sandbox");
+  });
+});
+
+describe("loadConfig", () => {
+  it("defaults to a local sandbox target", () => {
+    const cfg = loadConfig({ baseUrl: "http://localhost:3000" });
+    expect(cfg.host).toBe("localhost:3000");
+    expect(cfg.targetClass).toBe("sandbox");
+    expect(cfg.runDir.startsWith("bots/.runs/")).toBe(true);
+    expect(cfg.aiCostBudgetUsd).toBeGreaterThanOrEqual(0);
+  });
+  it("derives a deterministic runId from the clock", () => {
+    const cfg = loadConfig({ baseUrl: "http://localhost:3000" }, new Date("2026-05-29T12:34:56Z"));
+    expect(cfg.runId).toContain("2026-05-29");
+  });
+  it("respects explicit overrides", () => {
+    const cfg = loadConfig({ baseUrl: "https://x", concurrency: 12, aiCostBudgetUsd: 50 });
+    expect(cfg.concurrency).toBe(12);
+    expect(cfg.aiCostBudgetUsd).toBe(50);
+  });
+});
+
+describe("assertTargetAllowed", () => {
+  it("throws for a prod host without override", () => {
+    const cfg = loadConfig({ baseUrl: "https://invest.com.au", prodOverride: false });
+    expect(() => assertTargetAllowed(cfg)).toThrow(/production host/i);
+  });
+  it("allows a prod host with the explicit override", () => {
+    const cfg = loadConfig({ baseUrl: "https://invest.com.au", prodOverride: true });
+    expect(() => assertTargetAllowed(cfg)).not.toThrow();
+  });
+  it("allows non-prod hosts", () => {
+    const cfg = loadConfig({ baseUrl: "http://localhost:3000" });
+    expect(() => assertTargetAllowed(cfg)).not.toThrow();
+  });
+});

--- a/__tests__/bots/cost.test.ts
+++ b/__tests__/bots/cost.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { pricingFor, estimateUsd, CostLedger, MODEL_PRICING } from "../../bots/ai/cost";
+
+describe("pricingFor", () => {
+  it("maps model families by substring", () => {
+    expect(pricingFor("claude-opus-4-8")).toBe(MODEL_PRICING.opus);
+    expect(pricingFor("claude-sonnet-4-6")).toBe(MODEL_PRICING.sonnet);
+    expect(pricingFor("claude-haiku-4-5-20251001")).toBe(MODEL_PRICING.haiku);
+  });
+  it("falls back to sonnet (conservative middle) for unknown models", () => {
+    expect(pricingFor("some-future-model")).toBe(MODEL_PRICING.sonnet);
+  });
+});
+
+describe("estimateUsd", () => {
+  it("computes opus 1M in / 1M out as $90", () => {
+    expect(estimateUsd("claude-opus-4-8", { inputTokens: 1_000_000, outputTokens: 1_000_000 })).toBeCloseTo(90);
+  });
+  it("scales linearly", () => {
+    expect(estimateUsd("claude-haiku-4-5", { inputTokens: 500_000, outputTokens: 0 })).toBeCloseTo(0.4);
+  });
+});
+
+describe("CostLedger", () => {
+  it("accumulates tokens, cost and call count", () => {
+    const ledger = new CostLedger(0);
+    ledger.record("claude-sonnet-4-6", { inputTokens: 1_000_000, outputTokens: 0 }); // $3
+    const { totalUsd } = ledger.record("claude-sonnet-4-6", { inputTokens: 0, outputTokens: 1_000_000 }); // +$15
+    expect(totalUsd).toBeCloseTo(18);
+    expect(ledger.totals.calls).toBe(2);
+    expect(ledger.totals.inputTokens).toBe(1_000_000);
+    expect(ledger.totals.outputTokens).toBe(1_000_000);
+  });
+
+  it("never reports exceeded with a 0 (disabled) budget", () => {
+    const ledger = new CostLedger(0);
+    ledger.record("claude-opus-4-8", { inputTokens: 10_000_000, outputTokens: 10_000_000 });
+    expect(ledger.exceededBudget()).toBe(false);
+    expect(ledger.remainingUsd()).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  it("trips the budget guard once spend reaches the cap", () => {
+    const ledger = new CostLedger(10); // $10 cap
+    ledger.record("claude-sonnet-4-6", { inputTokens: 1_000_000, outputTokens: 0 }); // $3
+    expect(ledger.exceededBudget()).toBe(false);
+    expect(ledger.remainingUsd()).toBeCloseTo(7);
+    ledger.record("claude-sonnet-4-6", { inputTokens: 0, outputTokens: 1_000_000 }); // +$15 -> $18
+    expect(ledger.exceededBudget()).toBe(true);
+    expect(ledger.remainingUsd()).toBe(0);
+  });
+});

--- a/__tests__/bots/findings.test.ts
+++ b/__tests__/bots/findings.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizeUrl,
+  findingSignature,
+  type FindingInput,
+} from "../../bots/findings/types";
+import { FindingStore } from "../../bots/findings/store";
+
+describe("normalizeUrl", () => {
+  it("strips origin, query and hash", () => {
+    expect(normalizeUrl("https://x.com/compare?tab=fees#top")).toBe("/compare");
+    expect(normalizeUrl("/compare?tab=fees")).toBe("/compare");
+  });
+  it("collapses id-like segments", () => {
+    expect(normalizeUrl("/brokers/123")).toBe("/brokers/:id");
+    expect(normalizeUrl("/u/550e8400-e29b-41d4-a716-446655440000")).toBe("/u/:id");
+    expect(normalizeUrl("/x/deadbeefdeadbeef01")).toBe("/x/:id");
+  });
+  it("keeps human slugs", () => {
+    expect(normalizeUrl("/brokers/example-chess")).toBe("/brokers/example-chess");
+  });
+});
+
+describe("findingSignature", () => {
+  const base: FindingInput = {
+    severity: "high",
+    category: "http-error",
+    title: "500",
+    detail: "boom",
+    url: "/api/x",
+  };
+  it("is stable for equal inputs", () => {
+    expect(findingSignature(base)).toBe(findingSignature({ ...base }));
+  });
+  it("changes with category, url, or key", () => {
+    expect(findingSignature(base)).not.toBe(
+      findingSignature({ ...base, category: "a11y" }),
+    );
+    expect(findingSignature(base)).not.toBe(
+      findingSignature({ ...base, url: "/api/y" }),
+    );
+    expect(findingSignature(base)).not.toBe(
+      findingSignature({ ...base, signatureKey: "different" }),
+    );
+  });
+  it("ignores title when signatureKey is provided", () => {
+    const a = findingSignature({ ...base, title: "A", signatureKey: "k" });
+    const b = findingSignature({ ...base, title: "B", signatureKey: "k" });
+    expect(a).toBe(b);
+  });
+});
+
+describe("FindingStore", () => {
+  const mk = (over: Partial<FindingInput> = {}): FindingInput => ({
+    severity: "medium",
+    category: "console-error",
+    title: "TypeError: x is undefined",
+    detail: "...",
+    url: "/p",
+    ...over,
+  });
+
+  it("dedupes identical findings and counts occurrences", () => {
+    const store = new FindingStore();
+    store.add(mk({ persona: "alice" }));
+    store.add(mk({ persona: "bob" }));
+    expect(store.size).toBe(1);
+    const [f] = store.all();
+    expect(f?.occurrences).toBe(2);
+    expect(f?.personas.sort()).toEqual(["alice", "bob"]);
+    expect(f?.sampleUrls).toEqual(["/p"]);
+  });
+
+  it("escalates severity to the most severe seen", () => {
+    const store = new FindingStore();
+    store.add(mk({ severity: "low" }));
+    store.add(mk({ severity: "critical" }));
+    expect(store.all()[0]?.severity).toBe("critical");
+  });
+
+  it("dedupes across id-like URLs but keeps distinct samples", () => {
+    const store = new FindingStore();
+    store.add(mk({ category: "broken-link", url: "/brokers/1" }));
+    store.add(mk({ category: "broken-link", url: "/brokers/2" }));
+    expect(store.size).toBe(1);
+    expect(store.all()[0]?.sampleUrls.sort()).toEqual(["/brokers/1", "/brokers/2"]);
+  });
+
+  it("sorts by severity then occurrences and summarizes", () => {
+    const store = new FindingStore();
+    store.add(mk({ severity: "low", title: "low-thing" }));
+    store.add(mk({ severity: "critical", title: "crit-thing" }));
+    store.add(mk({ severity: "critical", title: "crit-thing" }));
+    const all = store.all();
+    expect(all[0]?.severity).toBe("critical");
+    const sum = store.summary();
+    expect(sum.critical).toBe(2);
+    expect(sum.low).toBe(1);
+    expect(sum.total).toBe(3);
+    expect(sum.distinct).toBe(2);
+  });
+
+  it("merges aggregated findings from shards", () => {
+    const a = new FindingStore();
+    a.add(mk({ title: "shared" }));
+    const b = new FindingStore();
+    b.add(mk({ title: "shared" }));
+    b.add(mk({ title: "unique" }));
+    a.merge(b.all());
+    expect(a.size).toBe(2);
+    const shared = a.all().find((f) => f.title === "shared");
+    expect(shared?.occurrences).toBe(2);
+  });
+});

--- a/__tests__/bots/money-paths.test.ts
+++ b/__tests__/bots/money-paths.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import {
+  classify,
+  resolveAction,
+  decide,
+  type PolicyOptions,
+} from "../../bots/safety/money-paths";
+
+const SANDBOX: PolicyOptions = {
+  targetClass: "sandbox",
+  mockAi: true,
+  allowDestructive: false,
+};
+const PROTECTED: PolicyOptions = {
+  targetClass: "protected",
+  mockAi: true,
+  allowDestructive: false,
+};
+
+describe("classify — real route paths", () => {
+  it.each([
+    ["/go/etoro", "GET", "affiliate"],
+    ["/api/affiliate/click", "POST", "affiliate"],
+    ["/api/track-click", "GET", "affiliate"],
+    ["/api/stripe/create-checkout", "POST", "payment"],
+    ["/api/advertise/create-checkout", "POST", "payment"],
+    ["/api/pros/billing/subscribe", "POST", "payment"],
+    ["/api/advisor-auth/billing-portal", "POST", "payment"],
+    ["/api/v1/billing/checkout", "POST", "payment"],
+    ["/api/booking/slot-123/checkout", "POST", "payment"],
+    ["/api/listings/checkout", "POST", "payment"],
+    ["/api/org-auth/stripe-connect/onboard", "POST", "external-integration"],
+    ["/api/account/holdings/sharesight/connect", "POST", "external-integration"],
+    ["/api/webhooks/broker-signup", "POST", "external-integration"],
+    ["/api/account/delete", "POST", "account-destructive"],
+    ["/api/account/documents/abc", "DELETE", "account-destructive"],
+    ["/api/advisor-lead", "POST", "lead"],
+    ["/api/submit-lead", "POST", "lead"],
+    ["/api/quiz/submit", "POST", "lead"],
+    ["/api/listings/owner-flow/42/submit", "POST", "lead"],
+    ["/api/newsletter", "POST", "email"],
+    ["/api/rate-alerts", "POST", "email"],
+    ["/api/chatbot", "POST", "ai"],
+    ["/api/concierge", "POST", "ai"],
+    ["/api/community/threads", "POST", "content"],
+    ["/api/follows/advisor", "POST", "content"],
+    ["/api/advisors/some-slug/endorse", "POST", "content"],
+    ["/api/account/bookmarks", "POST", "account"],
+    ["/api/account/goals", "PATCH", "account"],
+    ["/api/some-future-write", "POST", "content"], // catch-all
+  ])("%s %s -> %s", (path, method, expected) => {
+    expect(classify(path, method)).toBe(expected);
+  });
+
+  it.each([
+    ["/api/brokers", "GET"],
+    ["/api/quiz/data", "GET"],
+    ["/api/account/profile", "GET"], // reading own account is a safe GET
+    ["/compare", "GET"],
+    ["/advisors", "GET"],
+  ])("treats read %s %s as non-side-effecting (null)", (path, method) => {
+    expect(classify(path, method)).toBeNull();
+  });
+});
+
+describe("resolveAction — policy + overrides", () => {
+  it("always mocks irreversible/external categories on every target", () => {
+    for (const cat of ["payment", "affiliate", "external-integration"] as const) {
+      expect(resolveAction(cat, SANDBOX)).toBe("mock");
+      expect(resolveAction(cat, PROTECTED)).toBe("mock");
+    }
+  });
+
+  it("allows internal writes on sandbox, mocks them on protected", () => {
+    for (const cat of ["lead", "email", "content", "account"] as const) {
+      expect(resolveAction(cat, SANDBOX)).toBe("allow");
+      expect(resolveAction(cat, PROTECTED)).toBe("mock");
+    }
+  });
+
+  it("mocks AI when mockAi, allows it (cost-capped) otherwise", () => {
+    expect(resolveAction("ai", { ...SANDBOX, mockAi: true })).toBe("mock");
+    expect(resolveAction("ai", { ...PROTECTED, mockAi: false })).toBe("allow");
+  });
+
+  it("gates destructive account ops behind allowDestructive + sandbox", () => {
+    expect(resolveAction("account-destructive", SANDBOX)).toBe("mock");
+    expect(
+      resolveAction("account-destructive", { ...SANDBOX, allowDestructive: true }),
+    ).toBe("allow");
+    // Never destructive on a protected target, even if the flag is on.
+    expect(
+      resolveAction("account-destructive", { ...PROTECTED, allowDestructive: true }),
+    ).toBe("mock");
+  });
+});
+
+describe("decide", () => {
+  it("returns null for reads", () => {
+    expect(decide("/api/brokers", "GET", SANDBOX)).toBeNull();
+  });
+  it("mocks payments on sandbox", () => {
+    expect(decide("/api/stripe/x", "POST", SANDBOX)).toEqual({
+      category: "payment",
+      action: "mock",
+    });
+  });
+  it("allows content on sandbox, mocks on protected", () => {
+    expect(decide("/api/community/threads", "POST", SANDBOX)).toEqual({
+      category: "content",
+      action: "allow",
+    });
+    expect(decide("/api/community/threads", "POST", PROTECTED)).toEqual({
+      category: "content",
+      action: "mock",
+    });
+  });
+});

--- a/__tests__/bots/prompt.test.ts
+++ b/__tests__/bots/prompt.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { buildSystemPrompt, formatObservation, firstUserTurn } from "../../bots/ai/prompt";
+import type { PageObservation } from "../../bots/ai/types";
+
+describe("buildSystemPrompt", () => {
+  const sys = buildSystemPrompt("first-home-buyer", "find a mortgage broker");
+  it("embeds the persona and goal", () => {
+    expect(sys).toContain("first-home-buyer");
+    expect(sys).toContain("find a mortgage broker");
+  });
+  it("documents the action protocol and one-action rule", () => {
+    expect(sys).toContain("report_issue");
+    expect(sys).toContain("finish");
+    expect(sys).toMatch(/one action/i);
+    expect(sys).toMatch(/JSON object/i);
+  });
+  it("instructs it to watch for missing compliance disclosures", () => {
+    expect(sys).toMatch(/disclosure|disclaimer/i);
+    expect(sys).toContain("compliance");
+  });
+  it("forbids real personal/payment data", () => {
+    expect(sys).toMatch(/fake|never enter real/i);
+  });
+});
+
+describe("formatObservation", () => {
+  const obs: PageObservation = {
+    url: "/compare",
+    title: "Compare",
+    elements: [
+      { ref: "e1", role: "link", name: "Home" },
+      { ref: "e2", role: "textbox", name: "Email", inputType: "email", value: "x@y.z" },
+    ],
+  };
+  it("lists each element with its ref, role and name", () => {
+    const out = formatObservation(obs);
+    expect(out).toContain("URL: /compare");
+    expect(out).toContain('[e1] link "Home"');
+    expect(out).toContain('[e2] textbox "Email" <email>');
+  });
+  it("notes when a page has no interactable elements", () => {
+    const out = formatObservation({ url: "/x", title: "X", elements: [] });
+    expect(out).toMatch(/none found/i);
+  });
+  it("firstUserTurn frames the starting page", () => {
+    expect(firstUserTurn(obs)).toMatch(/first step/i);
+    expect(firstUserTurn(obs)).toContain("/compare");
+  });
+});

--- a/__tests__/bots/report.test.ts
+++ b/__tests__/bots/report.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { renderHtmlReport, summarize, type RunMeta } from "../../bots/findings/report";
+import {
+  renderHtmlReport,
+  renderMarkdownSummary,
+  summarize,
+  verdict,
+  type RunMeta,
+} from "../../bots/findings/report";
 import type { Finding } from "../../bots/findings/types";
 
 const META: RunMeta = {
@@ -72,5 +78,49 @@ describe("renderHtmlReport", () => {
     expect(html).toContain("AI cost");
     expect(html).toContain("$0.1234");
     expect(html).toContain("3 calls");
+  });
+
+  it("shows a plain-English verdict and 'what this means' explainer", () => {
+    const html = renderHtmlReport([finding({ category: "a11y", severity: "high" })], META);
+    expect(html).toMatch(/important issue/i); // verdict for a high finding
+    expect(html).toContain("What this means");
+    expect(html).toContain("accessibility"); // a11y category help text
+  });
+});
+
+describe("verdict", () => {
+  it("is all-clear when empty", () => {
+    expect(verdict(summarize([])).text).toMatch(/all clear/i);
+  });
+  it("flags serious issues when criticals are present", () => {
+    const v = verdict(summarize([finding({ severity: "critical" })]));
+    expect(v.text).toMatch(/serious/i);
+    expect(v.emoji).toBe("🛑");
+  });
+  it("flags minor when only low/medium are present", () => {
+    expect(verdict(summarize([finding({ severity: "low" })])).text).toMatch(/minor/i);
+  });
+});
+
+describe("renderMarkdownSummary", () => {
+  it("leads with the verdict and a severity table", () => {
+    const md = renderMarkdownSummary(
+      [finding({ severity: "critical", title: "500 on /x" })],
+      META,
+    );
+    expect(md).toContain("# 🤖 Bot fleet — latest results");
+    expect(md).toMatch(/serious issue/i);
+    expect(md).toContain("| Severity | Count |");
+    expect(md).toContain("500 on /x");
+  });
+  it("says nothing-to-action on a clean run", () => {
+    expect(renderMarkdownSummary([], META)).toMatch(/no problems|nothing to action/i);
+  });
+  it("omits info-level findings from the action list", () => {
+    const md = renderMarkdownSummary(
+      [finding({ severity: "info", category: "safety", title: "safety-net-summary" })],
+      META,
+    );
+    expect(md).not.toContain("safety-net-summary");
   });
 });

--- a/__tests__/bots/report.test.ts
+++ b/__tests__/bots/report.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { renderHtmlReport, summarize, type RunMeta } from "../../bots/findings/report";
+import type { Finding } from "../../bots/findings/types";
+
+const META: RunMeta = {
+  runId: "2026-05-29T00-00-00-abc123",
+  baseUrl: "http://localhost:3000",
+  targetClass: "sandbox",
+  startedAt: "2026-05-29T00:00:00.000Z",
+  finishedAt: "2026-05-29T00:05:00.000Z",
+  sessions: 3,
+  personas: ["first-home-buyer", "retiree"],
+};
+
+function finding(over: Partial<Finding> = {}): Finding {
+  return {
+    id: "abc",
+    severity: "high",
+    category: "http-error",
+    title: "500 on /api/quiz/submit",
+    detail: "Server returned 500",
+    url: "/get-matched",
+    occurrences: 2,
+    firstSeenAt: "2026-05-29T00:01:00.000Z",
+    sampleUrls: ["/get-matched"],
+    personas: ["retiree"],
+    ...over,
+  };
+}
+
+describe("summarize", () => {
+  it("counts by occurrences and distinct", () => {
+    const sum = summarize([finding({ severity: "high", occurrences: 2 }), finding({ id: "z", severity: "low", occurrences: 5 })]);
+    expect(sum.high).toBe(2);
+    expect(sum.low).toBe(5);
+    expect(sum.total).toBe(7);
+    expect(sum.distinct).toBe(2);
+  });
+});
+
+describe("renderHtmlReport", () => {
+  it("renders a clean-run message when empty", () => {
+    const html = renderHtmlReport([], META);
+    expect(html).toContain("No findings");
+    expect(html).toContain(META.runId);
+    expect(html).toContain("localhost:3000");
+  });
+
+  it("renders findings with severity, category and occurrence count", () => {
+    const html = renderHtmlReport([finding()], META);
+    expect(html).toContain("500 on /api/quiz/submit");
+    expect(html).toContain("high");
+    expect(html).toContain("http-error");
+    expect(html).toContain("×2");
+  });
+
+  it("escapes HTML in dynamic content (no injection)", () => {
+    const html = renderHtmlReport(
+      [finding({ title: "<script>alert(1)</script>", detail: "a & b < c" })],
+      META,
+    );
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).toContain("&lt;script&gt;");
+    expect(html).toContain("a &amp; b &lt; c");
+  });
+
+  it("includes a cost line when meta.cost is present", () => {
+    const html = renderHtmlReport([], {
+      ...META,
+      cost: { inputTokens: 1000, outputTokens: 500, usd: 0.1234, calls: 3 },
+    });
+    expect(html).toContain("AI cost");
+    expect(html).toContain("$0.1234");
+    expect(html).toContain("3 calls");
+  });
+});

--- a/app/compare/_components/CompareFooter.tsx
+++ b/app/compare/_components/CompareFooter.tsx
@@ -66,7 +66,7 @@ export default function CompareFooter({ sorted, brokers, activeFilter }: Props) 
       {/* Pro upsell hidden for launch */}
 
       {/* Trust signals */}
-      <div className="mt-4 md:mt-8 text-[0.62rem] md:text-xs text-slate-400 text-center">
+      <div className="mt-4 md:mt-8 text-[0.62rem] md:text-xs text-slate-600 text-center">
         <p>
           Fees verified against official pricing.{" "}
           <Link href="/how-we-verify" className="underline hover:text-slate-600">Verification</Link>
@@ -78,18 +78,18 @@ export default function CompareFooter({ sorted, brokers, activeFilter }: Props) 
       </div>
 
       {/* General Advice Warning */}
-      <p className="mt-2 md:mt-3 text-[0.69rem] md:text-xs text-slate-400 text-center leading-relaxed max-w-3xl mx-auto">
+      <p className="mt-2 md:mt-3 text-[0.69rem] md:text-xs text-slate-600 text-center leading-relaxed max-w-3xl mx-auto">
         {GENERAL_ADVICE_WARNING}
       </p>
 
       {/* Contextual risk warnings based on active filter */}
-      <div className="mt-2 text-[0.65rem] md:text-[0.72rem] text-slate-400 text-center leading-relaxed max-w-3xl mx-auto space-y-1.5">
+      <div className="mt-2 text-[0.65rem] md:text-[0.72rem] text-slate-600 text-center leading-relaxed max-w-3xl mx-auto space-y-1.5">
         <p>{PDS_CONSIDERATION} {FSG_NOTE}</p>
         {(activeFilter === 'cfd' || activeFilter === 'cfd-forex' || activeFilter === 'all') && (
-          <p className="text-red-400/80">{CFD_WARNING_SHORT}</p>
+          <p className="text-red-600">{CFD_WARNING_SHORT}</p>
         )}
         {(activeFilter === 'crypto' || activeFilter === 'crypto-exchanges' || activeFilter === 'all') && (
-          <p className="text-amber-500/80">{CRYPTO_WARNING}</p>
+          <p className="text-amber-700">{CRYPTO_WARNING}</p>
         )}
         {(activeFilter === 'super' || activeFilter === 'super-funds' || activeFilter === 'all') && (
           <p>{SUPER_WARNING_SHORT}</p>

--- a/bots/README.md
+++ b/bots/README.md
@@ -123,6 +123,7 @@ $5/IP/day, $200/day global), so even allowed AI traffic can't run away.
 | `BOTS_MOCK_AI` | `true` | Mock the app's own AI endpoints to save tokens |
 | `BOTS_ALLOW_DESTRUCTIVE` | `false` | Permit destructive account writes on a sandbox |
 | `BOTS_PROD_OVERRIDE` | `false` | Required to point at a prod host |
+| `BOTS_IGNORE_HTTPS_ERRORS` | `false` | Trust a self-signed/MITM cert (TLS-intercepting sandboxes only; never for real runs) |
 | `BOTS_SKIP_WEBSERVER` | — | Don't auto-start a local dev server |
 | `BOTS_WEBSERVER_CMD` | `npm run dev` | Command to auto-start a local target (e.g. `npm run start` for the prod build) |
 

--- a/bots/README.md
+++ b/bots/README.md
@@ -23,7 +23,28 @@ npm run bots                  # drive a local dev server (auto-started)
 BOTS_BASE_URL=https://my-preview.vercel.app npm run bots
 ```
 
-The run writes a report to `bots/.runs/<runId>/report.html` (+ `findings.json`).
+The run writes `bots/.runs/<runId>/report.html` (visual report), `summary.md`
+(plain-English digest), and `findings.json`.
+
+## Hands-off mode (recommended — no terminal)
+
+You don't need to run anything yourself. A GitHub Actions workflow
+(`.github/workflows/bots.yml`) runs the fleet for you:
+
+- **One click:** repo → **Actions** tab → **Bot fleet** → **Run workflow**
+  (optionally paste a URL to test).
+- **Automatically:** every night on a schedule.
+
+One-time setup: set a repo **Variable** `BOTS_TARGET_URL` to your
+preview/staging URL (Settings → Secrets and variables → Actions → Variables).
+Then every run:
+
+- uploads the full visual report as a downloadable **bot-report** artifact, and
+- creates/updates a single issue, **"🤖 Bot fleet — latest results"**, with a
+  plain-English summary of what was found.
+
+To turn on the AI bots in CI, add a secret `BOTS_ANTHROPIC_API_KEY` (its own
+billing line) and set the `BOTS_AI_TOKEN_BUDGET` variable above 0.
 
 ## Why this is safe
 

--- a/bots/README.md
+++ b/bots/README.md
@@ -101,6 +101,7 @@ $5/IP/day, $200/day global), so even allowed AI traffic can't run away.
 | `BOTS_ALLOW_DESTRUCTIVE` | `false` | Permit destructive account writes on a sandbox |
 | `BOTS_PROD_OVERRIDE` | `false` | Required to point at a prod host |
 | `BOTS_SKIP_WEBSERVER` | — | Don't auto-start a local dev server |
+| `BOTS_WEBSERVER_CMD` | `npm run dev` | Command to auto-start a local target (e.g. `npm run start` for the prod build) |
 
 ## Layout
 

--- a/bots/README.md
+++ b/bots/README.md
@@ -116,9 +116,11 @@ $5/IP/day, $200/day global), so even allowed AI traffic can't run away.
 | `BOTS_TARGET_CLASS` | derived from host | Force `sandbox` / `protected` |
 | `BOTS_CONCURRENCY` | `4` | Parallel sessions (Playwright workers) |
 | `BOTS_MAX_STEPS` | `40` | Max actions per AI session |
-| `BOTS_AI_TOKEN_BUDGET` | `0` (AI off) | Hard token cap for the run |
-| `BOTS_AI_COST_BUDGET_USD` | `20` | Hard dollar cap for the run |
-| `BOTS_MOCK_AI` | `true` | Mock AI endpoints to save tokens |
+| `BOTS_AI_TOKEN_BUDGET` | `0` (AI off) | Hard token cap for the run; > 0 enables AI bots |
+| `BOTS_AI_COST_BUDGET_USD` | `20` | Hard dollar cap per AI session |
+| `BOTS_ANTHROPIC_API_KEY` | — | Anthropic key for AI bots (own billing line; falls back to `ANTHROPIC_API_KEY`) |
+| `BOTS_AI_MODEL` | `claude-sonnet-4-6` | Model the AI bots use |
+| `BOTS_MOCK_AI` | `true` | Mock the app's own AI endpoints to save tokens |
 | `BOTS_ALLOW_DESTRUCTIVE` | `false` | Permit destructive account writes on a sandbox |
 | `BOTS_PROD_OVERRIDE` | `false` | Required to point at a prod host |
 | `BOTS_SKIP_WEBSERVER` | — | Don't auto-start a local dev server |
@@ -149,17 +151,33 @@ Pure modules carry no Playwright import and are unit-tested under
 `__tests__/bots/` (run with the normal `npm test`). Browser-driving modules are
 exercised by `npm run bots`.
 
-## Roadmap
+## AI-driven bots
 
-- **Phase 1** — deterministic critical/money-path flows (get-matched → action
-  plan, advisor lead, compare → affiliate (mocked), signup/login, top
-  calculators), reusing the existing auth scaffold for logged-in personas.
-- **Phase 2** — AI driver: Claude observes a compact a11y-tree snapshot, picks
-  the next action, and judges UX + that required financial disclosures are
-  present. Budget-capped and prompt-cached.
-- **Phase 3** — full-surface coverage: auto-discover all routes and let
-  persona+goal-driven AI bots roam, so we cover ~220 routes without
-  hand-writing specs.
-- **Phase 4** — opt-in GitHub issue filing for high-severity findings (deduped),
-  then a non-gating nightly CI workflow.
+When enabled, AI personas (`AI_PERSONAS` in `personas.ts`) pursue a goal like a
+real user — they observe the page, decide the next action, and **judge** the
+experience (flagging confusing/broken UX and missing financial disclosures).
+The loop is in `ai/driver.ts`; the model is wrapped in `ai/anthropic-client.ts`.
+
+Enable it:
+
+```bash
+BOTS_AI_TOKEN_BUDGET=50000 BOTS_ANTHROPIC_API_KEY=sk-ant-... \
+  BOTS_BASE_URL=https://my-preview.vercel.app npm run bots
+```
+
+Spend is bounded by a per-session dollar ledger (`BOTS_AI_COST_BUDGET_USD`) and
+reported on every run. In CI, set the `BOTS_ANTHROPIC_API_KEY` secret and the
+`BOTS_AI_TOKEN_BUDGET` variable.
+
+## Status & roadmap
+
+- ✅ **Foundation** — safety net, cross-cutting checks, findings, report.
+- ✅ **Hands-off ops** — one-click/nightly workflow, plain-English report +
+  rolling results issue.
+- ✅ **AI driver** — observe→act→judge loop, action model, budget guard, live
+  Playwright + Anthropic implementations, AI personas wired into the fleet.
+- **Next** — deterministic critical/money-path flows (get-matched → action plan,
+  advisor lead, signup/login) and authenticated personas via the existing auth
+  scaffold; auto-discovered full-surface coverage; opt-in per-finding GitHub
+  issues.
 ```

--- a/bots/README.md
+++ b/bots/README.md
@@ -1,0 +1,143 @@
+# 🤖 Bot fleet — AI-driven synthetic user testing
+
+A fleet of simulated users that exercise invest-com-au's features the way real
+people would, pre-launch, so we get broad QA coverage without humans. It mixes
+**deterministic scripted journeys** (reliable, repeatable) with **AI-driven
+explorers** (Claude picks what to click and *judges* whether pages make sense),
+and runs everything behind a **safety net** that guarantees no real-world side
+effects.
+
+> Status: **Phase 0 (foundation)** — safety net, cross-cutting checks, finding
+> store, report aggregation, and a deterministic smoke fleet are in place. AI
+> driver, authenticated personas, deep critical-path flows, full-surface
+> coverage, GitHub-issue filing and a CI workflow land in later phases (see
+> [Roadmap](#roadmap)).
+
+## Quick start
+
+```bash
+npm run bots:install          # one-time: install the chromium browser
+npm run bots                  # drive a local dev server (auto-started)
+
+# point at a deployed sandbox/staging instead of local:
+BOTS_BASE_URL=https://my-preview.vercel.app npm run bots
+```
+
+The run writes a report to `bots/.runs/<runId>/report.html` (+ `findings.json`).
+
+## Why this is safe
+
+The whole design hinges on one rule: **a bot must never trip a real-world side
+effect** — no Stripe charges, no real emails, no fraudulent affiliate clicks, no
+polluted revenue data, no destroyed fixtures.
+
+Two layers enforce it:
+
+1. **Per-request firewall** (`safety/intercept.ts` + `safety/money-paths.ts`).
+   Every same-origin request is classified and, per policy, either allowed
+   through or answered with a synthetic response. The classifier is built from
+   the live `app/api/**` + `app/go/**` route tree.
+
+2. **Target class** (`config.ts`). The fleet is environment-agnostic; safety
+   posture is derived from *where* it points:
+
+   | Category | `sandbox` (local / seeded staging) | `protected` (anything else) |
+   |---|---|---|
+   | payment, affiliate, external-integration, destructive | **mock** | **mock** |
+   | lead, email, content, account | allow (exercise for real) | **mock** |
+   | ai (server-side cost-capped) | allow / mockable | allow / mockable |
+
+   Irreversible/external effects are **always mocked**, on every target. Internal
+   writes are allowed only on a disposable `sandbox` so deep flows can run
+   end-to-end against throwaway data. `localhost` is auto-classified `sandbox`;
+   everything else defaults to `protected`. `assertTargetAllowed` refuses a
+   production host outright unless `BOTS_PROD_OVERRIDE=1`.
+
+## What each bot checks
+
+Cross-cutting, on every page a bot lands on:
+
+- **console errors** + unhandled page exceptions (`checks/console.ts`)
+- **first-party HTTP errors** (4xx/5xx) and request failures (`checks/network.ts`)
+- **accessibility** — axe-core serious/critical WCAG violations, same config as
+  `e2e/a11y.spec.ts` (`checks/a11y.ts`)
+- **broken internal links** — a capped sample, fetched safely (side-effecting
+  links like `/go/*` are skipped) (`checks/links.ts`)
+- **dead ends** — 2xx pages that render almost nothing
+
+Findings are deduplicated by a stable signature so the same broken thing seen by
+50 bots collapses to one row with an occurrence count
+(`findings/types.ts`, `findings/store.ts`), then rendered into a single report
+(`findings/report.ts`).
+
+## Cost & billing
+
+The AI-driven bots (later phase) call the Anthropic **API**, which is billed to
+whatever account owns the key — **separate from the Claude Code subscription**
+used to build this. To keep bot spend attributable and bounded:
+
+- Point `BOTS_ANTHROPIC_API_KEY` at a **dedicated key/project** so the spend
+  lands on its own billing line. (Falls back to `ANTHROPIC_API_KEY` if unset.)
+- Every run enforces a hard **dollar budget** (`BOTS_AI_COST_BUDGET_USD`, default
+  $20) *and* a token budget (`BOTS_AI_TOKEN_BUDGET`) — whichever trips first
+  stops AI for the run (`ai/cost.ts`).
+- The run report shows **tokens + estimated USD** per run, so each run is
+  "charge $X to the bots line".
+
+The app's own AI endpoints are independently cost-capped server-side (V-NEW-06:
+$5/IP/day, $200/day global), so even allowed AI traffic can't run away.
+
+## Configuration
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `BOTS_BASE_URL` | `E2E_BASE_URL` → `http://localhost:3000` | Target to drive |
+| `BOTS_TARGET_CLASS` | derived from host | Force `sandbox` / `protected` |
+| `BOTS_CONCURRENCY` | `4` | Parallel sessions (Playwright workers) |
+| `BOTS_MAX_STEPS` | `40` | Max actions per AI session |
+| `BOTS_AI_TOKEN_BUDGET` | `0` (AI off) | Hard token cap for the run |
+| `BOTS_AI_COST_BUDGET_USD` | `20` | Hard dollar cap for the run |
+| `BOTS_MOCK_AI` | `true` | Mock AI endpoints to save tokens |
+| `BOTS_ALLOW_DESTRUCTIVE` | `false` | Permit destructive account writes on a sandbox |
+| `BOTS_PROD_OVERRIDE` | `false` | Required to point at a prod host |
+| `BOTS_SKIP_WEBSERVER` | — | Don't auto-start a local dev server |
+
+## Layout
+
+```
+bots/
+├── config.ts            # run config, target-class model, prod guard      [pure]
+├── safety/
+│   ├── money-paths.ts   # request classifier + policy                     [pure]
+│   └── intercept.ts     # installs the per-request firewall on a page
+├── checks/              # console / network / a11y / links collectors
+├── findings/
+│   ├── types.ts         # Finding model + dedupe signature                [pure]
+│   ├── store.ts         # collect / dedupe / aggregate                     [pure]
+│   └── report.ts        # HTML+JSON report + shard aggregation            [pure render]
+├── ai/cost.ts           # token→USD ledger + budget guard                 [pure]
+├── personas.ts          # persona registry
+├── session.ts           # BotSession: safety + checks + findings per user
+├── fleet.spec.ts        # entrypoint (one session per persona)
+├── playwright.config.ts # dedicated runner config
+└── global-teardown.ts   # aggregates shards → report
+```
+
+Pure modules carry no Playwright import and are unit-tested under
+`__tests__/bots/` (run with the normal `npm test`). Browser-driving modules are
+exercised by `npm run bots`.
+
+## Roadmap
+
+- **Phase 1** — deterministic critical/money-path flows (get-matched → action
+  plan, advisor lead, compare → affiliate (mocked), signup/login, top
+  calculators), reusing the existing auth scaffold for logged-in personas.
+- **Phase 2** — AI driver: Claude observes a compact a11y-tree snapshot, picks
+  the next action, and judges UX + that required financial disclosures are
+  present. Budget-capped and prompt-cached.
+- **Phase 3** — full-surface coverage: auto-discover all routes and let
+  persona+goal-driven AI bots roam, so we cover ~220 routes without
+  hand-writing specs.
+- **Phase 4** — opt-in GitHub issue filing for high-severity findings (deduped),
+  then a non-gating nightly CI workflow.
+```

--- a/bots/ai/actions.ts
+++ b/bots/ai/actions.ts
@@ -1,0 +1,146 @@
+/**
+ * The action model for AI-driven bots.
+ *
+ * An AI bot observes a page, then emits ONE action. This module defines the
+ * closed set of actions it may take and validates the model's output into a
+ * typed, safe action. Pure module (no Playwright / SDK) so it's fully unit
+ * tested — the driver (ai/driver.ts) executes whatever this approves.
+ *
+ * Safety: the action set is deliberately small. There is no "run arbitrary
+ * script" or "go to arbitrary URL" action — `navigate` takes a same-site path
+ * only, and the page-level safety net still intercepts any side-effecting
+ * request the actions trigger.
+ */
+
+import type { Severity, FindingCategory } from "../findings/types";
+
+export type BotAction =
+  | { type: "click"; ref: string; note?: string }
+  | { type: "type"; ref: string; text: string; note?: string }
+  | { type: "navigate"; path: string; note?: string }
+  | { type: "scroll"; direction: "up" | "down"; note?: string }
+  | {
+      type: "report_issue";
+      severity: Severity;
+      category: ReportableCategory;
+      title: string;
+      detail: string;
+    }
+  | { type: "finish"; outcome: "success" | "blocked" | "gave_up"; note?: string };
+
+export type BotActionType = BotAction["type"];
+
+/**
+ * Categories an AI bot is allowed to raise. The automated checks own the
+ * mechanical ones (console/network/a11y/http); the AI owns judgement calls.
+ */
+export const REPORTABLE_CATEGORIES = [
+  "ux",
+  "compliance",
+  "flow-failure",
+  "dead-end",
+] as const satisfies readonly FindingCategory[];
+
+export type ReportableCategory = (typeof REPORTABLE_CATEGORIES)[number];
+
+const SEVERITIES: readonly Severity[] = ["critical", "high", "medium", "low", "info"];
+const OUTCOMES = ["success", "blocked", "gave_up"] as const;
+const MAX_TEXT = 2000;
+
+export type ParsedAction =
+  | { ok: true; action: BotAction }
+  | { ok: false; error: string };
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function str(v: unknown): string | null {
+  return typeof v === "string" ? v : null;
+}
+
+/**
+ * Validate a raw model output (an object, e.g. a tool-use input) into a typed
+ * BotAction. Returns a structured error rather than throwing so the driver can
+ * feed the message back to the model and let it correct itself.
+ */
+export function parseAction(input: unknown): ParsedAction {
+  if (!isRecord(input)) return { ok: false, error: "action must be an object" };
+  const type = str(input.type);
+  if (!type) return { ok: false, error: "action.type is required" };
+
+  switch (type) {
+    case "click": {
+      const ref = str(input.ref);
+      if (!ref) return { ok: false, error: "click requires a string `ref`" };
+      return { ok: true, action: { type, ref, note: str(input.note) ?? undefined } };
+    }
+    case "type": {
+      const ref = str(input.ref);
+      const text = str(input.text);
+      if (!ref) return { ok: false, error: "type requires a string `ref`" };
+      if (text === null) return { ok: false, error: "type requires a string `text`" };
+      return {
+        ok: true,
+        action: { type, ref, text: text.slice(0, MAX_TEXT), note: str(input.note) ?? undefined },
+      };
+    }
+    case "navigate": {
+      const path = str(input.path);
+      if (!path) return { ok: false, error: "navigate requires a string `path`" };
+      if (!path.startsWith("/") || path.startsWith("//")) {
+        return { ok: false, error: "navigate `path` must be a same-site path starting with '/'" };
+      }
+      return { ok: true, action: { type, path, note: str(input.note) ?? undefined } };
+    }
+    case "scroll": {
+      const direction = str(input.direction);
+      if (direction !== "up" && direction !== "down") {
+        return { ok: false, error: "scroll `direction` must be 'up' or 'down'" };
+      }
+      return { ok: true, action: { type, direction, note: str(input.note) ?? undefined } };
+    }
+    case "report_issue": {
+      const severity = str(input.severity);
+      const category = str(input.category);
+      const title = str(input.title);
+      const detail = str(input.detail);
+      if (!severity || !SEVERITIES.includes(severity as Severity)) {
+        return { ok: false, error: `report_issue.severity must be one of ${SEVERITIES.join(", ")}` };
+      }
+      if (!category || !REPORTABLE_CATEGORIES.includes(category as ReportableCategory)) {
+        return {
+          ok: false,
+          error: `report_issue.category must be one of ${REPORTABLE_CATEGORIES.join(", ")}`,
+        };
+      }
+      if (!title) return { ok: false, error: "report_issue requires a `title`" };
+      return {
+        ok: true,
+        action: {
+          type,
+          severity: severity as Severity,
+          category: category as ReportableCategory,
+          title: title.slice(0, 200),
+          detail: (detail ?? "").slice(0, MAX_TEXT),
+        },
+      };
+    }
+    case "finish": {
+      const outcome = str(input.outcome) ?? "success";
+      if (!OUTCOMES.includes(outcome as (typeof OUTCOMES)[number])) {
+        return { ok: false, error: `finish.outcome must be one of ${OUTCOMES.join(", ")}` };
+      }
+      return {
+        ok: true,
+        action: {
+          type,
+          outcome: outcome as "success" | "blocked" | "gave_up",
+          note: str(input.note) ?? undefined,
+        },
+      };
+    }
+    default:
+      return { ok: false, error: `unknown action type: ${type}` };
+  }
+}

--- a/bots/ai/anthropic-client.ts
+++ b/bots/ai/anthropic-client.ts
@@ -1,0 +1,92 @@
+/**
+ * Real LlmClient — wraps the Anthropic SDK.
+ *
+ * - Reads BOTS_ANTHROPIC_API_KEY (falls back to ANTHROPIC_API_KEY) so bot spend
+ *   bills to its own line, separate from anything else.
+ * - Prompt-caches the (stable) system prompt to cut cost on every turn.
+ * - Coalesces consecutive same-role turns so the message list is always valid
+ *   for the API, keeping the driver loop simple.
+ * - Extracts the single JSON action from the model's reply; if it can't, it
+ *   returns a malformed action and the driver's validate-and-retry loop handles
+ *   it (the model is asked to correct itself).
+ */
+
+import Anthropic from "@anthropic-ai/sdk";
+import type { ConversationTurn, LlmClient, LlmDecision } from "./types";
+
+export const DEFAULT_MODEL = "claude-sonnet-4-6";
+
+export function resolveAiKey(): string | null {
+  return process.env.BOTS_ANTHROPIC_API_KEY || process.env.ANTHROPIC_API_KEY || null;
+}
+
+/** Merge consecutive same-role turns into single messages (API requires alternation). */
+export function coalesceTurns(
+  turns: ConversationTurn[],
+): Array<{ role: "user" | "assistant"; content: string }> {
+  const out: Array<{ role: "user" | "assistant"; content: string }> = [];
+  for (const turn of turns) {
+    const last = out[out.length - 1];
+    if (last && last.role === turn.role) {
+      last.content += `\n\n${turn.content}`;
+    } else {
+      out.push({ role: turn.role, content: turn.content });
+    }
+  }
+  // The API requires the first message to be from the user.
+  while (out.length > 0 && out[0]?.role !== "user") out.shift();
+  return out;
+}
+
+/** Pull the first JSON object out of free text. */
+export function extractJsonObject(text: string): string | null {
+  const match = text.match(/\{[\s\S]*\}/);
+  return match?.[0] ?? null;
+}
+
+export function makeAnthropicClient(opts: { model?: string } = {}): LlmClient {
+  const apiKey = resolveAiKey();
+  if (!apiKey) {
+    throw new Error(
+      "No Anthropic API key — set BOTS_ANTHROPIC_API_KEY to enable AI-driven bots.",
+    );
+  }
+  const client = new Anthropic({ apiKey });
+  const model = opts.model ?? process.env.BOTS_AI_MODEL ?? DEFAULT_MODEL;
+
+  return async ({ system, turns }): Promise<LlmDecision> => {
+    const resp = await client.messages.create({
+      model,
+      max_tokens: 1024,
+      system: [{ type: "text", text: system, cache_control: { type: "ephemeral" } }],
+      messages: coalesceTurns(turns),
+    });
+
+    const parts: string[] = [];
+    for (const block of resp.content) {
+      if (block.type === "text") parts.push(block.text);
+    }
+    const text = parts.join("\n");
+    const json = extractJsonObject(text);
+
+    let rawAction: unknown;
+    if (json) {
+      try {
+        rawAction = JSON.parse(json);
+      } catch {
+        rawAction = { type: "__unparseable__", raw: text.slice(0, 200) };
+      }
+    } else {
+      rawAction = { type: "__unparseable__", raw: text.slice(0, 200) };
+    }
+
+    return {
+      rawAction,
+      usage: {
+        inputTokens: resp.usage.input_tokens,
+        outputTokens: resp.usage.output_tokens,
+      },
+      model,
+    };
+  };
+}

--- a/bots/ai/cost.ts
+++ b/bots/ai/cost.ts
@@ -1,0 +1,106 @@
+/**
+ * AI cost accounting + budget enforcement for the bot fleet.
+ *
+ * Pure module. The AI-driven driver (a later phase) feeds token usage from
+ * every Anthropic response into a CostLedger. The ledger:
+ *   - converts tokens → USD using a model price table,
+ *   - accumulates per-run spend,
+ *   - enforces a hard dollar budget so a runaway loop can't burn money,
+ *   - exposes totals for the run report so each run is cost-attributable.
+ *
+ * This is the engineering half of "charge the bots separately": spend is
+ * bounded, measured, and reported per run. The *billing* half (which Anthropic
+ * account/key the spend lands on) is set by the BOTS_ANTHROPIC_API_KEY env the
+ * driver reads — point it at a dedicated key/project and the cost shows up on
+ * that line, isolated from this dev session's subscription usage.
+ */
+
+export interface ModelPricing {
+  /** USD per 1,000,000 input tokens. */
+  inputPerMTok: number;
+  /** USD per 1,000,000 output tokens. */
+  outputPerMTok: number;
+}
+
+/**
+ * Approximate list prices (USD / MTok). Adjust if Anthropic pricing changes —
+ * these drive the budget guard and the reported cost, so erring slightly high
+ * is the safe direction (we'd stop spending sooner, not later).
+ */
+export const MODEL_PRICING: Record<string, ModelPricing> = {
+  opus: { inputPerMTok: 15, outputPerMTok: 75 },
+  sonnet: { inputPerMTok: 3, outputPerMTok: 15 },
+  haiku: { inputPerMTok: 0.8, outputPerMTok: 4 },
+};
+
+/** Conservative default for unknown model ids — mid-tier (sonnet) pricing. */
+const DEFAULT_PRICING: ModelPricing = MODEL_PRICING.sonnet ?? {
+  inputPerMTok: 3,
+  outputPerMTok: 15,
+};
+
+export function pricingFor(model: string): ModelPricing {
+  const m = model.toLowerCase();
+  if (m.includes("opus")) return MODEL_PRICING.opus ?? DEFAULT_PRICING;
+  if (m.includes("sonnet")) return MODEL_PRICING.sonnet ?? DEFAULT_PRICING;
+  if (m.includes("haiku")) return MODEL_PRICING.haiku ?? DEFAULT_PRICING;
+  return DEFAULT_PRICING;
+}
+
+export interface TokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+}
+
+export interface CostTotals {
+  inputTokens: number;
+  outputTokens: number;
+  usd: number;
+  calls: number;
+}
+
+export function estimateUsd(model: string, usage: TokenUsage): number {
+  const p = pricingFor(model);
+  return (
+    (usage.inputTokens / 1_000_000) * p.inputPerMTok +
+    (usage.outputTokens / 1_000_000) * p.outputPerMTok
+  );
+}
+
+export class CostLedger {
+  private inputTokens = 0;
+  private outputTokens = 0;
+  private usd = 0;
+  private calls = 0;
+
+  /** @param budgetUsd hard cap; 0 means "no dollar cap" (token cap may still apply). */
+  constructor(private readonly budgetUsd: number) {}
+
+  /** Record one API call's usage. Returns marginal + cumulative USD. */
+  record(model: string, usage: TokenUsage): { marginalUsd: number; totalUsd: number } {
+    const marginalUsd = estimateUsd(model, usage);
+    this.inputTokens += usage.inputTokens;
+    this.outputTokens += usage.outputTokens;
+    this.usd += marginalUsd;
+    this.calls += 1;
+    return { marginalUsd, totalUsd: this.usd };
+  }
+
+  get totals(): CostTotals {
+    return {
+      inputTokens: this.inputTokens,
+      outputTokens: this.outputTokens,
+      usd: this.usd,
+      calls: this.calls,
+    };
+  }
+
+  exceededBudget(): boolean {
+    return this.budgetUsd > 0 && this.usd >= this.budgetUsd;
+  }
+
+  remainingUsd(): number {
+    if (this.budgetUsd <= 0) return Number.POSITIVE_INFINITY;
+    return Math.max(0, this.budgetUsd - this.usd);
+  }
+}

--- a/bots/ai/driver.ts
+++ b/bots/ai/driver.ts
@@ -1,0 +1,144 @@
+/**
+ * The AI bot loop: observe → decide → act → judge, until the goal is met, the
+ * step limit is hit, or the spend budget trips.
+ *
+ * Depends only on the PageDriver + LlmClient abstractions (ai/types.ts), so it
+ * is fully unit-testable with fakes. The page-level safety net (installed by
+ * the session) still intercepts any side-effecting request these actions
+ * trigger, so the AI cannot cause a real-world effect.
+ */
+
+import type { FindingStore } from "../findings/store";
+import type { CostLedger } from "./cost";
+import type { ConversationTurn, LlmClient, PageDriver } from "./types";
+import { buildSystemPrompt, formatObservation, firstUserTurn } from "./prompt";
+import { parseAction } from "./actions";
+
+export interface AiSessionOptions {
+  persona: string;
+  goal: string;
+  startPath: string;
+  driver: PageDriver;
+  llm: LlmClient;
+  store: FindingStore;
+  ledger: CostLedger;
+  maxSteps: number;
+  /** Keep at most this many recent turns in context (token control). */
+  maxTurns?: number;
+}
+
+export type StopReason = "finished" | "budget" | "max_steps" | "error";
+
+export interface AiSessionResult {
+  steps: number;
+  outcome: string;
+  stopReason: StopReason;
+  issuesReported: number;
+}
+
+function trimTurns(turns: ConversationTurn[], maxTurns: number): ConversationTurn[] {
+  if (turns.length <= maxTurns) return turns;
+  // Keep the first turn (the goal/starting context) plus the most recent ones.
+  const head = turns[0];
+  const tail = turns.slice(turns.length - (maxTurns - 1));
+  return head ? [head, ...tail] : tail;
+}
+
+export async function runAiSession(opts: AiSessionOptions): Promise<AiSessionResult> {
+  const { persona, goal, driver, llm, store, ledger, maxSteps } = opts;
+  const maxTurns = opts.maxTurns ?? 12;
+  const system = buildSystemPrompt(persona, goal);
+  const turns: ConversationTurn[] = [];
+  let issuesReported = 0;
+
+  try {
+    await driver.navigate(opts.startPath);
+  } catch (err) {
+    store.add({
+      severity: "high",
+      category: "flow-failure",
+      title: `could not open ${opts.startPath}`,
+      detail: `AI session start navigation failed: ${(err as Error).message}`,
+      url: opts.startPath,
+      persona,
+      signatureKey: `ai-start-fail:${opts.startPath}`,
+    });
+    return { steps: 0, outcome: "blocked", stopReason: "error", issuesReported };
+  }
+
+  let firstTurn = true;
+  for (let step = 0; step < maxSteps; step++) {
+    if (ledger.exceededBudget()) {
+      return { steps: step, outcome: "blocked", stopReason: "budget", issuesReported };
+    }
+
+    let observation;
+    try {
+      observation = await driver.observe();
+    } catch (err) {
+      store.add({
+        severity: "medium",
+        category: "flow-failure",
+        title: "could not read the page",
+        detail: `observe() failed: ${(err as Error).message}`,
+        url: opts.startPath,
+        persona,
+        signatureKey: "ai-observe-fail",
+      });
+      return { steps: step, outcome: "blocked", stopReason: "error", issuesReported };
+    }
+
+    turns.push({
+      role: "user",
+      content: firstTurn ? firstUserTurn(observation) : formatObservation(observation),
+    });
+    firstTurn = false;
+
+    const decision = await llm({ system, turns: trimTurns(turns, maxTurns) });
+    ledger.record(decision.model, decision.usage);
+    turns.push({ role: "assistant", content: JSON.stringify(decision.rawAction) });
+
+    const parsed = parseAction(decision.rawAction);
+    if (!parsed.ok) {
+      turns.push({
+        role: "user",
+        content: `That was not a valid action (${parsed.error}). Reply with exactly one valid action as a JSON object.`,
+      });
+      continue;
+    }
+    const action = parsed.action;
+
+    if (action.type === "finish") {
+      return { steps: step + 1, outcome: action.outcome, stopReason: "finished", issuesReported };
+    }
+
+    if (action.type === "report_issue") {
+      store.add({
+        severity: action.severity,
+        category: action.category,
+        title: action.title,
+        detail: action.detail,
+        url: observation.url,
+        persona,
+        signatureKey: `ai:${action.category}:${action.title}`,
+      });
+      issuesReported += 1;
+      turns.push({ role: "user", content: "Logged. Continue toward your goal." });
+      continue;
+    }
+
+    try {
+      if (action.type === "click") await driver.click(action.ref);
+      else if (action.type === "type") await driver.fill(action.ref, action.text);
+      else if (action.type === "scroll") await driver.scroll(action.direction);
+      else if (action.type === "navigate") await driver.navigate(action.path);
+    } catch (err) {
+      turns.push({
+        role: "user",
+        content: `That action failed: ${(err as Error).message}. Try a different element or approach.`,
+      });
+    }
+  }
+
+  return { steps: maxSteps, outcome: "incomplete", stopReason: "max_steps", issuesReported };
+}

--- a/bots/ai/driver.ts
+++ b/bots/ai/driver.ts
@@ -10,7 +10,7 @@
 
 import type { FindingStore } from "../findings/store";
 import type { CostLedger } from "./cost";
-import type { ConversationTurn, LlmClient, PageDriver } from "./types";
+import type { ConversationTurn, LlmClient, PageDriver, PageObservation } from "./types";
 import { buildSystemPrompt, formatObservation, firstUserTurn } from "./prompt";
 import { parseAction } from "./actions";
 
@@ -72,7 +72,7 @@ export async function runAiSession(opts: AiSessionOptions): Promise<AiSessionRes
       return { steps: step, outcome: "blocked", stopReason: "budget", issuesReported };
     }
 
-    let observation;
+    let observation: PageObservation;
     try {
       observation = await driver.observe();
     } catch (err) {

--- a/bots/ai/playwright-page-driver.ts
+++ b/bots/ai/playwright-page-driver.ts
@@ -1,0 +1,117 @@
+/**
+ * Real PageDriver — wraps a Playwright Page so AI bots can see and act on a
+ * live page. The page-level safety net (bots/safety/intercept.ts) is already
+ * installed on the page, so any side-effecting request these actions trigger is
+ * still intercepted.
+ *
+ * `observe()` stamps a `data-bot-ref` on each visible interactable and returns
+ * a compact list; click/fill then target those stamps. Refs are re-stamped on
+ * every observe, so they stay valid across navigations.
+ */
+
+import type { Page } from "@playwright/test";
+import type { PageDriver, PageObservation } from "./types";
+
+const MAX_ELEMENTS = 60;
+
+export class PlaywrightPageDriver implements PageDriver {
+  constructor(
+    private readonly page: Page,
+    private readonly baseUrl: string,
+  ) {}
+
+  async observe(): Promise<PageObservation> {
+    return this.page.evaluate((max) => {
+      const selector = [
+        "a[href]",
+        "button",
+        "[role=button]",
+        "[role=link]",
+        "input:not([type=hidden])",
+        "select",
+        "textarea",
+        "[role=checkbox]",
+        "[role=radio]",
+        "[role=tab]",
+        "[role=menuitem]",
+        "summary",
+        "[onclick]",
+      ].join(",");
+
+      const elements: Array<{
+        ref: string;
+        role: string;
+        name: string;
+        inputType?: string;
+        value?: string;
+      }> = [];
+      let n = 0;
+
+      for (const node of Array.from(document.querySelectorAll(selector))) {
+        const el = node as HTMLElement;
+        const rect = el.getBoundingClientRect();
+        const style = getComputedStyle(el);
+        if (rect.width === 0 || rect.height === 0) continue;
+        if (style.visibility === "hidden" || style.display === "none") continue;
+        if (el.hasAttribute("disabled") || el.getAttribute("aria-hidden") === "true") continue;
+
+        n += 1;
+        if (n > max) break;
+        const ref = `e${n}`;
+        el.setAttribute("data-bot-ref", ref);
+
+        const input = el as HTMLInputElement;
+        const role = el.getAttribute("role") || el.tagName.toLowerCase();
+        const name = (
+          el.getAttribute("aria-label") ||
+          el.textContent ||
+          input.placeholder ||
+          el.getAttribute("title") ||
+          input.value ||
+          ""
+        )
+          .trim()
+          .replace(/\s+/g, " ")
+          .slice(0, 80);
+        const inputType = input.type || undefined;
+        const value = typeof input.value === "string" && input.value ? input.value.slice(0, 60) : undefined;
+
+        elements.push({ ref, role, name, inputType, value });
+      }
+
+      return {
+        url: location.pathname + location.search,
+        title: document.title,
+        elements,
+      };
+    }, MAX_ELEMENTS);
+  }
+
+  async click(ref: string): Promise<void> {
+    await this.page.click(`[data-bot-ref="${ref}"]`, { timeout: 10_000 });
+    await this.settle();
+  }
+
+  async fill(ref: string, text: string): Promise<void> {
+    await this.page.fill(`[data-bot-ref="${ref}"]`, text, { timeout: 10_000 });
+  }
+
+  async scroll(direction: "up" | "down"): Promise<void> {
+    await this.page.evaluate((dir) => {
+      const delta = window.innerHeight * 0.8 * (dir === "down" ? 1 : -1);
+      window.scrollBy(0, delta);
+    }, direction);
+    await this.page.waitForTimeout(300);
+  }
+
+  async navigate(path: string): Promise<void> {
+    const target = this.baseUrl.replace(/\/$/, "") + path;
+    await this.page.goto(target, { waitUntil: "domcontentloaded", timeout: 30_000 });
+    await this.settle();
+  }
+
+  private async settle(): Promise<void> {
+    await this.page.waitForLoadState("load", { timeout: 15_000 }).catch(() => undefined);
+    await this.page.waitForTimeout(400);
+  }
+}

--- a/bots/ai/prompt.ts
+++ b/bots/ai/prompt.ts
@@ -1,0 +1,66 @@
+/**
+ * Prompt construction for AI-driven bots. Pure — unit-tested.
+ *
+ * The system prompt is stable per (persona, goal) so the Anthropic client can
+ * prompt-cache it; only the rolling page snapshots change between turns.
+ */
+
+import type { PageObservation } from "./types";
+
+export function buildSystemPrompt(persona: string, goal: string): string {
+  return [
+    `You are an automated QA bot simulating a real visitor of invest.com.au, an`,
+    `Australian investment-comparison website. Behave like a genuine user, not a`,
+    `crawler.`,
+    ``,
+    `Persona: ${persona}`,
+    `Your goal this session: ${goal}`,
+    ``,
+    `Each turn you are shown a compact snapshot of the current page's interactable`,
+    `elements, each tagged with a [ref]. Respond with EXACTLY ONE action as a single`,
+    `JSON object and nothing else.`,
+    ``,
+    `Allowed actions:`,
+    `  {"type":"click","ref":"e3","note":"why"}`,
+    `  {"type":"type","ref":"e4","text":"realistic fake value"}`,
+    `  {"type":"scroll","direction":"down"}`,
+    `  {"type":"navigate","path":"/same-site-path"}`,
+    `  {"type":"report_issue","severity":"critical|high|medium|low","category":"ux|compliance|flow-failure|dead-end","title":"short","detail":"what & why"}`,
+    `  {"type":"finish","outcome":"success|blocked|gave_up","note":"summary"}`,
+    ``,
+    `Rules:`,
+    `- Pursue the goal step by step, like a real user would. Only use [ref]s shown`,
+    `  in the LATEST snapshot.`,
+    `- Use realistic but clearly fake test data for any form (e.g. "Test Bot",`,
+    `  "bot@example.com"). Never enter real personal or payment details.`,
+    `- Raise report_issue whenever something is broken, confusing, a dead end, or —`,
+    `  importantly for a regulated financial site — when a required disclosure or`,
+    `  disclaimer appears to be MISSING where you'd expect one (category`,
+    `  "compliance").`,
+    `- You can report more than one issue across the session, one action at a time.`,
+    `- finish as soon as you've achieved the goal or are genuinely stuck. Be concise.`,
+  ].join("\n");
+}
+
+export function formatObservation(obs: PageObservation): string {
+  const lines: string[] = [
+    `URL: ${obs.url}`,
+    `TITLE: ${obs.title}`,
+    `Interactable elements (${obs.elements.length}):`,
+  ];
+  for (const el of obs.elements) {
+    const bits: string[] = [`[${el.ref}]`, el.role];
+    if (el.name) bits.push(`"${el.name}"`);
+    if (el.inputType) bits.push(`<${el.inputType}>`);
+    if (el.value) bits.push(`= "${el.value}"`);
+    lines.push("  " + bits.join(" "));
+  }
+  if (obs.elements.length === 0) {
+    lines.push("  (none found — the page may be empty, broken, or still loading)");
+  }
+  return lines.join("\n");
+}
+
+export function firstUserTurn(obs: PageObservation): string {
+  return `Here is the starting page. Take the first step toward your goal.\n\n${formatObservation(obs)}`;
+}

--- a/bots/ai/types.ts
+++ b/bots/ai/types.ts
@@ -1,0 +1,57 @@
+/**
+ * Abstractions the AI driver loop depends on.
+ *
+ * The loop (ai/driver.ts) talks ONLY to these interfaces, so it can be
+ * unit-tested with fakes — no Playwright, no Anthropic key. The real
+ * implementations live in ai/playwright-page-driver.ts and
+ * ai/anthropic-client.ts.
+ */
+
+import type { TokenUsage } from "./cost";
+
+/** A single interactable element the bot can act on. */
+export interface SnapshotElement {
+  /** Stable handle the model references, e.g. "e5". */
+  ref: string;
+  /** Accessible role: link | button | textbox | checkbox | combobox … */
+  role: string;
+  /** Accessible name / visible text. */
+  name: string;
+  /** For inputs: the input type (text, email, radio…). */
+  inputType?: string;
+  /** Current value, if meaningful. */
+  value?: string;
+}
+
+export interface PageObservation {
+  url: string;
+  title: string;
+  elements: SnapshotElement[];
+}
+
+/** The browser surface the loop needs. Real impl wraps a Playwright Page. */
+export interface PageDriver {
+  observe(): Promise<PageObservation>;
+  click(ref: string): Promise<void>;
+  fill(ref: string, text: string): Promise<void>;
+  scroll(direction: "up" | "down"): Promise<void>;
+  navigate(path: string): Promise<void>;
+}
+
+export interface ConversationTurn {
+  role: "user" | "assistant";
+  content: string;
+}
+
+export interface LlmDecision {
+  /** The model's chosen action, to be validated by parseAction. */
+  rawAction: unknown;
+  usage: TokenUsage;
+  model: string;
+}
+
+/** The model surface the loop needs. Real impl wraps the Anthropic SDK. */
+export type LlmClient = (args: {
+  system: string;
+  turns: ConversationTurn[];
+}) => Promise<LlmDecision>;

--- a/bots/checks/a11y.ts
+++ b/bots/checks/a11y.ts
@@ -1,0 +1,40 @@
+/**
+ * Accessibility check. Runs axe-core (same tags/disabled-rules as the existing
+ * e2e/a11y.spec.ts) and records serious/critical WCAG violations as findings.
+ * Mirrors the project's a11y gate so bots surface the same class of blocker
+ * across the full surface, not just the curated route list.
+ */
+
+import type { Page } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+import type { FindingStore } from "../findings/store";
+
+// `region` fires on Next.js route-transition placeholders users can't reach.
+const DISABLED_RULES = ["region"];
+
+export async function runAxe(page: Page, store: FindingStore, persona: string): Promise<void> {
+  const results = await new AxeBuilder({ page })
+    .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"])
+    .disableRules(DISABLED_RULES)
+    .analyze()
+    .catch(() => null);
+  if (!results) return; // axe injection can fail on blank/error shells — non-fatal.
+
+  for (const v of results.violations) {
+    if (v.impact !== "critical" && v.impact !== "serious") continue;
+    const nodes = v.nodes
+      .slice(0, 3)
+      .map((n) => n.target.join(" "))
+      .join("; ");
+    store.add({
+      severity: v.impact === "critical" ? "high" : "medium",
+      category: "a11y",
+      title: `${v.id}: ${v.help}`,
+      detail: `${v.helpUrl}\nNodes: ${nodes}`,
+      url: page.url(),
+      persona,
+      signatureKey: v.id,
+      evidence: { rule: v.id, impact: v.impact, nodeCount: v.nodes.length },
+    });
+  }
+}

--- a/bots/checks/console.ts
+++ b/bots/checks/console.ts
@@ -1,0 +1,61 @@
+/**
+ * Console + page-error collector. Attaches to a page and records uncaught
+ * console.error output and unhandled exceptions as findings.
+ */
+
+import type { Page } from "@playwright/test";
+import type { FindingStore } from "../findings/store";
+
+const BENIGN = [
+  /favicon/i,
+  /Download the React DevTools/i,
+  /ResizeObserver loop/i,
+  /\[Fast Refresh\]/i,
+  /Failed to load resource:.*(analytics|posthog|sentry|googletagmanager|gtag|hotjar|clarity)/i,
+];
+
+function isBenign(text: string): boolean {
+  return BENIGN.some((re) => re.test(text));
+}
+
+/** Collapse volatile bits (urls, numbers) so the same error dedupes cleanly. */
+function stabilize(text: string): string {
+  return text
+    .replace(/https?:\/\/[^\s)'"]+/g, "<url>")
+    .replace(/\b\d+\b/g, "<n>")
+    .slice(0, 160);
+}
+
+function firstLine(text: string): string {
+  return (text.split("\n")[0] ?? text).slice(0, 120);
+}
+
+export function attachConsole(page: Page, store: FindingStore, persona: string): void {
+  page.on("console", (msg) => {
+    if (msg.type() !== "error") return;
+    const text = msg.text();
+    if (!text || isBenign(text)) return;
+    store.add({
+      severity: "high",
+      category: "console-error",
+      title: firstLine(text),
+      detail: text.slice(0, 2000),
+      url: page.url(),
+      persona,
+      signatureKey: stabilize(text),
+    });
+  });
+
+  page.on("pageerror", (err) => {
+    const message = err.message || String(err);
+    store.add({
+      severity: "critical",
+      category: "page-error",
+      title: firstLine(message),
+      detail: (err.stack ?? message).slice(0, 2000),
+      url: page.url(),
+      persona,
+      signatureKey: `${err.name}:${stabilize(message)}`,
+    });
+  });
+}

--- a/bots/checks/links.ts
+++ b/bots/checks/links.ts
@@ -1,0 +1,98 @@
+/**
+ * Broken-link check. Extracts same-origin links from the current page and
+ * fetches a capped sample to catch 4xx/5xx targets.
+ *
+ * Safety: link fetches go through `page.request` (an API context that bypasses
+ * the page-route safety net), so we must NOT fetch side-effecting paths. Every
+ * candidate is run through `decide()` and skipped if it carries any side effect
+ * (e.g. a `/go/*` redirect would write an affiliate click row on GET).
+ */
+
+import type { Page } from "@playwright/test";
+import type { BotConfig } from "../config";
+import type { FindingStore } from "../findings/store";
+import { decide } from "../safety/money-paths";
+import { normalizeUrl } from "../findings/types";
+
+export async function extractInternalLinks(page: Page, origin: string): Promise<string[]> {
+  const hrefs = await page.$$eval("a[href]", (els) =>
+    els.map((el) => (el as HTMLAnchorElement).href),
+  );
+  const seen = new Set<string>();
+  for (const href of hrefs) {
+    try {
+      const u = new URL(href);
+      if (u.origin === origin) seen.add(u.pathname + u.search);
+    } catch {
+      // ignore malformed hrefs (mailto:, tel:, javascript:)
+    }
+  }
+  return [...seen];
+}
+
+export interface LinkCheckOptions {
+  /** Max new links to fetch on this page. */
+  limit?: number;
+  /** Shared set of already-checked pathnames (dedupes across a session). */
+  checked: Set<string>;
+}
+
+export async function checkInternalLinks(
+  page: Page,
+  config: BotConfig,
+  store: FindingStore,
+  persona: string,
+  opts: LinkCheckOptions,
+): Promise<void> {
+  let origin = "";
+  try {
+    origin = new URL(config.baseUrl).origin;
+  } catch {
+    return;
+  }
+  const policy = {
+    targetClass: config.targetClass,
+    mockAi: config.mockAi,
+    allowDestructive: config.allowDestructive,
+  };
+  const limit = opts.limit ?? 12;
+  const links = await extractInternalLinks(page, origin);
+  let checkedNow = 0;
+
+  for (const link of links) {
+    if (checkedNow >= limit) break;
+    const pathname = link.split("?")[0] ?? link;
+    if (opts.checked.has(pathname)) continue;
+    // Skip anything side-effecting — never trip a money path via a GET.
+    if (decide(pathname, "GET", policy) !== null) continue;
+    opts.checked.add(pathname);
+    checkedNow += 1;
+
+    try {
+      const res = await page.request.get(origin + link, { maxRedirects: 5, timeout: 15_000 });
+      const status = res.status();
+      if (status >= 400) {
+        store.add({
+          severity: status >= 500 ? "critical" : "high",
+          category: "broken-link",
+          title: `${status} link → ${pathname}`,
+          detail: `Internal link ${link} (found on ${page.url()}) returned HTTP ${status}.`,
+          url: page.url(),
+          persona,
+          signatureKey: `${status}:${normalizeUrl(pathname)}`,
+          evidence: { status, link },
+        });
+      }
+    } catch (err) {
+      store.add({
+        severity: "medium",
+        category: "broken-link",
+        title: `unreachable link → ${pathname}`,
+        detail: `Internal link ${link} could not be fetched: ${(err as Error).message}`,
+        url: page.url(),
+        persona,
+        signatureKey: `unreachable:${normalizeUrl(pathname)}`,
+      });
+    }
+  }
+}

--- a/bots/checks/network.ts
+++ b/bots/checks/network.ts
@@ -1,0 +1,73 @@
+/**
+ * Network collector. Records first-party HTTP errors (>= 400) and outright
+ * request failures. Third-party hosts are ignored — we only care about our own
+ * endpoints. Aborted requests (cancelled navigations, intercepted routes) are
+ * not treated as failures.
+ */
+
+import type { Page } from "@playwright/test";
+import type { BotConfig } from "../config";
+import type { FindingStore } from "../findings/store";
+import { normalizeUrl } from "../findings/types";
+
+export function attachNetwork(
+  page: Page,
+  config: BotConfig,
+  store: FindingStore,
+  persona: string,
+): void {
+  let origin = "";
+  try {
+    origin = new URL(config.baseUrl).origin;
+  } catch {
+    origin = "";
+  }
+
+  page.on("response", (res) => {
+    let url: URL;
+    try {
+      url = new URL(res.url());
+    } catch {
+      return;
+    }
+    if (url.origin !== origin) return;
+    const status = res.status();
+    if (status < 400) return;
+    const req = res.request();
+    const resourceType = req.resourceType();
+    const severity =
+      status >= 500 ? "critical" : resourceType === "document" ? "high" : "medium";
+    store.add({
+      severity,
+      category: "http-error",
+      title: `${status} ${req.method()} ${url.pathname}`,
+      detail: `${req.method()} ${url.pathname} returned HTTP ${status} (${resourceType}).`,
+      url: page.url(),
+      persona,
+      signatureKey: `${status}:${req.method()}:${normalizeUrl(url.pathname)}`,
+      evidence: { status, method: req.method(), resourceType, path: url.pathname },
+    });
+  });
+
+  page.on("requestfailed", (req) => {
+    let url: URL;
+    try {
+      url = new URL(req.url());
+    } catch {
+      return;
+    }
+    if (url.origin !== origin) return;
+    const errorText = req.failure()?.errorText ?? "";
+    if (/aborted/i.test(errorText)) return;
+    store.add({
+      severity: "high",
+      category: "network-error",
+      title: `request failed: ${req.method()} ${url.pathname}`,
+      detail: `${req.method()} ${url.pathname} failed: ${errorText}`,
+      url: page.url(),
+      persona,
+      signatureKey: `netfail:${req.method()}:${normalizeUrl(url.pathname)}`,
+      evidence: { errorText, resourceType: req.resourceType() },
+    });
+  });
+}

--- a/bots/config.ts
+++ b/bots/config.ts
@@ -52,6 +52,11 @@ export interface BotConfig {
   allowDestructive: boolean;
   /** Loud, explicit override required to point at a prod-looking host. */
   prodOverride: boolean;
+  /**
+   * Trust an intercepting-proxy / self-signed cert. Sandbox-only escape hatch
+   * for TLS-MITM environments (e.g. this workspace); leave off for real runs.
+   */
+  ignoreHttpsErrors: boolean;
   /** Absolute-ish directory (relative to repo root) for this run's artifacts. */
   runDir: string;
   /** Unique id for this fleet run. */
@@ -136,6 +141,8 @@ export function loadConfig(overrides: Partial<BotConfig> = {}, now: Date = new D
     allowDestructive:
       overrides.allowDestructive ?? boolEnv("BOTS_ALLOW_DESTRUCTIVE", false),
     prodOverride: overrides.prodOverride ?? boolEnv("BOTS_PROD_OVERRIDE", false),
+    ignoreHttpsErrors:
+      overrides.ignoreHttpsErrors ?? boolEnv("BOTS_IGNORE_HTTPS_ERRORS", false),
     runDir: overrides.runDir ?? process.env.BOTS_RUN_DIR ?? `bots/.runs/${runId}`,
     runId,
   };

--- a/bots/config.ts
+++ b/bots/config.ts
@@ -1,0 +1,158 @@
+/**
+ * Central configuration for the bot fleet.
+ *
+ * Pure module — NO Playwright / browser imports — so it can be unit-tested
+ * under vitest and reused from any context (CLI, spec, aggregator).
+ *
+ * The fleet is environment-agnostic: it drives whatever `BOTS_BASE_URL`
+ * points at. Safety posture is derived from the *target class*:
+ *   - `sandbox`   — disposable target (local dev or a staging deploy seeded
+ *                   with throwaway data). Internal writes (forum posts,
+ *                   bookmarks, leads) are allowed so deep flows can be
+ *                   exercised end-to-end.
+ *   - `protected` — anything we must treat conservatively. Only reads and
+ *                   AI (which is server-side cost-capped) are allowed; every
+ *                   state-mutating write is intercepted and answered with a
+ *                   synthetic response so nothing real happens.
+ *
+ * Irreversible / external side-effects (payments, affiliate redirects,
+ * destructive account ops, third-party integrations) are ALWAYS mocked,
+ * regardless of target class — see `safety/money-paths.ts`.
+ */
+
+export type TargetClass = "sandbox" | "protected";
+
+export interface BotConfig {
+  /** Base URL the fleet drives, e.g. http://localhost:3000 */
+  baseUrl: string;
+  /** Lower-cased host parsed from baseUrl. */
+  host: string;
+  /** Derived safety posture. */
+  targetClass: TargetClass;
+  /** Number of concurrent bot sessions (maps to Playwright workers). */
+  concurrency: number;
+  /** Max actions an AI-driven session may take before it is force-stopped. */
+  maxStepsPerSession: number;
+  /**
+   * Hard cap on total Anthropic tokens (input + output) for the whole run.
+   * 0 disables AI-driven bots entirely (deterministic flows still run).
+   */
+  aiTokenBudget: number;
+  /**
+   * Hard cap on estimated AI spend (USD) for the whole run. Enforced
+   * independently of the token cap — whichever trips first stops AI. This is
+   * the "charge no more than $X to the bots line" guardrail. 0 = no $ cap
+   * (token cap still applies). Defaults to a conservative $20 so a misconfig
+   * can never run away.
+   */
+  aiCostBudgetUsd: number;
+  /** Mock AI endpoints (chatbot, concierge…) to save tokens. */
+  mockAi: boolean;
+  /** Permit destructive account writes (delete, doc removal) on a sandbox. */
+  allowDestructive: boolean;
+  /** Loud, explicit override required to point at a prod-looking host. */
+  prodOverride: boolean;
+  /** Absolute-ish directory (relative to repo root) for this run's artifacts. */
+  runDir: string;
+  /** Unique id for this fleet run. */
+  runId: string;
+}
+
+const LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "0.0.0.0", "::1"]);
+
+/** The production apex + any subdomain of it. Vercel previews (*.vercel.app) are NOT prod. */
+export function isProdHost(host: string): boolean {
+  const h = host.toLowerCase().replace(/:\d+$/, "");
+  return h === "invest.com.au" || h.endsWith(".invest.com.au");
+}
+
+export function resolveTargetClass(
+  host: string,
+  explicit?: string | null,
+): TargetClass {
+  if (explicit === "sandbox" || explicit === "protected") return explicit;
+  const h = host.toLowerCase().replace(/:\d+$/, "");
+  return LOCAL_HOSTS.has(h) ? "sandbox" : "protected";
+}
+
+function intEnv(key: string, fallback: number, min: number, max: number): number {
+  const raw = process.env[key];
+  if (!raw) return fallback;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(max, Math.max(min, n));
+}
+
+function boolEnv(key: string, fallback: boolean): boolean {
+  const raw = process.env[key];
+  if (raw === undefined || raw === "") return fallback;
+  return raw === "1" || raw.toLowerCase() === "true" || raw.toLowerCase() === "yes";
+}
+
+function hostOf(url: string): string {
+  try {
+    return new URL(url).host.toLowerCase();
+  } catch {
+    return "";
+  }
+}
+
+function makeRunId(now: Date): string {
+  const stamp = now.toISOString().replace(/[:.]/g, "-").slice(0, 19);
+  const rand = Math.random().toString(36).slice(2, 8);
+  return `${stamp}-${rand}`;
+}
+
+/**
+ * Build a BotConfig from the environment. Pure aside from reading
+ * `process.env` and the clock — both injectable via `overrides` for tests.
+ */
+export function loadConfig(overrides: Partial<BotConfig> = {}, now: Date = new Date()): BotConfig {
+  const baseUrl =
+    overrides.baseUrl ??
+    process.env.BOTS_BASE_URL ??
+    process.env.E2E_BASE_URL ??
+    "http://localhost:3000";
+  const host = overrides.host ?? hostOf(baseUrl);
+  const targetClass =
+    overrides.targetClass ?? resolveTargetClass(host, process.env.BOTS_TARGET_CLASS);
+  // BOTS_RUN_ID / BOTS_RUN_DIR let the Playwright config pin one run id that
+  // both the parallel workers and the (separate-process) globalTeardown share,
+  // so every shard lands in the same run directory and is aggregated together.
+  const runId = overrides.runId ?? process.env.BOTS_RUN_ID ?? makeRunId(now);
+
+  return {
+    baseUrl,
+    host,
+    targetClass,
+    concurrency: overrides.concurrency ?? intEnv("BOTS_CONCURRENCY", 4, 1, 64),
+    maxStepsPerSession:
+      overrides.maxStepsPerSession ?? intEnv("BOTS_MAX_STEPS", 40, 1, 500),
+    aiTokenBudget:
+      overrides.aiTokenBudget ?? intEnv("BOTS_AI_TOKEN_BUDGET", 0, 0, 100_000_000),
+    aiCostBudgetUsd:
+      overrides.aiCostBudgetUsd ?? intEnv("BOTS_AI_COST_BUDGET_USD", 20, 0, 100_000),
+    mockAi: overrides.mockAi ?? boolEnv("BOTS_MOCK_AI", true),
+    allowDestructive:
+      overrides.allowDestructive ?? boolEnv("BOTS_ALLOW_DESTRUCTIVE", false),
+    prodOverride: overrides.prodOverride ?? boolEnv("BOTS_PROD_OVERRIDE", false),
+    runDir: overrides.runDir ?? process.env.BOTS_RUN_DIR ?? `bots/.runs/${runId}`,
+    runId,
+  };
+}
+
+/**
+ * Refuse to drive a production host unless explicitly overridden. This is the
+ * last line of defence on top of per-request interception — a bot fleet must
+ * never be pointed at the live site by accident.
+ */
+export function assertTargetAllowed(config: BotConfig): void {
+  if (isProdHost(config.host) && !config.prodOverride) {
+    throw new Error(
+      `[bots] Refusing to run against a production host: "${config.host}". ` +
+        `The bot fleet is for local/staging targets. If you REALLY mean to ` +
+        `point at prod, set BOTS_PROD_OVERRIDE=1 — but note every write is ` +
+        `still intercepted, so this is rarely what you want.`,
+    );
+  }
+}

--- a/bots/findings/report.ts
+++ b/bots/findings/report.ts
@@ -37,6 +37,11 @@ export interface RunMeta {
 export interface Shard {
   persona: string;
   findings: Finding[];
+  cost?: CostTotals;
+}
+
+function emptyCost(): CostTotals {
+  return { inputTokens: 0, outputTokens: 0, usd: 0, calls: 0 };
 }
 
 const SEVERITIES: Severity[] = ["critical", "high", "medium", "low", "info"];
@@ -368,16 +373,17 @@ export async function writeReport(
 /** Read all `${runDir}/shards/*.json` and merge into one finding set. */
 export async function aggregateShards(
   runDir: string,
-): Promise<{ findings: Finding[]; sessions: number; personas: string[] }> {
+): Promise<{ findings: Finding[]; sessions: number; personas: string[]; cost: CostTotals }> {
   const shardsDir = path.join(runDir, "shards");
   let entries: string[] = [];
   try {
     entries = (await fs.readdir(shardsDir)).filter((f) => f.endsWith(".json"));
   } catch {
-    return { findings: [], sessions: 0, personas: [] };
+    return { findings: [], sessions: 0, personas: [], cost: emptyCost() };
   }
   const store = new FindingStore();
   const personas = new Set<string>();
+  const cost = emptyCost();
   let sessions = 0;
   for (const entry of entries) {
     try {
@@ -385,10 +391,16 @@ export async function aggregateShards(
       const shard = JSON.parse(raw) as Shard;
       store.merge(shard.findings ?? []);
       if (shard.persona) personas.add(shard.persona);
+      if (shard.cost) {
+        cost.inputTokens += shard.cost.inputTokens;
+        cost.outputTokens += shard.cost.outputTokens;
+        cost.usd += shard.cost.usd;
+        cost.calls += shard.cost.calls;
+      }
       sessions += 1;
     } catch {
       // Skip unreadable/partial shards rather than failing the whole report.
     }
   }
-  return { findings: store.all(), sessions, personas: [...personas] };
+  return { findings: store.all(), sessions, personas: [...personas], cost };
 }

--- a/bots/findings/report.ts
+++ b/bots/findings/report.ts
@@ -1,0 +1,210 @@
+/**
+ * Report rendering + shard aggregation.
+ *
+ * `renderHtmlReport` is pure (string in, string out) and unit-tested. The
+ * filesystem helpers (`writeReport`, `aggregateShards`) wrap it for the runner
+ * and the Playwright globalTeardown that fans many parallel bot shards into one
+ * report.
+ */
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { type Finding, type Severity, SEVERITY_ORDER } from "./types";
+import { FindingStore } from "./store";
+import type { CostTotals } from "../ai/cost";
+
+export interface RunMeta {
+  runId: string;
+  baseUrl: string;
+  targetClass: string;
+  startedAt: string;
+  finishedAt: string;
+  sessions: number;
+  personas: string[];
+  cost?: CostTotals;
+}
+
+/** One bot session's persisted output. */
+export interface Shard {
+  persona: string;
+  findings: Finding[];
+}
+
+const SEVERITIES: Severity[] = ["critical", "high", "medium", "low", "info"];
+
+const SEVERITY_COLOR: Record<Severity, string> = {
+  critical: "#b00020",
+  high: "#d9534f",
+  medium: "#e0a800",
+  low: "#6c757d",
+  info: "#0d6efd",
+};
+
+function escapeHtml(value: unknown): string {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function fmtUsd(usd: number): string {
+  return `$${usd.toFixed(usd < 1 ? 4 : 2)}`;
+}
+
+export function summarize(findings: Finding[]): Record<Severity, number> & {
+  total: number;
+  distinct: number;
+} {
+  const counts: Record<Severity, number> = {
+    critical: 0,
+    high: 0,
+    medium: 0,
+    low: 0,
+    info: 0,
+  };
+  let total = 0;
+  for (const f of findings) {
+    counts[f.severity] += f.occurrences;
+    total += f.occurrences;
+  }
+  return { ...counts, total, distinct: findings.length };
+}
+
+function renderFinding(f: Finding): string {
+  const color = SEVERITY_COLOR[f.severity];
+  const samples = f.sampleUrls
+    .slice(0, 8)
+    .map((u) => `<li><code>${escapeHtml(u)}</code></li>`)
+    .join("");
+  const personas = f.personas.length
+    ? `<div class="meta">personas: ${escapeHtml(f.personas.join(", "))}</div>`
+    : "";
+  return `
+    <details class="finding">
+      <summary>
+        <span class="badge" style="background:${color}">${escapeHtml(f.severity)}</span>
+        <span class="cat">${escapeHtml(f.category)}</span>
+        <span class="title">${escapeHtml(f.title)}</span>
+        <span class="count">×${f.occurrences}</span>
+      </summary>
+      <div class="body">
+        <p>${escapeHtml(f.detail)}</p>
+        ${personas}
+        <div class="meta">first seen: ${escapeHtml(f.firstSeenAt)}</div>
+        ${samples ? `<div class="meta">sample URLs:</div><ul>${samples}</ul>` : ""}
+      </div>
+    </details>`;
+}
+
+export function renderHtmlReport(findings: Finding[], meta: RunMeta): string {
+  const sum = summarize(findings);
+  const sorted = [...findings].sort((a, b) => {
+    const s = SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity];
+    return s !== 0 ? s : b.occurrences - a.occurrences;
+  });
+
+  const summaryChips = SEVERITIES.map(
+    (sev) =>
+      `<span class="chip" style="border-color:${SEVERITY_COLOR[sev]};color:${SEVERITY_COLOR[sev]}">${escapeHtml(sev)}: <b>${sum[sev]}</b></span>`,
+  ).join("");
+
+  const grouped = SEVERITIES.map((sev) => {
+    const group = sorted.filter((f) => f.severity === sev);
+    if (group.length === 0) return "";
+    return `<h2 style="color:${SEVERITY_COLOR[sev]}">${escapeHtml(sev)} (${group.length})</h2>${group
+      .map(renderFinding)
+      .join("")}`;
+  }).join("");
+
+  const cost = meta.cost
+    ? `<tr><th>AI cost</th><td>${fmtUsd(meta.cost.usd)} · ${meta.cost.calls} calls · ${meta.cost.inputTokens.toLocaleString()} in / ${meta.cost.outputTokens.toLocaleString()} out tokens</td></tr>`
+    : "";
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Bot fleet report — ${escapeHtml(meta.runId)}</title>
+<style>
+  :root { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+  body { margin: 0; padding: 1.5rem; color: #1a1a1a; background: #f7f7f8; }
+  h1 { font-size: 1.4rem; margin: 0 0 .25rem; }
+  table.meta-table { border-collapse: collapse; margin: 1rem 0; font-size: .9rem; }
+  table.meta-table th { text-align: left; padding: .2rem .8rem .2rem 0; color: #555; font-weight: 600; }
+  .chips { margin: 1rem 0; display: flex; gap: .5rem; flex-wrap: wrap; }
+  .chip { border: 2px solid; border-radius: 999px; padding: .15rem .7rem; font-size: .85rem; background: #fff; }
+  .finding { background: #fff; border: 1px solid #e3e3e6; border-radius: 8px; margin: .4rem 0; padding: .2rem .6rem; }
+  .finding summary { cursor: pointer; display: flex; gap: .6rem; align-items: center; flex-wrap: wrap; }
+  .badge { color: #fff; border-radius: 4px; padding: .05rem .45rem; font-size: .72rem; text-transform: uppercase; }
+  .cat { font-size: .78rem; color: #666; background: #eee; border-radius: 4px; padding: .05rem .4rem; }
+  .title { font-weight: 600; }
+  .count { margin-left: auto; color: #888; font-variant-numeric: tabular-nums; }
+  .body { padding: .4rem 0 .6rem; font-size: .9rem; }
+  .meta { color: #777; font-size: .8rem; margin: .2rem 0; }
+  code { background: #f0f0f2; padding: .05rem .3rem; border-radius: 3px; font-size: .82rem; word-break: break-all; }
+  .empty { color: #2e7d32; font-weight: 600; }
+</style>
+</head>
+<body>
+  <h1>🤖 Bot fleet report</h1>
+  <table class="meta-table">
+    <tr><th>Run</th><td><code>${escapeHtml(meta.runId)}</code></td></tr>
+    <tr><th>Target</th><td><code>${escapeHtml(meta.baseUrl)}</code> <span class="cat">${escapeHtml(meta.targetClass)}</span></td></tr>
+    <tr><th>Window</th><td>${escapeHtml(meta.startedAt)} → ${escapeHtml(meta.finishedAt)}</td></tr>
+    <tr><th>Sessions</th><td>${meta.sessions} (${escapeHtml(meta.personas.join(", ") || "—")})</td></tr>
+    <tr><th>Findings</th><td>${sum.distinct} distinct · ${sum.total} total observations</td></tr>
+    ${cost}
+  </table>
+  <div class="chips">${summaryChips}</div>
+  ${sorted.length === 0 ? '<p class="empty">✅ No findings — clean run.</p>' : grouped}
+</body>
+</html>`;
+}
+
+export async function writeReport(
+  outDir: string,
+  findings: Finding[],
+  meta: RunMeta,
+): Promise<{ htmlPath: string; jsonPath: string }> {
+  await fs.mkdir(outDir, { recursive: true });
+  const htmlPath = path.join(outDir, "report.html");
+  const jsonPath = path.join(outDir, "findings.json");
+  await fs.writeFile(htmlPath, renderHtmlReport(findings, meta), "utf8");
+  await fs.writeFile(
+    jsonPath,
+    JSON.stringify({ meta, summary: summarize(findings), findings }, null, 2),
+    "utf8",
+  );
+  return { htmlPath, jsonPath };
+}
+
+/** Read all `${runDir}/shards/*.json` and merge into one finding set. */
+export async function aggregateShards(
+  runDir: string,
+): Promise<{ findings: Finding[]; sessions: number; personas: string[] }> {
+  const shardsDir = path.join(runDir, "shards");
+  let entries: string[] = [];
+  try {
+    entries = (await fs.readdir(shardsDir)).filter((f) => f.endsWith(".json"));
+  } catch {
+    return { findings: [], sessions: 0, personas: [] };
+  }
+  const store = new FindingStore();
+  const personas = new Set<string>();
+  let sessions = 0;
+  for (const entry of entries) {
+    try {
+      const raw = await fs.readFile(path.join(shardsDir, entry), "utf8");
+      const shard = JSON.parse(raw) as Shard;
+      store.merge(shard.findings ?? []);
+      if (shard.persona) personas.add(shard.persona);
+      sessions += 1;
+    } catch {
+      // Skip unreadable/partial shards rather than failing the whole report.
+    }
+  }
+  return { findings: store.all(), sessions, personas: [...personas] };
+}

--- a/bots/findings/report.ts
+++ b/bots/findings/report.ts
@@ -1,15 +1,24 @@
 /**
  * Report rendering + shard aggregation.
  *
- * `renderHtmlReport` is pure (string in, string out) and unit-tested. The
- * filesystem helpers (`writeReport`, `aggregateShards`) wrap it for the runner
- * and the Playwright globalTeardown that fans many parallel bot shards into one
- * report.
+ * Pure render functions (string in, string out) — unit-tested. The filesystem
+ * helpers (`writeReport`, `aggregateShards`) wrap them for the runner and the
+ * Playwright globalTeardown that fans many parallel bot shards into one report.
+ *
+ * Two human-facing surfaces are produced for every run:
+ *   - report.html   — a visual report (verdict + plain-English guidance).
+ *   - summary.md     — a Markdown digest the automation posts as the rolling
+ *                      "🤖 Bot fleet — latest results" GitHub issue.
  */
 
 import { promises as fs } from "node:fs";
 import path from "node:path";
-import { type Finding, type Severity, SEVERITY_ORDER } from "./types";
+import {
+  type Finding,
+  type FindingCategory,
+  type Severity,
+  SEVERITY_ORDER,
+} from "./types";
 import { FindingStore } from "./store";
 import type { CostTotals } from "../ai/cost";
 
@@ -40,6 +49,71 @@ const SEVERITY_COLOR: Record<Severity, string> = {
   info: "#0d6efd",
 };
 
+const SEVERITY_EMOJI: Record<Severity, string> = {
+  critical: "🛑",
+  high: "⚠️",
+  medium: "👀",
+  low: "·",
+  info: "ℹ️",
+};
+
+/** Plain-English meaning of each severity, for the legend. */
+const SEVERITY_MEANING: Record<Severity, string> = {
+  critical: "Serious — likely broken for users or a crash. Fix first.",
+  high: "Important — a real problem worth fixing soon.",
+  medium: "Worth a look — may affect some users.",
+  low: "Minor — polish when convenient.",
+  info: "Just so you know — not a problem.",
+};
+
+/** Plain-English "what this means / what to do" per finding category. */
+const CATEGORY_HELP: Record<FindingCategory, { what: string; fix: string }> = {
+  "console-error": {
+    what: "The page's code logged an error in the browser — often a sign something didn't load or work as intended.",
+    fix: "Open the listed page, check the browser console, and fix the code path that errored.",
+  },
+  "page-error": {
+    what: "The page hit an unhandled crash (a JavaScript exception). Users may see a broken or frozen section.",
+    fix: "Reproduce on the listed page and add error handling or fix the root cause.",
+  },
+  "network-error": {
+    what: "A request the page made never completed — it couldn't connect, timed out, or was refused.",
+    fix: "Check that the endpoint or asset is reachable and returns a response.",
+  },
+  "http-error": {
+    what: "A page or request came back with an error status (e.g. 404 not-found or 500 server-error).",
+    fix: "404 = a missing page/link to restore; 500 = a server-side bug to investigate at the listed path.",
+  },
+  "broken-link": {
+    what: "A link on the site points somewhere that errors or no longer exists.",
+    fix: "Update or remove the link, or restore the missing page.",
+  },
+  a11y: {
+    what: "An accessibility problem that can block people using screen readers, keyboards, or with low vision.",
+    fix: "Follow the linked rule — e.g. add alt text, label the control, or fix colour contrast.",
+  },
+  "dead-end": {
+    what: "A page loaded but showed almost nothing, or navigation failed — a likely dead end for the visitor.",
+    fix: "Check the page renders real content and isn't silently failing to load data.",
+  },
+  ux: {
+    what: "An AI reviewer judged the experience here confusing, broken, or misleading.",
+    fix: "Read the detail and improve the flow, copy, or button/affordance.",
+  },
+  compliance: {
+    what: "A required financial disclosure or disclaimer appears to be missing where it's expected.",
+    fix: "Add the required disclosure (see lib/compliance.ts) — this matters for AFSL / ASIC.",
+  },
+  "flow-failure": {
+    what: "A multi-step task (like the quiz or signup) couldn't be completed all the way through.",
+    fix: "Reproduce the steps on the listed page and fix the blocking step.",
+  },
+  safety: {
+    what: "The safety net intercepted real-world actions (payments, emails, etc.) so nothing actually happened.",
+    fix: "No action needed — this confirms the safety net is working.",
+  },
+};
+
 function escapeHtml(value: unknown): string {
   return String(value)
     .replace(/&/g, "&amp;")
@@ -53,10 +127,12 @@ function fmtUsd(usd: number): string {
   return `$${usd.toFixed(usd < 1 ? 4 : 2)}`;
 }
 
-export function summarize(findings: Finding[]): Record<Severity, number> & {
+export type ReportSummary = Record<Severity, number> & {
   total: number;
   distinct: number;
-} {
+};
+
+export function summarize(findings: Finding[]): ReportSummary {
   const counts: Record<Severity, number> = {
     critical: 0,
     high: 0,
@@ -72,14 +148,54 @@ export function summarize(findings: Finding[]): Record<Severity, number> & {
   return { ...counts, total, distinct: findings.length };
 }
 
+export interface Verdict {
+  emoji: string;
+  text: string;
+  color: string;
+}
+
+/** One-line, plain-English bottom line for the whole run. */
+export function verdict(sum: ReportSummary): Verdict {
+  if (sum.critical > 0) {
+    return {
+      emoji: "🛑",
+      text: `${sum.critical} serious issue${sum.critical === 1 ? "" : "s"} need attention`,
+      color: SEVERITY_COLOR.critical,
+    };
+  }
+  if (sum.high > 0) {
+    return {
+      emoji: "⚠️",
+      text: `${sum.high} important issue${sum.high === 1 ? "" : "s"} to look at`,
+      color: SEVERITY_COLOR.high,
+    };
+  }
+  if (sum.medium + sum.low > 0) {
+    return {
+      emoji: "👀",
+      text: `${sum.medium + sum.low} minor thing${sum.medium + sum.low === 1 ? "" : "s"} to review when convenient`,
+      color: SEVERITY_COLOR.medium,
+    };
+  }
+  return { emoji: "✅", text: "All clear — nothing needs attention", color: "#2e7d32" };
+}
+
+function sortFindings(findings: Finding[]): Finding[] {
+  return [...findings].sort((a, b) => {
+    const s = SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity];
+    return s !== 0 ? s : b.occurrences - a.occurrences;
+  });
+}
+
 function renderFinding(f: Finding): string {
   const color = SEVERITY_COLOR[f.severity];
+  const help = CATEGORY_HELP[f.category];
   const samples = f.sampleUrls
     .slice(0, 8)
     .map((u) => `<li><code>${escapeHtml(u)}</code></li>`)
     .join("");
   const personas = f.personas.length
-    ? `<div class="meta">personas: ${escapeHtml(f.personas.join(", "))}</div>`
+    ? `<div class="meta">seen by: ${escapeHtml(f.personas.join(", "))}</div>`
     : "";
   return `
     <details class="finding">
@@ -90,30 +206,35 @@ function renderFinding(f: Finding): string {
         <span class="count">×${f.occurrences}</span>
       </summary>
       <div class="body">
-        <p>${escapeHtml(f.detail)}</p>
+        <p class="what"><b>What this means:</b> ${escapeHtml(help.what)}</p>
+        <p class="fix"><b>What to do:</b> ${escapeHtml(help.fix)}</p>
+        <p class="detail">${escapeHtml(f.detail)}</p>
         ${personas}
         <div class="meta">first seen: ${escapeHtml(f.firstSeenAt)}</div>
-        ${samples ? `<div class="meta">sample URLs:</div><ul>${samples}</ul>` : ""}
+        ${samples ? `<div class="meta">where:</div><ul>${samples}</ul>` : ""}
       </div>
     </details>`;
 }
 
 export function renderHtmlReport(findings: Finding[], meta: RunMeta): string {
   const sum = summarize(findings);
-  const sorted = [...findings].sort((a, b) => {
-    const s = SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity];
-    return s !== 0 ? s : b.occurrences - a.occurrences;
-  });
+  const v = verdict(sum);
+  const sorted = sortFindings(findings);
 
   const summaryChips = SEVERITIES.map(
     (sev) =>
-      `<span class="chip" style="border-color:${SEVERITY_COLOR[sev]};color:${SEVERITY_COLOR[sev]}">${escapeHtml(sev)}: <b>${sum[sev]}</b></span>`,
+      `<span class="chip" title="${escapeHtml(SEVERITY_MEANING[sev])}" style="border-color:${SEVERITY_COLOR[sev]};color:${SEVERITY_COLOR[sev]}">${SEVERITY_EMOJI[sev]} ${escapeHtml(sev)}: <b>${sum[sev]}</b></span>`,
+  ).join("");
+
+  const legend = SEVERITIES.map(
+    (sev) =>
+      `<li><b style="color:${SEVERITY_COLOR[sev]}">${SEVERITY_EMOJI[sev]} ${escapeHtml(sev)}</b> — ${escapeHtml(SEVERITY_MEANING[sev])}</li>`,
   ).join("");
 
   const grouped = SEVERITIES.map((sev) => {
     const group = sorted.filter((f) => f.severity === sev);
     if (group.length === 0) return "";
-    return `<h2 style="color:${SEVERITY_COLOR[sev]}">${escapeHtml(sev)} (${group.length})</h2>${group
+    return `<h2 style="color:${SEVERITY_COLOR[sev]}">${SEVERITY_EMOJI[sev]} ${escapeHtml(sev)} (${group.length})</h2>${group
       .map(renderFinding)
       .join("")}`;
   }).join("");
@@ -130,12 +251,15 @@ export function renderHtmlReport(findings: Finding[], meta: RunMeta): string {
 <title>Bot fleet report — ${escapeHtml(meta.runId)}</title>
 <style>
   :root { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
-  body { margin: 0; padding: 1.5rem; color: #1a1a1a; background: #f7f7f8; }
+  body { margin: 0; padding: 1.5rem; color: #1a1a1a; background: #f7f7f8; max-width: 60rem; }
   h1 { font-size: 1.4rem; margin: 0 0 .25rem; }
+  .verdict { font-size: 1.15rem; font-weight: 700; padding: .8rem 1rem; border-radius: 10px; background: #fff; border-left: 6px solid; margin: .8rem 0 1rem; }
   table.meta-table { border-collapse: collapse; margin: 1rem 0; font-size: .9rem; }
   table.meta-table th { text-align: left; padding: .2rem .8rem .2rem 0; color: #555; font-weight: 600; }
   .chips { margin: 1rem 0; display: flex; gap: .5rem; flex-wrap: wrap; }
   .chip { border: 2px solid; border-radius: 999px; padding: .15rem .7rem; font-size: .85rem; background: #fff; }
+  details.legend { margin: .5rem 0 1.5rem; font-size: .85rem; color: #444; }
+  details.legend ul { margin: .4rem 0; padding-left: 1.1rem; }
   .finding { background: #fff; border: 1px solid #e3e3e6; border-radius: 8px; margin: .4rem 0; padding: .2rem .6rem; }
   .finding summary { cursor: pointer; display: flex; gap: .6rem; align-items: center; flex-wrap: wrap; }
   .badge { color: #fff; border-radius: 4px; padding: .05rem .45rem; font-size: .72rem; text-transform: uppercase; }
@@ -143,6 +267,9 @@ export function renderHtmlReport(findings: Finding[], meta: RunMeta): string {
   .title { font-weight: 600; }
   .count { margin-left: auto; color: #888; font-variant-numeric: tabular-nums; }
   .body { padding: .4rem 0 .6rem; font-size: .9rem; }
+  .body .what { margin: .2rem 0; }
+  .body .fix { margin: .2rem 0; color: #1a5e34; }
+  .body .detail { margin: .4rem 0; color: #333; background: #f6f6f8; padding: .4rem .6rem; border-radius: 6px; white-space: pre-wrap; }
   .meta { color: #777; font-size: .8rem; margin: .2rem 0; }
   code { background: #f0f0f2; padding: .05rem .3rem; border-radius: 3px; font-size: .82rem; word-break: break-all; }
   .empty { color: #2e7d32; font-weight: 600; }
@@ -150,35 +277,92 @@ export function renderHtmlReport(findings: Finding[], meta: RunMeta): string {
 </head>
 <body>
   <h1>🤖 Bot fleet report</h1>
+  <div class="verdict" style="border-left-color:${v.color};color:${v.color}">${v.emoji} ${escapeHtml(v.text)}</div>
   <table class="meta-table">
-    <tr><th>Run</th><td><code>${escapeHtml(meta.runId)}</code></td></tr>
     <tr><th>Target</th><td><code>${escapeHtml(meta.baseUrl)}</code> <span class="cat">${escapeHtml(meta.targetClass)}</span></td></tr>
-    <tr><th>Window</th><td>${escapeHtml(meta.startedAt)} → ${escapeHtml(meta.finishedAt)}</td></tr>
-    <tr><th>Sessions</th><td>${meta.sessions} (${escapeHtml(meta.personas.join(", ") || "—")})</td></tr>
+    <tr><th>When</th><td>${escapeHtml(meta.finishedAt)}</td></tr>
+    <tr><th>Bots</th><td>${meta.sessions} session${meta.sessions === 1 ? "" : "s"} (${escapeHtml(meta.personas.join(", ") || "—")})</td></tr>
     <tr><th>Findings</th><td>${sum.distinct} distinct · ${sum.total} total observations</td></tr>
     ${cost}
+    <tr><th>Run id</th><td><code>${escapeHtml(meta.runId)}</code></td></tr>
   </table>
   <div class="chips">${summaryChips}</div>
+  <details class="legend"><summary>What do these mean?</summary><ul>${legend}</ul></details>
   ${sorted.length === 0 ? '<p class="empty">✅ No findings — clean run.</p>' : grouped}
 </body>
 </html>`;
+}
+
+/**
+ * Plain-English Markdown digest, posted as the rolling results issue. Caps the
+ * detailed list so the issue stays readable; the full report.html has everything.
+ */
+export function renderMarkdownSummary(findings: Finding[], meta: RunMeta): string {
+  const sum = summarize(findings);
+  const v = verdict(sum);
+  const sorted = sortFindings(findings).filter((f) => f.severity !== "info");
+  const cap = 25;
+
+  const lines: string[] = [];
+  lines.push(`# 🤖 Bot fleet — latest results`);
+  lines.push("");
+  lines.push(`## ${v.emoji} ${v.text}`);
+  lines.push("");
+  lines.push(
+    `**Target:** \`${meta.baseUrl}\` · **When:** ${meta.finishedAt} · **Bots:** ${meta.sessions}`,
+  );
+  if (meta.cost) {
+    lines.push("");
+    lines.push(`**AI cost this run:** ${fmtUsd(meta.cost.usd)} (${meta.cost.calls} calls)`);
+  }
+  lines.push("");
+  lines.push(`| Severity | Count |`);
+  lines.push(`|---|---|`);
+  for (const sev of SEVERITIES) {
+    lines.push(`| ${SEVERITY_EMOJI[sev]} ${sev} | ${sum[sev]} |`);
+  }
+  lines.push("");
+
+  if (sorted.length === 0) {
+    lines.push(`✅ Nothing to action — the bots found no problems this run.`);
+  } else {
+    lines.push(`## What needs attention`);
+    lines.push("");
+    for (const f of sorted.slice(0, cap)) {
+      const where = f.sampleUrls[0] ?? "";
+      const more = f.sampleUrls.length > 1 ? ` (+${f.sampleUrls.length - 1} more)` : "";
+      const loc = where ? ` — \`${where}\`${more}` : "";
+      lines.push(
+        `- ${SEVERITY_EMOJI[f.severity]} **${f.title}** — ${CATEGORY_HELP[f.category].what}${loc}`,
+      );
+    }
+    if (sorted.length > cap) {
+      lines.push("");
+      lines.push(`…and ${sorted.length - cap} more. See the full report attached to the run.`);
+    }
+  }
+  lines.push("");
+  lines.push(`<sub>Run \`${meta.runId}\` · generated by the bot fleet (bots/).</sub>`);
+  return lines.join("\n");
 }
 
 export async function writeReport(
   outDir: string,
   findings: Finding[],
   meta: RunMeta,
-): Promise<{ htmlPath: string; jsonPath: string }> {
+): Promise<{ htmlPath: string; jsonPath: string; summaryPath: string }> {
   await fs.mkdir(outDir, { recursive: true });
   const htmlPath = path.join(outDir, "report.html");
   const jsonPath = path.join(outDir, "findings.json");
+  const summaryPath = path.join(outDir, "summary.md");
   await fs.writeFile(htmlPath, renderHtmlReport(findings, meta), "utf8");
+  await fs.writeFile(summaryPath, renderMarkdownSummary(findings, meta), "utf8");
   await fs.writeFile(
     jsonPath,
     JSON.stringify({ meta, summary: summarize(findings), findings }, null, 2),
     "utf8",
   );
-  return { htmlPath, jsonPath };
+  return { htmlPath, jsonPath, summaryPath };
 }
 
 /** Read all `${runDir}/shards/*.json` and merge into one finding set. */

--- a/bots/findings/store.ts
+++ b/bots/findings/store.ts
@@ -1,0 +1,113 @@
+/**
+ * FindingStore — collects, deduplicates and aggregates findings.
+ *
+ * Pure module. Used two ways:
+ *   1. Per-session: each bot adds findings as it discovers them.
+ *   2. Aggregation: shards from many parallel bots are merged into one store
+ *      to produce the final report (see findings/report.ts).
+ */
+
+import {
+  type Finding,
+  type FindingInput,
+  type Severity,
+  SEVERITY_ORDER,
+  findingSignature,
+} from "./types";
+
+const MAX_SAMPLES = 15;
+
+function pushCapped(arr: string[], value: string | undefined): void {
+  if (!value) return;
+  if (arr.includes(value)) return;
+  if (arr.length < MAX_SAMPLES) arr.push(value);
+}
+
+/** Pick the more severe of two severities. */
+function moreSevere(a: Severity, b: Severity): Severity {
+  return SEVERITY_ORDER[a] <= SEVERITY_ORDER[b] ? a : b;
+}
+
+export class FindingStore {
+  private readonly map = new Map<string, Finding>();
+
+  add(input: FindingInput, now: Date = new Date()): Finding {
+    const id = findingSignature(input);
+    const existing = this.map.get(id);
+    if (existing) {
+      existing.occurrences += 1;
+      existing.severity = moreSevere(existing.severity, input.severity);
+      pushCapped(existing.sampleUrls, input.url);
+      pushCapped(existing.personas, input.persona);
+      return existing;
+    }
+    const finding: Finding = {
+      id,
+      severity: input.severity,
+      category: input.category,
+      title: input.title,
+      detail: input.detail,
+      url: input.url,
+      persona: input.persona,
+      evidence: input.evidence,
+      occurrences: 1,
+      firstSeenAt: now.toISOString(),
+      sampleUrls: input.url ? [input.url] : [],
+      personas: input.persona ? [input.persona] : [],
+    };
+    this.map.set(id, finding);
+    return finding;
+  }
+
+  addAll(inputs: FindingInput[], now: Date = new Date()): void {
+    for (const input of inputs) this.add(input, now);
+  }
+
+  /** Merge already-aggregated findings (e.g. from a shard) into this store. */
+  merge(findings: Finding[]): void {
+    for (const f of findings) {
+      const existing = this.map.get(f.id);
+      if (existing) {
+        existing.occurrences += f.occurrences;
+        existing.severity = moreSevere(existing.severity, f.severity);
+        for (const u of f.sampleUrls) pushCapped(existing.sampleUrls, u);
+        for (const p of f.personas) pushCapped(existing.personas, p);
+      } else {
+        this.map.set(f.id, { ...f, sampleUrls: [...f.sampleUrls], personas: [...f.personas] });
+      }
+    }
+  }
+
+  /** All findings, sorted by severity then occurrence count (desc). */
+  all(): Finding[] {
+    return [...this.map.values()].sort((a, b) => {
+      const s = SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity];
+      if (s !== 0) return s;
+      return b.occurrences - a.occurrences;
+    });
+  }
+
+  get size(): number {
+    return this.map.size;
+  }
+
+  summary(): Record<Severity, number> & { total: number; distinct: number } {
+    const counts: Record<Severity, number> = {
+      critical: 0,
+      high: 0,
+      medium: 0,
+      low: 0,
+      info: 0,
+    };
+    let total = 0;
+    for (const f of this.map.values()) {
+      counts[f.severity] += f.occurrences;
+      total += f.occurrences;
+    }
+    return { ...counts, total, distinct: this.map.size };
+  }
+
+  toJSON(): Finding[] {
+    return this.all();
+  }
+}

--- a/bots/findings/types.ts
+++ b/bots/findings/types.ts
@@ -1,0 +1,95 @@
+/**
+ * Finding model — the structured unit of everything the fleet discovers.
+ *
+ * Pure module. A Finding is deduplicated by a stable `id` derived from its
+ * category + normalized URL + a discriminating key, so the same broken thing
+ * seen by 50 bots collapses to one row with an occurrence count.
+ */
+
+import { createHash } from "node:crypto";
+
+export type Severity = "critical" | "high" | "medium" | "low" | "info";
+
+export type FindingCategory =
+  | "console-error" // uncaught console.error in the page
+  | "page-error" // unhandled exception / rejection in the page
+  | "network-error" // request failed (DNS, abort, connection)
+  | "http-error" // first-party response with status >= 400
+  | "broken-link" // internal <a> resolving to 4xx/5xx
+  | "a11y" // axe-core serious/critical violation
+  | "dead-end" // navigation produced an empty/error shell
+  | "ux" // AI judge: confusing/broken user experience
+  | "compliance" // AI judge: missing required financial disclosure
+  | "flow-failure" // a scripted/AI flow could not complete a step
+  | "safety"; // the safety net had to intercept something unexpected
+
+export const SEVERITY_ORDER: Record<Severity, number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+  info: 4,
+};
+
+export interface FindingInput {
+  severity: Severity;
+  category: FindingCategory;
+  /** Short human title, e.g. "500 on /api/quiz/submit". */
+  title: string;
+  /** Longer explanation / message body. */
+  detail: string;
+  /** Route or URL where it occurred. */
+  url: string;
+  /** Persona / bot that hit it. */
+  persona?: string;
+  /**
+   * Overrides the dedupe discriminator. Defaults to `title`. Use a stable key
+   * (axe rule id, HTTP status, error class) so cosmetic title differences
+   * don't fragment a single underlying issue.
+   */
+  signatureKey?: string;
+  /** Arbitrary structured context (status, selector, axe nodes, screenshot). */
+  evidence?: Record<string, unknown>;
+}
+
+export interface Finding extends Omit<FindingInput, "signatureKey"> {
+  /** Stable dedupe id. */
+  id: string;
+  /** How many times this exact finding was observed. */
+  occurrences: number;
+  /** ISO timestamp first seen. */
+  firstSeenAt: string;
+  /** Distinct URLs where it was seen (capped). */
+  sampleUrls: string[];
+  /** Distinct personas that hit it (capped). */
+  personas: string[];
+}
+
+/** Strip origin, query and hash; collapse id-like path segments to `:id`. */
+export function normalizeUrl(url: string): string {
+  let pathname = url;
+  try {
+    // Accept both absolute and root-relative URLs.
+    pathname = new URL(url, "http://x").pathname;
+  } catch {
+    const q = url.indexOf("?");
+    pathname = q >= 0 ? url.slice(0, q) : url;
+  }
+  return pathname
+    .split("/")
+    .map((seg) => {
+      if (/^\d+$/.test(seg)) return ":id";
+      if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(seg)) {
+        return ":id";
+      }
+      if (/^[0-9a-f]{16,}$/i.test(seg)) return ":id";
+      return seg;
+    })
+    .join("/");
+}
+
+export function findingSignature(input: FindingInput): string {
+  const key = input.signatureKey ?? input.title;
+  const basis = `${input.category}::${normalizeUrl(input.url)}::${key}`;
+  return createHash("sha1").update(basis).digest("hex").slice(0, 12);
+}

--- a/bots/fleet.spec.ts
+++ b/bots/fleet.spec.ts
@@ -1,7 +1,8 @@
 import { test } from "@playwright/test";
 import { loadConfig } from "./config";
 import { BotSession } from "./session";
-import { PHASE0_PERSONAS } from "./personas";
+import { PHASE0_PERSONAS, AI_PERSONAS } from "./personas";
+import { resolveAiKey } from "./ai/anthropic-client";
 
 /**
  * Fleet entrypoint.
@@ -25,7 +26,7 @@ for (const persona of PHASE0_PERSONAS) {
       storageStateFile: persona.storageStateFile,
     });
     try {
-      for (const route of persona.routes) {
+      for (const route of persona.routes ?? []) {
         await session.visit(route);
         await session.audit({ links: true });
       }
@@ -34,4 +35,31 @@ for (const persona of PHASE0_PERSONAS) {
       await session.close();
     }
   });
+}
+
+// AI-driven personas — only when AI is enabled (a budget is set AND a key is
+// present). Each pursues a goal like a real user and judges the experience.
+const aiEnabled = config.aiTokenBudget > 0 && resolveAiKey() !== null;
+
+if (aiEnabled) {
+  for (const persona of AI_PERSONAS) {
+    test(`AI bot: ${persona.name}`, async ({ browser }) => {
+      const session = await BotSession.create(browser, config, {
+        persona: persona.name,
+        storageStateFile: persona.storageStateFile,
+      });
+      try {
+        await session.runAiGoal(
+          persona.goal ??
+            "Explore the site like a real user; report anything broken, confusing, or non-compliant.",
+          persona.startPath ?? "/",
+        );
+        // Run the mechanical checks on wherever the bot ended up.
+        await session.audit();
+      } finally {
+        await session.persist();
+        await session.close();
+      }
+    });
+  }
 }

--- a/bots/fleet.spec.ts
+++ b/bots/fleet.spec.ts
@@ -1,0 +1,37 @@
+import { test } from "@playwright/test";
+import { loadConfig } from "./config";
+import { BotSession } from "./session";
+import { PHASE0_PERSONAS } from "./personas";
+
+/**
+ * Fleet entrypoint.
+ *
+ * Phase 0: one deterministic session per persona, each walking its route list
+ * and running the cross-cutting checks (console / network / a11y / broken
+ * links) under the safety net. Playwright distributes the sessions across
+ * `workers` (BOTS_CONCURRENCY) so the fleet runs concurrently. Each session
+ * persists a shard; globalTeardown aggregates them into one report.
+ *
+ * Later phases add: authenticated personas (storage states), deterministic
+ * critical-path flows, and the AI-driven explore/judge driver.
+ */
+
+const config = loadConfig();
+
+for (const persona of PHASE0_PERSONAS) {
+  test(`bot persona: ${persona.name}`, async ({ browser }) => {
+    const session = await BotSession.create(browser, config, {
+      persona: persona.name,
+      storageStateFile: persona.storageStateFile,
+    });
+    try {
+      for (const route of persona.routes) {
+        await session.visit(route);
+        await session.audit({ links: true });
+      }
+    } finally {
+      await session.persist();
+      await session.close();
+    }
+  });
+}

--- a/bots/global-teardown.ts
+++ b/bots/global-teardown.ts
@@ -1,0 +1,33 @@
+/**
+ * Runs once after all bot workers finish. Aggregates every session's shard into
+ * one deduplicated finding set and writes the run report (HTML + JSON).
+ *
+ * Lives in a separate process from the workers, so it relies on the run id/dir
+ * pinned into the environment by playwright.config.ts (see config.ts).
+ */
+
+import { loadConfig } from "./config";
+import { aggregateShards, writeReport, type RunMeta } from "./findings/report";
+
+export default async function globalTeardown(): Promise<void> {
+  const config = loadConfig();
+  const { findings, sessions, personas } = await aggregateShards(config.runDir);
+
+  const meta: RunMeta = {
+    runId: config.runId,
+    baseUrl: config.baseUrl,
+    targetClass: config.targetClass,
+    startedAt: process.env.BOTS_STARTED_AT ?? new Date().toISOString(),
+    finishedAt: new Date().toISOString(),
+    sessions,
+    personas,
+  };
+
+  const { htmlPath, jsonPath } = await writeReport(config.runDir, findings, meta);
+
+  console.log(
+    `\n[bots] ${findings.length} distinct finding(s) across ${sessions} session(s).` +
+      `\n[bots] report: ${htmlPath}` +
+      `\n[bots] json:   ${jsonPath}\n`,
+  );
+}

--- a/bots/global-teardown.ts
+++ b/bots/global-teardown.ts
@@ -11,7 +11,7 @@ import { aggregateShards, writeReport, type RunMeta } from "./findings/report";
 
 export default async function globalTeardown(): Promise<void> {
   const config = loadConfig();
-  const { findings, sessions, personas } = await aggregateShards(config.runDir);
+  const { findings, sessions, personas, cost } = await aggregateShards(config.runDir);
 
   const meta: RunMeta = {
     runId: config.runId,
@@ -21,6 +21,7 @@ export default async function globalTeardown(): Promise<void> {
     finishedAt: new Date().toISOString(),
     sessions,
     personas,
+    cost: cost.calls > 0 ? cost : undefined,
   };
 
   const { htmlPath, jsonPath } = await writeReport(config.runDir, findings, meta);

--- a/bots/personas.ts
+++ b/bots/personas.ts
@@ -11,8 +11,12 @@
 export interface Persona {
   name: string;
   description: string;
-  /** Routes this persona walks in Phase 0 (deterministic). */
-  routes: string[];
+  /** Routes this persona walks deterministically (the page sweep). */
+  routes?: string[];
+  /** Goal for an AI-driven persona to pursue. */
+  goal?: string;
+  /** Where an AI-driven persona starts. */
+  startPath?: string;
   /** Optional auth storage-state file for logged-in personas (later phases). */
   storageStateFile?: string;
 }
@@ -32,5 +36,31 @@ export const PHASE0_PERSONAS: Persona[] = [
     name: "learner",
     description: "Researching concepts and tools before investing.",
     routes: ["/", "/glossary", "/tools", "/foreign-investment"],
+  },
+];
+
+/**
+ * AI-driven personas: each is given a goal and left to pursue it like a real
+ * user, judging the experience along the way. Only run when AI is enabled
+ * (BOTS_AI_TOKEN_BUDGET > 0 and an Anthropic key is present).
+ */
+export const AI_PERSONAS: Persona[] = [
+  {
+    name: "ai-first-home-buyer",
+    description: "A beginner comparing investment platforms for the first time.",
+    startPath: "/",
+    goal: "As a complete beginner, find and compare investment platforms suitable for someone just starting out, and get to the point where you could open an account. Note anything confusing, broken, or any missing fees/risk disclosures.",
+  },
+  {
+    name: "ai-advice-seeker",
+    description: "A pre-retiree looking for a financial adviser.",
+    startPath: "/advisors",
+    goal: "Find a financial adviser who would suit someone near retirement, and try to make contact or book a consultation. Flag dead ends, confusing steps, or missing disclosures.",
+  },
+  {
+    name: "ai-quiz-taker",
+    description: "A visitor using the guided 'get matched' quiz.",
+    startPath: "/get-matched",
+    goal: "Complete the get-matched quiz as a long-term investor and reach a personalised action plan. Judge whether the result is clear and trustworthy, and flag anything broken or missing.",
   },
 ];

--- a/bots/personas.ts
+++ b/bots/personas.ts
@@ -1,0 +1,36 @@
+/**
+ * Persona registry.
+ *
+ * A persona is a simulated user with a goal and a route emphasis. Phase 0 ships
+ * anonymous personas over public, placeholder-cred-safe routes (the same routes
+ * the a11y suite trusts to render without a seeded DB). Later phases attach
+ * auth states (reusing e2e/visual/state-registry.ts) and AI-driven goals so a
+ * persona can roam and judge the experience, not just load a fixed list.
+ */
+
+export interface Persona {
+  name: string;
+  description: string;
+  /** Routes this persona walks in Phase 0 (deterministic). */
+  routes: string[];
+  /** Optional auth storage-state file for logged-in personas (later phases). */
+  storageStateFile?: string;
+}
+
+export const PHASE0_PERSONAS: Persona[] = [
+  {
+    name: "broker-shopper",
+    description: "Comparing brokers/platforms before opening an account.",
+    routes: ["/", "/compare", "/calculators", "/how-we-earn"],
+  },
+  {
+    name: "advice-seeker",
+    description: "Looking for a financial adviser to talk to.",
+    routes: ["/", "/advisors", "/find-advisor", "/about"],
+  },
+  {
+    name: "learner",
+    description: "Researching concepts and tools before investing.",
+    routes: ["/", "/glossary", "/tools", "/foreign-investment"],
+  },
+];

--- a/bots/playwright.config.ts
+++ b/bots/playwright.config.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { defineConfig, devices } from "@playwright/test";
 import { loadConfig, assertTargetAllowed } from "./config";
 
@@ -27,8 +28,10 @@ export default defineConfig({
   testDir: ".",
   testMatch: /.*\.spec\.ts$/,
   // Keep Playwright artifacts inside the (gitignored) run dir so bot runs never
-  // dirty the tracked tree.
-  outputDir: `${config.runDir}/artifacts`,
+  // dirty the tracked tree. Absolute path because Playwright resolves a
+  // relative outputDir against the config's dir (bots/), which would otherwise
+  // produce bots/bots/.runs/… and escape .gitignore.
+  outputDir: path.resolve(process.cwd(), config.runDir, "artifacts"),
   // Sessions visit several routes and run axe + link checks; give them room.
   timeout: 180_000,
   fullyParallel: true,

--- a/bots/playwright.config.ts
+++ b/bots/playwright.config.ts
@@ -26,6 +26,9 @@ const isLocal = /^(localhost|127\.0\.0\.1|0\.0\.0\.0)(:\d+)?$/.test(config.host)
 export default defineConfig({
   testDir: ".",
   testMatch: /.*\.spec\.ts$/,
+  // Keep Playwright artifacts inside the (gitignored) run dir so bot runs never
+  // dirty the tracked tree.
+  outputDir: `${config.runDir}/artifacts`,
   // Sessions visit several routes and run axe + link checks; give them room.
   timeout: 180_000,
   fullyParallel: true,
@@ -47,7 +50,9 @@ export default defineConfig({
     process.env.BOTS_SKIP_WEBSERVER === "1" || !isLocal
       ? undefined
       : {
-          command: "npm run dev",
+          // Defaults to the dev server; override with BOTS_WEBSERVER_CMD (e.g.
+          // "npm run start" to drive the production build instead).
+          command: process.env.BOTS_WEBSERVER_CMD ?? "npm run dev",
           url: config.baseUrl,
           reuseExistingServer: true,
           timeout: 600_000,

--- a/bots/playwright.config.ts
+++ b/bots/playwright.config.ts
@@ -1,0 +1,57 @@
+import { defineConfig, devices } from "@playwright/test";
+import { loadConfig, assertTargetAllowed } from "./config";
+
+/**
+ * Dedicated Playwright config for the bot fleet.
+ *
+ * Run: `npm run bots` (drives whatever BOTS_BASE_URL points at; defaults to a
+ * local dev server). Kept separate from the main e2e config so the fleet —
+ * which is long-running and AI-driven in later phases — never runs in per-PR
+ * CI by accident.
+ */
+
+const config = loadConfig();
+// Last line of defence: refuse a prod target unless explicitly overridden.
+assertTargetAllowed(config);
+
+// Pin one run id/dir + start time so the parallel workers and the
+// separate-process globalTeardown all share a single run directory.
+process.env.BOTS_RUN_ID = config.runId;
+process.env.BOTS_RUN_DIR = config.runDir;
+process.env.BOTS_BASE_URL = config.baseUrl;
+process.env.BOTS_STARTED_AT = process.env.BOTS_STARTED_AT ?? new Date().toISOString();
+
+const isLocal = /^(localhost|127\.0\.0\.1|0\.0\.0\.0)(:\d+)?$/.test(config.host);
+
+export default defineConfig({
+  testDir: ".",
+  testMatch: /.*\.spec\.ts$/,
+  // Sessions visit several routes and run axe + link checks; give them room.
+  timeout: 180_000,
+  fullyParallel: true,
+  retries: 0,
+  workers: config.concurrency,
+  reporter: [["list"]],
+  globalTeardown: "./global-teardown.ts",
+  use: {
+    baseURL: config.baseUrl,
+    actionTimeout: 15_000,
+    navigationTimeout: 30_000,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+  projects: [{ name: "bots", use: { ...devices["Desktop Chrome"] } }],
+  // Only boot a dev server for a local target. A remote preview/staging URL is
+  // assumed to be already live.
+  webServer:
+    process.env.BOTS_SKIP_WEBSERVER === "1" || !isLocal
+      ? undefined
+      : {
+          command: "npm run dev",
+          url: config.baseUrl,
+          reuseExistingServer: true,
+          timeout: 600_000,
+          stdout: "pipe",
+          stderr: "pipe",
+        },
+});

--- a/bots/safety/intercept.ts
+++ b/bots/safety/intercept.ts
@@ -1,0 +1,141 @@
+/**
+ * The side-effect firewall, installed on every bot page.
+ *
+ * Intercepts ALL same-origin requests and, for anything the policy says must
+ * be mocked, answers with a synthetic response so no real-world action occurs:
+ *   - payments never reach Stripe,
+ *   - `/go/*` affiliate redirects never reach the partner (no click row, no
+ *     fraud signal),
+ *   - leads/emails/content writes are mocked on protected targets.
+ *
+ * On a sandbox target, internal writes are allowed through so deep flows can be
+ * exercised against disposable data. See ../safety/money-paths.ts for the
+ * policy and ../config.ts for the target-class model.
+ */
+
+import type { Page, Route } from "@playwright/test";
+import { decide } from "./money-paths";
+import type { BotConfig } from "../config";
+
+export interface InterceptedCall {
+  method: string;
+  pathname: string;
+  category: string;
+  action: "allow" | "mock";
+  at: number;
+}
+
+export interface SafetyNet {
+  readonly intercepted: InterceptedCall[];
+  summary(): Record<string, number>;
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function originOf(url: string): string {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return "";
+  }
+}
+
+async function fulfillSynthetic(route: Route, baseOrigin: string, category: string): Promise<void> {
+  const request = route.request();
+  const pathname = (() => {
+    try {
+      return new URL(request.url()).pathname;
+    } catch {
+      return request.url();
+    }
+  })();
+
+  if (request.resourceType() === "document") {
+    await route.fulfill({
+      status: 200,
+      contentType: "text/html; charset=utf-8",
+      body:
+        `<!doctype html><meta charset="utf-8"><title>bots: intercepted</title>` +
+        `<body style="font-family:system-ui;padding:2rem;color:#333">` +
+        `<h1>🤖 Side-effect intercepted</h1><p>The bot safety net blocked a ` +
+        `<b>${escapeHtml(category)}</b> ${escapeHtml(request.method())} to ` +
+        `<code>${escapeHtml(pathname)}</code> so no real-world action occurred.</p></body>`,
+    });
+    return;
+  }
+
+  await route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify({
+      ok: true,
+      mocked: true,
+      bots: true,
+      category,
+      // Some clients redirect to a returned `url` (e.g. Stripe checkout). Keep
+      // it same-origin and harmless.
+      url: `${baseOrigin}/?bots-mock=1`,
+    }),
+  });
+}
+
+export async function installSafetyNet(page: Page, config: BotConfig): Promise<SafetyNet> {
+  const intercepted: InterceptedCall[] = [];
+  const opts = {
+    targetClass: config.targetClass,
+    mockAi: config.mockAi,
+    allowDestructive: config.allowDestructive,
+  };
+  const baseOrigin = originOf(config.baseUrl);
+
+  await page.route("**/*", async (route) => {
+    try {
+      const request = route.request();
+      const url = new URL(request.url());
+
+      // Third-party assets (fonts/CDNs/analytics) proceed untouched. Affiliate
+      // partner hops don't happen because /go redirects are mocked below.
+      if (url.origin !== baseOrigin) {
+        await route.continue();
+        return;
+      }
+
+      const decision = decide(url.pathname, request.method(), opts);
+      if (decision === null) {
+        await route.continue();
+        return;
+      }
+
+      intercepted.push({
+        method: request.method(),
+        pathname: url.pathname,
+        category: decision.category,
+        action: decision.action,
+        at: Date.now(),
+      });
+
+      if (decision.action === "allow") {
+        await route.continue();
+        return;
+      }
+      await fulfillSynthetic(route, baseOrigin, decision.category);
+    } catch {
+      // Never leave a request hanging because the handler threw.
+      await route.continue().catch(() => undefined);
+    }
+  });
+
+  return {
+    intercepted,
+    summary() {
+      const out: Record<string, number> = {};
+      for (const call of intercepted) {
+        const key = `${call.category}:${call.action}`;
+        out[key] = (out[key] ?? 0) + 1;
+      }
+      return out;
+    },
+  };
+}

--- a/bots/safety/money-paths.ts
+++ b/bots/safety/money-paths.ts
@@ -1,0 +1,170 @@
+/**
+ * The side-effect firewall — request classification + policy resolution.
+ *
+ * Pure module (no Playwright). Given a request's pathname + method, it decides
+ * whether the bot fleet may let the request hit the server for real (`allow`)
+ * or must intercept it with a synthetic response (`mock`).
+ *
+ * Two-axis model:
+ *   1. Category — what kind of side effect the endpoint has.
+ *   2. Target class — `sandbox` (disposable) vs `protected` (conservative).
+ *
+ * Some categories are ALWAYS mocked regardless of target because their effects
+ * reach external/irreversible systems (real card charges, affiliate-network
+ * postbacks, third-party OAuth) or destroy fixtures we rely on.
+ *
+ * Route inventory derived from the live `app/api/**` + `app/go/**` tree
+ * (see __tests__/bots/money-paths.test.ts for the asserted cases).
+ */
+
+export type SideEffectCategory =
+  | "payment"
+  | "affiliate"
+  | "lead"
+  | "email"
+  | "content"
+  | "account"
+  | "account-destructive"
+  | "ai"
+  | "external-integration";
+
+export type SafetyAction = "allow" | "mock";
+
+export interface PolicyOptions {
+  targetClass: "sandbox" | "protected";
+  /** Mock AI endpoints to save tokens even when they'd otherwise be allowed. */
+  mockAi: boolean;
+  /** Permit destructive account writes on a sandbox target. */
+  allowDestructive: boolean;
+}
+
+/** Base policy per category. Overrides (mockAi, allowDestructive) applied in resolveAction. */
+const POLICY: Record<SideEffectCategory, Record<"sandbox" | "protected", SafetyAction>> = {
+  // Irreversible / external — never hit live, on any target.
+  payment: { sandbox: "mock", protected: "mock" },
+  affiliate: { sandbox: "mock", protected: "mock" },
+  "external-integration": { sandbox: "mock", protected: "mock" },
+  // Destroys seeded fixtures — mocked unless explicitly allowed on a sandbox.
+  "account-destructive": { sandbox: "mock", protected: "mock" },
+  // Internal state — exercise for real on a sandbox, mock on anything protected.
+  lead: { sandbox: "allow", protected: "mock" },
+  email: { sandbox: "allow", protected: "mock" },
+  content: { sandbox: "allow", protected: "mock" },
+  account: { sandbox: "allow", protected: "mock" },
+  // Server-side cost-capped; allowed everywhere, but mockable to save tokens.
+  ai: { sandbox: "allow", protected: "allow" },
+};
+
+interface Rule {
+  category: SideEffectCategory;
+  test: RegExp;
+  /** Restrict to these HTTP methods. */
+  methods?: ReadonlySet<string>;
+  /** Also match safe (GET/HEAD) methods — used by tracking pixels/redirects. */
+  includeGet?: boolean;
+}
+
+const WRITE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+// Ordered — first match wins. More specific / higher-risk rules come first.
+const RULES: readonly Rule[] = [
+  // ── Affiliate / click tracking (GET redirects + tracking beacons) ──────────
+  { category: "affiliate", test: /^\/go\//, includeGet: true },
+  {
+    category: "affiliate",
+    test: /^\/api\/(affiliate\/click|track-click|ab-track|drip-click|attribution\/touch|form-event|track-event)\b/,
+    includeGet: true,
+  },
+  // ── Payments — never hit live. Deliberately broad substring matches:
+  //    over-mocking a payment path is the safe failure direction, and these
+  //    catch hyphenated variants like `create-checkout` / `billing-portal`
+  //    that a `/checkout` or `/billing/` segment match would miss. ──────────
+  { category: "payment", test: /^\/api\/stripe\// },
+  { category: "payment", test: /billing/i },
+  { category: "payment", test: /checkout/i },
+  { category: "payment", test: /^\/api\/(sponsored-booking|course\/purchase)\b/ },
+  // ── Third-party integrations / OAuth / inbound webhooks ────────────────────
+  {
+    category: "external-integration",
+    test: /^\/api\/(account\/holdings\/sharesight|org-auth\/stripe-connect|webhooks\/)/,
+  },
+  // ── Destructive account ops ────────────────────────────────────────────────
+  { category: "account-destructive", test: /^\/api\/account\/(delete|documents)\b/ },
+  // ── Lead generation / quiz capture (money pipeline) ────────────────────────
+  {
+    category: "lead",
+    test: /^\/api\/(advisor-lead|submit-lead|quiz-lead|quiz\/submit|hub-quiz\/capture|developer-leads|report-leads|report-download|org-apply|exit-match|advisor-enquiry|claim-listing)\b/,
+  },
+  { category: "lead", test: /^\/api\/listings\/owner-flow\/[^/]+\/submit\b/ },
+  // ── Email capture / alert subscriptions / outbound mail triggers ───────────
+  {
+    category: "email",
+    test: /^\/api\/(newsletter|email-capture|rate-alerts|fee-alerts|country-rule-alerts|unsubscribe|send-switching-report|review-incentive|broker-review-invite)\b/,
+  },
+  // ── AI endpoints (server-side cost-capped) ─────────────────────────────────
+  {
+    category: "ai",
+    test: /^\/api\/(chatbot|concierge|search-semantic|answers\/ask)\b/,
+  },
+  { category: "ai", test: /^\/api\/calculator\/explain\b/ },
+  // ── Community / content writes ─────────────────────────────────────────────
+  {
+    category: "content",
+    test: /^\/api\/(community|reviews|advisor-review|user-review|follows|office-hours|events|answers|article-reactions|article-comments|bug-report|complaints|nps|churn-survey|questions|rba-polls)\b/,
+  },
+  { category: "content", test: /\/endorse\b/ },
+  // ── Account writes (non-destructive) ───────────────────────────────────────
+  { category: "account", test: /^\/api\/account\// },
+  // ── Catch-all: any other API write is treated as content (allow on sandbox,
+  //    mock on protected). Unknown high-risk paths are covered by the broad
+  //    payment/affiliate rules above. ───────────────────────────────────────
+  { category: "content", test: /^\/api\// },
+];
+
+function methodMatches(rule: Rule, method: string): boolean {
+  if (rule.methods) return rule.methods.has(method);
+  if (rule.includeGet) return true;
+  return WRITE_METHODS.has(method);
+}
+
+/**
+ * Classify a request by its side-effect category, or `null` if it carries no
+ * side effect we care about (e.g. a plain GET read).
+ */
+export function classify(pathname: string, method: string): SideEffectCategory | null {
+  const m = method.toUpperCase();
+  for (const rule of RULES) {
+    if (rule.test.test(pathname) && methodMatches(rule, m)) {
+      return rule.category;
+    }
+  }
+  return null;
+}
+
+/** Resolve the action (allow | mock) for a category under the given options. */
+export function resolveAction(category: SideEffectCategory, opts: PolicyOptions): SafetyAction {
+  if (category === "ai" && opts.mockAi) return "mock";
+  if (
+    category === "account-destructive" &&
+    opts.allowDestructive &&
+    opts.targetClass === "sandbox"
+  ) {
+    return "allow";
+  }
+  return POLICY[category][opts.targetClass];
+}
+
+export interface Decision {
+  category: SideEffectCategory;
+  action: SafetyAction;
+}
+
+/**
+ * One-shot helper: classify + resolve. Returns `null` when the request should
+ * proceed untouched (no side effect).
+ */
+export function decide(pathname: string, method: string, opts: PolicyOptions): Decision | null {
+  const category = classify(pathname, method);
+  if (category === null) return null;
+  return { category, action: resolveAction(category, opts) };
+}

--- a/bots/session.ts
+++ b/bots/session.ts
@@ -42,9 +42,10 @@ export class BotSession {
   ) {}
 
   static async create(browser: Browser, config: BotConfig, opts: SessionOptions): Promise<BotSession> {
-    const context = await browser.newContext(
-      opts.storageStateFile ? { storageState: opts.storageStateFile } : undefined,
-    );
+    const context = await browser.newContext({
+      ...(opts.storageStateFile ? { storageState: opts.storageStateFile } : {}),
+      ...(config.ignoreHttpsErrors ? { ignoreHTTPSErrors: true } : {}),
+    });
     const page = await context.newPage();
     const session = new BotSession(context, page, config, opts.persona);
     session.net = await installSafetyNet(page, config);

--- a/bots/session.ts
+++ b/bots/session.ts
@@ -17,6 +17,10 @@ import { attachConsole } from "./checks/console";
 import { attachNetwork } from "./checks/network";
 import { runAxe } from "./checks/a11y";
 import { checkInternalLinks } from "./checks/links";
+import { CostLedger } from "./ai/cost";
+import { PlaywrightPageDriver } from "./ai/playwright-page-driver";
+import { makeAnthropicClient } from "./ai/anthropic-client";
+import { runAiSession, type AiSessionResult } from "./ai/driver";
 
 export interface SessionOptions {
   persona: string;
@@ -28,6 +32,7 @@ export class BotSession {
   readonly store = new FindingStore();
   private readonly checkedLinks = new Set<string>();
   private net: SafetyNet | null = null;
+  private ledger: CostLedger | null = null;
 
   private constructor(
     readonly context: BrowserContext,
@@ -112,6 +117,28 @@ export class BotSession {
     }
   }
 
+  /**
+   * Let an AI bot pursue a goal on this session's page. Findings (including the
+   * AI's judgement calls) land in the same store; spend is bounded by a
+   * per-session cost ledger. Requires an Anthropic key (caller should gate on
+   * that). Cross-cutting checks still apply via the page collectors.
+   */
+  async runAiGoal(goal: string, startPath: string): Promise<AiSessionResult> {
+    const driver = new PlaywrightPageDriver(this.page, this.config.baseUrl);
+    const llm = makeAnthropicClient();
+    if (!this.ledger) this.ledger = new CostLedger(this.config.aiCostBudgetUsd);
+    return runAiSession({
+      persona: this.persona,
+      goal,
+      startPath,
+      driver,
+      llm,
+      store: this.store,
+      ledger: this.ledger,
+      maxSteps: this.config.maxStepsPerSession,
+    });
+  }
+
   /** Persist this session's findings as a shard for run-level aggregation. */
   async persist(): Promise<void> {
     if (this.net && this.net.intercepted.length > 0) {
@@ -132,7 +159,15 @@ export class BotSession {
     const file = path.join(shardsDir, `${safePersona}-${rand}.json`);
     await fs.writeFile(
       file,
-      JSON.stringify({ persona: this.persona, findings: this.store.all() }, null, 2),
+      JSON.stringify(
+        {
+          persona: this.persona,
+          findings: this.store.all(),
+          cost: this.ledger ? this.ledger.totals : undefined,
+        },
+        null,
+        2,
+      ),
       "utf8",
     );
   }

--- a/bots/session.ts
+++ b/bots/session.ts
@@ -1,0 +1,143 @@
+/**
+ * BotSession — one simulated user. Wraps a Playwright browser context with the
+ * safety net + check collectors, exposes navigation/audit helpers, and persists
+ * its findings as a shard for the run-level aggregator (findings/report.ts).
+ *
+ * Both deterministic scripted flows and the (future) AI-driven driver build on
+ * this: create a session, drive the page, persist, close.
+ */
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import type { Browser, BrowserContext, Page } from "@playwright/test";
+import type { BotConfig } from "./config";
+import { FindingStore } from "./findings/store";
+import { installSafetyNet, type SafetyNet } from "./safety/intercept";
+import { attachConsole } from "./checks/console";
+import { attachNetwork } from "./checks/network";
+import { runAxe } from "./checks/a11y";
+import { checkInternalLinks } from "./checks/links";
+
+export interface SessionOptions {
+  persona: string;
+  /** Storage-state file for an authenticated persona (reuses e2e auth states). */
+  storageStateFile?: string;
+}
+
+export class BotSession {
+  readonly store = new FindingStore();
+  private readonly checkedLinks = new Set<string>();
+  private net: SafetyNet | null = null;
+
+  private constructor(
+    readonly context: BrowserContext,
+    readonly page: Page,
+    private readonly config: BotConfig,
+    private readonly persona: string,
+  ) {}
+
+  static async create(browser: Browser, config: BotConfig, opts: SessionOptions): Promise<BotSession> {
+    const context = await browser.newContext(
+      opts.storageStateFile ? { storageState: opts.storageStateFile } : undefined,
+    );
+    const page = await context.newPage();
+    const session = new BotSession(context, page, config, opts.persona);
+    session.net = await installSafetyNet(page, config);
+    attachConsole(page, session.store, opts.persona);
+    attachNetwork(page, config, session.store, opts.persona);
+    return session;
+  }
+
+  /** Navigate to a route (relative to baseUrl) and record load problems. */
+  async visit(route: string): Promise<number> {
+    const target = this.config.baseUrl.replace(/\/$/, "") + route;
+    let status = 0;
+    try {
+      const res = await this.page.goto(target, { waitUntil: "domcontentloaded", timeout: 30_000 });
+      status = res?.status() ?? 0;
+      await this.page.waitForLoadState("load", { timeout: 30_000 }).catch(() => undefined);
+      await this.page.waitForTimeout(600);
+    } catch (err) {
+      this.store.add({
+        severity: "high",
+        category: "dead-end",
+        title: `navigation failed: ${route}`,
+        detail: `goto(${route}) threw: ${(err as Error).message}`,
+        url: target,
+        persona: this.persona,
+        signatureKey: `nav-failed:${route}`,
+      });
+      return status;
+    }
+
+    if (status >= 400) {
+      this.store.add({
+        severity: status >= 500 ? "critical" : "high",
+        category: "http-error",
+        title: `${status} on ${route}`,
+        detail: `Navigating to ${route} returned HTTP ${status}.`,
+        url: target,
+        persona: this.persona,
+        signatureKey: `nav:${status}:${route}`,
+      });
+    }
+
+    // Dead-end heuristic: a 2xx page that rendered almost nothing.
+    const bodyText = await this.page
+      .locator("main, body")
+      .first()
+      .innerText()
+      .catch(() => "");
+    if (status > 0 && status < 400 && bodyText.trim().length < 20) {
+      this.store.add({
+        severity: "medium",
+        category: "dead-end",
+        title: `empty page: ${route}`,
+        detail: `Route ${route} returned ${status} but rendered ${bodyText.trim().length} chars of text.`,
+        url: target,
+        persona: this.persona,
+        signatureKey: `empty:${route}`,
+      });
+    }
+    return status;
+  }
+
+  /** Run the cross-cutting checks on whatever is currently on screen. */
+  async audit(opts: { links?: boolean } = {}): Promise<void> {
+    await runAxe(this.page, this.store, this.persona);
+    if (opts.links) {
+      await checkInternalLinks(this.page, this.config, this.store, this.persona, {
+        checked: this.checkedLinks,
+      });
+    }
+  }
+
+  /** Persist this session's findings as a shard for run-level aggregation. */
+  async persist(): Promise<void> {
+    if (this.net && this.net.intercepted.length > 0) {
+      this.store.add({
+        severity: "info",
+        category: "safety",
+        title: `safety net intercepted ${this.net.intercepted.length} side-effecting call(s)`,
+        detail: `Breakdown (category:action → count): ${JSON.stringify(this.net.summary())}`,
+        url: "(fleet)",
+        persona: this.persona,
+        signatureKey: "safety-summary",
+      });
+    }
+    const shardsDir = path.join(this.config.runDir, "shards");
+    await fs.mkdir(shardsDir, { recursive: true });
+    const safePersona = this.persona.replace(/[^a-z0-9-]/gi, "-");
+    const rand = Math.random().toString(36).slice(2, 8);
+    const file = path.join(shardsDir, `${safePersona}-${rand}.json`);
+    await fs.writeFile(
+      file,
+      JSON.stringify({ persona: this.persona, findings: this.store.all() }, null, 2),
+      "utf8",
+    );
+  }
+
+  async close(): Promise<void> {
+    await this.context.close().catch(() => undefined);
+  }
+}

--- a/components/layout/SiteFooter.tsx
+++ b/components/layout/SiteFooter.tsx
@@ -146,7 +146,7 @@ export function SiteFooter() {
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
                   </svg>
                 </summary>
-                <p className="text-[0.7rem] text-slate-500 leading-relaxed pt-2 pb-1">{item.content}</p>
+                <p className="text-[0.7rem] text-slate-400 leading-relaxed pt-2 pb-1">{item.content}</p>
               </details>
             ))}
           </div>
@@ -164,7 +164,7 @@ export function SiteFooter() {
               </p>
             </div>
 
-            <nav className="flex flex-wrap gap-x-5 gap-y-2 text-xs text-slate-500" aria-label="Legal links">
+            <nav className="flex flex-wrap gap-x-5 gap-y-2 text-xs text-slate-400" aria-label="Legal links">
               {[
                 { label: "Privacy", href: "/privacy" },
                 { label: "Terms", href: "/terms" },
@@ -192,10 +192,10 @@ export function SiteFooter() {
 
           {/* Social media */}
           <div className="flex items-center gap-3 mt-3">
-            <a href="https://twitter.com/investcomau" target="_blank" rel="noopener noreferrer" className="text-slate-500 hover:text-amber-400 transition-colors" aria-label="Twitter / X">
+            <a href="https://twitter.com/investcomau" target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-amber-400 transition-colors" aria-label="Twitter / X">
               <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
             </a>
-            <a href="https://linkedin.com/company/investcomau" target="_blank" rel="noopener noreferrer" className="text-slate-500 hover:text-amber-400 transition-colors" aria-label="LinkedIn">
+            <a href="https://linkedin.com/company/investcomau" target="_blank" rel="noopener noreferrer" className="text-slate-400 hover:text-amber-400 transition-colors" aria-label="LinkedIn">
               <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
             </a>
           </div>

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui",
     "e2e:install": "playwright install --with-deps chromium webkit",
+    "bots": "playwright test --config bots/playwright.config.ts",
+    "bots:install": "playwright install --with-deps chromium",
     "screenshots": "playwright test --config e2e/visual/playwright.config.ts e2e/visual/screenshots.spec.ts",
     "screenshots:seed": "node scripts/screenshots-seed.mjs",
     "screenshots:auto-seed": "node scripts/screenshots-auto-seed.mjs",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,6 +41,7 @@
   "exclude": [
     "node_modules",
     "e2e/**",
+    "bots/**",
     "playwright.config.ts",
     "supabase/functions/**"
   ]


### PR DESCRIPTION
## What

A fleet of simulated users that exercises invest-com-au's features the way real people would — pre-launch QA without humans. This PR lands **Phase 0: the foundation** every bot depends on. Deterministic critical-path flows, the AI explore/judge driver, authenticated personas, and full-surface coverage build on top of it (roadmap below).

Lives in a self-contained `bots/` subsystem with its own Playwright config, kept out of per-PR CI (like the visual pipeline). Run it with `npm run bots`.

## The safety model (the whole point)

A bot must **never** trip a real-world side effect — no Stripe charges, real emails, fraudulent affiliate clicks, polluted revenue data, or destroyed fixtures. Two layers enforce it:

1. **Per-request firewall** (`bots/safety/intercept.ts` + `money-paths.ts`) — classifies every same-origin request against the live `app/api/**` + `app/go/**` route tree and answers anything that must be mocked with a synthetic response. Built from the real route inventory (Stripe, `/go` affiliate redirects, leads, email capture, content/account writes, AI, third-party integrations).
2. **Target-class model** (`bots/config.ts`):

   | Category | `sandbox` (localhost / seeded staging) | `protected` (anything else) |
   |---|---|---|
   | payment · affiliate · external-integration · destructive | **mock** | **mock** |
   | lead · email · content · account | allow (run for real on disposable data) | **mock** |
   | ai (server-side cost-capped) | allow / mockable | allow / mockable |

   Irreversible/external effects are **always mocked**. `assertTargetAllowed` refuses a production host outright unless `BOTS_PROD_OVERRIDE=1`.

## What every bot checks

console/page errors · first-party HTTP 4xx/5xx · axe-core a11y (same tags/rules as `e2e/a11y.spec.ts`) · broken internal links (side-effecting links skipped) · dead-end pages. Findings dedupe by a stable signature and aggregate across all parallel sessions into one **HTML + JSON report**.

## Cost & billing (bot AI spend is separate and bounded)

The AI driver (later phase) calls the Anthropic **API**, billed to whatever account owns the key — separate from the Claude Code subscription. So bot spend is attributable and capped:
- reads a dedicated `BOTS_ANTHROPIC_API_KEY` → lands on its own billing line;
- a token→USD ledger (`bots/ai/cost.ts`) enforces a hard **dollar + token budget** per run (default $20);
- the report shows tokens + estimated USD per run.

## Verification

- **80 unit tests** for the pure core (classifier, findings dedupe, report render/escaping, cost math, config guards) — `npm test -- __tests__/bots`
- `tsc --noEmit` clean · `eslint` clean · Playwright config + spec load and enumerate the personas
- Pure modules carry no Playwright import (unit-tested); browser-driving modules run via `npm run bots`

## Roadmap (next phases, this PR will grow)

1. Deterministic critical/money-path flows (get-matched → action plan, advisor lead, compare → affiliate (mocked), signup/login, calculators) + authenticated personas via the existing auth scaffold.
2. AI driver — Claude observes a compact a11y-tree snapshot, picks the next action, and judges UX + required financial disclosures. Budget-capped + prompt-cached.
3. Full-surface coverage — auto-discover all ~220 routes; persona+goal-driven AI roaming.
4. Opt-in GitHub-issue filing for high-severity findings (deduped), then a non-gating nightly CI workflow.

https://claude.ai/code/session_01AX16WTaqAs2W33uydbBWLa

---
_Generated by [Claude Code](https://claude.ai/code/session_01AX16WTaqAs2W33uydbBWLa)_