### PR TITLE
feat(ui): v2 coral redesign of /invest marketplace + advisor directory

### DIFF
--- a/app/advisors/AdvisorsClient.tsx
+++ b/app/advisors/AdvisorsClient.tsx
@@ -143,7 +143,7 @@ function LocationSearch({ onSelect, selected }: { onSelect: (p: PostcodeResult |
             <button
               key={p.postcode}
               onClick={() => { onSelect(p); setQuery(`${p.locality}, ${p.state}`); setOpen(false); }}
-              className="w-full text-left px-3 py-2 hover:bg-amber-50 text-sm text-slate-700 flex items-center justify-between"
+              className="w-full text-left px-3 py-2 hover:bg-coral-50 text-sm text-slate-700 flex items-center justify-between"
             >
               <span>{p.locality}, {p.state}</span>
               <span className="text-xs text-slate-400">{p.postcode}</span>
@@ -687,7 +687,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
                   }`}
                 >
                   {label}
-                  <span className={`text-[0.6rem] md:text-[0.65rem] font-bold px-1.5 py-0.5 rounded ${active ? "bg-amber-100 text-amber-700" : "bg-slate-200 text-slate-500"}`}>
+                  <span className={`text-[0.6rem] md:text-[0.65rem] font-bold px-1.5 py-0.5 rounded ${active ? "bg-coral-100 text-coral-700" : "bg-slate-200 text-slate-500"}`}>
                     {count}
                   </span>
                 </button>
@@ -798,7 +798,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
               </div>
               <div className="flex items-end">
                 <label className="flex items-center gap-2 cursor-pointer py-2">
-                  <input type="checkbox" checked={verifiedOnly} onChange={() => setVerifiedOnly(!verifiedOnly)} className="w-4 h-4 rounded border-slate-300 text-coral-600 focus:ring-amber-500" />
+                  <input type="checkbox" checked={verifiedOnly} onChange={() => setVerifiedOnly(!verifiedOnly)} className="w-4 h-4 rounded border-slate-300 text-coral-600 focus:ring-coral-500" />
                   <span className="text-xs font-semibold text-slate-700">Verified only</span>
                 </label>
               </div>
@@ -1063,7 +1063,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
                             Firm
                           </span>
                           {firm.afsl_number && (
-                            <span className="shrink-0 text-[0.58rem] font-bold px-1.5 py-0.5 rounded-full bg-amber-50 text-amber-700 border border-amber-200">
+                            <span className="shrink-0 text-[0.58rem] font-bold px-1.5 py-0.5 rounded-full bg-coral-50 text-coral-700 border border-coral-200">
                               AFSL {firm.afsl_number}
                             </span>
                           )}
@@ -1393,9 +1393,9 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
               <button onClick={clearAll} className="text-xs text-coral-600 font-semibold hover:text-coral-800">Clear all filters</button>
             </div>
             {/* Alert capture */}
-            <div className="px-5 py-5 bg-amber-50">
+            <div className="px-5 py-5 bg-coral-50">
               <div className="flex items-start gap-3 mb-3">
-                <div className="w-8 h-8 bg-amber-100 rounded-lg flex items-center justify-center shrink-0">
+                <div className="w-8 h-8 bg-coral-100 rounded-lg flex items-center justify-center shrink-0">
                   <Icon name="bell" size={16} className="text-coral-600" />
                 </div>
                 <div>
@@ -1415,7 +1415,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
                     value={alertEmail}
                     onChange={(e) => { setAlertEmail(e.target.value); setAlertError(""); }}
                     placeholder="your@email.com"
-                    className="flex-1 px-3 py-2 border border-amber-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-amber-400 bg-white"
+                    className="flex-1 px-3 py-2 border border-coral-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-coral-400 bg-white"
                     onKeyDown={(e) => e.key === "Enter" && saveAlert()}
                   />
                   <button
@@ -1468,10 +1468,10 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
               </ul>
             </div>
             <div className="grid md:grid-cols-2 gap-4">
-              <div className="bg-gradient-to-br from-coral-50/80 via-white to-white border border-amber-100 rounded-2xl p-5 md:p-6 shadow-sm">
+              <div className="bg-gradient-to-br from-coral-50/80 via-white to-white border border-coral-100 rounded-2xl p-5 md:p-6 shadow-sm">
                 <div className="flex items-center gap-2.5 mb-3">
-                  <div className="w-8 h-8 rounded-xl bg-amber-100 flex items-center justify-center shrink-0">
-                    <Icon name="dollar-sign" size={15} className="text-amber-700" />
+                  <div className="w-8 h-8 rounded-xl bg-coral-100 flex items-center justify-center shrink-0">
+                    <Icon name="dollar-sign" size={15} className="text-coral-700" />
                   </div>
                   <h2 className="text-base md:text-lg font-extrabold text-slate-900">Cost Guide</h2>
                 </div>
@@ -1499,7 +1499,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
                 <details key={i} className="group">
                   <summary className="px-4 py-3.5 md:px-5 md:py-4 font-semibold text-xs md:text-sm text-slate-800 cursor-pointer hover:bg-slate-50/80 transition-colors list-none flex items-center justify-between gap-3">
                     <span>{faq.q}</span>
-                    <span className="shrink-0 w-5 h-5 rounded-full border border-slate-200 bg-slate-50 flex items-center justify-center text-slate-400 group-open:bg-amber-50 group-open:border-amber-200 group-open:text-coral-600 transition-all">
+                    <span className="shrink-0 w-5 h-5 rounded-full border border-slate-200 bg-slate-50 flex items-center justify-center text-slate-400 group-open:bg-coral-50 group-open:border-coral-200 group-open:text-coral-600 transition-all">
                       <svg className="w-2.5 h-2.5 group-open:rotate-180 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M19 9l-7 7-7-7" /></svg>
                     </span>
                   </summary>
@@ -1528,8 +1528,8 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
               { title: "Crypto Advisor", href: "/advisor-guides/how-to-choose-crypto-advisor", icon: "bitcoin" },
               { title: "Debt Counsellor", href: "/advisor-guides/how-to-choose-debt-counsellor", icon: "credit-card" },
             ].map(g => (
-              <Link key={g.href} href={g.href} className="group flex items-center gap-2.5 p-3 bg-white border border-slate-100 rounded-xl shadow-sm hover:shadow-md hover:border-amber-100 hover:bg-amber-50/30 transition-all">
-                <div className="w-7 h-7 rounded-lg bg-slate-50 border border-slate-100 flex items-center justify-center shrink-0 group-hover:bg-amber-100 group-hover:border-amber-200 transition-all">
+              <Link key={g.href} href={g.href} className="group flex items-center gap-2.5 p-3 bg-white border border-slate-100 rounded-xl shadow-sm hover:shadow-md hover:border-coral-100 hover:bg-coral-50/30 transition-all">
+                <div className="w-7 h-7 rounded-lg bg-slate-50 border border-slate-100 flex items-center justify-center shrink-0 group-hover:bg-coral-100 group-hover:border-coral-200 transition-all">
                   <Icon name={g.icon} size={14} className="text-slate-500 group-hover:text-coral-600 transition-colors" />
                 </div>
                 <span className="text-xs font-semibold text-slate-600 group-hover:text-slate-800 leading-tight">How to Choose: {g.title}</span>
@@ -1539,9 +1539,9 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
         </div>
 
         {/* Saved search / alert widget */}
-        <div className="mt-6 md:mt-8 bg-gradient-to-br from-coral-50/80 via-white to-white border border-amber-100 rounded-2xl p-4 md:p-6 shadow-sm">
+        <div className="mt-6 md:mt-8 bg-gradient-to-br from-coral-50/80 via-white to-white border border-coral-100 rounded-2xl p-4 md:p-6 shadow-sm">
           <div className="flex items-start gap-3 mb-3.5">
-            <div className="w-10 h-10 bg-amber-100 border border-amber-200 rounded-xl flex items-center justify-center shrink-0 shadow-sm shadow-amber-100">
+            <div className="w-10 h-10 bg-coral-100 border border-coral-200 rounded-xl flex items-center justify-center shrink-0 shadow-sm shadow-coral-100">
               <Icon name="bell" size={18} className="text-coral-600" />
             </div>
             <div>
@@ -1561,7 +1561,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
                 value={alertEmail}
                 onChange={(e) => { setAlertEmail(e.target.value); setAlertError(""); }}
                 placeholder="your@email.com"
-                className="flex-1 px-3 py-2 border border-amber-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-amber-400 bg-white"
+                className="flex-1 px-3 py-2 border border-coral-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-coral-400 bg-white"
                 onKeyDown={(e) => e.key === "Enter" && saveAlert()}
               />
               <button
@@ -1579,11 +1579,11 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
         <div className="mt-6 md:mt-10 relative overflow-hidden bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 rounded-2xl p-5 md:p-8 text-center shadow-xl shadow-slate-900/10">
           <div className="absolute inset-0 opacity-5" style={{backgroundImage: 'radial-gradient(circle at 20% 50%, white 1px, transparent 1px), radial-gradient(circle at 80% 20%, white 1px, transparent 1px)', backgroundSize: '32px 32px'}} />
           <div className="relative">
-            <p className="text-[0.65rem] font-bold uppercase tracking-widest text-amber-400 mb-2">For Professionals</p>
+            <p className="text-[0.65rem] font-bold uppercase tracking-widest text-coral-400 mb-2">For Professionals</p>
             <h3 className="text-base md:text-xl font-extrabold text-white mb-1.5 md:mb-2">Are you a financial professional?</h3>
             <p className="text-xs md:text-sm text-slate-400 mb-4 md:mb-5">List your practice for free. Only pay when you receive an enquiry.</p>
             <div className="flex items-center justify-center gap-3 flex-wrap">
-              <Link href="/advisor-apply" className="inline-flex items-center gap-2 px-5 py-2.5 md:px-6 md:py-3 bg-coral-500 text-white text-sm font-bold rounded-xl hover:bg-coral-400 transition-colors shadow-lg shadow-amber-500/25">
+              <Link href="/advisor-apply" className="inline-flex items-center gap-2 px-5 py-2.5 md:px-6 md:py-3 bg-coral-500 text-white text-sm font-bold rounded-xl hover:bg-coral-400 transition-colors shadow-lg shadow-coral-500/25">
                 Get Listed Free
                 <Icon name="arrow-right" size={15} />
               </Link>

--- a/app/advisors/AdvisorsClient.tsx
+++ b/app/advisors/AdvisorsClient.tsx
@@ -1153,11 +1153,11 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
               return (
                 <Link key={item.key} href={`/advisor/${pro.slug}`} className={`group block bg-white rounded-2xl transition-all duration-200 overflow-hidden ${
                   isFeatured
-                    ? "shadow-md shadow-amber-50 hover:shadow-xl hover:shadow-amber-100/50 hover:-translate-y-0.5 ring-1 ring-amber-200/80 border border-amber-200"
+                    ? "shadow-md shadow-coral-50 hover:shadow-xl hover:shadow-coral-100/50 hover:-translate-y-0.5 ring-1 ring-coral-200/80 border border-coral-200"
                     : "shadow-sm border border-slate-100 hover:shadow-md hover:shadow-slate-100 hover:-translate-y-0.5 hover:border-slate-200"
                 }`}>
                   {isFeatured && (
-                    <div className="h-0.5 bg-gradient-to-r from-amber-300 via-amber-500 to-amber-300" />
+                    <div className="h-0.5 bg-gradient-to-r from-coral-300 via-coral-500 to-coral-300" />
                   )}
                   <div className="p-4 md:p-5 flex gap-4">
                     {/* Photo */}
@@ -1176,12 +1176,12 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
                           />
                         </div>
                       ) : (
-                        <div className="w-15 h-15 md:w-20 md:h-20 rounded-2xl bg-gradient-to-br from-amber-400 to-amber-600 flex items-center justify-center text-white font-bold text-xl md:text-2xl shadow-md shadow-amber-200/60 select-none">
+                        <div className="w-15 h-15 md:w-20 md:h-20 rounded-2xl bg-gradient-to-br from-coral-400 to-coral-600 flex items-center justify-center text-white font-bold text-xl md:text-2xl shadow-md shadow-coral-200/60 select-none">
                           {pro.name.split(" ").map((n: string) => n[0]).join("").slice(0, 2).toUpperCase()}
                         </div>
                       )}
                       {pro.verified && (
-                        <div className="absolute -bottom-1 -right-1 w-4.5 h-4.5 bg-amber-500 rounded-full border-2 border-white flex items-center justify-center shadow-sm">
+                        <div className="absolute -bottom-1 -right-1 w-4.5 h-4.5 bg-emerald-500 rounded-full border-2 border-white flex items-center justify-center shadow-sm">
                           <svg className="w-2.5 h-2.5 text-white" fill="currentColor" viewBox="0 0 20 20">
                             <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
                           </svg>
@@ -1204,7 +1204,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
                           )}
                           <div className="flex items-center gap-1.5 flex-wrap mt-1.5">
                             {pro.verified && (
-                              <span className="shrink-0 text-[0.58rem] font-bold px-1.5 py-0.5 rounded-full bg-amber-50 text-amber-700 border border-amber-200 flex items-center gap-0.5">
+                              <span className="shrink-0 text-[0.58rem] font-bold px-1.5 py-0.5 rounded-full bg-emerald-50 text-emerald-700 border border-emerald-200 flex items-center gap-0.5">
                                 <svg className="w-2 h-2" fill="currentColor" viewBox="0 0 20 20"><path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" /></svg>
                                 Verified
                               </span>
@@ -1218,7 +1218,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
                             {isFeatured && (
                               <span
                                 title={SPONSORED_DISCLOSURE_SHORT}
-                                className="shrink-0 text-[0.58rem] font-bold px-1.5 py-0.5 rounded-full bg-amber-500 text-white flex items-center gap-0.5 shadow-sm cursor-help"
+                                className="shrink-0 text-[0.58rem] font-bold px-1.5 py-0.5 rounded-full bg-coral-500 text-white flex items-center gap-0.5 shadow-sm cursor-help"
                               >
                                 <Icon name="star" size={9} />
                                 Featured · Paid
@@ -1264,7 +1264,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
                             type="advisor"
                             ref={pro.slug}
                             label={pro.name}
-                            className="shrink-0 p-1.5 rounded-lg text-slate-300 hover:text-amber-600 hover:bg-amber-50 transition-colors"
+                            className="shrink-0 p-1.5 rounded-lg text-slate-300 hover:text-coral-600 hover:bg-coral-50 transition-colors"
                           />
                           <button
                             onClick={(e) => { e.preventDefault(); toggleShortlist(pro.slug); }}
@@ -1279,7 +1279,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
 
                       {/* Type + Location row */}
                       <div className="flex items-center gap-1.5 mt-1.5 flex-wrap">
-                        <span className="shrink-0 text-[0.65rem] text-amber-700 bg-amber-50 border border-amber-100 px-2 py-0.5 rounded-full font-semibold">{PROFESSIONAL_TYPE_LABELS[pro.type]}</span>
+                        <span className="shrink-0 text-[0.65rem] text-coral-700 bg-coral-50 border border-coral-100 px-2 py-0.5 rounded-full font-semibold">{PROFESSIONAL_TYPE_LABELS[pro.type]}</span>
                         {pro.account_type === "firm_member" ? (
                           <span className="shrink-0 text-[0.6rem] font-semibold text-blue-600 bg-blue-50 border border-blue-100 px-1.5 py-0.5 rounded-full flex items-center gap-0.5">
                             <Icon name="users" size={9} className="text-blue-400" />Firm
@@ -1363,18 +1363,19 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
 
                       {/* Offer */}
                       {pro.offer_active && pro.offer_text && (
-                        <div className="mt-2 bg-gradient-to-r from-amber-50 to-amber-50/0 border border-amber-200 rounded-lg px-2.5 py-1.5 flex items-center gap-1.5">
-                          <Icon name="tag" size={11} className="text-amber-500 shrink-0" />
-                          <span className="text-[0.6rem] md:text-[0.65rem] font-bold text-amber-700 truncate">{pro.offer_text}</span>
+                        <div className="mt-2 bg-gradient-to-r from-coral-50 to-coral-50/0 border border-coral-200 rounded-lg px-2.5 py-1.5 flex items-center gap-1.5">
+                          <Icon name="tag" size={11} className="text-coral-500 shrink-0" />
+                          <span className="text-[0.6rem] md:text-[0.65rem] font-bold text-coral-700 truncate">{pro.offer_text}</span>
                         </div>
                       )}
                     </div>
 
-                    {/* Right arrow */}
+                    {/* View profile CTA */}
                     <div className="shrink-0 self-center hidden md:flex ml-1">
-                      <div className="w-8 h-8 rounded-full border border-slate-200 bg-slate-50 flex items-center justify-center group-hover:bg-amber-50 group-hover:border-amber-200 transition-all">
-                        <Icon name="chevron-right" size={14} className="text-slate-400 group-hover:text-amber-500 transition-colors" />
-                      </div>
+                      <span className="inline-flex items-center gap-1 rounded-lg bg-coral-500 px-3.5 py-2 text-xs font-semibold text-white whitespace-nowrap shadow-sm transition-colors group-hover:bg-coral-600">
+                        View profile
+                        <Icon name="chevron-right" size={13} />
+                      </span>
                     </div>
                   </div>
                 </Link>

--- a/app/advisors/AdvisorsClient.tsx
+++ b/app/advisors/AdvisorsClient.tsx
@@ -129,7 +129,7 @@ function LocationSearch({ onSelect, selected }: { onSelect: (p: PostcodeResult |
           onChange={e => { setQuery(e.target.value); search(e.target.value); }}
           onFocus={() => results.length > 0 && setOpen(true)}
           placeholder="Suburb or postcode..."
-          className="w-full pl-8 pr-8 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-amber-500/30"
+          className="w-full pl-8 pr-8 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-coral-500/30"
         />
         {selected && (
           <button onClick={() => { setQuery(""); onSelect(null); setResults([]); }} className="absolute right-2.5 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600">
@@ -173,7 +173,7 @@ function UseMyLocation({ onLocate }: { onLocate: (lat: number, lng: number) => v
           { enableHighAccuracy: false, timeout: 10000 }
         );
       }}
-      className="flex items-center gap-1 text-[0.65rem] font-semibold text-amber-600 hover:text-amber-800 transition-colors"
+      className="flex items-center gap-1 text-[0.65rem] font-semibold text-coral-600 hover:text-coral-800 transition-colors"
     >
       <Icon name="navigation" size={12} />
       {loading ? "Locating..." : "Use my location"}
@@ -596,8 +596,8 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
           <span className="text-slate-700">{activeTypeLabel || "Find an Advisor"}</span>
         </nav>
 
-        <div className="relative overflow-hidden bg-gradient-to-br from-amber-50 via-white to-slate-50/80 border border-slate-200 rounded-2xl p-4 md:p-8 mb-4 md:mb-6 shadow-sm">
-          <div className="absolute top-0 left-0 right-0 h-0.5 bg-gradient-to-r from-amber-300 via-amber-500 to-amber-300" />
+        <div className="relative overflow-hidden bg-gradient-to-br from-coral-50 via-white to-slate-50/80 border border-slate-200 rounded-2xl p-4 md:p-8 mb-4 md:mb-6 shadow-sm">
+          <div className="absolute top-0 left-0 right-0 h-0.5 bg-gradient-to-r from-coral-300 via-coral-500 to-coral-300" />
           <h1 className="text-xl md:text-4xl font-extrabold mb-1.5 md:mb-3 text-slate-900 tracking-tight">{dynamicTitle}</h1>
           <p className="text-xs md:text-base text-slate-500 mb-4 max-w-2xl leading-relaxed">
             <span className="md:hidden">{dynamicDescription.slice(0, 70)}…</span>
@@ -609,10 +609,10 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
               <span className="font-bold text-slate-900">{providerTypeCounts.all}</span> listings
             </div>
             <div className="flex items-center gap-1.5 px-3 py-1.5 bg-white border border-slate-200 rounded-full shadow-sm text-[0.65rem] md:text-xs font-semibold text-slate-600">
-              <Icon name="shield" size={13} className="text-amber-500" />ASIC verified
+              <Icon name="shield" size={13} className="text-coral-500" />ASIC verified
             </div>
             <div className="flex items-center gap-1.5 px-3 py-1.5 bg-white border border-slate-200 rounded-full shadow-sm text-[0.65rem] md:text-xs font-semibold text-slate-600">
-              <Icon name="clock" size={13} className="text-amber-500" />Free consultation
+              <Icon name="clock" size={13} className="text-coral-500" />Free consultation
             </div>
           </div>
           <GetMatchedEmbed context="advisor_directory" />
@@ -626,7 +626,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
                   source: "advisors_hero",
                 })
               }
-              className="font-semibold text-slate-700 hover:text-amber-700 underline-offset-2 hover:underline"
+              className="font-semibold text-slate-700 hover:text-coral-700 underline-offset-2 hover:underline"
             >
               Ask the AI concierge →
             </Link>
@@ -700,19 +700,19 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
         <div className="flex gap-2 mb-3 md:mb-4">
           <div className="relative flex-1">
             <Icon name="search" size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" />
-            <input type="text" placeholder="Search name, firm, team, specialty, suburb..." value={search} onChange={e => setSearch(e.target.value)} aria-label="Search advisors" className="w-full pl-9 pr-4 py-2.5 md:py-3 text-sm border border-slate-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-amber-500/30 focus:border-amber-400 transition-all" />
+            <input type="text" placeholder="Search name, firm, team, specialty, suburb..." value={search} onChange={e => setSearch(e.target.value)} aria-label="Search advisors" className="w-full pl-9 pr-4 py-2.5 md:py-3 text-sm border border-slate-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-coral-500/30 focus:border-coral-400 transition-all" />
             {search && <button onClick={() => setSearch("")} className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600"><Icon name="x" size={16} /></button>}
           </div>
-          <button onClick={() => setFiltersOpen(!filtersOpen)} className={`flex items-center gap-1.5 px-3 md:px-4 py-2.5 border rounded-xl text-sm font-semibold transition-all shrink-0 ${filtersOpen || activeFilterCount > 0 ? "bg-amber-50 border-amber-300 text-amber-700" : "bg-white border-slate-200 text-slate-600 hover:bg-slate-50"}`}>
+          <button onClick={() => setFiltersOpen(!filtersOpen)} className={`flex items-center gap-1.5 px-3 md:px-4 py-2.5 border rounded-xl text-sm font-semibold transition-all shrink-0 ${filtersOpen || activeFilterCount > 0 ? "bg-coral-50 border-coral-300 text-coral-700" : "bg-white border-slate-200 text-slate-600 hover:bg-slate-50"}`}>
             <Icon name="sliders" size={16} />
             <span className="hidden md:inline">Filters</span>
-            {activeFilterCount > 0 && <span className="w-5 h-5 bg-amber-600 text-white text-[0.6rem] font-bold rounded-full flex items-center justify-center">{activeFilterCount}</span>}
+            {activeFilterCount > 0 && <span className="w-5 h-5 bg-coral-600 text-white text-[0.6rem] font-bold rounded-full flex items-center justify-center">{activeFilterCount}</span>}
           </button>
           <select
             value={sortBy}
             onChange={e => setSortBy(e.target.value as SortKey)}
             aria-label="Sort results"
-            className="hidden md:block px-3 py-2.5 border border-slate-200 rounded-xl text-sm text-slate-600 bg-white focus:outline-none focus:ring-2 focus:ring-amber-500/30"
+            className="hidden md:block px-3 py-2.5 border border-slate-200 rounded-xl text-sm text-slate-600 bg-white focus:outline-none focus:ring-2 focus:ring-coral-500/30"
           >
             {SORT_OPTIONS.map(o => <option key={o.key} value={o.key}>{o.label}</option>)}
           </select>
@@ -724,7 +724,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
             {/* Location / Near me */}
             <div>
               <label className="text-xs font-bold text-slate-700 mb-2 block flex items-center gap-1.5">
-                <Icon name="map-pin" size={13} className="text-amber-500" />
+                <Icon name="map-pin" size={13} className="text-coral-500" />
                 Location
               </label>
               <div className="grid grid-cols-1 md:grid-cols-3 gap-2">
@@ -732,7 +732,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
                   <LocationSearch selected={locationSearch} onSelect={(p) => { setLocationSearch(p); if (!p) { setUserLat(null); setUserLng(null); } }} />
                 </div>
                 <div className="flex items-center gap-2">
-                  <select value={radius} onChange={e => setRadius(Number(e.target.value))} className="flex-1 px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-amber-500/30" disabled={!isLocationActive}>
+                  <select value={radius} onChange={e => setRadius(Number(e.target.value))} className="flex-1 px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-coral-500/30" disabled={!isLocationActive}>
                     {RADIUS_OPTIONS.map(r => <option key={r.value} value={r.value}>{r.label}</option>)}
                   </select>
                   <UseMyLocation onLocate={(lat, lng) => { setUserLat(lat); setUserLng(lng); setSortBy("distance"); setLocationSearch({ postcode: "", locality: "My location", state: "", latitude: lat, longitude: lng }); }} />
@@ -745,10 +745,10 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
               <label className="text-xs font-bold text-slate-700 mb-2 block">Advisor Type</label>
               <div className="flex flex-wrap gap-1.5">
                 {TYPE_FILTERS.map(f => (
-                  <button key={f.key} onClick={() => toggleType(f.key)} className={`flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold rounded-lg transition-all ${(f.key === "all" ? typeFilters.size === 0 : typeFilters.has(f.key as ProfessionalType)) ? "bg-amber-600 text-white shadow-sm" : "bg-slate-50 text-slate-600 hover:bg-slate-100 border border-slate-200"}`}>
-                    <Icon name={f.icon} size={13} className={(f.key === "all" ? typeFilters.size === 0 : typeFilters.has(f.key as ProfessionalType)) ? "text-amber-200" : "text-slate-400"} />
+                  <button key={f.key} onClick={() => toggleType(f.key)} className={`flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold rounded-lg transition-all ${(f.key === "all" ? typeFilters.size === 0 : typeFilters.has(f.key as ProfessionalType)) ? "bg-coral-600 text-white shadow-sm" : "bg-slate-50 text-slate-600 hover:bg-slate-100 border border-slate-200"}`}>
+                    <Icon name={f.icon} size={13} className={(f.key === "all" ? typeFilters.size === 0 : typeFilters.has(f.key as ProfessionalType)) ? "text-coral-200" : "text-slate-400"} />
                     {f.label}
-                    {typeCounts[f.key] ? <span className={(f.key === "all" ? typeFilters.size === 0 : typeFilters.has(f.key as ProfessionalType)) ? "text-amber-200" : "text-slate-400"}>({typeCounts[f.key]})</span> : null}
+                    {typeCounts[f.key] ? <span className={(f.key === "all" ? typeFilters.size === 0 : typeFilters.has(f.key as ProfessionalType)) ? "text-coral-200" : "text-slate-400"}>({typeCounts[f.key]})</span> : null}
                   </button>
                 ))}
               </div>
@@ -757,14 +757,14 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
             <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3">
               <div>
                 <label className="text-xs font-bold text-slate-700 mb-1.5 block">State</label>
-                <select value={stateFilter} onChange={e => setStateFilter(e.target.value)} className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-amber-500/30" disabled={isLocationActive}>
+                <select value={stateFilter} onChange={e => setStateFilter(e.target.value)} className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-coral-500/30" disabled={isLocationActive}>
                   <option value="all">All States</option>
                   {AU_STATES.map(s => <option key={s} value={s}>{s}</option>)}
                 </select>
               </div>
               <div>
                 <label className="text-xs font-bold text-slate-700 mb-1.5 block">Fee Structure</label>
-                <select value={feeFilter} onChange={e => setFeeFilter(e.target.value)} className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-amber-500/30">
+                <select value={feeFilter} onChange={e => setFeeFilter(e.target.value)} className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-coral-500/30">
                   <option value="all">Any</option>
                   <option value="fee-for-service">Fee for Service</option>
                   <option value="commission">Commission</option>
@@ -774,14 +774,14 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
               </div>
               <div>
                 <label className="text-xs font-bold text-slate-700 mb-1.5 block">Advisory Firm</label>
-                <select value={firmFilter} onChange={e => setFirmFilter(e.target.value)} className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-amber-500/30">
+                <select value={firmFilter} onChange={e => setFirmFilter(e.target.value)} className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-coral-500/30">
                   <option value="all">All Firms</option>
                   {allFirmNames.map(f => <option key={f} value={f}>{f}</option>)}
                 </select>
               </div>
               <div>
                 <label className="text-xs font-bold text-slate-700 mb-1.5 block">Min Rating</label>
-                <select value={minRating} onChange={e => setMinRating(Number(e.target.value))} className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-amber-500/30">
+                <select value={minRating} onChange={e => setMinRating(Number(e.target.value))} className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-coral-500/30">
                   <option value={0}>Any</option>
                   <option value={4.5}>4.5+ ★</option>
                   <option value={4.0}>4.0+ ★</option>
@@ -791,14 +791,14 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
               </div>
               <div>
                 <label className="text-xs font-bold text-slate-700 mb-1.5 block">Language</label>
-                <select value={languageFilter} onChange={e => setLanguageFilter(e.target.value)} className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-amber-500/30">
+                <select value={languageFilter} onChange={e => setLanguageFilter(e.target.value)} className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-coral-500/30">
                   <option value="all">Any</option>
                   {allLanguages.map(l => <option key={l} value={l}>{l}</option>)}
                 </select>
               </div>
               <div className="flex items-end">
                 <label className="flex items-center gap-2 cursor-pointer py-2">
-                  <input type="checkbox" checked={verifiedOnly} onChange={() => setVerifiedOnly(!verifiedOnly)} className="w-4 h-4 rounded border-slate-300 text-amber-600 focus:ring-amber-500" />
+                  <input type="checkbox" checked={verifiedOnly} onChange={() => setVerifiedOnly(!verifiedOnly)} className="w-4 h-4 rounded border-slate-300 text-coral-600 focus:ring-amber-500" />
                   <span className="text-xs font-semibold text-slate-700">Verified only</span>
                 </label>
               </div>
@@ -852,17 +852,17 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
 
             {/* Specialties */}
             <div>
-              <label className="text-xs font-bold text-slate-700 mb-2 block">Specialties {specialtyFilters.length > 0 && <span className="text-amber-600">({specialtyFilters.length} selected)</span>}</label>
+              <label className="text-xs font-bold text-slate-700 mb-2 block">Specialties {specialtyFilters.length > 0 && <span className="text-coral-600">({specialtyFilters.length} selected)</span>}</label>
               <div className="flex flex-wrap gap-1.5 max-h-28 overflow-y-auto">
                 {allSpecialties.map(s => (
-                  <button key={s} onClick={() => toggleSpecialty(s)} className={`px-2.5 py-1 text-[0.65rem] font-medium rounded-full transition-all ${specialtyFilters.includes(s) ? "bg-amber-100 text-amber-700 border border-amber-300" : "bg-slate-50 text-slate-500 border border-slate-200 hover:bg-slate-100"}`}>{s}</button>
+                  <button key={s} onClick={() => toggleSpecialty(s)} className={`px-2.5 py-1 text-[0.65rem] font-medium rounded-full transition-all ${specialtyFilters.includes(s) ? "bg-coral-100 text-coral-700 border border-coral-300" : "bg-slate-50 text-slate-500 border border-slate-200 hover:bg-slate-100"}`}>{s}</button>
                 ))}
               </div>
             </div>
 
             <div className="flex items-center justify-between pt-2 border-t border-slate-100">
               <button onClick={clearAll} className="text-xs text-slate-500 hover:text-slate-700 font-medium">Clear all filters</button>
-              <button onClick={() => setFiltersOpen(false)} className="px-4 py-2 bg-amber-600 text-white text-xs font-bold rounded-lg hover:bg-amber-700 transition-colors">
+              <button onClick={() => setFiltersOpen(false)} className="px-4 py-2 bg-coral-600 text-white text-xs font-bold rounded-lg hover:bg-coral-700 transition-colors">
                 {nearbyLoading ? "Searching..." : `Show ${feed.length} result${feed.length !== 1 ? "s" : ""}`}
               </button>
             </div>
@@ -873,16 +873,16 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
         {activeFilterCount > 0 && !filtersOpen && (
           <div className="flex flex-wrap items-center gap-1.5 mb-3">
             {isLocationActive && locationSearch && (
-              <span className="inline-flex items-center gap-1 px-2.5 py-1 bg-amber-100 text-amber-700 text-[0.65rem] font-semibold rounded-full">
+              <span className="inline-flex items-center gap-1 px-2.5 py-1 bg-coral-100 text-coral-700 text-[0.65rem] font-semibold rounded-full">
                 <Icon name="map-pin" size={11} />
                 {radius > 0 ? `${radius}km from ` : "Near "}{locationSearch.locality}
-                <button onClick={() => { setLocationSearch(null); setUserLat(null); setUserLng(null); }} className="hover:text-amber-900"><Icon name="x" size={12} /></button>
+                <button onClick={() => { setLocationSearch(null); setUserLat(null); setUserLng(null); }} className="hover:text-coral-900"><Icon name="x" size={12} /></button>
               </span>
             )}
             {Array.from(typeFilters).map(t => (
-              <span key={t} className="inline-flex items-center gap-1 px-2.5 py-1 bg-amber-100 text-amber-700 text-[0.65rem] font-semibold rounded-full">
+              <span key={t} className="inline-flex items-center gap-1 px-2.5 py-1 bg-coral-100 text-coral-700 text-[0.65rem] font-semibold rounded-full">
                 {TYPE_FILTERS.find(f => f.key === t)?.label}
-                <button onClick={() => toggleType(t)} className="hover:text-amber-900"><Icon name="x" size={12} /></button>
+                <button onClick={() => toggleType(t)} className="hover:text-coral-900"><Icon name="x" size={12} /></button>
               </span>
             ))}
             {stateFilter !== "all" && (
@@ -898,9 +898,9 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
               </span>
             ))}
             {feeFilter !== "all" && (
-              <span className="inline-flex items-center gap-1 px-2.5 py-1 bg-amber-100 text-amber-700 text-[0.65rem] font-semibold rounded-full">
+              <span className="inline-flex items-center gap-1 px-2.5 py-1 bg-coral-100 text-coral-700 text-[0.65rem] font-semibold rounded-full">
                 {feeFilter}
-                <button onClick={() => setFeeFilter("all")} className="hover:text-amber-900"><Icon name="x" size={12} /></button>
+                <button onClick={() => setFeeFilter("all")} className="hover:text-coral-900"><Icon name="x" size={12} /></button>
               </span>
             )}
             {firmFilter !== "all" && (
@@ -910,9 +910,9 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
               </span>
             )}
             {minRating > 0 && (
-              <span className="inline-flex items-center gap-1 px-2.5 py-1 bg-amber-100 text-amber-700 text-[0.65rem] font-semibold rounded-full">
+              <span className="inline-flex items-center gap-1 px-2.5 py-1 bg-coral-100 text-coral-700 text-[0.65rem] font-semibold rounded-full">
                 {minRating}+ ★
-                <button onClick={() => setMinRating(0)} className="hover:text-amber-900"><Icon name="x" size={12} /></button>
+                <button onClick={() => setMinRating(0)} className="hover:text-coral-900"><Icon name="x" size={12} /></button>
               </span>
             )}
             {verifiedOnly && (
@@ -993,7 +993,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
                     firmFilter === firm.name ? "bg-slate-900 text-white" : "bg-white border border-slate-200 text-slate-600 hover:bg-slate-50"
                   }`}
                 >
-                  <span className={`w-4 h-4 rounded flex items-center justify-center text-[0.5rem] font-bold shrink-0 ${firmFilter === firm.name ? "bg-white/20 text-white" : "bg-amber-100 text-amber-600"}`}>
+                  <span className={`w-4 h-4 rounded flex items-center justify-center text-[0.5rem] font-bold shrink-0 ${firmFilter === firm.name ? "bg-white/20 text-white" : "bg-coral-100 text-coral-600"}`}>
                     {firm.name.split(/\s+/).slice(0, 2).map((w: string) => w[0]).join("").toUpperCase()}
                   </span>
                   {firm.name}
@@ -1136,7 +1136,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
                           </Link>
                           <Link
                             href={`/briefs/new?team=${encodeURIComponent(team.slug)}`}
-                            className="text-[0.7rem] md:text-xs font-bold text-slate-900 bg-amber-500 hover:bg-amber-400 rounded-md px-3 py-1.5 inline-flex items-center gap-1"
+                            className="text-[0.7rem] md:text-xs font-bold text-slate-900 bg-coral-500 hover:bg-coral-400 rounded-md px-3 py-1.5 inline-flex items-center gap-1"
                           >
                             Create brief
                             <Icon name="arrow-right" size={11} />
@@ -1390,13 +1390,13 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
               <p className="text-xs text-slate-400 mb-3">
                 {isLocationActive ? `No advisors within ${radius}km. Try a larger radius.` : search ? `No results for "${search}".` : "Try adjusting your filters."}
               </p>
-              <button onClick={clearAll} className="text-xs text-amber-600 font-semibold hover:text-amber-800">Clear all filters</button>
+              <button onClick={clearAll} className="text-xs text-coral-600 font-semibold hover:text-coral-800">Clear all filters</button>
             </div>
             {/* Alert capture */}
             <div className="px-5 py-5 bg-amber-50">
               <div className="flex items-start gap-3 mb-3">
                 <div className="w-8 h-8 bg-amber-100 rounded-lg flex items-center justify-center shrink-0">
-                  <Icon name="bell" size={16} className="text-amber-600" />
+                  <Icon name="bell" size={16} className="text-coral-600" />
                 </div>
                 <div>
                   <p className="text-sm font-bold text-slate-800">Get notified when one joins</p>
@@ -1421,7 +1421,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
                   <button
                     onClick={saveAlert}
                     disabled={alertStatus === "submitting"}
-                    className="px-4 py-2 bg-amber-500 text-white text-sm font-semibold rounded-lg hover:bg-amber-600 disabled:opacity-60 transition-colors whitespace-nowrap"
+                    className="px-4 py-2 bg-coral-500 text-white text-sm font-semibold rounded-lg hover:bg-coral-600 disabled:opacity-60 transition-colors whitespace-nowrap"
                   >
                     {alertStatus === "submitting" ? "Saving..." : "Notify Me"}
                   </button>
@@ -1442,7 +1442,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
               else if (page <= 4) pn = i + 1;
               else if (page >= totalPages - 3) pn = totalPages - 6 + i;
               else pn = page - 3 + i;
-              return <button key={pn} onClick={() => setPage(pn)} className={`w-9 h-9 text-xs font-semibold rounded-lg transition-all ${page === pn ? "bg-amber-600 text-white" : "border border-slate-200 text-slate-600 hover:bg-slate-50"}`}>{pn}</button>;
+              return <button key={pn} onClick={() => setPage(pn)} className={`w-9 h-9 text-xs font-semibold rounded-lg transition-all ${page === pn ? "bg-coral-600 text-white" : "border border-slate-200 text-slate-600 hover:bg-slate-50"}`}>{pn}</button>;
             })}
             <button onClick={() => setPage(p => Math.min(totalPages, p + 1))} disabled={page === totalPages} className="px-3 py-2 text-xs font-semibold border border-slate-200 rounded-lg hover:bg-slate-50 disabled:opacity-40 disabled:cursor-not-allowed">Next {"\u2192"}</button>
           </div>
@@ -1468,7 +1468,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
               </ul>
             </div>
             <div className="grid md:grid-cols-2 gap-4">
-              <div className="bg-gradient-to-br from-amber-50/80 via-white to-white border border-amber-100 rounded-2xl p-5 md:p-6 shadow-sm">
+              <div className="bg-gradient-to-br from-coral-50/80 via-white to-white border border-amber-100 rounded-2xl p-5 md:p-6 shadow-sm">
                 <div className="flex items-center gap-2.5 mb-3">
                   <div className="w-8 h-8 rounded-xl bg-amber-100 flex items-center justify-center shrink-0">
                     <Icon name="dollar-sign" size={15} className="text-amber-700" />
@@ -1499,7 +1499,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
                 <details key={i} className="group">
                   <summary className="px-4 py-3.5 md:px-5 md:py-4 font-semibold text-xs md:text-sm text-slate-800 cursor-pointer hover:bg-slate-50/80 transition-colors list-none flex items-center justify-between gap-3">
                     <span>{faq.q}</span>
-                    <span className="shrink-0 w-5 h-5 rounded-full border border-slate-200 bg-slate-50 flex items-center justify-center text-slate-400 group-open:bg-amber-50 group-open:border-amber-200 group-open:text-amber-600 transition-all">
+                    <span className="shrink-0 w-5 h-5 rounded-full border border-slate-200 bg-slate-50 flex items-center justify-center text-slate-400 group-open:bg-amber-50 group-open:border-amber-200 group-open:text-coral-600 transition-all">
                       <svg className="w-2.5 h-2.5 group-open:rotate-180 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M19 9l-7 7-7-7" /></svg>
                     </span>
                   </summary>
@@ -1530,7 +1530,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
             ].map(g => (
               <Link key={g.href} href={g.href} className="group flex items-center gap-2.5 p-3 bg-white border border-slate-100 rounded-xl shadow-sm hover:shadow-md hover:border-amber-100 hover:bg-amber-50/30 transition-all">
                 <div className="w-7 h-7 rounded-lg bg-slate-50 border border-slate-100 flex items-center justify-center shrink-0 group-hover:bg-amber-100 group-hover:border-amber-200 transition-all">
-                  <Icon name={g.icon} size={14} className="text-slate-500 group-hover:text-amber-600 transition-colors" />
+                  <Icon name={g.icon} size={14} className="text-slate-500 group-hover:text-coral-600 transition-colors" />
                 </div>
                 <span className="text-xs font-semibold text-slate-600 group-hover:text-slate-800 leading-tight">How to Choose: {g.title}</span>
               </Link>
@@ -1539,10 +1539,10 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
         </div>
 
         {/* Saved search / alert widget */}
-        <div className="mt-6 md:mt-8 bg-gradient-to-br from-amber-50/80 via-white to-white border border-amber-100 rounded-2xl p-4 md:p-6 shadow-sm">
+        <div className="mt-6 md:mt-8 bg-gradient-to-br from-coral-50/80 via-white to-white border border-amber-100 rounded-2xl p-4 md:p-6 shadow-sm">
           <div className="flex items-start gap-3 mb-3.5">
             <div className="w-10 h-10 bg-amber-100 border border-amber-200 rounded-xl flex items-center justify-center shrink-0 shadow-sm shadow-amber-100">
-              <Icon name="bell" size={18} className="text-amber-600" />
+              <Icon name="bell" size={18} className="text-coral-600" />
             </div>
             <div>
               <h3 className="text-sm font-extrabold text-slate-800">Can&apos;t find the right advisor?</h3>
@@ -1567,7 +1567,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
               <button
                 onClick={saveAlert}
                 disabled={alertStatus === "submitting"}
-                className="px-4 py-2 bg-amber-500 text-white text-sm font-semibold rounded-lg hover:bg-amber-600 disabled:opacity-60 transition-colors whitespace-nowrap"
+                className="px-4 py-2 bg-coral-500 text-white text-sm font-semibold rounded-lg hover:bg-coral-600 disabled:opacity-60 transition-colors whitespace-nowrap"
               >
                 {alertStatus === "submitting" ? "Saving..." : "Set Alert"}
               </button>
@@ -1583,7 +1583,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
             <h3 className="text-base md:text-xl font-extrabold text-white mb-1.5 md:mb-2">Are you a financial professional?</h3>
             <p className="text-xs md:text-sm text-slate-400 mb-4 md:mb-5">List your practice for free. Only pay when you receive an enquiry.</p>
             <div className="flex items-center justify-center gap-3 flex-wrap">
-              <Link href="/advisor-apply" className="inline-flex items-center gap-2 px-5 py-2.5 md:px-6 md:py-3 bg-amber-500 text-white text-sm font-bold rounded-xl hover:bg-amber-400 transition-colors shadow-lg shadow-amber-500/25">
+              <Link href="/advisor-apply" className="inline-flex items-center gap-2 px-5 py-2.5 md:px-6 md:py-3 bg-coral-500 text-white text-sm font-bold rounded-xl hover:bg-coral-400 transition-colors shadow-lg shadow-amber-500/25">
                 Get Listed Free
                 <Icon name="arrow-right" size={15} />
               </Link>

--- a/app/advisors/AdvisorsClient.tsx
+++ b/app/advisors/AdvisorsClient.tsx
@@ -1218,7 +1218,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
                             {isFeatured && (
                               <span
                                 title={SPONSORED_DISCLOSURE_SHORT}
-                                className="shrink-0 text-[0.58rem] font-bold px-1.5 py-0.5 rounded-full bg-coral-500 text-white flex items-center gap-0.5 shadow-sm cursor-help"
+                                className="shrink-0 text-[0.58rem] font-bold px-1.5 py-0.5 rounded-full bg-coral-600 text-white flex items-center gap-0.5 shadow-sm cursor-help"
                               >
                                 <Icon name="star" size={9} />
                                 Featured · Paid
@@ -1372,7 +1372,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
 
                     {/* View profile CTA */}
                     <div className="shrink-0 self-center hidden md:flex ml-1">
-                      <span className="inline-flex items-center gap-1 rounded-lg bg-coral-500 px-3.5 py-2 text-xs font-semibold text-white whitespace-nowrap shadow-sm transition-colors group-hover:bg-coral-600">
+                      <span className="inline-flex items-center gap-1 rounded-lg bg-coral-600 px-3.5 py-2 text-xs font-semibold text-white whitespace-nowrap shadow-sm transition-colors group-hover:bg-coral-700">
                         View profile
                         <Icon name="chevron-right" size={13} />
                       </span>
@@ -1421,7 +1421,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
                   <button
                     onClick={saveAlert}
                     disabled={alertStatus === "submitting"}
-                    className="px-4 py-2 bg-coral-500 text-white text-sm font-semibold rounded-lg hover:bg-coral-600 disabled:opacity-60 transition-colors whitespace-nowrap"
+                    className="px-4 py-2 bg-coral-600 text-white text-sm font-semibold rounded-lg hover:bg-coral-600 disabled:opacity-60 transition-colors whitespace-nowrap"
                   >
                     {alertStatus === "submitting" ? "Saving..." : "Notify Me"}
                   </button>
@@ -1567,7 +1567,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
               <button
                 onClick={saveAlert}
                 disabled={alertStatus === "submitting"}
-                className="px-4 py-2 bg-coral-500 text-white text-sm font-semibold rounded-lg hover:bg-coral-600 disabled:opacity-60 transition-colors whitespace-nowrap"
+                className="px-4 py-2 bg-coral-600 text-white text-sm font-semibold rounded-lg hover:bg-coral-600 disabled:opacity-60 transition-colors whitespace-nowrap"
               >
                 {alertStatus === "submitting" ? "Saving..." : "Set Alert"}
               </button>
@@ -1583,7 +1583,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
             <h3 className="text-base md:text-xl font-extrabold text-white mb-1.5 md:mb-2">Are you a financial professional?</h3>
             <p className="text-xs md:text-sm text-slate-400 mb-4 md:mb-5">List your practice for free. Only pay when you receive an enquiry.</p>
             <div className="flex items-center justify-center gap-3 flex-wrap">
-              <Link href="/advisor-apply" className="inline-flex items-center gap-2 px-5 py-2.5 md:px-6 md:py-3 bg-coral-500 text-white text-sm font-bold rounded-xl hover:bg-coral-400 transition-colors shadow-lg shadow-coral-500/25">
+              <Link href="/advisor-apply" className="inline-flex items-center gap-2 px-5 py-2.5 md:px-6 md:py-3 bg-coral-600 text-white text-sm font-bold rounded-xl hover:bg-coral-400 transition-colors shadow-lg shadow-coral-500/25">
                 Get Listed Free
                 <Icon name="arrow-right" size={15} />
               </Link>

--- a/app/invest/page.tsx
+++ b/app/invest/page.tsx
@@ -140,11 +140,13 @@ export default async function InvestMarketplacePage() {
   const verticalCounts: Record<string, number> = {};
   let firbCount = 0;
   let sivCount = 0;
+  let aggregateAskCents = 0;
   for (const l of listings) {
     const v = l.vertical as string;
     if (v) verticalCounts[v] = (verticalCounts[v] || 0) + 1;
     if (l.firb_eligible) firbCount++;
     if (l.siv_complying) sivCount++;
+    if (l.asking_price_cents) aggregateAskCents += l.asking_price_cents;
   }
 
   // Wave 3 — load page-side context (advisor opt-in counts, claimed
@@ -202,59 +204,90 @@ export default async function InvestMarketplacePage() {
     isPartOf: { "@type": "WebSite", name: SITE_NAME, url: absoluteUrl("/") },
   };
 
+  // Hero stat tiles — all derived from the live listing set (no invented
+  // figures). Compact billions-aware AUD formatter for the aggregate ask.
+  const sectorCount = Object.keys(verticalCounts).length;
+  const formatAudBig = (cents: number): string => {
+    const d = cents / 100;
+    if (d >= 1e9) return `$${(d / 1e9).toFixed(1).replace(/\.0$/, "")}B`;
+    if (d >= 1e6) return `$${Math.round(d / 1e6)}M`;
+    if (d >= 1e3) return `$${Math.round(d / 1e3)}k`;
+    return `$${Math.round(d)}`;
+  };
+  const heroStats = (
+    [
+      aggregateAskCents > 0 ? { v: formatAudBig(aggregateAskCents), l: "Aggregate ask" } : null,
+      { v: listings.length.toLocaleString("en-AU"), l: "Live opportunities" },
+      { v: String(sectorCount), l: "Sectors" },
+      firbCount > 0 ? { v: String(firbCount), l: "FIRB-eligible" } : null,
+      sivCount > 0 ? { v: String(sivCount), l: "SIV-complying" } : null,
+    ].filter(Boolean) as { v: string; l: string }[]
+  ).slice(0, 4);
+
   return (
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(itemListJsonLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbs) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(webPageJsonLd) }} />
 
-      {/* ── Slim hero (was 40% of fold, now ~15%) ────────────────── */}
-      <div className="container-custom max-w-6xl pt-5 md:pt-8 pb-3">
-        <nav className="text-xs md:text-sm text-slate-500 mb-2">
-          <Link href="/" className="hover:text-slate-900">Home</Link>
-          <span className="mx-2">/</span>
-          <span className="text-slate-700">Opportunities</span>
-        </nav>
-
-        <DirectoryBanners surface="invest" />
-
-        <h1 className="text-2xl md:text-4xl font-extrabold mb-2 text-slate-900 tracking-tight">
-          Australian Investment Opportunities
-        </h1>
-        <p className="text-sm md:text-base text-slate-600 mb-3 max-w-3xl">
-          Businesses, property, projects, funds, syndicates & collectibles — all filterable in one place.
-          To compare super funds or share-trading platforms,{" "}
-          <Link href="/compare" className="text-amber-700 underline hover:no-underline">visit Compare</Link>.
-        </p>
-
-        {/* Trust pills */}
-        <div className="flex items-center gap-2 flex-wrap">
-          <span className="inline-flex items-center gap-1.5 px-3 py-1 bg-white border border-slate-200 rounded-full text-[0.65rem] md:text-xs font-semibold text-slate-700 shadow-sm">
-            <span className="w-1.5 h-1.5 bg-emerald-500 rounded-full animate-pulse" />
-            <span className="font-bold text-slate-900">{listings.length}</span> live opportunities
-          </span>
-          {firbCount > 0 && (
-            <span className="inline-flex items-center gap-1.5 px-3 py-1 bg-white border border-blue-200 rounded-full text-[0.65rem] md:text-xs font-semibold text-blue-700 shadow-sm">
-              <Icon name="globe" size={11} />
-              <span className="font-bold">{firbCount}</span> FIRB-eligible
-            </span>
-          )}
-          {sivCount > 0 && (
-            <span className="inline-flex items-center gap-1.5 px-3 py-1 bg-white border border-emerald-200 rounded-full text-[0.65rem] md:text-xs font-semibold text-emerald-700 shadow-sm">
-              <Icon name="shield-check" size={11} />
-              <span className="font-bold">{sivCount}</span> SIV-complying
-            </span>
-          )}
-          {ctx.isListingOwner && (
-            <Link
-              href="/account/my-listings"
-              className="inline-flex items-center gap-1.5 px-3 py-1 bg-amber-50 border border-amber-200 rounded-full text-[0.65rem] md:text-xs font-semibold text-amber-700 hover:bg-amber-100 transition-colors shadow-sm"
-            >
-              <Icon name="user-check" size={11} />
-              My listings →
-            </Link>
-          )}
+      {/* ── Dark marketplace hero (v2 confident-fintech) ─────────── */}
+      <section className="relative overflow-hidden bg-gradient-to-b from-ink-900 to-ink-800 text-white">
+        <div
+          aria-hidden
+          className="pointer-events-none absolute -right-24 -top-24 h-96 w-96 rounded-full"
+          style={{ background: "radial-gradient(circle, rgba(242,88,34,.18), transparent 65%)" }}
+        />
+        <div className="container-custom max-w-6xl relative py-8 md:py-12">
+          <nav className="text-xs md:text-sm text-white/55 mb-3">
+            <Link href="/" className="hover:text-white">Home</Link>
+            <span className="mx-2">/</span>
+            <span className="text-white/80">Opportunities</span>
+          </nav>
+          <div className="grid gap-8 md:grid-cols-[1.4fr_1fr] md:items-end">
+            <div>
+              <span className="iv2-pill border border-coral-500/30 bg-coral-500/15 text-coral-300">
+                <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-coral-400" />
+                Live marketplace
+              </span>
+              <h1 className="mt-4 text-3xl font-extrabold leading-[1.04] tracking-tight md:text-5xl">
+                {listings.length.toLocaleString("en-AU")} live opportunities.
+                {aggregateAskCents > 0 && (
+                  <>
+                    <br />
+                    <span className="text-coral-400">{formatAudBig(aggregateAskCents)} in aggregate ask.</span>
+                  </>
+                )}
+              </h1>
+              <p className="mt-4 max-w-xl text-sm leading-relaxed text-white/70 md:text-base">
+                Businesses, property, projects, funds, syndicates &amp; collectibles — all filterable in one place.
+                To compare super funds or share-trading platforms,{" "}
+                <Link href="/compare" className="text-coral-300 underline hover:no-underline">visit Compare</Link>.
+              </p>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              {heroStats.map((s) => (
+                <div key={s.l} className="rounded-xl border border-white/10 bg-white/[0.04] px-4 py-3">
+                  <div className="iv2-bignum text-2xl text-white md:text-3xl">{s.v}</div>
+                  <div className="mt-1 text-[11px] font-semibold text-white/55 md:text-xs">{s.l}</div>
+                </div>
+              ))}
+            </div>
+          </div>
         </div>
+      </section>
+
+      {/* Country/FIRB notices + owner link on the light band below the hero */}
+      <div className="container-custom max-w-6xl pt-4">
+        <DirectoryBanners surface="invest" />
+        {ctx.isListingOwner && (
+          <Link
+            href="/account/my-listings"
+            className="mt-2 inline-flex items-center gap-1.5 rounded-full border border-coral-200 bg-coral-50 px-3 py-1 text-[0.65rem] font-semibold text-coral-700 shadow-sm transition-colors hover:bg-coral-100 md:text-xs"
+          >
+            <Icon name="user-check" size={11} />
+            My listings →
+          </Link>
+        )}
       </div>
 
       {/* ── Marketplace (primary — no two-step) ───────────────── */}

--- a/components/InvestListingCard.tsx
+++ b/components/InvestListingCard.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import Image from "next/image";
-import type { InvestmentListing } from "@/lib/types";
+import type { InvestmentListing, ListingKind } from "@/lib/types";
 import { listingUrl } from "@/lib/listing-url";
 import { getListingHeroImage } from "@/lib/listing-vertical-images";
 import {
@@ -50,6 +50,22 @@ const VERTICAL_ICON: Record<string, string> = {
 };
 
 /**
+ * Per-kind hue for the 3px colour strip across the top of the card hero
+ * (the marketplace "vstrip" signature from the v2 design language). Mirrors
+ * the hue of `meta.accent` so the strip + kind badge read as one system.
+ */
+const KIND_STRIP: Record<ListingKind, string> = {
+  for_sale_business: "bg-blue-600",
+  for_sale_asset: "bg-slate-600",
+  equity_raise: "bg-indigo-600",
+  project_equity: "bg-amber-600",
+  royalty: "bg-rose-600",
+  fund: "bg-violet-600",
+  physical_asset: "bg-fuchsia-600",
+  listed_security: "bg-sky-600",
+};
+
+/**
  * Card variants:
  *   - `grid` (default): full card with hero image (the marketplace grid)
  *   - `list`: horizontal layout, denser, no large hero
@@ -59,6 +75,10 @@ const VERTICAL_ICON: Record<string, string> = {
  *   - Price label ("Asking" / "Min investment" / "Raising" / "ASX")
  *   - CTA verb ("Enquire" / "Request IM" / "Buy via broker" / "Express interest")
  *   - Kind chip colour + icon
+ *
+ * Visual language: v2 "confident fintech" — coral action accent, deep-ink
+ * titles, sand-neutral surfaces, big tabular price (`.iv2-bignum`), pill
+ * trust chips. Tokens live in `globals.css` (`--color-coral-*`, `--color-ink-*`).
  *
  * The blanket "FIRB" badge that used to fire on every row is now gated
  * to listings where the visitor's intent country matters AND the listing
@@ -98,6 +118,7 @@ export default function InvestListingCard({
   const fresh = freshnessSignal(listing);
   const price = formatListingPrice(listing);
   const location = formatLocation(listing.location_state, listing.location_city);
+  const stripColor = KIND_STRIP[kind];
 
   const metricEntries = listing.key_metrics
     ? Object.entries(listing.key_metrics).slice(0, 3)
@@ -118,57 +139,97 @@ export default function InvestListingCard({
   const fallbackIcon = VERTICAL_ICON[listing.vertical] ?? "📊";
   const isFeatured = listing.listing_type === "featured" || listing.listing_type === "premium";
 
+  // Reusable kind badge (white pill over the hero image).
+  const kindBadge = (
+    <span className="iv2-pill bg-white/95 text-ink-800 shadow-sm backdrop-blur-sm" style={{ fontSize: "10px", letterSpacing: "0.05em", textTransform: "uppercase" }}>
+      <Icon name={meta.icon} size={11} />
+      {meta.label}
+    </span>
+  );
+
+  // Inline metric line ("$720k EBITDA · 3.6× · 18.8% margin").
+  const metricLine = metricEntries.length > 0 && (
+    <p className="text-xs leading-relaxed text-slate-600">
+      {metricEntries.map(([k, v], i) => (
+        <span key={k}>
+          {i > 0 && <span className="text-slate-300"> · </span>}
+          <span className="font-bold text-ink-800">{formatKeyMetricValue(v)}</span>{" "}
+          <span className="text-slate-400">{k.replace(/_/g, " ")}</span>
+        </span>
+      ))}
+    </p>
+  );
+
+  // Trust chips (Featured / FIRB / SIV) — shared by both variants.
+  const trustChips = (
+    <>
+      {isFeatured && (
+        <span className="iv2-pill border border-coral-100 bg-coral-50 text-coral-700" style={{ fontSize: "10.5px" }}>
+          <Icon name="star" size={10} />
+          Featured
+        </span>
+      )}
+      {showFirbBadge && listing.firb_eligible && (
+        <span className="iv2-pill border border-blue-100 bg-blue-50 text-blue-700" style={{ fontSize: "10.5px" }}>
+          FIRB eligible
+        </span>
+      )}
+      {listing.siv_complying && (
+        <span className="iv2-pill border border-emerald-100 bg-emerald-50 text-emerald-700" style={{ fontSize: "10.5px" }}>
+          SIV-complying
+        </span>
+      )}
+    </>
+  );
+
   // ── List variant ──────────────────────────────────────────────────
   if (variant === "list") {
     return (
       <Link
         href={listingUrl(listing)}
-        className={`group flex gap-4 rounded-xl border bg-white p-3 shadow-sm hover:shadow-md hover:-translate-y-0.5 transition-all duration-200 ${meta.accent.border}`}
+        className={`group flex gap-4 rounded-[14px] border bg-white p-3 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-ink-200 hover:shadow-lg ${
+          isFeatured ? "border-coral-200 ring-1 ring-coral-100" : "border-slate-200"
+        }`}
       >
         {/* Compact thumb */}
-        <div className="relative w-32 h-24 sm:w-40 sm:h-28 rounded-lg overflow-hidden shrink-0 bg-slate-100">
+        <div className="relative h-24 w-32 shrink-0 overflow-hidden rounded-lg bg-ink-900 sm:h-28 sm:w-40">
           {heroImage ? (
             <Image
               src={heroImage}
               alt={listing.title}
               fill
               sizes="160px"
-              className="object-cover transition-transform duration-500 group-hover:scale-105"
+              className="object-cover opacity-95 transition-transform duration-500 group-hover:scale-105"
               loading="lazy"
             />
           ) : (
-            <div className={`absolute inset-0 bg-gradient-to-br ${fallbackGradient} flex items-center justify-center text-3xl opacity-40`}>
+            <div className={`absolute inset-0 bg-gradient-to-br ${fallbackGradient} flex items-center justify-center text-3xl opacity-50`}>
               {fallbackIcon}
             </div>
           )}
           {heroImage && heroIsSeed && (
             <div className={`absolute inset-0 bg-gradient-to-br ${fallbackGradient} opacity-30 mix-blend-multiply`} />
           )}
+          <div className={`absolute inset-x-0 top-0 h-[3px] ${stripColor}`} />
           {/* Top-left kind badge */}
-          <span className={`absolute top-1.5 left-1.5 inline-flex items-center gap-1 ${meta.accent.badge} text-[0.55rem] font-extrabold uppercase tracking-wider px-1.5 py-0.5 rounded shadow-sm`}>
-            <Icon name={meta.icon} size={9} />
-            {meta.label}
-          </span>
+          <span className="absolute left-1.5 top-1.5">{kindBadge}</span>
+          {matchScore != null && (
+            <span className="iv2-pill absolute bottom-1.5 left-1.5 bg-emerald-500 text-white" style={{ fontSize: "10px" }}>
+              {matchScore}% match
+            </span>
+          )}
           {/* Top-right shortlist button */}
-          <div className="absolute top-1 right-1">
+          <div className="absolute right-1 top-1">
             <ListingShortlistButton slug={listing.slug} size="sm" />
           </div>
         </div>
 
         {/* Content */}
-        <div className="flex-1 min-w-0 flex flex-col">
-          <div className="flex items-start justify-between gap-2">
-            <h3 className={`font-bold text-sm md:text-base text-slate-900 line-clamp-2 leading-snug ${meta.accent.text.replace("text-", "group-hover:text-")}`}>
-              {listing.title}
-            </h3>
-            {price && (
-              <div className="shrink-0 text-right">
-                <div className="text-[0.55rem] text-slate-400 uppercase tracking-wide font-semibold">{price.label}</div>
-                <div className="text-sm font-extrabold text-slate-900">{price.value}</div>
-              </div>
-            )}
-          </div>
-          <div className="flex items-center gap-2 mt-1 text-xs text-slate-500 flex-wrap">
+        <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+          <h3 className="line-clamp-2 text-sm font-bold leading-snug text-ink-800 group-hover:text-coral-700 md:text-base">
+            {listing.title}
+          </h3>
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-xs text-slate-500">
             {location && (
               <span className="inline-flex items-center gap-0.5">
                 <Icon name="map-pin" size={11} className="text-slate-400" />
@@ -177,36 +238,38 @@ export default function InvestListingCard({
             )}
             {listing.industry && <span>· {listing.industry}</span>}
             {fresh === "new_this_week" && (
-              <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full bg-emerald-50 text-emerald-700 text-[0.55rem] font-bold uppercase tracking-wide">
-                New
-              </span>
+              <span className="iv2-pill bg-emerald-50 text-emerald-700" style={{ fontSize: "10px" }}>New this week</span>
             )}
             {fresh === "closing_soon" && (
-              <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full bg-rose-50 text-rose-700 text-[0.55rem] font-bold uppercase tracking-wide">
-                Closing soon
-              </span>
+              <span className="iv2-pill bg-rose-50 text-rose-600" style={{ fontSize: "10px" }}>Closing soon</span>
             )}
-            {isFeatured && (
-              <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full bg-amber-100 text-amber-700 text-[0.55rem] font-bold uppercase tracking-wide">
-                ★ Featured
-              </span>
-            )}
-            {matchScore != null && (
-              <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-full bg-emerald-600 text-white text-[0.55rem] font-bold uppercase tracking-wide">
-                {matchScore}% match
+          </div>
+          {metricLine}
+          <div className="mt-auto flex flex-wrap items-center gap-1.5 pt-1">
+            {trustChips}
+            {advisorOptInCount > 0 && (
+              <span className="iv2-pill border border-emerald-200 bg-emerald-50 text-emerald-700" style={{ fontSize: "10px" }}>
+                <Icon name="user-check" size={10} />
+                {advisorOptInCount} can assess
               </span>
             )}
           </div>
-          {metricEntries.length > 0 && (
-            <div className="mt-auto pt-2 flex gap-3 text-[0.62rem] text-slate-600">
-              {metricEntries.map(([k, v]) => (
-                <span key={k}>
-                  <span className="text-slate-400 capitalize">{k.replace(/_/g, " ")}: </span>
-                  <span className="font-semibold text-slate-800">{formatKeyMetricValue(v)}</span>
-                </span>
-              ))}
+        </div>
+
+        {/* Right rail — price + CTA */}
+        <div className="flex shrink-0 flex-col items-end justify-between gap-2 text-right">
+          {price ? (
+            <div>
+              <div className="iv2-mini">{price.label}</div>
+              <div className="iv2-bignum text-xl text-ink-900">{price.value}</div>
             </div>
+          ) : (
+            <span />
           )}
+          <span className="inline-flex items-center gap-1 rounded-lg bg-coral-500 px-3 py-1.5 text-xs font-semibold text-white transition-colors group-hover:bg-coral-600">
+            View
+            <Icon name="chevron-right" size={12} />
+          </span>
         </div>
       </Link>
     );
@@ -216,12 +279,12 @@ export default function InvestListingCard({
   return (
     <Link
       href={listingUrl(listing)}
-      className={`group relative block overflow-hidden rounded-2xl border bg-white shadow-sm hover:shadow-xl hover:border-slate-300 transition-all duration-300 hover:-translate-y-0.5 ${meta.accent.border} ${
-        isFeatured ? "ring-1 ring-amber-200/80 shadow-amber-50" : ""
+      className={`group relative flex h-full flex-col overflow-hidden rounded-[14px] border bg-white shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-xl ${
+        isFeatured ? "border-coral-200 ring-1 ring-coral-100" : "border-slate-200 hover:border-ink-200"
       }`}
     >
       {/* Hero image */}
-      <div className="relative aspect-[16/10] overflow-hidden bg-slate-100">
+      <div className="relative aspect-[16/10] overflow-hidden bg-ink-900">
         {heroImage ? (
           <>
             <Image
@@ -229,7 +292,7 @@ export default function InvestListingCard({
               alt={listing.title}
               fill
               sizes="(max-width: 768px) 100vw, (max-width: 1280px) 50vw, 33vw"
-              className="object-cover transition-transform duration-500 group-hover:scale-105"
+              className="object-cover opacity-95 transition-transform duration-500 group-hover:scale-105"
               loading="lazy"
             />
             {heroIsSeed && (
@@ -241,129 +304,91 @@ export default function InvestListingCard({
           </>
         ) : (
           <div className={`absolute inset-0 bg-gradient-to-br ${fallbackGradient} flex items-center justify-center`}>
-            <div className="text-6xl opacity-40 group-hover:scale-110 transition-transform duration-500">
+            <div className="text-6xl opacity-40 transition-transform duration-500 group-hover:scale-110">
               {fallbackIcon}
             </div>
           </div>
         )}
 
+        {/* Gradient scrim so the location/strip read over any photo */}
+        <div aria-hidden className="absolute inset-0 bg-gradient-to-t from-ink-900/65 via-transparent to-transparent" />
+
+        {/* Category colour strip */}
+        <div className={`absolute inset-x-0 top-0 h-[3px] ${stripColor}`} />
+
         {/* Top-left badges: kind + featured + provided badge */}
-        <div className="absolute top-3 left-3 flex flex-wrap gap-1.5 max-w-[70%]">
-          <span className={`inline-flex items-center gap-1 ${meta.accent.badge} text-[0.62rem] font-extrabold uppercase tracking-wider px-2 py-1 rounded-md shadow-sm`}>
-            <Icon name={meta.icon} size={10} />
-            {meta.label}
-          </span>
-          {isFeatured && (
-            <span className="bg-amber-500 text-slate-900 text-[0.62rem] font-extrabold uppercase tracking-wider px-2 py-1 rounded-md shadow-sm">
-              ★ Featured
-            </span>
-          )}
+        <div className="absolute left-3 top-3 flex max-w-[72%] flex-wrap items-center gap-1.5">
+          {kindBadge}
           {badge && (
-            <span className="bg-white/95 backdrop-blur text-slate-800 text-[0.62rem] font-extrabold uppercase tracking-wider px-2 py-1 rounded-md shadow-sm">
+            <span className="iv2-pill bg-white/95 text-ink-800 shadow-sm backdrop-blur-sm" style={{ fontSize: "10px", textTransform: "uppercase", letterSpacing: "0.05em" }}>
               {badge}
             </span>
           )}
         </div>
 
-        {/* Top-right: shortlist bookmark + compliance + freshness */}
-        <div className="absolute top-3 right-3 flex flex-wrap gap-1.5 justify-end items-start max-w-[55%]">
+        {/* Top-right: shortlist bookmark + match */}
+        <div className="absolute right-3 top-3 flex flex-col items-end gap-1.5">
           <ListingShortlistButton slug={listing.slug} />
-          {showFirbBadge && listing.firb_eligible && (
-            <span className="bg-blue-600 text-white text-[0.6rem] font-extrabold uppercase tracking-wider px-2 py-1 rounded-md shadow-sm">
-              FIRB
-            </span>
-          )}
-          {listing.siv_complying && (
-            <span className="bg-emerald-600 text-white text-[0.6rem] font-extrabold uppercase tracking-wider px-2 py-1 rounded-md shadow-sm">
-              SIV
-            </span>
-          )}
-          {fresh === "new_this_week" && (
-            <span className="bg-emerald-500 text-white text-[0.6rem] font-extrabold uppercase tracking-wider px-2 py-1 rounded-md shadow-sm">
-              New
-            </span>
-          )}
-          {fresh === "closing_soon" && (
-            <span className="bg-rose-500 text-white text-[0.6rem] font-extrabold uppercase tracking-wider px-2 py-1 rounded-md shadow-sm">
-              Closing
+          {matchScore != null && (
+            <span className="iv2-pill bg-emerald-500 text-white shadow-sm" style={{ fontSize: "10px" }}>
+              {matchScore}% match
             </span>
           )}
         </div>
 
-        {/* Bottom price overlay */}
-        {price && (
-          <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent p-3">
-            <div className="flex items-end justify-between gap-2">
-              <div>
-                <div className="text-white text-[0.65rem] font-semibold opacity-80 uppercase tracking-wide">{price.label}</div>
-                <div className="text-white text-lg font-extrabold leading-tight">{price.value}</div>
-              </div>
-              {matchScore != null && (
-                <span className="bg-emerald-500 text-white text-[0.6rem] font-extrabold uppercase tracking-wider px-2 py-1 rounded-md shadow-sm">
-                  {matchScore}% match
-                </span>
-              )}
-            </div>
+        {/* Bottom-left: location */}
+        {location && (
+          <div className="absolute bottom-2.5 left-3 flex items-center gap-1 text-[11px] font-semibold text-white drop-shadow">
+            <Icon name="map-pin" size={11} />
+            {location}
           </div>
+        )}
+        {/* Bottom-right: freshness flag */}
+        {fresh === "new_this_week" && (
+          <span className="iv2-pill absolute bottom-2.5 right-3 bg-emerald-500 text-white shadow-sm" style={{ fontSize: "10px" }}>New</span>
+        )}
+        {fresh === "closing_soon" && (
+          <span className="iv2-pill absolute bottom-2.5 right-3 bg-rose-500 text-white shadow-sm" style={{ fontSize: "10px" }}>Closing soon</span>
         )}
       </div>
 
       {/* Content */}
-      <div className="p-4">
-        <h3 className={`font-bold text-base text-slate-900 transition-colors line-clamp-2 mb-1.5 leading-snug ${meta.accent.text.replace("text-", "group-hover:text-")}`}>
+      <div className="flex flex-1 flex-col gap-2.5 p-4">
+        <h3 className="line-clamp-2 text-[15px] font-bold leading-snug text-ink-800 transition-colors group-hover:text-coral-700">
           {listing.title}
         </h3>
 
-        {location && (
-          <p className="flex items-center gap-1 text-xs text-slate-500 mb-3">
-            <Icon name="map-pin" size={11} className="text-slate-400" />
-            {location}
+        {(listing.industry || listing.sub_category) && (
+          <p className="-mt-1 text-xs capitalize text-slate-500">
+            {[listing.industry, listing.sub_category?.replace(/_/g, " ")].filter(Boolean).join(" · ")}
           </p>
         )}
 
-        {(listing.industry || listing.sub_category) && (
-          <div className="flex flex-wrap items-center gap-1 mb-3">
-            {listing.industry && (
-              <span className="text-[0.62rem] px-2 py-0.5 bg-slate-100 rounded-full font-semibold text-slate-600">
-                {listing.industry}
-              </span>
-            )}
-            {listing.sub_category && (
-              <span className="text-[0.62rem] px-2 py-0.5 bg-slate-100 rounded-full font-semibold text-slate-600 capitalize">
-                {listing.sub_category.replace(/_/g, " ")}
-              </span>
-            )}
+        {/* Price — the hero number */}
+        {price && (
+          <div className="flex items-end justify-between gap-2">
+            <div>
+              <div className="iv2-mini">{price.label}</div>
+              <div className="iv2-bignum text-2xl text-ink-900">{price.value}</div>
+            </div>
           </div>
         )}
 
-        {metricEntries.length > 0 && (
-          <div className="grid grid-cols-3 gap-2 pt-3 mt-2 border-t border-slate-100">
-            {metricEntries.map(([key, value]) => (
-              <div key={key} className="text-center">
-                <div className="text-[0.6rem] text-slate-400 uppercase tracking-wide font-medium truncate">
-                  {key.replace(/_/g, " ")}
-                </div>
-                <div className="text-xs font-bold text-slate-900 truncate">
-                  {formatKeyMetricValue(value)}
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
+        {/* Key metrics line */}
+        {metricLine}
 
-        {/* Advisor opt-in pill — surfaces "X advisors can assess this"
-            when listing_advisor_opt_ins has rows for this listing. Closes
-            the loop with /advisors. */}
+        {/* Trust chips */}
+        <div className="flex flex-wrap items-center gap-1.5">{trustChips}</div>
+
+        {/* Advisor opt-in pill — "X advisors can assess this" */}
         {advisorOptInCount > 0 && (
-          <div className="mt-3 inline-flex items-center gap-1.5 text-[0.62rem] font-semibold text-emerald-700 bg-emerald-50 border border-emerald-200 rounded-full px-2.5 py-1">
+          <div className="inline-flex w-fit items-center gap-1.5 rounded-full border border-emerald-200 bg-emerald-50 px-2.5 py-1 text-[0.62rem] font-semibold text-emerald-700">
             <Icon name="user-check" size={11} />
             {advisorOptInCount} advisor{advisorOptInCount !== 1 ? "s" : ""} can assess this
           </div>
         )}
 
-        {/* Claim-your-listing prompt — shown when the listing has no
-            approved row in listing_claims. Routes to the existing claim
-            flow with target_slug pre-filled. */}
+        {/* Claim-your-listing prompt */}
         {showClaimBadge && (
           <ListingClaimLink
             slug={listing.slug}
@@ -371,11 +396,10 @@ export default function InvestListingCard({
           />
         )}
 
-        {/* CTA row — kind-aware verb. Listed securities use an external
-            "Buy via broker" link to /compare instead of the Enquire flow. */}
-        <div className="flex items-center gap-2 mt-4 pt-3 border-t border-slate-100">
+        {/* CTA row — kind-aware verb. Listed securities route externally. */}
+        <div className="mt-auto flex items-center justify-between gap-2 border-t border-slate-100 pt-3">
           {meta.externalCta ? (
-            <span className={`inline-flex items-center gap-1 text-xs font-bold ${meta.accent.text}`}>
+            <span className="inline-flex items-center gap-1 text-xs font-semibold text-ink-500">
               <Icon name="external-link" size={12} />
               {meta.ctaLabel}
             </span>
@@ -383,12 +407,12 @@ export default function InvestListingCard({
             <EnquireButton
               listingId={listing.id}
               listingTitle={listing.title}
-              buttonCls="bg-amber-500 hover:bg-amber-600 text-white"
+              buttonCls="bg-coral-500 hover:bg-coral-600 text-white"
             />
           )}
-          <span className={`flex-1 inline-flex items-center justify-end gap-1 text-xs font-bold ${meta.accent.text} group-hover:gap-2 transition-all`}>
-            View Details
-            <Icon name="chevron-right" size={12} />
+          <span className="inline-flex items-center gap-1 text-sm font-semibold text-coral-600 transition-all group-hover:gap-1.5">
+            View
+            <Icon name="chevron-right" size={13} />
           </span>
         </div>
       </div>

--- a/components/InvestListingCard.tsx
+++ b/components/InvestListingCard.tsx
@@ -266,7 +266,7 @@ export default function InvestListingCard({
           ) : (
             <span />
           )}
-          <span className="inline-flex items-center gap-1 rounded-lg bg-coral-500 px-3 py-1.5 text-xs font-semibold text-white transition-colors group-hover:bg-coral-600">
+          <span className="inline-flex items-center gap-1 rounded-lg bg-coral-600 px-3 py-1.5 text-xs font-semibold text-white transition-colors group-hover:bg-coral-700">
             View
             <Icon name="chevron-right" size={12} />
           </span>
@@ -407,7 +407,7 @@ export default function InvestListingCard({
             <EnquireButton
               listingId={listing.id}
               listingTitle={listing.title}
-              buttonCls="bg-coral-500 hover:bg-coral-600 text-white"
+              buttonCls="bg-coral-600 hover:bg-coral-700 text-white"
             />
           )}
           <span className="inline-flex items-center gap-1 text-sm font-semibold text-coral-600 transition-all group-hover:gap-1.5">

--- a/components/InvestListingsClient.tsx
+++ b/components/InvestListingsClient.tsx
@@ -9,6 +9,7 @@ import {
   TICKET_BUCKETS,
   ticketBucketByKey,
   INVESTOR_TYPES,
+  ALL_LISTING_KINDS,
   type InvestorType,
   deriveListingKind,
   listingKindMeta,
@@ -539,29 +540,36 @@ export default function InvestListingsClient({
           </div>
 
           {/* Primary facet pill-bar + active-filter chips (compliance-safe).
-              Reads/writes the SAME URL params as the "All filters" drawer. */}
-          <MarketplaceFilterBar
-            params={new URLSearchParams(searchParams.toString())}
-            setParams={setParams}
-            onOpenAllFilters={() => setDrawerOpen(true)}
-            advancedCount={advancedCount}
-            resultCount={filtered.length}
-            categories={categories}
-            categoryCounts={categoryCounts}
-            kindCounts={kindCounts}
-            stateCounts={stateCounts}
-            activeChips={activeChips}
-            onClearAll={clearAllFilters}
-            showSector={!lockedCategory}
-          />
+              Reads/writes the SAME URL params as the "All filters" drawer.
+              Desktop (lg+) drives filters from the sticky left rail below,
+              so the pill bar is mobile/tablet-only there. */}
+          <div className="lg:hidden">
+            <MarketplaceFilterBar
+              params={new URLSearchParams(searchParams.toString())}
+              setParams={setParams}
+              onOpenAllFilters={() => setDrawerOpen(true)}
+              advancedCount={advancedCount}
+              resultCount={filtered.length}
+              categories={categories}
+              categoryCounts={categoryCounts}
+              kindCounts={kindCounts}
+              stateCounts={stateCounts}
+              activeChips={activeChips}
+              onClearAll={clearAllFilters}
+              showSector={!lockedCategory}
+            />
+          </div>
 
         </div>
       </div>
 
-      {/* ── Advanced filters (drawer) + results ─────────────────────── */}
+      {/* ── Two-column marketplace: sticky filter rail (lg+) + results ── */}
       <div className="container-custom py-5 md:py-8">
-        {/* Long-tail facets — drawer on all breakpoints, opened from the
-            pill bar's "All filters" button. Primary facets live in the bar. */}
+        {/* Long-tail facets — bottom-sheet drawer on mobile/tablet, opened
+            from the pill bar's "All filters" button. On lg+ the same filter
+            dimensions live in the sticky left rail, so the drawer is the
+            small-screen entry point only. Both read/write the SAME URL
+            params, so the filter pipeline downstream is untouched. */}
         <FilterPanel
           open={drawerOpen}
           onClose={() => setDrawerOpen(false)}
@@ -588,8 +596,44 @@ export default function InvestListingsClient({
               />
         </FilterPanel>
 
-        {/* Results */}
-        <div className="min-w-0">
+        <div className="lg:grid lg:grid-cols-[260px_minmax(0,1fr)] lg:gap-8 lg:items-start">
+          {/* ── Sticky LEFT facet rail (desktop / lg+ only) ──────────
+              The HTML `hidden` attribute keeps this out of the a11y tree on
+              mobile (and in jsdom — so its controls don't collide with the
+              mobile pill bar + drawer); `lg:!block` re-shows it at ≥1024px,
+              overriding the attribute. Every control is wired to the SAME
+              state + setParams the mobile chrome uses. */}
+          <aside hidden className="hidden lg:!block lg:sticky lg:top-4 self-start">
+            <DesktopFilterRail
+              categories={categories}
+              categoryCounts={categoryCounts}
+              kindCounts={kindCounts}
+              stateCounts={stateCounts}
+              complianceCounts={complianceCounts}
+              activeCategory={lockedCategory ? "" : activeCategory}
+              activeKinds={activeKinds}
+              activeState={activeState}
+              activeTicket={activeTicket}
+              activeInvestorType={activeInvestorType}
+              activeFirbOnly={activeFirbOnly}
+              activeSivOnly={activeSivOnly}
+              activeWholesaleOnly={activeWholesaleOnly}
+              activeFreshness={activeFreshness}
+              activeFeaturedOnly={activeFeaturedOnly}
+              activeMinYield={activeMinYield}
+              activeEsicOnly={activeEsicOnly}
+              kindSpec={kindSpec}
+              intentCountry={intentCountry ?? null}
+              activeChipsCount={activeChips.length}
+              showSector={!lockedCategory}
+              onToggleKind={toggleKind}
+              onClearAll={clearAllFilters}
+              setParams={setParams}
+            />
+          </aside>
+
+          {/* Results */}
+          <div className="min-w-0">
             {subCategories.length > 0 && (
               <div className="mb-5">
                 <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500 mb-1.5">Narrow by sub-type</p>
@@ -652,6 +696,7 @@ export default function InvestListingsClient({
                 ))}
               </div>
             )}
+          </div>
         </div>
       </div>
 
@@ -921,5 +966,281 @@ function Section({ title, children }: { title: string; children: React.ReactNode
       <h3 className="text-[10px] font-extrabold uppercase tracking-wider text-slate-500 mb-2">{title}</h3>
       {children}
     </section>
+  );
+}
+
+// ─── Desktop sticky LEFT facet rail (lg+) ─────────────────────────────
+// A v2-styled `.iv2-card` panel that hosts every filter dimension wired to
+// the SAME state + setParams the mobile pill bar / drawer use. This is a
+// LAYOUT surface only — no new filter logic. Hidden on mobile (the pill
+// bar + bottom-sheet drawer drive filters there); see the `hidden` attr +
+// `lg:!block` on the wrapping <aside>.
+interface DesktopFilterRailProps {
+  categories: { slug: string; label: string }[];
+  categoryCounts: Record<string, number>;
+  kindCounts: Record<string, number>;
+  stateCounts: Record<string, number>;
+  complianceCounts: Record<string, number>;
+  activeCategory: string;
+  activeKinds: ReadonlySet<ListingKind>;
+  activeState: string;
+  activeTicket: string;
+  activeInvestorType: InvestorType;
+  activeFirbOnly: boolean;
+  activeSivOnly: boolean;
+  activeWholesaleOnly: boolean;
+  activeFreshness: string;
+  activeFeaturedOnly: boolean;
+  activeMinYield: string;
+  activeEsicOnly: boolean;
+  kindSpec: ReturnType<typeof filterSpecForKind>;
+  intentCountry: string | null;
+  activeChipsCount: number;
+  showSector: boolean;
+  onToggleKind: (k: ListingKind) => void;
+  onClearAll: () => void;
+  setParams: (updates: Record<string, string>) => void;
+}
+
+/** Small uppercase section label (v2 `.iv2-mini`). */
+function RailLabel({ children }: { children: React.ReactNode }) {
+  return <p className="iv2-mini mb-2">{children}</p>;
+}
+
+function DesktopFilterRail({
+  categories, categoryCounts, kindCounts, stateCounts, complianceCounts,
+  activeCategory, activeKinds, activeState, activeTicket, activeInvestorType,
+  activeFirbOnly, activeSivOnly, activeWholesaleOnly, activeFreshness,
+  activeFeaturedOnly, activeMinYield, activeEsicOnly, kindSpec, intentCountry,
+  activeChipsCount, showSector, onToggleKind, onClearAll, setParams,
+}: DesktopFilterRailProps) {
+  const complianceOptions = [
+    { value: "firb", label: "FIRB-eligible" },
+    { value: "siv", label: "SIV-complying" },
+    { value: "wholesale", label: "Wholesale only" },
+    ...(kindSpec.showEsicToggle ? [{ value: "esic", label: "ESIC-eligible" }] : []),
+  ];
+  const complianceSelected = new Set<string>();
+  if (activeFirbOnly) complianceSelected.add("firb");
+  if (activeSivOnly) complianceSelected.add("siv");
+  if (activeWholesaleOnly) complianceSelected.add("wholesale");
+  if (activeEsicOnly) complianceSelected.add("esic");
+  const minYieldValue = Number(activeMinYield) || 0;
+
+  return (
+    <div className="iv2-card p-4 space-y-5">
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-extrabold text-ink-900">Filters</h2>
+        {activeChipsCount > 0 && (
+          <span className="text-[11px] font-semibold text-coral-700">{activeChipsCount} active</span>
+        )}
+      </div>
+
+      {/* Category / vertical facet list */}
+      {showSector && categories.length > 0 && (
+        <section>
+          <RailLabel>Category</RailLabel>
+          <ul className="space-y-0.5">
+            {[{ slug: "all", label: "All categories" }, ...categories].map((c) => {
+              const count = c.slug === "all" ? (categoryCounts["all"] ?? 0) : (categoryCounts[c.slug] ?? 0);
+              const isActive = c.slug === "all" ? activeCategory === "all" : activeCategory === c.slug;
+              const isDisabled = c.slug !== "all" && count === 0 && !isActive;
+              return (
+                <li key={c.slug}>
+                  <button
+                    type="button"
+                    disabled={isDisabled}
+                    aria-pressed={isActive}
+                    onClick={() => setParams({ category: c.slug === "all" ? "" : c.slug, sub: "" })}
+                    className={`flex w-full items-center justify-between gap-2 rounded-lg px-2.5 py-1.5 text-left text-[13px] font-semibold transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
+                      isActive ? "bg-ink-900 text-white" : "text-ink-700 hover:bg-ink-50"
+                    }`}
+                  >
+                    <span className="truncate">{c.label}</span>
+                    <span
+                      className={`shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-bold tabular-nums ${
+                        isActive ? "bg-white/20 text-white" : "bg-ink-50 text-ink-400"
+                      }`}
+                    >
+                      {count}
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      )}
+
+      {/* Kind (listing-kind) */}
+      <section>
+        <RailLabel>Kind</RailLabel>
+        <div className="flex flex-wrap gap-1.5">
+          {ALL_LISTING_KINDS.map((k) => {
+            const meta = listingKindMeta(k);
+            const count = kindCounts[k] ?? 0;
+            const selected = activeKinds.has(k);
+            const disabled = count === 0 && !selected;
+            return (
+              <button
+                key={k}
+                type="button"
+                disabled={disabled}
+                aria-pressed={selected}
+                onClick={() => onToggleKind(k)}
+                className={`inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs font-semibold transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
+                  selected
+                    ? "border-ink-900 bg-ink-900 text-white"
+                    : "border-ink-100 bg-white text-ink-700 hover:border-ink-300"
+                }`}
+              >
+                <Icon name={meta.icon} size={11} />
+                {meta.label}
+                <span className={`tabular-nums text-[10px] ${selected ? "text-white/70" : "text-ink-400"}`}>{count}</span>
+              </button>
+            );
+          })}
+        </div>
+      </section>
+
+      {/* Ticket size */}
+      <section>
+        <RailLabel>Ticket size</RailLabel>
+        <div className="grid grid-cols-2 gap-1.5">
+          {TICKET_BUCKETS.map((b) => (
+            <button
+              key={b.key || "any"}
+              type="button"
+              onClick={() => setParams({ price: b.key })}
+              aria-pressed={activeTicket === b.key}
+              className={`rounded-lg px-2 py-1.5 text-[11px] font-semibold transition-colors ${
+                activeTicket === b.key
+                  ? "bg-ink-900 text-white shadow-sm"
+                  : "bg-ink-50 text-ink-600 hover:bg-ink-100"
+              }`}
+            >
+              {b.label}
+            </button>
+          ))}
+        </div>
+      </section>
+
+      {/* Investor type */}
+      <section>
+        <RailLabel>Investor type</RailLabel>
+        <select
+          value={activeInvestorType}
+          onChange={(e) => setParams({ investor: e.target.value })}
+          aria-label="Investor type"
+          className="w-full rounded-lg border border-ink-100 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-coral-400"
+        >
+          {INVESTOR_TYPES.map((t) => <option key={t.value} value={t.value}>{t.label}</option>)}
+        </select>
+        <p className="mt-1.5 text-[10px] leading-snug text-ink-400">
+          Narrows out listings restricted to a category you don&apos;t qualify for. Doesn&apos;t verify status — that happens at enquiry.
+        </p>
+      </section>
+
+      {/* State chips */}
+      <section>
+        <RailLabel>State</RailLabel>
+        <div className="flex flex-wrap gap-1.5">
+          {STATES.map((s) => {
+            const count = stateCounts[s] ?? 0;
+            const selected = activeState === s;
+            const disabled = count === 0 && !selected;
+            return (
+              <button
+                key={s}
+                type="button"
+                disabled={disabled}
+                aria-pressed={selected}
+                onClick={() => setParams({ state: selected ? "" : s })}
+                className={`inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-xs font-semibold transition-colors disabled:opacity-40 disabled:cursor-not-allowed ${
+                  selected
+                    ? "border-coral-100 bg-coral-50 text-coral-700"
+                    : "border-ink-100 bg-white text-ink-600 hover:border-ink-300"
+                }`}
+              >
+                {s}
+                <span className={`tabular-nums text-[10px] ${selected ? "text-coral-700/70" : "text-ink-400"}`}>{count}</span>
+              </button>
+            );
+          })}
+        </div>
+      </section>
+
+      {/* Compliance & structure */}
+      <section>
+        <FacetGroup
+          label="Compliance & structure"
+          options={complianceOptions}
+          selected={complianceSelected}
+          counts={complianceCounts}
+          onChange={(next) =>
+            setParams({
+              firb: next.has("firb") ? "eligible" : "",
+              siv: next.has("siv") ? "complying" : "",
+              wholesale: next.has("wholesale") ? "true" : "",
+              ...(kindSpec.showEsicToggle ? { esic: next.has("esic") ? "true" : "" } : {}),
+            })
+          }
+        />
+        <p className="mt-1.5 text-[10px] leading-snug text-ink-400">
+          {intentCountry ? "FIRB-eligible recommended — your visit comes via a foreign-investment page. " : ""}
+          SIV = $5M+ across complying assets. Wholesale = s708 / sophisticated-investor only.
+        </p>
+      </section>
+
+      {/* Yield / return (kind-aware) */}
+      {kindSpec.showYield && (
+        <section>
+          <RangeSlider
+            label="Minimum yield / return"
+            min={0}
+            max={15}
+            step={1}
+            value={minYieldValue}
+            onChange={(v) => setParams({ min_yield: v === 0 ? "" : String(v) })}
+            formatValue={(v) => (v === 0 ? "Any" : `${v}%`)}
+            presets={YIELD_PRESETS}
+          />
+        </section>
+      )}
+
+      {/* Listing status + featured */}
+      <section>
+        <RailLabel>Listing status</RailLabel>
+        <select
+          value={activeFreshness}
+          onChange={(e) => setParams({ fresh: e.target.value })}
+          aria-label="Listing freshness"
+          className="w-full rounded-lg border border-ink-100 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-coral-400"
+        >
+          <option value="">Any status</option>
+          <option value="new_this_week">New this week</option>
+          <option value="closing_soon">Closing soon</option>
+        </select>
+        <label className="mt-2.5 flex cursor-pointer items-center gap-2 text-sm text-ink-700">
+          <input
+            type="checkbox"
+            checked={activeFeaturedOnly}
+            onChange={(e) => setParams({ featured: e.target.checked ? "true" : "" })}
+            className="h-4 w-4 shrink-0 accent-coral-500"
+          />
+          Featured / Premium only
+        </label>
+      </section>
+
+      {/* Reset — full-width ghost */}
+      <button
+        type="button"
+        onClick={onClearAll}
+        disabled={activeChipsCount === 0}
+        className="iv2-cta-ghost w-full justify-center disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        Reset filters
+      </button>
+    </div>
   );
 }


### PR DESCRIPTION
Brings the two main directory surfaces — `/invest` (marketplace listings) and `/advisors` — onto the v2 "confident fintech" design language (`--color-coral / ink / sand-*` + `.iv2-*`, already defined in `globals.css`), matching the marketplace + advisor mockups. Both surfaces were previously on the legacy amber/slate palette.

**Listings — `/invest`**
- `InvestListingCard` (grid + list): per-kind category colour-strip, deep-ink title + `location · industry · sub-category`, big tabular asking price (`.iv2-bignum`), inline key-metrics line, trust pills (Featured / FIRB / SIV), coral Enquire + `View →`. All kind logic preserved (price label, CTA verb, external-CTA kinds, FIRB gating, match score, advisor opt-in, claim link).
- Dark-navy + coral-glow hero with **real-data** stat tiles (aggregate ask, sectors, FIRB/SIV — degrades cleanly to the empty-data path).
- Filters restructured into a **sticky 260px left facet rail** on desktop (lg+); mobile keeps the existing pill bar + bottom-sheet drawer. Layout-only: same URL-param state, sort, view modes, match scores, advisor opt-in, claim links and compare bar.

**Advisors — `/advisors`**
- Advisor card: coral accent, **green Verified**, coral **`View profile →`** CTA.
- Hero + filter rail (search, type pills, filter button, apply, active chips, specialty selector, pagination, CTAs) → coral. Gold rating stars and the amber "waitlist" status are intentionally preserved.

No data-model, routing, or compliance-copy changes — presentation layer only. `npm run type-check` is green; the `InvestListingsClient` + `AdvisorsClient` suites pass.

Independent of the separate Vercel account-block issue — review via the diff or a local `npm run dev` with Supabase creds. The red `Supabase types drift` / `Preview smoke test` / `Bundle size diff` checks are pre-existing / blocked-Vercel / advisory respectively, not introduced here.

https://claude.ai/code/session_01UB2jjWmzZYM88xZXFqYP7e