### PR TITLE
fix(country-mode): key per-country supply override by lowercase intent code

### DIFF
--- a/__tests__/lib/country-mode/supply-thresholds.test.ts
+++ b/__tests__/lib/country-mode/supply-thresholds.test.ts
@@ -80,14 +80,24 @@ describe("applySupplyThresholds", () => {
 });
 
 describe("PER_COUNTRY_THRESHOLDS", () => {
-  it("has NZ experts threshold lower than the global default", () => {
-    expect(PER_COUNTRY_THRESHOLDS["NZ"]?.experts).toBe(1);
-    expect((PER_COUNTRY_THRESHOLDS["NZ"]?.experts ?? 0) < SUPPLY_THRESHOLDS.experts).toBe(true);
+  it("has nz experts threshold lower than the global default (keyed by lowercase intent code)", () => {
+    expect(PER_COUNTRY_THRESHOLDS["nz"]?.experts).toBe(1);
+    expect((PER_COUNTRY_THRESHOLDS["nz"]?.experts ?? 0) < SUPPLY_THRESHOLDS.experts).toBe(true);
   });
 });
 
 describe("applySupplyThresholds — per-country overrides", () => {
-  it("NZ experts: one expert passes (below global threshold of 2)", () => {
+  it("nz experts: one expert passes (below global threshold of 2) — lowercase intent code, as callers pass", () => {
+    // Regression: callers pass the lowercase IntentCountryCode ("nz"), but the
+    // override was keyed "NZ", so the override was dead and this single expert
+    // was wrongly hidden. This test now uses the casing production actually uses.
+    expect(applySupplyThresholds(["nz-expert-1"], "experts", "nz")).toEqual({
+      rows: ["nz-expert-1"],
+      didFallback: false,
+    });
+  });
+
+  it("nz experts: uppercase ISO 'NZ' also resolves the override (case-insensitive lookup)", () => {
     expect(applySupplyThresholds(["nz-expert-1"], "experts", "NZ")).toEqual({
       rows: ["nz-expert-1"],
       didFallback: false,

--- a/lib/country-mode/supply-thresholds.ts
+++ b/lib/country-mode/supply-thresholds.ts
@@ -34,7 +34,13 @@ export type SupplyKind = keyof typeof SUPPLY_THRESHOLDS;
 export const PER_COUNTRY_THRESHOLDS: Partial<
   Record<string, Partial<Record<SupplyKind, number>>>
 > = {
-  NZ: { experts: 1 },
+  // Keyed by IntentCountryCode (lowercase) — that is what every caller passes
+  // (`getIntentCountry()` returns a lowercase `IntentCountryCode`). The lookup
+  // in applySupplyThresholds lowercases the incoming code so either casing
+  // works. (Previously keyed "NZ"; the lowercase intent code never matched, so
+  // this override was dead and a country with a single expert had its strip
+  // wrongly hidden.)
+  nz: { experts: 1 },
 };
 
 export interface SupplyResult<T> {
@@ -66,7 +72,9 @@ export function applySupplyThresholds<T>(
   kind: SupplyKind,
   countryCode?: string | null,
 ): SupplyResult<T> {
-  const perCountry = countryCode ? PER_COUNTRY_THRESHOLDS[countryCode] : undefined;
+  const perCountry = countryCode
+    ? PER_COUNTRY_THRESHOLDS[countryCode.toLowerCase()]
+    : undefined;
   const threshold = perCountry?.[kind] ?? SUPPLY_THRESHOLDS[kind];
   if (rows.length < threshold) {
     return { rows: [], didFallback: true };


### PR DESCRIPTION
## Problem (P1, dead override → real strips hidden)
`PER_COUNTRY_THRESHOLDS` (`lib/country-mode/supply-thresholds.ts`) was keyed by uppercase ISO (`NZ`), but every caller passes the resolved **lowercase** `IntentCountryCode` (`nz`) — `getIntentCountry()` → `IntentCountryCode`, handed straight to `applySupplyThresholds` in `CountryExpertsPreview` / `CountryListingsPreview` / `CountryComparePreview`. So `PER_COUNTRY_THRESHOLDS["nz"]` was `undefined`, the override was dead, and the **global** threshold (2) applied.

**Effect:** an NZ visitor with exactly one NZ-focused expert had the strip hidden — the precise case the override exists to prevent. The unit test masked it by passing uppercase `"NZ"` (green test, broken prod). Found by the 2026-06-03 lib-logic code-review pass.

## Fix
Re-key the override to the lowercase intent code and `.toLowerCase()` the incoming code in the lookup so either casing resolves. Test updated to the casing callers actually use, plus a case-insensitivity test.

`vitest` 14/14, `tsc` + eslint clean (pre-push passed).

**Tier B** (country-mode directory behavior).