### PR TITLE
ci: trigger CI on ready_for_review so un-drafting runs the gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,12 @@ on:
       - "docs/audits/**"
       - "LOOP_DONE"
   pull_request:
+    # Default types are opened/synchronize/reopened; adding ready_for_review
+    # means flipping a draft → ready triggers CI. Without it, un-drafting
+    # fires no workflow run (only push/synchronize do), so the required gates
+    # never ran on un-draft and the audit-remediation loop had to push empty
+    # "ci: re-trigger" commits every time (REMEDIATION_QUEUE iters 557/559/561).
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
     paths-ignore:
       - "docs/audits/**"


### PR DESCRIPTION
Closes a documented, recurring CI tax: **un-drafting a PR never triggered CI.**

## Problem
`ci.yml`'s `pull_request` trigger had no `types:`, so it used the default `[opened, synchronize, reopened]`. The `ready_for_review` event (fired when a draft is marked ready) is **not** in that set, and GitHub does not fire `synchronize` on a draft→ready flip. So every required gate in `ci.yml` (Lint·Type-check·Test·Build + the compliance/RLS/secret-scan/types-drift jobs) simply **didn't run** when a PR was un-drafted.

The audit-remediation loop hit this repeatedly and worked around it by pushing empty `ci: re-trigger` commits (`REMEDIATION_QUEUE.md` iters 557 / 559 / 561 / 568). I hit the same friction marking #1302 ready.

## Fix
Add `ready_for_review` to the trigger's `types`, keeping the three defaults explicitly (specifying `types` replaces the default set, so they must be re-listed):

```yaml
types: [opened, synchronize, reopened, ready_for_review]
```

Purely additive — drafts still get CI on push exactly as before; this only *adds* a run on the draft→ready transition. `concurrency: cancel-in-progress` already collapses any overlap with a near-simultaneous push.

## Verification
- YAML parses; the change is a single trigger line + comment.
- **This PR is its own test:** opened as a draft, then flipped to ready — the CI run that fires on that flip is the behaviour that previously didn't exist.

Opened as a **draft** (Tier C — touches `.github/workflows/*`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01UB2jjWmzZYM88xZXFqYP7e)_