### PR TITLE
perf(account): batch signed-URL generation for the document vault

### DIFF
--- a/__tests__/api/account-documents.test.ts
+++ b/__tests__/api/account-documents.test.ts
@@ -4,10 +4,10 @@ vi.mock("@/lib/logger", () => ({
   logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
 }));
 
-const { mockGetUser, mockOrder, mockCreateSignedUrl } = vi.hoisted(() => ({
+const { mockGetUser, mockOrder, mockCreateSignedUrls } = vi.hoisted(() => ({
   mockGetUser: vi.fn(),
   mockOrder: vi.fn(),
-  mockCreateSignedUrl: vi.fn(),
+  mockCreateSignedUrls: vi.fn(),
 }));
 
 vi.mock("@/lib/supabase/server", () => ({
@@ -16,7 +16,7 @@ vi.mock("@/lib/supabase/server", () => ({
     from: vi.fn(() => ({
       select: vi.fn(() => ({ order: mockOrder })),
     })),
-    storage: { from: vi.fn(() => ({ createSignedUrl: mockCreateSignedUrl })) },
+    storage: { from: vi.fn(() => ({ createSignedUrls: mockCreateSignedUrls })) },
   })),
 }));
 
@@ -27,7 +27,7 @@ describe("GET /api/account/documents", () => {
     vi.clearAllMocks();
     mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } } });
     mockOrder.mockResolvedValue({ data: [], error: null });
-    mockCreateSignedUrl.mockResolvedValue({ data: { signedUrl: "https://x/y" } });
+    mockCreateSignedUrls.mockResolvedValue({ data: [{ signedUrl: "https://x/y" }] });
   });
 
   it("returns 401 when unauthenticated", async () => {
@@ -56,7 +56,7 @@ describe("GET /api/account/documents", () => {
 
   it("tolerates a missing signed url (download_url null)", async () => {
     mockOrder.mockResolvedValue({ data: [{ id: "d1", file_path: "p" }], error: null });
-    mockCreateSignedUrl.mockResolvedValue({ data: null });
+    mockCreateSignedUrls.mockResolvedValue({ data: null });
     const res = await GET();
     expect(res.status).toBe(200);
     const body = await res.json();

--- a/app/account/vault/page.tsx
+++ b/app/account/vault/page.tsx
@@ -45,24 +45,31 @@ export default async function VaultPage() {
     .select("id, document_type, file_name, file_path, file_size_bytes, mime_type, description, created_at")
     .order("created_at", { ascending: false });
 
-  const documents: Document[] = await Promise.all(
-    (rows ?? []).map(async (row) => {
-      const { data: signed } = await supabase.storage
-        .from(STORAGE_BUCKET)
-        .createSignedUrl(row.file_path as string, SIGNED_URL_EXPIRY);
-      return {
-        ...row,
-        document_type: row.document_type as DocType,
-        file_name: row.file_name as string,
-        file_path: row.file_path as string,
-        file_size_bytes: row.file_size_bytes as number,
-        mime_type: row.mime_type as string,
-        description: (row.description as string | null) ?? null,
-        created_at: row.created_at as string,
-        download_url: signed?.signedUrl ?? null,
-      };
-    }),
-  );
+  // Batch the signed-URL generation into a single storage round-trip
+  // (createSignedUrls preserves input order) instead of one call per document.
+  const rowList = rows ?? [];
+  const signed =
+    rowList.length === 0
+      ? []
+      : (
+          await supabase.storage
+            .from(STORAGE_BUCKET)
+            .createSignedUrls(
+              rowList.map((r) => r.file_path as string),
+              SIGNED_URL_EXPIRY,
+            )
+        ).data ?? [];
+  const documents: Document[] = rowList.map((row, i) => ({
+    ...row,
+    document_type: row.document_type as DocType,
+    file_name: row.file_name as string,
+    file_path: row.file_path as string,
+    file_size_bytes: row.file_size_bytes as number,
+    mime_type: row.mime_type as string,
+    description: (row.description as string | null) ?? null,
+    created_at: row.created_at as string,
+    download_url: signed[i]?.signedUrl ?? null,
+  }));
 
   return <VaultClient initialDocs={documents} />;
 }

--- a/app/api/account/documents/route.ts
+++ b/app/api/account/documents/route.ts
@@ -37,14 +37,24 @@ export async function GET(): Promise<NextResponse> {
     return NextResponse.json({ error: "Failed to load documents" }, { status: 500 });
   }
 
-  const documents = await Promise.all(
-    (rows ?? []).map(async (row) => {
-      const { data: signed } = await supabase.storage
-        .from(STORAGE_BUCKET)
-        .createSignedUrl(row.file_path, SIGNED_URL_EXPIRY_SECONDS);
-      return { ...row, download_url: signed?.signedUrl ?? null };
-    }),
-  );
+  // Batch the signed-URL generation into a single storage round-trip
+  // (createSignedUrls preserves input order) instead of one call per document.
+  const rowList = rows ?? [];
+  const signed =
+    rowList.length === 0
+      ? []
+      : (
+          await supabase.storage
+            .from(STORAGE_BUCKET)
+            .createSignedUrls(
+              rowList.map((r) => r.file_path),
+              SIGNED_URL_EXPIRY_SECONDS,
+            )
+        ).data ?? [];
+  const documents = rowList.map((row, i) => ({
+    ...row,
+    download_url: signed[i]?.signedUrl ?? null,
+  }));
 
   return NextResponse.json({ documents });
 }


### PR DESCRIPTION
Review-found (perf wave): `/account/vault` + `/api/account/documents` each issued one `supabase.storage.createSignedUrl()` round-trip **per document** inside `Promise.all`. Replaced with a single **`createSignedUrls(paths)`** batch (order preserved) — N storage round-trips → 1 per page load. Small N (a user's own docs) so modest, but free. Updated the documents test mock to the batched API. Verified: tsc 0, lint clean, `account-documents` 4/4.

https://claude.ai/code/session_01AX16WTaqAs2W33uydbBWLa

---
_Generated by [Claude Code](https://claude.ai/code/session_01AX16WTaqAs2W33uydbBWLa)_