### PR TITLE
fix(tracking): clamp renderStars rating to 0–5 — no RangeError on bad data

### DIFF
--- a/__tests__/lib/tracking.test.ts
+++ b/__tests__/lib/tracking.test.ts
@@ -198,6 +198,23 @@ describe("renderStars", () => {
   it("renders 4 full + half at 4.7", () => {
     expect(renderStars(4.7)).toBe("★★★★½");
   });
+
+  // Defensive clamp: out-of-range / NaN input must degrade, not throw
+  // RangeError ('☆'.repeat(negative)) — that previously crashed SSR.
+  it("clamps a rating above 5 to 5 full stars (no RangeError)", () => {
+    expect(() => renderStars(7)).not.toThrow();
+    expect(renderStars(7)).toBe("★★★★★");
+  });
+
+  it("clamps a negative rating to 0 stars (no RangeError)", () => {
+    expect(() => renderStars(-3)).not.toThrow();
+    expect(renderStars(-3)).toBe("☆☆☆☆☆");
+  });
+
+  it("treats NaN as 0 stars", () => {
+    expect(() => renderStars(NaN)).not.toThrow();
+    expect(renderStars(NaN)).toBe("☆☆☆☆☆");
+  });
 });
 
 // ─── Browser-API functions ────────────────────────────────────────────────────

--- a/lib/tracking.ts
+++ b/lib/tracking.ts
@@ -144,9 +144,14 @@ export function formatPercent(n: number, decimals = 2): string {
 }
 
 export function renderStars(rating: number): string {
-  const full = Math.floor(rating);
-  const half = rating % 1 >= 0.5 ? 1 : 0;
-  const empty = 5 - full - half;
+  // Clamp to the conventional 0–5 scale. Out-of-range or NaN input (bad data, a
+  // different scale leaking in, or a null coerced to NaN) previously made
+  // '☆'.repeat(negative) throw a RangeError — a hard SSR crash on any page that
+  // rendered the stars. Clamping is identity for valid 0–5 ratings.
+  const r = Math.max(0, Math.min(5, Number.isFinite(rating) ? rating : 0));
+  const full = Math.floor(r);
+  const half = r % 1 >= 0.5 ? 1 : 0;
+  const empty = Math.max(0, 5 - full - half);
   return '★'.repeat(full) + (half ? '½' : '') + '☆'.repeat(empty);
 }
 


### PR DESCRIPTION
`renderStars` did `'☆'.repeat(5 - full - half)`; a rating >5 makes the count negative → `String.repeat` throws **RangeError**, crashing SSR on any page rendering the stars (a negative rating or NaN-from-null throws too). Ratings flow in from data and at least one caller (`app/compare/non-residents/page.tsx`) passes `provider.rating` without a `|| 0` floor. Clamp to [0,5] (non-finite → 0) and floor `empty` at 0 — identity for valid 0–5, graceful for bad data. +3 tests (>5, negative, NaN). Found by the 2026-06-03 lib-logic review. **Tier B** (single-source helper).