### PR TITLE
refactor(compare): adopt shared TabBar + SortDropdown on super/etfs/insurance

### DIFF
--- a/app/compare/etfs/ETFCompareClient.tsx
+++ b/app/compare/etfs/ETFCompareClient.tsx
@@ -5,6 +5,8 @@ import Link from "next/link";
 import Icon from "@/components/Icon";
 import SocialProofCounter from "@/components/SocialProofCounter";
 import ResultCount from "@/components/directory/ResultCount";
+import TabBar from "@/components/directory/TabBar";
+import SortDropdown from "@/components/directory/SortDropdown";
 
 /* ─── Types ─── */
 
@@ -42,6 +44,12 @@ const ETF_DATA: ETF[] = [
 
 const CATEGORIES: Category[] = ["All", "Australian Shares", "International", "Bonds", "Property", "Thematic", "Diversified"];
 
+/** Module-scoped so it isn't re-created each render (react-hooks/static-components). */
+function SortIndicator({ column, sortKey, sortAsc }: { column: SortKey; sortKey: SortKey; sortAsc: boolean }) {
+  if (sortKey !== column) return null;
+  return <Icon name={sortAsc ? "arrow-up" : "arrow-down"} size={14} className="inline ml-0.5 text-coral-600" />;
+}
+
 /* ─── Component ─── */
 
 export default function ETFCompareClient() {
@@ -61,6 +69,12 @@ export default function ETFCompareClient() {
     return list;
   }, [activeCategory, sortKey, sortAsc]);
 
+  const etfCounts = useMemo(() => {
+    const c: Record<string, number> = { All: ETF_DATA.length };
+    for (const cat of CATEGORIES) if (cat !== "All") c[cat] = ETF_DATA.filter((e) => e.category === cat).length;
+    return c;
+  }, []);
+
   function handleSort(key: SortKey) {
     if (sortKey === key) {
       setSortAsc((prev) => !prev);
@@ -70,23 +84,16 @@ export default function ETFCompareClient() {
     }
   }
 
-  const SortIndicator = ({ column }: { column: SortKey }) => {
-    if (sortKey !== column) return null;
-    return (
-      <Icon name={sortAsc ? "arrow-up" : "arrow-down"} size={14} className="inline ml-0.5 text-indigo-600" />
-    );
-  };
-
   return (
     <>
       {/* ─── Hero ─── */}
-      <section className="bg-gradient-to-br from-indigo-600 to-indigo-800 text-white">
+      <section className="bg-gradient-to-br from-slate-900 to-slate-800 text-white">
         <div className="container-custom py-10 md:py-16">
           <div className="max-w-3xl">
             <h1 className="text-2xl md:text-4xl font-extrabold tracking-tight mb-2 md:mb-3">
               Compare Australian ETFs
             </h1>
-            <p className="text-indigo-100 text-sm md:text-base leading-relaxed max-w-2xl mb-3">
+            <p className="text-slate-300 text-sm md:text-base leading-relaxed max-w-2xl mb-3">
               Side-by-side comparison of management fees, categories and providers for
               Australia&apos;s most popular exchange-traded funds. Filter by category and sort
               to find the right ETF for your portfolio.
@@ -98,22 +105,17 @@ export default function ETFCompareClient() {
 
       {/* ─── Main Content ─── */}
       <div className="container-custom py-6 md:py-10">
-        {/* Category Tabs */}
-        <div className="flex flex-wrap gap-2 mb-5 md:mb-6">
-          {CATEGORIES.map((cat) => (
-            <button
-              key={cat}
-              onClick={() => setActiveCategory(cat)}
-              className={`px-3 py-1.5 rounded-full text-xs md:text-sm font-semibold transition-colors ${
-                activeCategory === cat
-                  ? "bg-indigo-600 text-white shadow-sm"
-                  : "bg-slate-100 text-slate-600 hover:bg-slate-200"
-              }`}
-            >
-              {cat}
-            </button>
-          ))}
-        </div>
+        {/* Category Tabs — canonical TabBar primitive */}
+        <TabBar
+          variant="chip"
+          ariaLabel="ETF category"
+          className="mb-5 md:mb-6"
+          value={activeCategory}
+          onChange={setActiveCategory}
+          zeroCountBehavior="show"
+          alwaysShow="All"
+          tabs={CATEGORIES.map((cat) => ({ id: cat, label: cat, count: etfCounts[cat] ?? 0 }))}
+        />
 
         <ResultCount
           total={filtered.length}
@@ -127,14 +129,14 @@ export default function ETFCompareClient() {
             <thead>
               <tr className="bg-slate-50 border-b border-slate-200 text-left text-slate-500 text-xs uppercase tracking-wide">
                 <th className="px-4 py-3 cursor-pointer select-none hover:text-slate-900" onClick={() => handleSort("ticker")}>
-                  Ticker <SortIndicator column="ticker" />
+                  Ticker <SortIndicator column="ticker" sortKey={sortKey} sortAsc={sortAsc} />
                 </th>
                 <th className="px-4 py-3 cursor-pointer select-none hover:text-slate-900" onClick={() => handleSort("name")}>
-                  Fund Name <SortIndicator column="name" />
+                  Fund Name <SortIndicator column="name" sortKey={sortKey} sortAsc={sortAsc} />
                 </th>
                 <th className="px-4 py-3">Provider</th>
                 <th className="px-4 py-3 cursor-pointer select-none hover:text-slate-900 text-right" onClick={() => handleSort("mer")}>
-                  MER % <SortIndicator column="mer" />
+                  MER % <SortIndicator column="mer" sortKey={sortKey} sortAsc={sortAsc} />
                 </th>
                 <th className="px-4 py-3">Category</th>
               </tr>
@@ -147,7 +149,7 @@ export default function ETFCompareClient() {
                       href={`https://www.google.com/search?q=${encodeURIComponent(`${etf.ticker} ASX ETF`)}`}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="font-bold text-indigo-600 hover:text-indigo-800 hover:underline"
+                      className="font-bold text-coral-600 hover:text-coral-700 hover:underline"
                     >
                       {etf.ticker}
                     </Link>
@@ -175,27 +177,18 @@ export default function ETFCompareClient() {
 
         {/* ─── Mobile Cards ─── */}
         <div className="md:hidden space-y-3 mb-6">
-          {/* Mobile sort controls */}
-          <div className="flex items-center gap-2 mb-3">
-            <span className="text-xs text-slate-500 font-medium">Sort by:</span>
-            {(
-              [
-                { key: "mer" as SortKey, label: "MER" },
-                { key: "name" as SortKey, label: "Name" },
-                { key: "ticker" as SortKey, label: "Ticker" },
-              ] as const
-            ).map(({ key, label }) => (
-              <button
-                key={key}
-                onClick={() => handleSort(key)}
-                className={`px-2.5 py-1 rounded-full text-xs font-semibold transition-colors ${
-                  sortKey === key ? "bg-indigo-600 text-white" : "bg-slate-100 text-slate-600"
-                }`}
-              >
-                {label} {sortKey === key && (sortAsc ? "\u2191" : "\u2193")}
-              </button>
-            ))}
-          </div>
+          {/* Mobile sort — canonical SortDropdown primitive (desktop sorts via column headers) */}
+          <SortDropdown
+            className="!block w-full mb-1"
+            ariaLabel="Sort ETFs"
+            value={sortKey}
+            onChange={(v) => { setSortKey(v as SortKey); setSortAsc(true); }}
+            options={[
+              { value: "mer", label: "Lowest fee (MER)" },
+              { value: "name", label: "Name (A\u2013Z)" },
+              { value: "ticker", label: "Ticker (A\u2013Z)" },
+            ]}
+          />
 
           {filtered.map((etf) => (
             <div key={etf.ticker} className="border border-slate-200 rounded-xl p-3">
@@ -205,7 +198,7 @@ export default function ETFCompareClient() {
                     href={`https://www.google.com/search?q=${encodeURIComponent(`${etf.ticker} ASX ETF`)}`}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="font-bold text-indigo-600 hover:underline text-sm"
+                    className="font-bold text-coral-600 hover:underline text-sm"
                   >
                     {etf.ticker}
                   </Link>

--- a/app/compare/insurance/InsuranceCompareClient.tsx
+++ b/app/compare/insurance/InsuranceCompareClient.tsx
@@ -6,6 +6,7 @@ import Icon from "@/components/Icon";
 import SocialProofCounter from "@/components/SocialProofCounter";
 import AdvisorMatchCTA from "@/components/AdvisorMatchCTA";
 import ResultCount from "@/components/directory/ResultCount";
+import TabBar from "@/components/directory/TabBar";
 
 /* ─── Types ─── */
 
@@ -200,6 +201,12 @@ const CATEGORY_COLORS: Record<InsuranceCategory, string> = {
 export default function InsuranceCompareClient() {
   const [category, setCategory] = useState<FilterCategory>("All");
 
+  const insuranceCounts = useMemo(() => {
+    const c: Record<string, number> = { All: INSURERS.length };
+    for (const cat of CATEGORIES) if (cat !== "All") c[cat] = INSURERS.filter((i) => i.categories.includes(cat as InsuranceCategory)).length;
+    return c;
+  }, []);
+
   const filtered = useMemo(() => {
     if (category === "All") return INSURERS;
     return INSURERS.filter((ins) => ins.categories.includes(category as InsuranceCategory));
@@ -208,12 +215,12 @@ export default function InsuranceCompareClient() {
   return (
     <div>
       {/* ─── Hero ─── */}
-      <section className="bg-gradient-to-br from-sky-600 to-sky-800 text-white py-14 md:py-20">
+      <section className="bg-gradient-to-br from-slate-900 to-slate-800 text-white py-14 md:py-20">
         <div className="container-custom text-center">
           <h1 className="text-3xl md:text-5xl font-extrabold mb-3">
             Compare Insurance in Australia
           </h1>
-          <p className="text-sky-200 text-lg md:text-xl max-w-2xl mx-auto mb-4">
+          <p className="text-slate-300 text-lg md:text-xl max-w-2xl mx-auto mb-4">
             Life insurance, income protection, home &amp; contents, and health insurance &mdash;
             compare Australia&rsquo;s leading insurers side by side.
           </p>
@@ -223,22 +230,17 @@ export default function InsuranceCompareClient() {
 
       {/* ─── Main content ─── */}
       <div className="container-custom py-8 md:py-12">
-        {/* Category filter tabs */}
-        <div className="flex flex-wrap gap-2 mb-6">
-          {CATEGORIES.map((cat) => (
-            <button
-              key={cat}
-              onClick={() => setCategory(cat)}
-              className={`px-4 py-2 rounded-full text-sm font-medium transition-colors ${
-                category === cat
-                  ? "bg-sky-600 text-white"
-                  : "bg-slate-100 text-slate-600 hover:bg-slate-200"
-              }`}
-            >
-              {cat}
-            </button>
-          ))}
-        </div>
+        {/* Category filter tabs — canonical TabBar primitive */}
+        <TabBar
+          variant="chip"
+          ariaLabel="Insurance category"
+          className="mb-6"
+          value={category}
+          onChange={setCategory}
+          zeroCountBehavior="show"
+          alwaysShow="All"
+          tabs={CATEGORIES.map((cat) => ({ id: cat, label: cat, count: insuranceCounts[cat] ?? 0 }))}
+        />
 
         <ResultCount
           total={filtered.length}
@@ -284,7 +286,7 @@ export default function InsuranceCompareClient() {
               {/* CTA */}
               <Link
                 href={`/find-advisor?need=insurance`}
-                className="block w-full text-center px-4 py-2.5 bg-sky-600 text-white font-semibold rounded-lg hover:bg-sky-700 transition-colors text-sm"
+                className="block w-full text-center px-4 py-2.5 bg-coral-600 text-white font-semibold rounded-lg hover:bg-coral-700 transition-colors text-sm"
               >
                 Get a Quote
               </Link>

--- a/app/compare/super/SuperCompareClient.tsx
+++ b/app/compare/super/SuperCompareClient.tsx
@@ -5,6 +5,8 @@ import Icon from "@/components/Icon";
 import SocialProofCounter from "@/components/SocialProofCounter";
 import AdvisorMatchCTA from "@/components/AdvisorMatchCTA";
 import ResultCount from "@/components/directory/ResultCount";
+import TabBar from "@/components/directory/TabBar";
+import SortDropdown from "@/components/directory/SortDropdown";
 
 /* ─── Types ─── */
 
@@ -172,6 +174,14 @@ export default function SuperCompareClient() {
   const [sortKey, setSortKey] = useState<SortKey>("balanced_fee_pct");
   const [sortDir, setSortDir] = useState<SortDir>("asc");
 
+  const superCounts = useMemo(() => ({
+    All: SUPER_FUNDS.length,
+    Industry: SUPER_FUNDS.filter((f) => f.type === "Industry").length,
+    Retail: SUPER_FUNDS.filter((f) => f.type === "Retail" || f.type === "Retail/Index").length,
+    Balanced: SUPER_FUNDS.filter((f) => f.balanced_fee_pct <= 0.7).length,
+    "High Growth": SUPER_FUNDS.filter((f) => f.investment_options >= 10).length,
+  } as Record<string, number>), []);
+
   const handleSort = (key: SortKey) => {
     if (sortKey === key) {
       setSortDir(sortDir === "asc" ? "desc" : "asc");
@@ -213,7 +223,7 @@ export default function SuperCompareClient() {
       <Icon
         name={sortDir === "asc" ? "arrow-up" : "arrow-down"}
         size={14}
-        className="inline ml-1 text-violet-400"
+        className="inline ml-1 text-coral-500"
       />
     );
   };
@@ -221,12 +231,12 @@ export default function SuperCompareClient() {
   return (
     <div>
       {/* ─── Hero ─── */}
-      <section className="bg-gradient-to-br from-violet-600 to-violet-800 text-white py-14 md:py-20">
+      <section className="bg-gradient-to-br from-slate-900 to-slate-800 text-white py-14 md:py-20">
         <div className="container-custom text-center">
           <h1 className="text-3xl md:text-5xl font-extrabold mb-3">
             Compare Super Funds in Australia
           </h1>
-          <p className="text-violet-200 text-lg md:text-xl max-w-2xl mx-auto mb-4">
+          <p className="text-slate-300 text-lg md:text-xl max-w-2xl mx-auto mb-4">
             Side-by-side fees, performance, and features for Australia&rsquo;s biggest super funds
             &mdash; industry vs retail, balanced options, and insurance.
           </p>
@@ -236,22 +246,17 @@ export default function SuperCompareClient() {
 
       {/* ─── Main content ─── */}
       <div className="container-custom py-8 md:py-12">
-        {/* Category filter tabs */}
-        <div className="flex flex-wrap gap-2 mb-6">
-          {CATEGORIES.map((cat) => (
-            <button
-              key={cat}
-              onClick={() => setCategory(cat)}
-              className={`px-4 py-2 rounded-full text-sm font-medium transition-colors ${
-                category === cat
-                  ? "bg-violet-600 text-white"
-                  : "bg-slate-100 text-slate-600 hover:bg-slate-200"
-              }`}
-            >
-              {cat}
-            </button>
-          ))}
-        </div>
+        {/* Category filter tabs — canonical TabBar primitive */}
+        <TabBar
+          variant="chip"
+          ariaLabel="Super fund category"
+          className="mb-6"
+          value={category}
+          onChange={setCategory}
+          zeroCountBehavior="show"
+          alwaysShow="All"
+          tabs={CATEGORIES.map((cat) => ({ id: cat, label: cat, count: superCounts[cat] ?? 0 }))}
+        />
 
         <ResultCount
           total={filtered.length}
@@ -330,6 +335,18 @@ export default function SuperCompareClient() {
 
         {/* ─── Mobile cards ─── */}
         <div className="md:hidden space-y-3">
+          {/* Mobile sort — canonical SortDropdown (desktop sorts via column headers) */}
+          <SortDropdown
+            className="!block w-full mb-1"
+            ariaLabel="Sort super funds"
+            value={sortKey}
+            onChange={(v) => { setSortKey(v as SortKey); setSortDir("asc"); }}
+            options={[
+              { value: "balanced_fee_pct", label: "Lowest fee" },
+              { value: "name", label: "Name (A\u2013Z)" },
+              { value: "investment_options", label: "Most options" },
+            ]}
+          />
           {filtered.map((fund) => (
             <div key={fund.name} className="border border-slate-200 rounded-xl p-4">
               <div className="flex items-start justify-between mb-2">
@@ -347,7 +364,7 @@ export default function SuperCompareClient() {
                     {fund.type}
                   </span>
                 </div>
-                <span className="font-mono text-lg font-bold text-violet-700">
+                <span className="font-mono text-lg font-bold text-coral-700">
                   {fund.balanced_fee_pct.toFixed(2)}%
                 </span>
               </div>


### PR DESCRIPTION
## Phase 3 — finish design-system adoption (part 1 of 3)

Follow-up to the directory unification. The three `/compare/{super,etfs,insurance}` sub-pages each hand-rolled their own category-tab row, sort controls, and a bright single-hue hero (indigo / violet / sky) that drifted from the unified slate/coral system.

### What changed (all data, filtering, sorting & SEO copy preserved)
- **Category tabs → canonical `TabBar` (chip)** with per-category **live counts** and neutral active styling — drops the indigo/violet/sky pill fills.
- **ETF + Super mobile sort → canonical `SortDropdown`** (desktop keeps its column-header sort); ETF's bespoke sort-pill row removed.
- **Heroes recoloured** indigo/violet/sky → `slate-900/800` to match `/invest`'s verticals and the directory system; primary CTAs / ticker links / sort indicators → **coral**. Per-category *semantic* badge colours (fund type, insurance category) kept.
- ETF `SortIndicator` lifted to module scope (clears a pre-existing `react-hooks/static-components` warning).

### Verified
- `type-check` ✓ · `lint` ✓ (0 warnings) · real-browser pass on all three — slate hero, chip TabBar with counts, sort, coral CTAs all render, no page errors.

### Next in Phase 3 (separate PRs)
- **B:** ETF + LIC screeners → `SearchInput` + `FilterPanel` + `RangeSlider`.
- **C:** `/invest/funds` category tabs → `TabBar` (quick win).


---
_Generated by [Claude Code](https://claude.ai/code/session_01UB2jjWmzZYM88xZXFqYP7e)_