### PR TITLE
fix(netlify): skip type-check + lint on Netlify builds only (unblock mirror)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -22,9 +22,6 @@ const nextConfig: NextConfig = {
   typescript: {
     ignoreBuildErrors: process.env.NETLIFY === "true",
   },
-  eslint: {
-    ignoreDuringBuilds: process.env.NETLIFY === "true",
-  },
   experimental: {
     // Reduce aggressive prefetching — only prefetch on hover, not on viewport
     optimisticClientCache: false,

--- a/next.config.ts
+++ b/next.config.ts
@@ -14,6 +14,17 @@ const nextConfig: NextConfig = {
   // past 60s. 180s leaves headroom without masking a genuinely-broken
   // page (Next.js still retries 3 times before failing).
   staticPageGenerationTimeout: 180,
+  // Netlify mirror builds (NETLIFY=true) OOM during `next build` type-checking
+  // on Netlify's small build VMs. Skip type-check + lint ONLY on Netlify so the
+  // temporary mirror can build while Vercel is paused. Vercel + CI run with
+  // NETLIFY unset, and the gating `tsc --noEmit` CI job is unaffected — the
+  // primary pipeline keeps its strict, no-escape-hatch guarantee.
+  typescript: {
+    ignoreBuildErrors: process.env.NETLIFY === "true",
+  },
+  eslint: {
+    ignoreDuringBuilds: process.env.NETLIFY === "true",
+  },
   experimental: {
     // Reduce aggressive prefetching — only prefetch on hover, not on viewport
     optimisticClientCache: false,


### PR DESCRIPTION
Unblocks the temporary **Netlify** mirror (Vercel is paused for billing).

**Problem:** Netlify's build VMs run out of memory during `next build` type-checking — the app *compiles* fine, then the TS checker exhausts the heap even with `NODE_OPTIONS=--max-old-space-size=4096`.

**Fix:** gate `typescript.ignoreBuildErrors` + `eslint.ignoreDuringBuilds` on `process.env.NETLIFY === "true"`. Netlify sets `NETLIFY=true`; Vercel and GitHub CI do not — so Netlify skips the OOM-causing type-check, while **Vercel + CI stay strict** and the separate gating `tsc --noEmit` job still type-checks every PR. No global escape hatch (per CLAUDE.md).

Verified `tsc --noEmit` clean locally. Reversible — delete the two gated blocks once Vercel is restored.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UB2jjWmzZYM88xZXFqYP7e)_