### PR TITLE
fix(postback): accept string conversion_value_cents — restore dropped partner conversions

### DIFF
--- a/__tests__/api/marketplace-postback.test.ts
+++ b/__tests__/api/marketplace-postback.test.ts
@@ -202,6 +202,31 @@ describe("POST /api/marketplace/postback", () => {
     expect(body.conversion_id).toBe("conv-1");
   });
 
+  it("records the conversion when conversion_value_cents is a string (S2S postbacks serialise numbers as strings)", async () => {
+    // Regression: a strict z.number() on conversion_value_cents previously
+    // failed the whole-body parse, collapsing click_id/event_type to undefined
+    // and returning a spurious 400 — dropping the conversion entirely.
+    const res = await POST(
+      makePost(
+        { ...VALID_BODY, conversion_value_cents: "500" },
+        VALID_API_KEY
+      )
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.conversion_id).toBe("conv-1");
+  });
+
+  it("records the conversion when conversion_value_cents is omitted entirely", async () => {
+    const { conversion_value_cents: _omit, ...noValue } = VALID_BODY;
+    const res = await POST(makePost(noValue, VALID_API_KEY));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.conversion_id).toBe("conv-1");
+  });
+
   it("returns 200 already_recorded on 23505 unique constraint race", async () => {
     setupFromMock({
       insertError: { code: "23505", message: "unique violation" },

--- a/app/api/marketplace/postback/route.ts
+++ b/app/api/marketplace/postback/route.ts
@@ -13,7 +13,13 @@ const Body = z
   .object({
     click_id: z.string().optional(),
     event_type: z.string().optional(),
-    conversion_value_cents: z.number().optional(),
+    // Accept any type here — partner S2S postbacks routinely serialise every
+    // field as a string (e.g. "500"). A strict `z.number()` would fail the
+    // whole-body parse, collapsing click_id/event_type to undefined and
+    // returning a spurious 400 (dropping the conversion). The downstream
+    // `typeof … === "number" ? … : 0` guard already coerces a non-number to 0,
+    // matching the documented "never rejected" contract.
+    conversion_value_cents: z.unknown().optional(),
     metadata: z.record(z.string(), z.unknown()).optional(),
   })
   .passthrough();


### PR DESCRIPTION
## What

`app/api/marketplace/postback/route.ts` — loosen `conversion_value_cents` from `z.number().optional()` to `z.unknown().optional()`.

## Why

The 15-wave hardening (#1271) added a Zod `Body` schema whose comment promised *"permissive … currently-valid postbacks are never rejected."* But `conversion_value_cents: z.number()` broke that contract:

- Server-to-server conversion postbacks routinely serialise **every** field as a string (e.g. `"500"`).
- A string `conversion_value_cents` fails `Body.safeParse`, and the route falls through to `parsedBody.success ? parsedBody.data : {}` — so **all** fields, including `click_id` and `event_type`, collapse to `undefined`.
- Result: a spurious `400 click_id is required`, and the partner conversion is **dropped entirely** (revenue / attribution loss).

The downstream guard `typeof conversion_value_cents === "number" ? … : 0` was already designed to tolerate a non-number and store `0` — exactly the pre-#1271 behaviour. Loosening the schema field lets that guard do its job again. `z.unknown()` is preferred over `z.coerce.number()` to avoid a `NaN`-insert path on unparseable strings.

## Tests

Two regression tests added to `__tests__/api/marketplace-postback.test.ts`: a string-valued and an omitted `conversion_value_cents` both still record the conversion (`200`), covering the collapse-to-`{}` path the existing numeric-only test missed.

## Tier

**Tier C** (webhook-class route) — per `docs/audits/MERGE_AUTHORIZATION.md`, merge after a 30-min quiet window unless `STOP`.

## Local gate

`tsc --noEmit` ✅ · `vitest` 15/15 ✅ · `eslint` ✅ · pre-push hook ✅