### PR TITLE
fix(api): guard unvalidated request.json() + JSON.parse against 500s

### DIFF
--- a/app/api/advisor-auth/profile/route.ts
+++ b/app/api/advisor-auth/profile/route.ts
@@ -12,8 +12,17 @@ export async function PATCH(request: NextRequest) {
   const advisorId = await requireAdvisorSession(request);
   if (!advisorId) return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
 
-  // eslint-disable-next-line invest/no-unvalidated-req-json -- field-level allowlist below enforces the contract; full Zod schema would duplicate that list.
-  const body = await request.json();
+  let raw: unknown;
+  try {
+    // eslint-disable-next-line invest/no-unvalidated-req-json -- field-level allowlist below enforces the contract; full Zod schema would duplicate that list.
+    raw = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+  const body = raw as Record<string, unknown>;
 
   // Only allow updating specific fields (not status, verified, rating, etc.)
   // available_in_countries is the advisor's self-asserted corridor coverage

--- a/app/broker-portal/invoices/[id]/page.tsx
+++ b/app/broker-portal/invoices/[id]/page.tsx
@@ -85,10 +85,18 @@ export default function InvoiceDetailPage() {
     );
   }
 
-  const lineItems: LineItem[] =
-    typeof invoice.line_items === "string"
-      ? JSON.parse(invoice.line_items)
-      : invoice.line_items || [];
+  let lineItems: LineItem[] = [];
+  if (invoice.line_items) {
+    try {
+      const parsed =
+        typeof invoice.line_items === "string"
+          ? JSON.parse(invoice.line_items)
+          : invoice.line_items;
+      if (Array.isArray(parsed)) lineItems = parsed;
+    } catch {
+      // Malformed JSONB → render with no line items rather than crashing the page.
+    }
+  }
 
   const formatAUD = (cents: number) =>
     `$${(cents / 100).toLocaleString("en-AU", { minimumFractionDigits: 2 })}`;


### PR DESCRIPTION
**Resilience review (code-review agent).** Two unguarded parse-throws that surface as 500s / page crashes instead of degrading:

- **`advisor-auth/profile` PATCH** — `await request.json()` was unguarded; a malformed/empty body from an authenticated advisor threw `SyntaxError` → **500** (and `body[field]` would `TypeError` on a `null` JSON body). Now wrapped in try/catch → **400**, with a non-null-object guard. Keeps the existing field-allowlist + eslint-disable.
- **`broker-portal/invoices/[id]`** — `JSON.parse(invoice.line_items)` was unguarded *during render*; a malformed JSONB string crashed the page. Now mirrors the **safe sibling** (the PDF route): try/catch + `Array.isArray` guard, default `[]`.

Verified: `advisor-auth-profile` tests 6/6, `tsc --noEmit` 0. (The admin `regulatory-impacts` route shares the pattern but is admin-only + needs a Zod schema — deferred to a follow-up.)

Both agents this cycle confirmed the codebase is **mature/well-hardened** — these are the genuine untracked outliers.

https://claude.ai/code/session_01AX16WTaqAs2W33uydbBWLa

---
_Generated by [Claude Code](https://claude.ai/code/session_01AX16WTaqAs2W33uydbBWLa)_