### PR TITLE
fix(netlify): drop custom /_next/static header rule (intermittent JS 503s)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,18 +1,16 @@
 # Netlify configuration — temporary production mirror while Vercel is parked.
 #
-# Why this file exists: the site was deploying on Netlify via pure
-# auto-detection (no committed config). That left two things to chance:
-#   1. Node version. This project requires Node 20+ (CLAUDE.md: Node 18
-#      "silently installs but builds break at runtime"). Vercel ran Node 24;
-#      an unpinned Netlify build could land on anything. Pin it to 20 to match
-#      the bundle-size / e2e CI jobs.
-#   2. Asset post-processing. Netlify's legacy post-processing re-minifies
-#      JS that Next.js has *already* minified+fingerprinted. That re-bundling
-#      is the most likely cause of `/_next/static/chunks/*.js` returning 503
-#      while same-folder CSS returns 200. Next output is immutable and
-#      content-hashed — never let Netlify touch it.
+# Scope deliberately minimal: pin the Node version and declare the Next.js
+# runtime. Everything else about serving a Next app — routing, static-asset
+# headers, caching of /_next/static/* — is owned by @netlify/plugin-nextjs.
+# We do NOT add custom rules on those paths (see the header note below).
 #
-# next.config.ts already keys its mirror-only behaviour (ignoreBuildErrors,
+#   Node version. This project requires Node 20+ (CLAUDE.md: Node 18
+#   "silently installs but builds break at runtime" via
+#   globalThis.AbortSignal.timeout). An unpinned Netlify build could land on
+#   any default; pin it to 20 to match the bundle-size / e2e CI jobs.
+#
+# next.config.ts keys its mirror-only behaviour (ignoreBuildErrors,
 # outputFileTracingExcludes) off NETLIFY=true, which Netlify sets in its build
 # environment automatically — no need to set it here.
 
@@ -32,15 +30,18 @@
 [[plugins]]
   package = "@netlify/plugin-nextjs"
 
-# Do NOT let Netlify re-process the build output. Next.js already minifies JS
-# and CSS and fingerprints every static asset; a second pass only risks
-# corrupting chunks. This is the direct mitigation for the JS-chunk 503s.
-[build.processing]
-  skip_processing = true
-
-# Long-lived immutable caching for fingerprinted static assets. These paths
-# are content-hashed by Next, so they can be cached forever and safely.
-[[headers]]
-  for = "/_next/static/*"
-  [headers.values]
-    Cache-Control = "public, max-age=31536000, immutable"
+# NOTE: no custom [[headers]] rule for /_next/static/*. PR #1288 added one
+# (immutable Cache-Control), and the deploy log responded with:
+#   "Warning: Custom Cache-Control headers detected for the following routes:
+#      - /_next/static/(.*)"
+# The Next.js runtime already serves /_next/static/* directly from the CDN with
+# the correct immutable Cache-Control AND excludes those paths from the
+# catch-all server function. Layering a custom header rule on the same path can
+# disturb that exclusion and route cold-cache asset requests through the SSR
+# function instead of the CDN — exactly the surface that returned intermittent
+# 503s on JS chunks. Let the runtime own it. (The framework already sets
+# `public, max-age=31536000, immutable` on fingerprinted assets.)
+#
+# Likewise no [build.processing] override: skip_processing is the legacy
+# post-processor toggle and does not apply to Next-runtime output, so it was
+# noise. Removing it keeps this file to only what actually changes behaviour.


### PR DESCRIPTION
## Symptom

On some networks/edge locations, `/_next/static/chunks/*.js` returns **503** while the HTML document and CSS return 200. React never hydrates, so `/invest` (and other pages) stay pinned on their loading skeleton. Confirmed live by a browser session; the served HTML actually contains the real listings, so this is a static-asset *serving* fault, not a data/env/build fault.

## Ruled out (each verified, not assumed)

- **Env vars** — `NEXT_PUBLIC_SUPABASE_ANON_KEY` is present, correct (char-for-char), all scopes incl. Builds/Production. The key is in a lazy-loaded chunk, which earlier scans of only the initial chunks missed.
- **Supabase** — project `ACTIVE_HEALTHY`.
- **Quota** — Pro plan, <1% of monthly credits used, no overdue invoices.
- **Build** — latest deploy Published, 765 files, anon key inlined.

## Likely cause

PR #1288 added a custom immutable `Cache-Control` `[[headers]]` rule on `/_next/static/*`. The deploy log warned about exactly that path:

```
Warning: Custom Cache-Control headers detected for the following routes:
  - /_next/static/(.*)
```

`@netlify/plugin-nextjs` already serves `/_next/static/*` directly from the CDN with the correct immutable `Cache-Control` **and** excludes those paths from the catch-all SSR function. Layering a custom header rule on the same path can disturb that exclusion, so cold-cache asset requests fall through to the server function — the surface that intermittently 503s.

## Change

Strip `netlify.toml` to only what changes behaviour:
- **Keep** the Node 20 pin (CLAUDE.md requires Node 20+) and the explicit `@netlify/plugin-nextjs` declaration.
- **Remove** the custom `/_next/static/*` header rule (let the runtime own static serving + caching).
- **Remove** `[build.processing] skip_processing` — that's the legacy post-processor toggle and does not apply to Next-runtime output; it was inert.

Vercel path unaffected (Vercel ignores `netlify.toml`).

## Caveat / verification

I was **unable to reproduce the 503 from the build sandbox** — every request to those chunk URLs (sequential, parallel burst, forced cache-miss, full browser-shaped headers) returned 200. That points to the failure being **specific to the requesting network/edge POP**, which means this change may not be the complete fix. It is, however, the one config issue the deploy log explicitly flagged, and removing it is correct regardless. After this deploys, please re-test `https://lambent-sawine-17c3dd.netlify.app/invest` from the affected browser. If 503s persist, the next step is a Netlify support ticket about edge-node asset serving (with an `x-nf-request-id` from a failed request), not a further code change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UB2jjWmzZYM88xZXFqYP7e)_