### PR TITLE
fix(api): sanitize advisor-search q before the PostgREST .or() filter

### DIFF
--- a/__tests__/api/advisor-search.test.ts
+++ b/__tests__/api/advisor-search.test.ts
@@ -198,4 +198,19 @@ describe("GET /api/advisor-search", () => {
     const res = await GET(makeGet());
     expect(res.status).toBe(500);
   });
+
+  it("sanitizes q before the .or() filter — strips injection metacharacters", async () => {
+    const chain = makeProfessionalsChain({ data: [], error: null, count: 0 });
+    mockServerFrom.mockReturnValue(chain);
+    // A crafted q that, unsanitized, would inject a PostgREST OR predicate.
+    await GET(makeGet({ q: "x),verified.is.true,name.ilike.(y" }));
+    const orCalls = (chain.or as ReturnType<typeof vi.fn>).mock.calls;
+    expect(orCalls).toHaveLength(1);
+    const filter = orCalls[0][0] as string;
+    // No parens survive from q, and only the 3 clause-separator commas remain
+    // (4 ilike clauses) — the injected `,`/`()` can't break out of the value.
+    expect(filter).not.toMatch(/[()]/);
+    expect(filter.split(",")).toHaveLength(4);
+    expect(filter).toContain("name.ilike.");
+  });
 });

--- a/app/api/advisor-search/route.ts
+++ b/app/api/advisor-search/route.ts
@@ -77,8 +77,16 @@ export async function GET(request: NextRequest) {
       if (specialty) query = query.contains("specialties", [specialty]);
       if (verified === "true") query = query.eq("verified", true);
       if (q) {
-        const term = `%${q}%`;
-        query = query.or(`name.ilike.${term},firm_name.ilike.${term},location_display.ilike.${term},location_suburb.ilike.${term}`);
+        // Sanitize before interpolating into the PostgREST `.or()` filter
+        // string: postgrest-js does NOT escape `.or()` contents, so a crafted
+        // `q` containing the grammar metacharacters `,` (condition separator)
+        // or `()` (grouping) could inject arbitrary filter predicates. Strip
+        // them and cap length; legitimate names/suburbs don't need them.
+        const safe = q.replace(/[,()]/g, " ").slice(0, 100).trim();
+        if (safe) {
+          const term = `%${safe}%`;
+          query = query.or(`name.ilike.${term},firm_name.ilike.${term},location_display.ilike.${term},location_suburb.ilike.${term}`);
+        }
       }
 
       // For "relevance" sort, fetch more and re-rank client-side with composite score.


### PR DESCRIPTION
**Code-review finding (P3 security).** `GET /api/advisor-search` interpolated the raw `q` param into a PostgREST `.or()` filter string. postgrest-js doesn't escape `.or()` contents, so a crafted `q` (e.g. `x),verified.is.true,name.ilike.(y`) could inject filter predicates. Bounded — it reads only public columns and is ANDed with `status=active`, so the realistic effect is match-set manipulation / error-probing, not private-data exfiltration — but real.

**Fix:** strip the `.or()` grammar metacharacters (`,` `(` `)`) from `q` and cap length before building the filter. Adds a regression test asserting a malicious `q` yields a sanitized filter (no injected parens; only the 3 clause-separator commas). Verified: 13/13 advisor-search tests, tsc 0.

https://claude.ai/code/session_01AX16WTaqAs2W33uydbBWLa

---
_Generated by [Claude Code](https://claude.ai/code/session_01AX16WTaqAs2W33uydbBWLa)_