### PR TITLE
fix(getmatched): remap quiz_weights columns so top-match scoring uses real weights

### DIFF
--- a/__tests__/lib/getmatched/top-match-weights.test.ts
+++ b/__tests__/lib/getmatched/top-match-weights.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from "vitest";
+
+// top-match.ts imports the service-role admin client at module scope; stub it
+// so importing the pure reshape helper needs no env / DB.
+vi.mock("@/lib/supabase/admin", () => ({ createAdminClient: vi.fn() }));
+
+import { reshapeWeightRow } from "@/lib/getmatched/top-match";
+
+describe("reshapeWeightRow", () => {
+  it("maps the flat *_weight DB columns onto the scorer's unsuffixed WeightKeys", () => {
+    expect(
+      reshapeWeightRow({
+        broker_slug: "acme",
+        beginner_weight: 1,
+        low_fee_weight: 2,
+        us_shares_weight: 3,
+        smsf_weight: 4,
+        crypto_weight: 5,
+        advanced_weight: 6,
+        property_weight: 7,
+        robo_weight: 8,
+      }),
+    ).toEqual({
+      beginner: 1, low_fee: 2, us_shares: 3, smsf: 4,
+      crypto: 5, advanced: 6, property: 7, robo: 8,
+    });
+  });
+
+  it("coerces null columns to 0 — the regression: keys must never be undefined", () => {
+    const w = reshapeWeightRow({
+      broker_slug: "acme",
+      beginner_weight: null,
+      low_fee_weight: null,
+      us_shares_weight: null,
+      smsf_weight: null,
+      crypto_weight: null,
+      advanced_weight: null,
+      property_weight: null,
+      robo_weight: null,
+    });
+    expect(w).toEqual({
+      beginner: 0, low_fee: 0, us_shares: 0, smsf: 0,
+      crypto: 0, advanced: 0, property: 0, robo: 0,
+    });
+    // The bug produced `undefined` for every key (wrong column names); the
+    // scorer then read `undefined → 0`. Assert all 8 keys are real numbers.
+    const keys = ["beginner", "low_fee", "us_shares", "smsf", "crypto", "advanced", "property", "robo"] as const;
+    for (const k of keys) expect(typeof w[k]).toBe("number");
+  });
+});

--- a/lib/getmatched/top-match.ts
+++ b/lib/getmatched/top-match.ts
@@ -27,6 +27,41 @@ import type { ActionPlanAnswers, TopMatch, Vertical } from "./types";
 
 const log = logger("getmatched:top-match");
 
+/** A `quiz_weights` row as Supabase returns it — flat, suffixed `*_weight` columns. */
+export type QuizWeightRow = {
+  broker_slug: string;
+  beginner_weight: number | null;
+  low_fee_weight: number | null;
+  us_shares_weight: number | null;
+  smsf_weight: number | null;
+  crypto_weight: number | null;
+  advanced_weight: number | null;
+  property_weight: number | null;
+  robo_weight: number | null;
+};
+
+/**
+ * Remap a flat `quiz_weights` row onto the scorer's `QuizWeights` shape.
+ * The DB columns are suffixed (`beginner_weight`) but `QuizWeights`/`WeightKey`
+ * are unsuffixed (`beginner`). The previous `{ broker_slug, ...weights } as
+ * QuizWeights` produced an object keyed by `*_weight`, so the scorer read
+ * `scores["beginner"]` → `undefined` → `0` for EVERY category — silently
+ * dropping the user's quiz answers and collapsing the match to the rating
+ * tiebreaker. The `as QuizWeights` cast hid the mismatch from the type-checker.
+ */
+export function reshapeWeightRow(row: QuizWeightRow): QuizWeights {
+  return {
+    beginner: row.beginner_weight ?? 0,
+    low_fee: row.low_fee_weight ?? 0,
+    us_shares: row.us_shares_weight ?? 0,
+    smsf: row.smsf_weight ?? 0,
+    crypto: row.crypto_weight ?? 0,
+    advanced: row.advanced_weight ?? 0,
+    property: row.property_weight ?? 0,
+    robo: row.robo_weight ?? 0,
+  };
+}
+
 /**
  * The new quiz uses different budget bucket labels than the legacy
  * `AmountKey` enum the scorer expects. Map them.
@@ -92,17 +127,14 @@ export async function computeTopMatch(
     if (weightsRes.error) throw weightsRes.error;
 
     const brokers = (brokersRes.data ?? []) as Broker[];
-    const weightRows = (weightsRes.data ?? []) as Array<{
-      broker_slug: string;
-    } & QuizWeights>;
+    const weightRows = (weightsRes.data ?? []) as QuizWeightRow[];
 
     if (brokers.length === 0 || weightRows.length === 0) return null;
 
     // Reshape `quiz_weights` rows → `Record<slug, QuizWeights>`
     const weightsMap: Record<string, QuizWeights> = {};
     for (const row of weightRows) {
-      const { broker_slug, ...weights } = row;
-      weightsMap[broker_slug] = weights as QuizWeights;
+      weightsMap[row.broker_slug] = reshapeWeightRow(row);
     }
 
     const answersList = buildAnswersList(answers);
@@ -169,15 +201,12 @@ export async function computeTopMatches(
     if (weightsRes.error) throw weightsRes.error;
 
     const brokers = (brokersRes.data ?? []) as Broker[];
-    const weightRows = (weightsRes.data ?? []) as Array<{
-      broker_slug: string;
-    } & QuizWeights>;
+    const weightRows = (weightsRes.data ?? []) as QuizWeightRow[];
     if (brokers.length === 0 || weightRows.length === 0) return [];
 
     const weightsMap: Record<string, QuizWeights> = {};
     for (const row of weightRows) {
-      const { broker_slug, ...weights } = row;
-      weightsMap[broker_slug] = weights as QuizWeights;
+      weightsMap[row.broker_slug] = reshapeWeightRow(row);
     }
 
     const answersList = buildAnswersList(answers);


### PR DESCRIPTION
**Code-review finding (P2).** `computeTopMatch`/`computeTopMatches` (powering the Get-Matched result hero + carousel) **silently ignored every quiz weight**: `quiz_weights` rows have flat `*_weight` columns (`beginner_weight`…), but the code spread the row and cast `as QuizWeights` (unsuffixed keys `beginner`…), so `weightsMap[slug].beginner` was `undefined` → the scorer read **0 for every category** → the "top match" collapsed to the rating/name tiebreaker, dropping the user's answers. The cast + a false `& QuizWeights` row annotation hid it from `tsc`.

**Fix:** a typed `QuizWeightRow` + `reshapeWeightRow()` mapping `*_weight` → `WeightKey` (null → 0), used at both sites; unsafe casts removed. New `top-match-weights.test.ts` (2 tests) locks in the column→key mapping and that keys are never `undefined`.

Caveat: only bites when `quiz_weights` has admin-entered rows (both fns early-return when empty) — so it's a latent-but-real scoring bug. Verified: tsc 0, 2/2 tests.

https://claude.ai/code/session_01AX16WTaqAs2W33uydbBWLa

---
_Generated by [Claude Code](https://claude.ai/code/session_01AX16WTaqAs2W33uydbBWLa)_