### PR TITLE
fix(netlify): trim server-function trace under the 250MB limit

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -22,6 +22,38 @@ const nextConfig: NextConfig = {
   typescript: {
     ignoreBuildErrors: process.env.NETLIFY === "true",
   },
+  // Netlify bundles the whole server into ONE function with a hard 250MB limit,
+  // which this app blows past. Trim build-only / test-only / client-only /
+  // CDN-handled deps out of the function trace so it fits. NETLIFY-gated so
+  // Vercel's trace is untouched (Vercel DOES need sharp in-function for
+  // next/image; Netlify serves /_next/image via its own Image CDN instead).
+  // Biggest offenders excluded: @next/swc (~200MB of build-time Rust binaries),
+  // @img/sharp (~33MB), posthog-js (client-only, ~37MB), typescript (~23MB),
+  // plus test + CSS/JS build tooling. Nothing runtime-critical (next, @sentry,
+  // @opentelemetry, yahoo-finance2, @anthropic-ai, supabase) is excluded.
+  ...(process.env.NETLIFY === "true"
+    ? {
+        outputFileTracingExcludes: {
+          "*": [
+            "node_modules/@next/swc-*/**/*",
+            "node_modules/@img/**/*",
+            "node_modules/sharp/**/*",
+            "node_modules/posthog-js/**/*",
+            "node_modules/typescript/**/*",
+            "node_modules/playwright-core/**/*",
+            "node_modules/jsdom/**/*",
+            "node_modules/@testing-library/**/*",
+            "node_modules/@esbuild/**/*",
+            "node_modules/esbuild/**/*",
+            "node_modules/lightningcss-*/**/*",
+            "node_modules/@babel/**/*",
+            "node_modules/@typescript-eslint/**/*",
+            "node_modules/eslint/**/*",
+            "node_modules/terser/**/*",
+          ],
+        },
+      }
+    : {}),
   experimental: {
     // Reduce aggressive prefetching — only prefetch on hover, not on viewport
     optimisticClientCache: false,


### PR DESCRIPTION
Second (and final) Netlify-mirror blocker. After the type-check OOM fix (#1285), `next build` succeeds — but the **deploy** fails because `@netlify/plugin-nextjs` bundles the server into one function (`___netlify-server-handler`) that **exceeds Netlify's hard 250 MB limit**:
```
The function exceeds the maximum size of 250 MB
Failed to upload file: ___netlify-server-handler
```

**Fix:** a NETLIFY-gated `outputFileTracingExcludes` that drops deps the runtime function doesn't need:
- `@next/swc-*` — ~200 MB of build-time Rust compiler binaries (never used at runtime) ← the main offender
- `@img` / `sharp` — Netlify serves `/_next/image` via its own Image CDN, so sharp isn't invoked in-function
- `posthog-js` (client-only), `typescript`, `playwright-core`/`jsdom`/`@testing-library` (test-only), `esbuild`/`lightningcss`/`@babel`/`eslint`/`terser` (build-only)

Gated on `NETLIFY=true` so **Vercel's trace is unchanged** (Vercel needs sharp in-function). Nothing runtime-critical is excluded (`next`, `@sentry`, `@opentelemetry`, `yahoo-finance2`, `@anthropic-ai`, supabase all kept). `tsc --noEmit` clean.

Note: I can't run Netlify's bundler locally, so this is a targeted best-effort — it removes ~350 MB of the largest trace contributors, which should bring the function well under 250 MB. If it's still over after redeploy, the log will show what's left and I'll trim further.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UB2jjWmzZYM88xZXFqYP7e)_