### PR TITLE
fix(org): enforce viewer role guard on lesson + event mutations

### DIFF
--- a/__tests__/api/org-auth-courses-lessons.test.ts
+++ b/__tests__/api/org-auth-courses-lessons.test.ts
@@ -4,9 +4,9 @@ import type { NextRequest } from "next/server";
 // ── Hoisted mock refs (must use vi.hoisted so they're available inside vi.mock factories) ──
 
 const { mockRequireOrgSession, mockAdminFrom } = vi.hoisted(() => ({
-  mockRequireOrgSession: vi.fn<() => Promise<{ organisationId: number; email: string }>>(
-    async () => ({ organisationId: 1, email: "org@example.com" }),
-  ),
+  mockRequireOrgSession: vi.fn<
+    () => Promise<{ organisationId: number; email: string; role?: string }>
+  >(async () => ({ organisationId: 1, email: "org@example.com" })),
   mockAdminFrom: vi.fn(() => makeChain()),
 }));
 
@@ -216,6 +216,39 @@ describe("POST /api/org-auth/courses/[courseId]/lessons", () => {
     expect(json).toHaveProperty("lesson");
     expect(json.lesson.title).toBe("Intro to Investing");
   });
+
+  it("returns 403 when the session role is viewer", async () => {
+    mockRequireOrgSession.mockResolvedValue({
+      organisationId: 1,
+      email: "viewer@example.com",
+      role: "viewer",
+    });
+    const req = makeReq("POST", COURSE_URL, validCreateBody);
+    const res = await POST(req);
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.error).toMatch(/forbidden/i);
+    // Guard must short-circuit before any DB access
+    expect(mockAdminFrom).not.toHaveBeenCalled();
+  });
+
+  it.each(["editor", "admin"])("allows a %s to create a lesson", async (role) => {
+    mockRequireOrgSession.mockResolvedValue({
+      organisationId: 1,
+      email: `${role}@example.com`,
+      role,
+    });
+    const newLesson = { id: 11, title: "Intro to Investing", slug: "intro-to-investing" };
+    let callCount = 0;
+    mockAdminFrom.mockImplementation(() => {
+      callCount += 1;
+      if (callCount === 1) return makeChain({ data: { id: 42, slug: "my-course" }, error: null });
+      return makeChain({ data: newLesson, error: null });
+    });
+    const req = makeReq("POST", COURSE_URL, validCreateBody);
+    const res = await POST(req);
+    expect(res.status).toBe(201);
+  });
 });
 
 // ── PATCH ───────────────────────────────────────────────────────────────────
@@ -292,5 +325,39 @@ describe("PATCH /api/org-auth/courses/[courseId]/lessons", () => {
     const req = makeReq("PATCH", "http://localhost/api/org-auth/courses/bad/lessons", validPatchBody);
     const res = await PATCH(req);
     expect(res.status).toBe(400);
+  });
+
+  it("returns 403 when the session role is viewer", async () => {
+    mockRequireOrgSession.mockResolvedValue({
+      organisationId: 1,
+      email: "viewer@example.com",
+      role: "viewer",
+    });
+    const req = makeReq("PATCH", COURSE_URL, validPatchBody);
+    const res = await PATCH(req);
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.error).toMatch(/forbidden/i);
+    // Guard must short-circuit before any DB access
+    expect(mockAdminFrom).not.toHaveBeenCalled();
+  });
+
+  it.each(["editor", "admin"])("allows a %s to edit a lesson", async (role) => {
+    mockRequireOrgSession.mockResolvedValue({
+      organisationId: 1,
+      email: `${role}@example.com`,
+      role,
+    });
+    const updatedLesson = { id: 7, title: "Updated Title", slug: "intro-to-investing" };
+    let callCount = 0;
+    mockAdminFrom.mockImplementation(() => {
+      callCount += 1;
+      if (callCount === 1) return makeChain({ data: { id: 42, slug: "my-course" }, error: null });
+      if (callCount === 2) return makeChain({ data: { id: 7 }, error: null });
+      return makeChain({ data: updatedLesson, error: null });
+    });
+    const req = makeReq("PATCH", COURSE_URL, validPatchBody);
+    const res = await PATCH(req);
+    expect(res.status).toBe(200);
   });
 });

--- a/__tests__/api/org-auth-events-id.test.ts
+++ b/__tests__/api/org-auth-events-id.test.ts
@@ -5,9 +5,9 @@ import type { NextRequest } from "next/server";
 
 const { mockIsRateLimited, mockRequireOrgSession, mockAdminFrom } = vi.hoisted(() => ({
   mockIsRateLimited: vi.fn<() => Promise<boolean>>(async () => false),
-  mockRequireOrgSession: vi.fn<() => Promise<{ organisationId: number; email: string }>>(
-    async () => ({ organisationId: 1, email: "org@example.com" }),
-  ),
+  mockRequireOrgSession: vi.fn<
+    () => Promise<{ organisationId: number; email: string; role?: string }>
+  >(async () => ({ organisationId: 1, email: "org@example.com" })),
   mockAdminFrom: vi.fn(() => makeChain()),
 }));
 
@@ -175,6 +175,40 @@ describe("PATCH /api/org-auth/events/[eventId]", () => {
     const json = await res.json();
     expect(json.event.status).toBe("published");
   });
+
+  it("returns 403 when the session role is viewer", async () => {
+    mockRequireOrgSession.mockResolvedValue({
+      organisationId: 1,
+      email: "viewer@example.com",
+      role: "viewer",
+    });
+    const req = makeReq("PATCH", EVENT_URL, { title: "New Title" });
+    const res = await PATCH(req);
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.error).toMatch(/forbidden/i);
+    // Guard must short-circuit before any DB access
+    expect(mockAdminFrom).not.toHaveBeenCalled();
+  });
+
+  it.each(["editor", "admin"])("allows a %s to edit an event", async (role) => {
+    mockRequireOrgSession.mockResolvedValue({
+      organisationId: 1,
+      email: `${role}@example.com`,
+      role,
+    });
+    const updatedEvent = { id: 99, title: "New Title", status: "draft" };
+    let callCount = 0;
+    mockAdminFrom.mockImplementation(() => {
+      callCount += 1;
+      if (callCount === 1)
+        return makeChain({ data: { id: 99, status: "draft", organisation_id: 1 }, error: null });
+      return makeChain({ data: updatedEvent, error: null });
+    });
+    const req = makeReq("PATCH", EVENT_URL, { title: "New Title" });
+    const res = await PATCH(req);
+    expect(res.status).toBe(200);
+  });
 });
 
 // ── DELETE ──────────────────────────────────────────────────────────────────
@@ -252,5 +286,38 @@ describe("DELETE /api/org-auth/events/[eventId]", () => {
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.success).toBe(true);
+  });
+
+  it("returns 403 when the session role is viewer", async () => {
+    mockRequireOrgSession.mockResolvedValue({
+      organisationId: 1,
+      email: "viewer@example.com",
+      role: "viewer",
+    });
+    const req = makeReq("DELETE", EVENT_URL);
+    const res = await DELETE(req, { params: Promise.resolve({ eventId: "99" }) });
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.error).toMatch(/forbidden/i);
+    // Guard must short-circuit before any DB access
+    expect(mockAdminFrom).not.toHaveBeenCalled();
+  });
+
+  it.each(["editor", "admin"])("allows a %s to delete a draft event", async (role) => {
+    mockRequireOrgSession.mockResolvedValue({
+      organisationId: 1,
+      email: `${role}@example.com`,
+      role,
+    });
+    let callCount = 0;
+    mockAdminFrom.mockImplementation(() => {
+      callCount += 1;
+      if (callCount === 1)
+        return makeChain({ data: { id: 99, status: "draft", organisation_id: 1 }, error: null });
+      return makeChain({ data: null, error: null });
+    });
+    const req = makeReq("DELETE", EVENT_URL);
+    const res = await DELETE(req, { params: Promise.resolve({ eventId: "99" }) });
+    expect(res.status).toBe(200);
   });
 });

--- a/app/api/org-auth/courses/[courseId]/lessons/route.ts
+++ b/app/api/org-auth/courses/[courseId]/lessons/route.ts
@@ -98,6 +98,9 @@ export const POST = withValidatedBody(
   async (request: NextRequest, body) => {
     try {
       const session = await requireOrgSession();
+      if (session.role === "viewer") {
+        return NextResponse.json({ error: "Forbidden — viewers cannot create lessons." }, { status: 403 });
+      }
       const admin = createAdminClient();
 
       // Parse courseId from URL
@@ -165,6 +168,9 @@ export const PATCH = withValidatedBody(
   async (request: NextRequest, body) => {
     try {
       const session = await requireOrgSession();
+      if (session.role === "viewer") {
+        return NextResponse.json({ error: "Forbidden — viewers cannot edit lessons." }, { status: 403 });
+      }
       const admin = createAdminClient();
 
       // Parse courseId from URL

--- a/app/api/org-auth/events/[eventId]/route.ts
+++ b/app/api/org-auth/events/[eventId]/route.ts
@@ -39,6 +39,9 @@ export const PATCH = withValidatedBody(
       }
 
       const session = await requireOrgSession();
+      if (session.role === "viewer") {
+        return NextResponse.json({ error: "Forbidden — viewers cannot edit events." }, { status: 403 });
+      }
       const admin = createAdminClient();
 
       const url = new URL(request.url);
@@ -132,6 +135,9 @@ export async function DELETE(
     }
 
     const session = await requireOrgSession();
+    if (session.role === "viewer") {
+      return NextResponse.json({ error: "Forbidden — viewers cannot delete events." }, { status: 403 });
+    }
     const admin = createAdminClient();
 
     const { eventId: eventIdStr } = await params;


### PR DESCRIPTION
## Bug (P1 — broken access control)

The org **`viewer`** role is real and assignable: `app/api/org-auth/team/invite/route.ts` (L13) accepts `role: z.enum(["admin", "editor", "viewer"])`, and `requireOrgSession()` returns that role on the session (`OrgRole = "admin" | "editor" | "viewer"`).

Four org-mutation handlers called `requireOrgSession()` but **never checked `session.role`**, so an authenticated **viewer** of an org could mutate that org's content:

- `POST /api/org-auth/courses/[courseId]/lessons` — create a lesson
- `PATCH /api/org-auth/courses/[courseId]/lessons` — edit a lesson
- `PATCH /api/org-auth/events/[eventId]` — edit an event (incl. status transitions)
- `DELETE /api/org-auth/events/[eventId]` — delete a draft event

Ownership scoping (`organisation_id = session.organisationId`) was present, so this was a privilege issue **within an org**, not cross-org — a viewer could write where they should only read.

## Sibling-asymmetry evidence

The sibling routes already block viewers with a 403 **immediately after `requireOrgSession()`**, before any DB access:

- `app/api/org-auth/courses/route.ts` — `POST` (L102–104) and `PATCH` (L186–188):
  ```ts
  const session = await requireOrgSession();
  if (session.role === "viewer") {
    return NextResponse.json({ error: "Forbidden — viewers cannot create courses." }, { status: 403 });
  }
  ```
- `app/api/org-auth/events/route.ts` — `POST` (L76–78), same shape.

The four handlers above were the only org-mutation handlers missing this guard — a clear copy-paste-drift gap between the collection routes (guarded) and their nested/`[id]` routes (unguarded).

## Fix

Added the **exact same** viewer 403 guard (same status `403`, same `{ error: "Forbidden — viewers cannot <verb>." }` shape, same placement directly after `requireOrgSession()` and before `createAdminClient()`) to all four handlers. The verb is specialised per handler (create/edit lessons, edit/delete events). **Only the role guard was added** — ownership checks, rate limits, status-transition logic, and Zod validation are unchanged.

```
app/api/org-auth/courses/[courseId]/lessons/route.ts | 6 ++   (POST + PATCH)
app/api/org-auth/events/[eventId]/route.ts           | 6 ++   (PATCH + DELETE)
```

## Tests added

Extended the existing route tests (mirroring the sibling test setup; `vi.hoisted` for the mock refs, widened the `requireOrgSession` mock return type to include optional `role`). For **each of the 4 handlers**:

- `viewer` → **403**, and asserts the guard short-circuits **before any admin DB call** (`mockAdminFrom` not called).
- `editor` and `admin` (parametrised via `it.each`) → **allowed** (201 for create, 200 for edit/delete).

```
__tests__/api/org-auth-courses-lessons.test.ts | +67   (POST + PATCH viewer/editor/admin)
__tests__/api/org-auth-events-id.test.ts       | +67   (PATCH + DELETE viewer/editor/admin)
```

Existing tests stay green: they mock a session without a `role`, so `session.role === "viewer"` is `false` and the prior behaviour is preserved.

## Verification

- `NODE_OPTIONS=--max-old-space-size=5120 npx tsc --noEmit` — clean (exit 0)
- `NODE_PATH=node_modules npx vitest run <both changed test files>` — **45 passed (45)**
- `npx eslint <4 changed files>` — clean (exit 0)
- pre-push hook (type-check + rate-limit audit + changed-file tests) — passed

## Merge tier

**Tier B (authz)** — additive role guard + additive API tests, no schema/middleware/webhook changes. Per `docs/audits/MERGE_AUTHORIZATION.md`: merge after CI green + 15-min observation window.

https://claude.ai/code/session_01AX16WTaqAs2W33uydbBWLa

---
_Generated by [Claude Code](https://claude.ai/code/session_01AX16WTaqAs2W33uydbBWLa)_