### PR TITLE
fix(tco): treat fx_rate as a percentage (÷100), matching the DB + all consumers

### DIFF
--- a/__tests__/lib/tco.test.ts
+++ b/__tests__/lib/tco.test.ts
@@ -9,7 +9,7 @@ const FULL_BROKER: BrokerFeeProfile = {
   slug: "full",
   asx_fee_value: 5,
   us_fee_value: 10,
-  fx_rate: 0.006,
+  fx_rate: 0.6, // percentage number (0.6 = 0.6%), matching the brokers.fx_rate column
   inactivity_fee_value: 50,
   account_transfer_out_fee: 100,
   inactivity_threshold_balance: 10_000,
@@ -50,7 +50,7 @@ describe("computeTrueCost — happy path", () => {
       us_trades_per_month: 5,
       avg_us_trade_amount_usd: 1000,
     });
-    // USD volume / yr = 5*12*1000 = $60,000; spread 0.6% = $360
+    // USD volume/yr = 5*12*1000 = $60,000; fx_rate 0.6 (i.e. 0.6%) → $360
     const fx = out.components.find((c) => c.sourceField === "fx_rate");
     expect(fx?.amount).toBe(360);
   });

--- a/lib/tco.ts
+++ b/lib/tco.ts
@@ -144,19 +144,22 @@ export function computeTrueCost(
   }
 
   // --- FX spread on USD volume ---
-  // Only relevant when there's USD volume. fx_rate is a decimal (0.006 = 0.6%).
+  // Only relevant when there's USD volume. fx_rate is a PERCENTAGE number
+  // (0.6 = 0.6%), matching the brokers.fx_rate NUMERIC(5,3) column and every
+  // other consumer (compare-engine, cost-scenarios, EmbeddedFxCalc, …) — so
+  // divide by 100 to get the fraction applied to USD volume.
   const usdVolumeYr =
     (p.us_trades_per_month ?? 0) * 12 * (p.avg_us_trade_amount_usd ?? 0);
   if (usdVolumeYr > 0) {
     totalApplicable += 1;
     if (broker.fx_rate !== null && broker.fx_rate !== undefined) {
       knownApplicable += 1;
-      const fxCostUsd = usdVolumeYr * broker.fx_rate;
+      const fxCostUsd = usdVolumeYr * (broker.fx_rate / 100);
       // Keep the math intuitive — caller can convert USD→AUD with their own
       // rate; for the headline figure we treat 1 USD ≈ 1 AUD so the "FX cost"
       // line stays in AUD-equivalents. (Spread itself is the dominant variable.)
       components.push({
-        label: `FX spread (${(broker.fx_rate * 100).toFixed(2)}% on ~$${Math.round(usdVolumeYr).toLocaleString()} USD)`,
+        label: `FX spread (${broker.fx_rate.toFixed(2)}% on ~$${Math.round(usdVolumeYr).toLocaleString()} USD)`,
         amount: fxCostUsd,
         sourceField: "fx_rate",
         fromKnownData: true,


### PR DESCRIPTION
**Code-review finding (P2, latent).** `computeTrueCost` treated `brokers.fx_rate` as a fraction (`fxCost = volume * fx_rate`; label `fx_rate*100`), but the column is a **percentage number** (`0.6` = 0.6%) and *every* other consumer (`compare-engine`, `cost-scenarios`, `EmbeddedFxCalc`, the renderers) divides by 100. Latent today — the helper has **no production importer** (grep-confirmed: only the test uses it) — but the test enshrined the wrong contract (`fx_rate: 0.006`), so it would ship **100× wrong** the moment the helper is wired to real broker data.

**Fix:** `* (fx_rate / 100)` + label `fx_rate.toFixed(2)%` + corrected docstring; fixture → `0.6` (the `$360` assertion is unchanged — 0.6% of $60k = $360 either way). Verified: 18/18 tco tests, tsc 0.

https://claude.ai/code/session_01AX16WTaqAs2W33uydbBWLa

---
_Generated by [Claude Code](https://claude.ai/code/session_01AX16WTaqAs2W33uydbBWLa)_