### PR TITLE
fix(netlify): graceful 404 for compare + invest-listings (was 500) + gate Vercel SpeedInsights

### DIFF
--- a/app/compare/[versus]/not-found.tsx
+++ b/app/compare/[versus]/not-found.tsx
@@ -1,0 +1,51 @@
+import Link from "next/link";
+import Icon from "@/components/Icon";
+
+// Co-located not-found boundary. Without it, `notFound()` in this route falls
+// back to the root boundary, which the @netlify/plugin-nextjs runtime serves as
+// a 500 ("Server Error") instead of a graceful not-found page. The 8 other
+// dynamic routes that already ship a co-located not-found.tsx degrade cleanly;
+// this one and the invest-listings route were the two that still 500'd.
+export default function CompareNotFound() {
+  return (
+    <div className="min-h-[50vh] flex items-center justify-center px-4 py-12">
+      <div className="text-center max-w-md">
+        <div className="w-16 h-16 rounded-full bg-slate-100 flex items-center justify-center mx-auto mb-4">
+          <Icon name="scale" size={28} className="text-slate-300" />
+        </div>
+        <h1 className="text-xl font-bold text-slate-900 mb-2">Comparison Not Found</h1>
+        <p className="text-sm text-slate-500 mb-6">
+          We couldn&apos;t find that comparison. One or more brokers may have been renamed or removed.
+        </p>
+        <div className="flex flex-col sm:flex-row items-center justify-center gap-3 mb-8">
+          <Link
+            href="/compare"
+            className="w-full sm:w-auto px-5 py-2.5 bg-slate-900 text-white text-sm font-semibold rounded-lg hover:bg-slate-800 transition-colors text-center"
+          >
+            Compare All Brokers
+          </Link>
+          <Link
+            href="/best"
+            className="w-full sm:w-auto px-5 py-2.5 border border-slate-200 text-slate-700 text-sm font-semibold rounded-lg hover:bg-slate-50 transition-colors text-center"
+          >
+            Best-Of Rankings
+          </Link>
+        </div>
+        <div className="border-t border-slate-100 pt-5">
+          <p className="text-xs font-semibold text-slate-400 uppercase tracking-wide mb-3">Popular comparisons</p>
+          <div className="flex flex-wrap justify-center gap-2">
+            <Link href="/versus/commsec-vs-stake" className="px-3 py-1.5 rounded-full bg-slate-50 hover:bg-slate-100 text-xs font-medium text-slate-600 transition-colors">
+              CommSec vs Stake
+            </Link>
+            <Link href="/versus/selfwealth-vs-pearler" className="px-3 py-1.5 rounded-full bg-slate-50 hover:bg-slate-100 text-xs font-medium text-slate-600 transition-colors">
+              SelfWealth vs Pearler
+            </Link>
+            <Link href="/best/brokers" className="px-3 py-1.5 rounded-full bg-slate-50 hover:bg-slate-100 text-xs font-medium text-slate-600 transition-colors">
+              Best brokers
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/invest/[slug]/listings/[subcategory]/not-found.tsx
+++ b/app/invest/[slug]/listings/[subcategory]/not-found.tsx
@@ -1,0 +1,52 @@
+import Link from "next/link";
+import Icon from "@/components/Icon";
+
+// Co-located not-found boundary. Without it, `notFound()` (called here for an
+// unknown category or sub-category) falls back to the root boundary, which the
+// @netlify/plugin-nextjs runtime serves as a 500 instead of a graceful 404.
+// This route handles every vertical that lacks a dedicated `listings/[slug]`
+// detail route (funds, digital-infrastructure, venture-capital, …), so the
+// missing boundary made every such listing-detail link 500 on the live mirror.
+export default function InvestListingNotFound() {
+  return (
+    <div className="min-h-[50vh] flex items-center justify-center px-4 py-12">
+      <div className="text-center max-w-md">
+        <div className="w-16 h-16 rounded-full bg-slate-100 flex items-center justify-center mx-auto mb-4">
+          <Icon name="trending-up" size={28} className="text-slate-300" />
+        </div>
+        <h1 className="text-xl font-bold text-slate-900 mb-2">Listing Category Not Found</h1>
+        <p className="text-sm text-slate-500 mb-6">
+          That investment listing category doesn&apos;t exist. Browse our investment verticals below.
+        </p>
+        <div className="flex flex-col sm:flex-row items-center justify-center gap-3 mb-8">
+          <Link
+            href="/invest"
+            className="w-full sm:w-auto px-5 py-2.5 bg-slate-900 text-white text-sm font-semibold rounded-lg hover:bg-slate-800 transition-colors text-center"
+          >
+            Explore Investments
+          </Link>
+          <Link
+            href="/invest/listings"
+            className="w-full sm:w-auto px-5 py-2.5 border border-slate-200 text-slate-700 text-sm font-semibold rounded-lg hover:bg-slate-50 transition-colors text-center"
+          >
+            All Listings
+          </Link>
+        </div>
+        <div className="border-t border-slate-100 pt-5">
+          <p className="text-xs font-semibold text-slate-400 uppercase tracking-wide mb-3">Popular verticals</p>
+          <div className="flex flex-wrap justify-center gap-2">
+            <Link href="/invest/funds/listings" className="px-3 py-1.5 rounded-full bg-slate-50 hover:bg-slate-100 text-xs font-medium text-slate-600 transition-colors">
+              Funds
+            </Link>
+            <Link href="/invest/commercial-property/listings" className="px-3 py-1.5 rounded-full bg-slate-50 hover:bg-slate-100 text-xs font-medium text-slate-600 transition-colors">
+              Commercial property
+            </Link>
+            <Link href="/invest/farmland/listings" className="px-3 py-1.5 rounded-full bg-slate-50 hover:bg-slate-100 text-xs font-medium text-slate-600 transition-colors">
+              Farmland
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/LayoutSideEffects.tsx
+++ b/components/LayoutSideEffects.tsx
@@ -52,7 +52,11 @@ export default function LayoutSideEffects() {
       <ServiceWorkerRegistrar />
       <ClaimAnonymousOnAuth />
       <WebVitals />
-      <SpeedInsights />
+      {/* Vercel-only: the injected /_vercel/speed-insights/script.js 404s on the
+          Netlify mirror (it only exists on Vercel). NEXT_PUBLIC_VERCEL_ENV is
+          set only in Vercel builds, so Speed Insights renders at launch (Vercel)
+          and stays off on Netlify — no more per-page 404 + MIME console error. */}
+      {process.env.NEXT_PUBLIC_VERCEL_ENV ? <SpeedInsights /> : null}
       <UserOnboarding />
     </>
   );


### PR DESCRIPTION
**Live-bot QA on the Netlify production mirror** found `/invest` listing-detail URLs **and** `/compare/[versus]` (high-traffic) returning **500 "Server Error"** for unknown params.

**Root cause:** on `@netlify/plugin-nextjs`, a `notFound()` that falls back to the *root* not-found boundary is served as a **500**, while a **co-located** `not-found.tsx` degrades gracefully. 8 dynamic routes already ship one (versus, best, article, advisor, scenario, …); these two were missed — so every listing-detail link for the **11 verticals without a `listings/[slug]` route** (funds, digital-infrastructure, venture-capital, …) 500'd, as did invalid `/compare/X-vs-Y` URLs.

**Fix:**
- Add `app/compare/[versus]/not-found.tsx` + `app/invest/[slug]/listings/[subcategory]/not-found.tsx` (mirrors `app/versus/[slugs]/not-found.tsx`). 500 → graceful not-found page.
- Gate `<SpeedInsights />` behind `NEXT_PUBLIC_VERCEL_ENV` — the Vercel-only `/_vercel/speed-insights/script.js` 404'd on **every** Netlify page (console MIME error); now off on Netlify, on at launch (Vercel).

Verified: `tsc` 0, lint clean. The 500→graceful change confirms on the next Netlify deploy (I'll re-curl post-merge). Doesn't touch the avoid-list wholesale verticals' *functionality* — only replaces a crash with a graceful 404.

https://claude.ai/code/session_01AX16WTaqAs2W33uydbBWLa

---
_Generated by [Claude Code](https://claude.ai/code/session_01AX16WTaqAs2W33uydbBWLa)_