### PR TITLE
fix(auth): repair 7 dead sign-in/sign-up links (404s) + redirect safety-net

### DIFF
--- a/__tests__/components/FollowAdvisorButton.test.tsx
+++ b/__tests__/components/FollowAdvisorButton.test.tsx
@@ -90,7 +90,7 @@ describe("FollowAdvisorButton", () => {
     );
   });
 
-  it("redirects to /sign-in when API returns 401", async () => {
+  it("redirects to /auth/login (with a next param) when API returns 401", async () => {
     mockFetch.mockImplementation(unauthorizedResponse);
     const user = userEvent.setup();
     render(<FollowAdvisorButton professionalId={2} initialFollowing={false} />);
@@ -100,7 +100,9 @@ describe("FollowAdvisorButton", () => {
     });
 
     await waitFor(() => {
-      expect(mockPush).toHaveBeenCalledWith("/sign-in");
+      expect(mockPush).toHaveBeenCalledWith(
+        expect.stringContaining("/auth/login?next="),
+      );
     });
   });
 

--- a/app/feed/FeedPageClient.tsx
+++ b/app/feed/FeedPageClient.tsx
@@ -215,7 +215,7 @@ export default function FeedPageClient({ initialPosts }: Props) {
             <div style={{ fontSize: 36, marginBottom: 16 }}>🔒</div>
             <p style={{ fontSize: 16, fontWeight: 600, color: "var(--color-ink-900)", marginBottom: 8 }}>Sign in to see your following feed</p>
             <p style={{ fontSize: 14, color: "var(--color-ink-500)", marginBottom: 24 }}>Create a free account to follow advisors and get a personalised feed.</p>
-            <Link href="/sign-in" style={{ display: "inline-block", padding: "10px 22px", borderRadius: 8, background: "var(--color-ink-900)", color: "white", fontSize: 14, fontWeight: 600, textDecoration: "none" }}>
+            <Link href="/auth/login?next=/feed" style={{ display: "inline-block", padding: "10px 22px", borderRadius: 8, background: "var(--color-ink-900)", color: "white", fontSize: 14, fontWeight: 600, textDecoration: "none" }}>
               Sign in
             </Link>
           </div>

--- a/app/get-matched/GetMatchedClient.tsx
+++ b/app/get-matched/GetMatchedClient.tsx
@@ -831,7 +831,7 @@ function ActionPlanScreen({
                 {saving ? "Saving…" : "Email me my plan"}
               </button>
               <Link
-                href="/auth/sign-up"
+                href="/auth/signup"
                 className="inline-flex items-center justify-center gap-2 bg-white border border-slate-200 text-slate-800 font-semibold text-sm px-5 py-2.5 rounded-lg hover:border-slate-300"
               >
                 Create free account

--- a/app/plans/[token]/page.tsx
+++ b/app/plans/[token]/page.tsx
@@ -120,7 +120,7 @@ export default async function PlanPublicPage({
 
           <div className="text-center text-xs text-slate-500">
             Want to keep tracking this plan and any briefs you create?{" "}
-            <Link href="/auth/sign-up" className="underline">
+            <Link href="/auth/signup" className="underline">
               Create a free account
             </Link>
             .

--- a/components/FollowAdvisorButton.tsx
+++ b/components/FollowAdvisorButton.tsx
@@ -45,7 +45,7 @@ export default function FollowAdvisorButton({
         // Revert optimistic update and redirect to sign-in
         setFollowing(following);
         setCount(initialCount);
-        router.push("/sign-in");
+        router.push(`/auth/login?next=${encodeURIComponent(window.location.pathname)}`);
         return;
       }
 

--- a/components/IpoWatchlistButton.tsx
+++ b/components/IpoWatchlistButton.tsx
@@ -50,7 +50,7 @@ export default function IpoWatchlistButton({
 
   async function toggle() {
     if (!userId) {
-      window.location.href = "/login?redirect=/invest/ipo-calendar";
+      window.location.href = "/auth/login?next=/invest/ipo-calendar";
       return;
     }
     if (loading) return;

--- a/components/OfficeHoursLiveStream.tsx
+++ b/components/OfficeHoursLiveStream.tsx
@@ -232,7 +232,7 @@ export default function OfficeHoursLiveStream({
               <span className="text-xs text-slate-400">{questionText.length}/500</span>
               {!userId ? (
                 <a
-                  href="/login?redirect=/questions"
+                  href="/auth/login?next=/questions"
                   className="text-xs font-semibold text-indigo-600 hover:underline"
                 >
                   Sign in to ask

--- a/components/RsvpButton.tsx
+++ b/components/RsvpButton.tsx
@@ -34,7 +34,7 @@ export default function RsvpButton({ sessionId, className = "" }: Props) {
 
   async function toggle() {
     if (!userId) {
-      window.location.href = `/login?redirect=/office-hours/${sessionId}`;
+      window.location.href = `/auth/login?next=/office-hours/${sessionId}`;
       return;
     }
     if (loading || !checked) return;

--- a/next.config.ts
+++ b/next.config.ts
@@ -203,6 +203,26 @@ const nextConfig: NextConfig = {
         destination: "/auth/login",
         permanent: false,
       },
+      // Same root cause for three more legacy sign-in URLs that internal CTAs
+      // and external bookmarks still hit (RsvpButton, IpoWatchlistButton,
+      // OfficeHoursLiveStream used `/login?redirect=`; FollowAdvisorButton +
+      // feed used `/sign-in`; plans + get-matched used `/auth/sign-up`). The
+      // call sites are also fixed; these rules catch bookmarks / external links.
+      {
+        source: "/login",
+        has: [{ type: "query", key: "redirect", value: "(?<dest>.*)" }],
+        destination: "/auth/login?next=:dest",
+        permanent: false,
+      },
+      { source: "/login", destination: "/auth/login", permanent: false },
+      {
+        source: "/sign-in",
+        has: [{ type: "query", key: "redirect", value: "(?<dest>.*)" }],
+        destination: "/auth/login?next=:dest",
+        permanent: false,
+      },
+      { source: "/sign-in", destination: "/auth/login", permanent: false },
+      { source: "/auth/sign-up", destination: "/auth/signup", permanent: false },
 
       // /brokers (plural) used to 404 even though every natural link,
       // internal nav, and Google result expects the plural. The actual


### PR DESCRIPTION
Found by a code-review pass during the sprint. **7 internal CTAs linked to routes that don't exist → every click 404s.** Real routes are `/auth/login` (reads `?next=`) and `/auth/signup`.

| Call site | was | now |
|---|---|---|
| `app/plans/[token]/page.tsx` | `/auth/sign-up` | `/auth/signup` |
| `app/get-matched/GetMatchedClient.tsx` | `/auth/sign-up` | `/auth/signup` |
| `app/feed/FeedPageClient.tsx` | `/sign-in` | `/auth/login?next=/feed` |
| `components/FollowAdvisorButton.tsx` (401 path) | `/sign-in` | `/auth/login?next=<path>` |
| `components/RsvpButton.tsx` | `/login?redirect=` | `/auth/login?next=` |
| `components/OfficeHoursLiveStream.tsx` | `/login?redirect=` | `/auth/login?next=` |
| `components/IpoWatchlistButton.tsx` | `/login?redirect=` | `/auth/login?next=` |

Plus next.config redirects for `/login`, `/sign-in`, `/auth/sign-up` (mirroring the existing `/account/login` rule from the 2026-06-02 sweep) to also catch external bookmarks / stale links.

Verified: lint clean on all changed files, `tsc --noEmit` exit 0. These hit real conversion CTAs (get-matched account creation, follow-advisor, IPO watchlist, office-hours RSVP).

https://claude.ai/code/session_01AX16WTaqAs2W33uydbBWLa

---
_Generated by [Claude Code](https://claude.ai/code/session_01AX16WTaqAs2W33uydbBWLa)_