### PR TITLE
fix(netlify): exclude e2e/coverage/test dirs from server function (371MB→191MB, verified)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -35,6 +35,18 @@ const nextConfig: NextConfig = {
     ? {
         outputFileTracingExcludes: {
           "*": [
+            // Project dirs the serverless function never needs — the REAL bloat:
+            // e2e/ alone is ~119MB of committed Playwright visual snapshots.
+            // (coverage/ is gitignored so it's local-only, but exclude anyway.)
+            "e2e/**/*",
+            "coverage/**/*",
+            "__tests__/**/*",
+            "docs/**/*",
+            "scripts/**/*",
+            "supabase/**/*",
+            "tsconfig.tsbuildinfo",
+            ".next/cache/**/*",
+            // Build-only / client-only / CDN-handled node_modules:
             "node_modules/@next/swc-*/**/*",
             "node_modules/@img/**/*",
             "node_modules/sharp/**/*",


### PR DESCRIPTION
**Verified fix for the Netlify 250 MB function limit.**

After #1286, `next build` succeeded but the deploy still failed: `___netlify-server-handler` exceeded 250 MB. I reproduced Netlify's exact function bundle locally (ran the Netlify Next runtime) and measured it: **371 MB**. The bloat was NOT node_modules (already trimmed to 23 MB) — it was project dirs the runtime copies in, overwhelmingly **`e2e/` = 119 MB of committed Playwright visual-regression snapshot PNGs** (`e2e/visual/snapshots/.../*.png`), plus `coverage/`, `__tests__/`, `docs/`, etc.

Added those project dirs to the NETLIFY-gated `outputFileTracingExcludes`. **Re-measured the local Netlify build: 371 MB → 191 MB** — comfortably under 250 MB. e2e/coverage confirmed gone from the bundle; `app/`, `lib/`, `components/`, traced node_modules all retained.

NETLIFY-gated so Vercel is untouched. Nothing runtime-needed is excluded.

(Side note for later: 119 MB of committed PNG snapshots in `e2e/visual/snapshots/` is a lot of binary weight in the repo — worth moving to CI artifacts or a snapshot store eventually, but out of scope here.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UB2jjWmzZYM88xZXFqYP7e)_