### PR TITLE
fix(seo): populate sitemap shards on Netlify (string id) + point robots at shards

### DIFF
--- a/__tests__/app/robots.test.ts
+++ b/__tests__/app/robots.test.ts
@@ -28,7 +28,11 @@ describe("app/robots.ts", () => {
     }
   });
 
-  it("points at the sitemap", () => {
-    expect(String(out.sitemap)).toMatch(/\/sitemap\.xml$/);
+  it("points crawlers at all 8 sitemap shards (the /sitemap.xml index 404s on the Netlify runtime)", () => {
+    const sitemaps = Array.isArray(out.sitemap) ? out.sitemap : [out.sitemap];
+    expect(sitemaps).toHaveLength(8);
+    sitemaps.forEach((url, i) =>
+      expect(url).toMatch(new RegExp(`/sitemap/${i}\\.xml$`)),
+    );
   });
 });

--- a/__tests__/lib/sitemap.test.ts
+++ b/__tests__/lib/sitemap.test.ts
@@ -87,6 +87,17 @@ async function getAllUrls(): Promise<string[]> {
   return shards.flat().map((e) => e.url);
 }
 
+describe("sitemap shard id coercion (Netlify passes string ids)", () => {
+  it("populates the shard for a string id instead of returning an empty []", async () => {
+    // @netlify/plugin-nextjs passes the shard id as "0"; before the Number(id)
+    // coercion this fell through to `default: []` and served empty sitemaps.
+    const asString = await sitemap({ id: "0" as unknown as number });
+    const asNumber = await sitemap({ id: 0 });
+    expect(asString.length).toBeGreaterThan(0);
+    expect(asString.length).toBe(asNumber.length);
+  });
+});
+
 /** Build a single shard and return its URLs. */
 async function getShardUrls(id: number): Promise<string[]> {
   const entries = await sitemap({ id });

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -30,6 +30,11 @@ export default function robots(): MetadataRoute.Robots {
         ],
       },
     ],
-    sitemap: `${baseUrl}/sitemap.xml`,
+    // Point crawlers directly at the 8 sitemap shards. The Next-generated index
+    // at /sitemap.xml 404s on the @netlify/plugin-nextjs runtime (it serves each
+    // shard at /sitemap/[id].xml but not the auto-index), so listing the shards
+    // makes discovery work on both Netlify (now) and Vercel (at launch). Keep in
+    // sync with generateSitemaps() in app/sitemap.ts (currently 8 shards: 0-7).
+    sitemap: Array.from({ length: 8 }, (_, i) => `${baseUrl}/sitemap/${i}.xml`),
   };
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1194,7 +1194,11 @@ async function buildShard7(): Promise<MetadataRoute.Sitemap> {
 // robots.ts already points to `/sitemap.xml` so no change is needed there.
 
 export default async function sitemap({ id }: { id: number }): Promise<MetadataRoute.Sitemap> {
-  switch (id) {
+  // The @netlify/plugin-nextjs runtime passes the shard `id` as a STRING ("0"),
+  // so a numeric `switch (id)` fell through to `default: []` — EVERY shard served
+  // an empty <urlset> on the live mirror (Google was getting empty sitemaps).
+  // Vercel passes a number. Coerce so both platforms populate the shards.
+  switch (Number(id)) {
     case 0: return buildShard0();
     case 1: return buildShard1();
     case 2: return buildShard2();


### PR DESCRIPTION
**Live SEO audit found Google is served EMPTY sitemaps on the Netlify production mirror.**
- `/sitemap.xml` (the Next-generated index) **404s** on `@netlify/plugin-nextjs`.
- `/sitemap/0.xml`…`/sitemap/7.xml` return **200 but EMPTY** (110-byte empty `<urlset>`).

**Root cause:** with `generateSitemaps()`, the Netlify runtime passes the shard `id` as a **string `"0"`**, but `sitemap({ id })` used a numeric `switch (id)` → fell through to `default: return []` → every shard empties. Vercel passes a number, so it works there.

**Fix:**
- `switch (Number(id))` in `app/sitemap.ts` — populates shards on both runtimes.
- `app/robots.ts` points crawlers at the 8 shard URLs directly (the index 404 means a crawler following `robots → /sitemap.xml` found nothing).

Verified: tsc 0, lint clean, robots + sitemap tests **44/44** (incl. a new string-id regression test). Confirms on the next Netlify deploy — I'll re-curl `/sitemap/0.xml` and expect populated `<url>` entries. This is a material SEO fix for a search/GEO-dependent site (empty sitemaps → Google can't efficiently discover/prioritise ~thousands of pages).

https://claude.ai/code/session_01AX16WTaqAs2W33uydbBWLa

---
_Generated by [Claude Code](https://claude.ai/code/session_01AX16WTaqAs2W33uydbBWLa)_