### PR TITLE
fix(postback): set next_retry_at on enqueue — broker webhooks were never delivered

### DIFF
--- a/__tests__/api/marketplace-postback.test.ts
+++ b/__tests__/api/marketplace-postback.test.ts
@@ -227,6 +227,78 @@ describe("POST /api/marketplace/postback", () => {
     expect(body.conversion_id).toBe("conv-1");
   });
 
+  it("enqueues the broker webhook with next_retry_at set so the retry cron can pick it up", async () => {
+    // Regression: the enqueue omitted next_retry_at (nullable, no DB default).
+    // The retry-webhooks cron selects `.lte("next_retry_at", now)`, and in
+    // Postgres `NULL <= now()` is NULL — so the row was never delivered.
+    const webhookInsert = vi.fn().mockResolvedValue({ data: null, error: null });
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "broker_accounts") {
+        // One object serves both the API-key lookup (broker_slug/status) and
+        // the webhook_url lookup, so the enqueue branch is exercised.
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          not: vi.fn().mockReturnThis(),
+          limit: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({
+            data: {
+              broker_slug: "commsec",
+              status: "active",
+              webhook_url: "https://broker.example/hook",
+            },
+            error: null,
+          }),
+        };
+      }
+      if (table === "affiliate_clicks") {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({ data: CLICK, error: null }),
+        };
+      }
+      if (table === "conversion_events") {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          insert: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+          single: vi.fn().mockResolvedValue({ data: CONVERSION, error: null }),
+        };
+      }
+      if (table === "campaign_events") {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          limit: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+        };
+      }
+      if (table === "webhook_delivery_queue") {
+        return { insert: webhookInsert };
+      }
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        update: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+      };
+    });
+
+    const before = Date.now();
+    const res = await POST(makePost(VALID_BODY, VALID_API_KEY));
+    expect(res.status).toBe(200);
+    expect(webhookInsert).toHaveBeenCalledTimes(1);
+    const row = webhookInsert.mock.calls[0]![0] as { next_retry_at?: string };
+    expect(row.next_retry_at).toBeTruthy();
+    const dueAt = new Date(row.next_retry_at!).getTime();
+    expect(Number.isNaN(dueAt)).toBe(false);
+    // Due immediately (at or before "now"), so the very next cron run picks it up.
+    expect(dueAt).toBeGreaterThanOrEqual(before - 1000);
+    expect(dueAt).toBeLessThanOrEqual(Date.now() + 1000);
+  });
+
   it("returns 200 already_recorded on 23505 unique constraint race", async () => {
     setupFromMock({
       insertError: { code: "23505", message: "unique violation" },

--- a/app/api/marketplace/postback/route.ts
+++ b/app/api/marketplace/postback/route.ts
@@ -213,6 +213,12 @@ export async function POST(request: NextRequest) {
           metadata: metadata || {},
           timestamp: conversion?.created_at,
         },
+        // next_retry_at has no DB default, and the retry-webhooks cron selects
+        // rows with `.lte("next_retry_at", now)`. In Postgres `NULL <= now()` is
+        // NULL (not true), so a row enqueued without it is NEVER picked up — the
+        // broker receives zero conversion webhooks. Make the first attempt due
+        // immediately; the cron handles backoff/retries from there.
+        next_retry_at: new Date().toISOString(),
       });
     }
   } catch (err) {


### PR DESCRIPTION
## Problem (P1, silent revenue-integration data loss)
The postback route enqueues into `webhook_delivery_queue` **without `next_retry_at`** (`app/api/marketplace/postback/route.ts`). That column is nullable with no DB default (`supabase/migrations/20260703_a05_batch2_ops_tables_rls.sql:76`), and the only consumer — `app/api/cron/retry-webhooks/route.ts:44-45` — selects `.eq("status","pending").lte("next_retry_at", now)`. In Postgres **`NULL <= now()` is NULL (not true)**, so a row with a NULL `next_retry_at` is never selected — first pass or ever. There is no inline first-attempt send.

**Net effect:** every broker with a `webhook_url` configured receives **zero** conversion webhooks. Found by the 2026-06-03 marketplace code-review pass.

## Fix
Set `next_retry_at: new Date().toISOString()` at enqueue so the first attempt is due immediately; the cron's exponential backoff (1m→5m→30m→2h→12h) handles retries from there. `status`/`attempt_count`/`max_attempts` already have correct DB defaults, so no migration is needed.

## Tests
+1 regression test asserting the enqueued row carries an immediately-due `next_retry_at`. Postback suite 16/16; `tsc` + eslint clean (pre-push passed).

**Tier C** (webhook-class route) — merge after a 30-min quiet window unless STOP.