### PR TITLE
ci: stop bundle-size + E2E going red on every PR

### DIFF
--- a/.github/workflows/bundle-baseline.yml
+++ b/.github/workflows/bundle-baseline.yml
@@ -1,0 +1,74 @@
+name: Bundle size baseline (main)
+
+# Builds main once per push and caches the bundle-size summary so the
+# per-PR "Bundle size budget" job (bundle-size.yml) can diff against it
+# WITHOUT rebuilding the base branch. The old per-PR job built base +
+# head (~13 min each) and blew its timeout, showing CANCELLED on every
+# code PR. This moves the base build here — once per main commit —
+# instead of once per PR.
+
+on:
+  push:
+    branches: [main]
+    # Mirror bundle-size.yml's filter: only refresh the baseline when
+    # something that affects the bundle actually changed.
+    paths:
+      - "app/**"
+      - "components/**"
+      - "lib/**"
+      - "public/**"
+      - "next.config.ts"
+      - "package-lock.json"
+      - "package.json"
+      - "scripts/bundle-size-summary.mjs"
+  # Manual seed — prime the cache the first time, before any qualifying
+  # push to main has run this workflow.
+  workflow_dispatch: {}
+
+concurrency:
+  group: bundle-baseline-main
+  cancel-in-progress: true
+
+jobs:
+  baseline:
+    name: Build + cache main bundle baseline
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    permissions:
+      contents: read
+
+    env:
+      # Placeholder secrets — we only measure JS output, nothing runs.
+      NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: placeholder
+      SUPABASE_SERVICE_ROLE_KEY: placeholder
+      RESEND_API_KEY: placeholder
+      STRIPE_SECRET_KEY: placeholder
+      STRIPE_WEBHOOK_SECRET: placeholder
+      NEXT_PUBLIC_SITE_URL: https://invest.com.au
+      CRON_SECRET: placeholder
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Build + summarise
+        run: |
+          npm ci
+          npm run build
+          mkdir -p bundle-baseline-out
+          node scripts/bundle-size-summary.mjs > bundle-baseline-out/summary.json
+          cat bundle-baseline-out/summary.json
+
+      - name: Cache baseline for PRs to diff against
+        uses: actions/cache/save@v5
+        with:
+          # Keyed per-commit; bundle-size.yml restores the newest match
+          # via the `bundle-baseline-` restore-key prefix. Caches written
+          # on the default branch are readable from PR runs.
+          path: bundle-baseline-out
+          key: bundle-baseline-${{ github.sha }}

--- a/.github/workflows/bundle-baseline.yml
+++ b/.github/workflows/bundle-baseline.yml
@@ -38,6 +38,9 @@ jobs:
       contents: read
 
     env:
+      # next build's TypeScript phase OOMs at Node's default ~4 GB heap
+      # on the runner (SIGABRT mid-build). Match ci.yml's main build job.
+      NODE_OPTIONS: "--max-old-space-size=6144"
       # Placeholder secrets — we only measure JS output, nothing runs.
       NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
       NEXT_PUBLIC_SUPABASE_ANON_KEY: placeholder

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -61,6 +61,9 @@ jobs:
       pull-requests: write
 
     env:
+      # next build's TypeScript phase OOMs at Node's default ~4 GB heap
+      # on the runner (SIGABRT mid-build). Match ci.yml's main build job.
+      NODE_OPTIONS: "--max-old-space-size=6144"
       # Placeholder secrets for the build; we're only measuring
       # JS output, not executing anything.
       NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -6,9 +6,13 @@ name: Bundle size budget
 # a hard gate (regression can sometimes be justified).
 #
 # How it works:
-#   1. Check out base branch, build, capture .next/app-build-manifest
-#      + per-route chunk sizes into a JSON summary.
-#   2. Check out PR head, build, capture the same summary.
+#   1. Build PR head once, capture per-route chunk sizes into a JSON
+#      summary.
+#   2. Restore the base-branch summary from the cache that
+#      bundle-baseline.yml writes on every push to main — NO second
+#      build on the common path. Falls back to building the base branch
+#      only when no baseline is cached yet (the first main run after
+#      this lands, or a 7-day cache eviction).
 #   3. Diff the two summaries per route. Output table formatted
 #      markdown and post it as a sticky PR comment (same comment
 #      updated every run — the thread doesn't fill with noise).
@@ -45,12 +49,13 @@ jobs:
   bundle-size:
     name: Bundle size diff vs base
     runs-on: ubuntu-latest
-    # Two full Next.js builds (base + head) take ~13 min each on this
-    # codebase. 15 min was guaranteed to timeout and showed CANCELLED
-    # on every wave-3 PR. 30 min gives a comfortable buffer without
-    # ballooning cost — the job is already path-filtered to skip
-    # docs-only / config-only PRs.
-    timeout-minutes: 30
+    # Common path builds head ONCE and diffs against the cached main
+    # baseline (bundle-baseline.yml) → ~13 min. The 45-min budget only
+    # matters for the rare cold-cache fallback that also builds the base
+    # branch (~26 min of builds); kept generous so that path finishes
+    # instead of showing CANCELLED like the old 30-min cap did. The job
+    # is already path-filtered to skip docs-only / config-only PRs.
+    timeout-minutes: 45
     permissions:
       contents: read
       pull-requests: write
@@ -95,13 +100,42 @@ jobs:
           node /tmp/bundle-scripts/bundle-size-summary.mjs > /tmp/bundle-size/head.json
           cat /tmp/bundle-size/head.json
 
-      - name: Checkout base branch
+      - name: Restore base baseline (from main)
+        id: restore-baseline
+        uses: actions/cache/restore@v5
+        with:
+          # bundle-baseline.yml saves one summary per main commit under
+          # bundle-baseline-<sha>; restore-keys grabs the most recent
+          # baseline when the PR's exact base SHA isn't cached.
+          path: bundle-baseline-out
+          key: bundle-baseline-${{ github.event.pull_request.base.sha }}
+          restore-keys: |
+            bundle-baseline-
+
+      - name: Resolve base summary
+        id: baseline
+        run: |
+          mkdir -p /tmp/bundle-size
+          if [ -f bundle-baseline-out/summary.json ]; then
+            cp bundle-baseline-out/summary.json /tmp/bundle-size/base.json
+            echo "has_baseline=true" >> "$GITHUB_OUTPUT"
+            echo "Using cached main baseline — skipping the base rebuild."
+          else
+            echo "has_baseline=false" >> "$GITHUB_OUTPUT"
+            echo "No cached baseline yet — falling back to building the base branch."
+          fi
+
+      # Fallback only: build the base branch when no baseline is cached.
+      # Skipped on the common path (saves ~13 min + the second npm ci).
+      - name: Checkout base branch (fallback)
+        if: steps.baseline.outputs.has_baseline != 'true'
         run: |
           git fetch origin ${{ github.base_ref }}:base-ref
           git checkout base-ref
           git reset --hard origin/${{ github.base_ref }}
 
-      - name: Build base branch
+      - name: Build base branch (fallback)
+        if: steps.baseline.outputs.has_baseline != 'true'
         run: |
           npm ci
           npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,20 +320,21 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}-chromium-webkit
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}-chromium
 
       - name: Install Playwright browsers
-        # Install chromium + webkit for cross-browser coverage. Firefox
-        # is omitted to keep the install under 90s on cold cache; the
-        # Blink/WebKit pair catches the vast majority of engine bugs.
-        # On cache hit, skip the browser download (saves ~60–90s) but
-        # still install OS-level deps because those live outside the
-        # cached path.
+        # Chromium only. WebKit + mobile-safari were dropped from this
+        # placeholder-creds smoke after repeated 25-min CANCELLED runs
+        # caused by WebKit's flaky networkidle timeouts (see CLAUDE.md).
+        # The a11y job already runs chromium-only for the same reason;
+        # genuine cross-browser coverage runs against real data in
+        # e2e-preview.yml. On cache hit, skip the browser download but
+        # still install OS-level deps (they live outside the cached path).
         run: |
           if [ "${{ steps.playwright-cache.outputs.cache-hit }}" = "true" ]; then
-            npx playwright install-deps chromium webkit
+            npx playwright install-deps chromium
           else
-            npx playwright install --with-deps chromium webkit
+            npx playwright install --with-deps chromium
           fi
 
       - name: Download .next build from ci job
@@ -352,7 +353,7 @@ jobs:
         # screen. Flip back to hard-fail once staging creds are
         # wired into CI (see docs/staging-environment.md).
         continue-on-error: true
-        run: npx playwright test --retries=2 --reporter=blob,github
+        run: npx playwright test --project=chromium --retries=2 --reporter=blob,github
 
       - name: Upload report
         if: always()


### PR DESCRIPTION
Two CI changes that remove the checks going red/cancelled on *every* PR — pure wasted agent iteration, unrelated to the code under review. Both touched checks are advisory/non-required, so the worst case is unchanged from today (already red).

## 1. E2E (Playwright) → chromium-only in CI
`ci.yml`'s E2E job installed chromium + webkit and ran all three configured projects (chromium, webkit, mobile-safari) with no `--project` filter under a 25-min cap. WebKit's flaky networkidle timeouts (documented in `CLAUDE.md`) pushed it past 25 min → `CANCELLED`, for no real signal (the job is `continue-on-error` and runs on placeholder creds). The **a11y job already does exactly this** with `--project=chromium`; genuine cross-browser coverage stays in `e2e-preview.yml` against real data.

## 2. Bundle size → diff against a cached main baseline (build once, not twice)
The job rebuilt **both** base and head (~13 min each) on every code PR → blew even the 30-min cap → perpetual `CANCELLED`.

- New **`bundle-baseline.yml`** builds main once per qualifying push and caches the summary under `bundle-baseline-<sha>`.
- **`bundle-size.yml`** now restores the newest baseline (restore-key prefix) and builds **head only**. A guarded fallback rebuilds the base branch only when no baseline is cached yet; the timeout moves to 45 min so even that cold path finishes.

### ⚠️ Transition behaviour
The baseline cache is empty until the **first qualifying push to main runs `bundle-baseline.yml`** (i.e. after this merges) — or until someone triggers it via `workflow_dispatch`. Until then, this PR's own bundle-size job takes the **fallback** (still builds base, but now under the 45-min cap, so it completes instead of cancelling). The fast single-build path engages automatically once the first baseline exists.

## Verification
- All three workflows pass local YAML parse; the changes mirror the existing chromium-only a11y job and the existing `actions/cache@v5` patterns.
- Actions logic can't be fully exercised locally — **CI on this PR is the real test.**

Opened as a **draft**; holding the merge for explicit sign-off (Tier C — touches `.github/workflows/*`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01UB2jjWmzZYM88xZXFqYP7e)_