### PR TITLE
fix(seo): parse sitemap shard id with parseInt — Number("0.xml") was NaN

### DIFF
--- a/__tests__/lib/sitemap.test.ts
+++ b/__tests__/lib/sitemap.test.ts
@@ -89,12 +89,28 @@ async function getAllUrls(): Promise<string[]> {
 
 describe("sitemap shard id coercion (Netlify passes string ids)", () => {
   it("populates the shard for a string id instead of returning an empty []", async () => {
-    // @netlify/plugin-nextjs passes the shard id as "0"; before the Number(id)
-    // coercion this fell through to `default: []` and served empty sitemaps.
     const asString = await sitemap({ id: "0" as unknown as number });
     const asNumber = await sitemap({ id: 0 });
     expect(asString.length).toBeGreaterThan(0);
     expect(asString.length).toBe(asNumber.length);
+  });
+
+  it("populates the shard when Netlify passes the FILENAME id ('0.xml')", async () => {
+    // The real prod failure: @netlify/plugin-nextjs passes "0.xml", not "0", so
+    // Number("0.xml") was NaN → default:[] → empty sitemaps in production while
+    // CI (which only tested "0") stayed green. parseInt("0.xml",10) === 0.
+    const withExtension = await sitemap({ id: "0.xml" as unknown as number });
+    const asNumber = await sitemap({ id: 0 });
+    expect(withExtension.length).toBeGreaterThan(0);
+    expect(withExtension.length).toBe(asNumber.length);
+  });
+
+  it("each shard's filename id ('N.xml') resolves to that shard", async () => {
+    for (let i = 0; i < 8; i++) {
+      const byFilename = await sitemap({ id: `${i}.xml` as unknown as number });
+      const byNumber = await sitemap({ id: i });
+      expect(byFilename.length).toBe(byNumber.length);
+    }
   });
 });
 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -15,6 +15,9 @@ import { generateVersusPairs } from "@/lib/versus-pairs";
 import { BCP47_TAG } from "@/lib/i18n/locales";
 import { AUSTRALIAN_STATES } from "@/lib/seo/best-pages";
 import { getEnabledIntents } from "@/lib/getmatched/intents";
+import { logger } from "@/lib/logger";
+
+const log = logger("sitemap");
 
 // Regenerate each shard at most once per day — avoids per-request DB queries
 export const revalidate = 86400;
@@ -1194,11 +1197,15 @@ async function buildShard7(): Promise<MetadataRoute.Sitemap> {
 // robots.ts already points to `/sitemap.xml` so no change is needed there.
 
 export default async function sitemap({ id }: { id: number }): Promise<MetadataRoute.Sitemap> {
-  // The @netlify/plugin-nextjs runtime passes the shard `id` as a STRING ("0"),
-  // so a numeric `switch (id)` fell through to `default: []` — EVERY shard served
-  // an empty <urlset> on the live mirror (Google was getting empty sitemaps).
-  // Vercel passes a number. Coerce so both platforms populate the shards.
-  switch (Number(id)) {
+  // The @netlify/plugin-nextjs runtime passes the shard `id` as the request
+  // FILENAME — "0.xml", not "0" — so `Number("0.xml")` is NaN and the switch
+  // fell through to `default: []`, serving an empty <urlset> for EVERY shard
+  // (Google got empty sitemaps). `parseInt` reads the leading integer from any
+  // form ("0", "0.xml", or a real number) → correct shard on both Netlify and
+  // Vercel. (#1316 used `Number(id)`, which does NOT handle the ".xml" suffix —
+  // its test only exercised "0", so CI was green while prod served empties.)
+  const shard = parseInt(String(id), 10);
+  switch (shard) {
     case 0: return buildShard0();
     case 1: return buildShard1();
     case 2: return buildShard2();
@@ -1207,6 +1214,9 @@ export default async function sitemap({ id }: { id: number }): Promise<MetadataR
     case 5: return buildShard5();
     case 6: return buildShard6();
     case 7: return buildShard7();
-    default: return [];
+    default:
+      // Never fail silently again: an unrecognised id means empty sitemaps.
+      log.warn("sitemap: unrecognised shard id — serving empty urlset", { id, shard });
+      return [];
   }
 }


### PR DESCRIPTION
## Problem (P1, still live after #1316)
#1316 changed shard dispatch to `switch (Number(id))` assuming Netlify passes `"0"`. It actually passes the request **filename `"0.xml"`** → `Number("0.xml")` is **NaN** → `default: []` → **every sitemap shard still serves an empty `<urlset>` in production.** Verified live: `/sitemap/{0..7}.xml` all return 0 `<url>` entries (even shard 0, which is built from a large *static* path list — proving the dispatch, not the data layer, is the cause). CI stayed green because the test only exercised `"0"`.

## Fix
Dispatch on `parseInt(String(id), 10)` — reads the leading integer from `"0"`, `"0.xml"`, or a number. `default` now **logs** instead of silently returning `[]`. Tests added for the `"N.xml"` filename form across all 8 shards (the case that actually breaks; fails on `Number`, passes on `parseInt`).

⚠️ **Needs live re-verification after deploy** — I'll re-curl `/sitemap/0.xml` to confirm >0 URLs once it lands. (This corrects a fix that merged green but didn't work in prod.)

**Tier B** (SEO infra).