### PR TITLE
feat(routing): graceful not-found boundaries across dynamic routes

### DIFF
--- a/app/[suburb]/property-investing/not-found.tsx
+++ b/app/[suburb]/property-investing/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function SuburbPropertyInvestingNotFound() {
+  return (
+    <RouteNotFound
+      iconName="home"
+      title="Suburb Not Found"
+      description="We couldn't find a property-investing guide for that suburb. It may have been renamed or removed."
+      primaryCta={{ href: "/", label: "Go Home" }}
+      secondaryCta={{ href: "/property", label: "Property Hub" }}
+    />
+  );
+}

--- a/app/academy/[slug]/not-found.tsx
+++ b/app/academy/[slug]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function AcademyNotFound() {
+  return (
+    <RouteNotFound
+      iconName="book-open"
+      title="Lesson Not Found"
+      description="We couldn't find that academy lesson. It may have been renamed or removed."
+      primaryCta={{ href: "/academy", label: "Visit Academy" }}
+      secondaryCta={{ href: "/courses", label: "Browse Courses" }}
+    />
+  );
+}

--- a/app/account/life-events/[eventId]/not-found.tsx
+++ b/app/account/life-events/[eventId]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function AccountLifeEventNotFound() {
+  return (
+    <RouteNotFound
+      iconName="calendar"
+      title="Life Event Not Found"
+      description="We couldn't find that life event, or it doesn't belong to your account."
+      primaryCta={{ href: "/account", label: "Account Home" }}
+      secondaryCta={{ href: "/account/plans", label: "Your Plans" }}
+    />
+  );
+}

--- a/app/account/plans/[id]/not-found.tsx
+++ b/app/account/plans/[id]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function AccountPlanNotFound() {
+  return (
+    <RouteNotFound
+      iconName="clipboard-list"
+      title="Plan Not Found"
+      description="We couldn't find that plan, or it doesn't belong to your account."
+      primaryCta={{ href: "/account/plans", label: "Your Plans" }}
+      secondaryCta={{ href: "/account", label: "Account Home" }}
+    />
+  );
+}

--- a/app/advisor-jobs/[id]/not-found.tsx
+++ b/app/advisor-jobs/[id]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function AdvisorJobNotFound() {
+  return (
+    <RouteNotFound
+      iconName="briefcase"
+      title="Job Not Found"
+      description="We couldn't find that job listing. It may have been filled or removed."
+      primaryCta={{ href: "/advisor-jobs", label: "Browse Jobs" }}
+      secondaryCta={{ href: "/advisors", label: "Browse Advisors" }}
+    />
+  );
+}

--- a/app/advisors/[type]/not-found.tsx
+++ b/app/advisors/[type]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function AdvisorTypeNotFound() {
+  return (
+    <RouteNotFound
+      iconName="users"
+      title="Advisor Category Not Found"
+      description="We couldn't find that advisor category. It may have been renamed or removed."
+      primaryCta={{ href: "/advisors", label: "Browse Advisors" }}
+      secondaryCta={{ href: "/find-advisor", label: "Find an Advisor" }}
+    />
+  );
+}

--- a/app/afsl/[number]/not-found.tsx
+++ b/app/afsl/[number]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function AfslNotFound() {
+  return (
+    <RouteNotFound
+      iconName="shield-check"
+      title="AFSL Not Found"
+      description="We couldn't find a record for that AFSL number. It may have been cancelled or entered incorrectly."
+      primaryCta={{ href: "/afsl", label: "AFSL Lookup" }}
+      secondaryCta={{ href: "/find-advisor", label: "Find an Advisor" }}
+    />
+  );
+}

--- a/app/alerts/[slug]/not-found.tsx
+++ b/app/alerts/[slug]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function AlertNotFound() {
+  return (
+    <RouteNotFound
+      iconName="bell"
+      title="Alert Not Found"
+      description="We couldn't find that alert. It may have been renamed or removed."
+      primaryCta={{ href: "/alerts", label: "Browse Alerts" }}
+      secondaryCta={{ href: "/", label: "Go Home" }}
+    />
+  );
+}

--- a/app/authors/[slug]/not-found.tsx
+++ b/app/authors/[slug]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function AuthorNotFound() {
+  return (
+    <RouteNotFound
+      iconName="user"
+      title="Author Not Found"
+      description="We couldn't find that author profile. They may have been renamed or removed."
+      primaryCta={{ href: "/articles", label: "Read Articles" }}
+      secondaryCta={{ href: "/", label: "Go Home" }}
+    />
+  );
+}

--- a/app/best-for/[slug]/not-found.tsx
+++ b/app/best-for/[slug]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function BestForNotFound() {
+  return (
+    <RouteNotFound
+      iconName="award"
+      title="Page Not Found"
+      description="We couldn't find that best-for guide. It may have been renamed or removed."
+      primaryCta={{ href: "/best", label: "Best-Of Rankings" }}
+      secondaryCta={{ href: "/brokers", label: "Compare Brokers" }}
+    />
+  );
+}

--- a/app/brokers/full-service/[slug]/not-found.tsx
+++ b/app/brokers/full-service/[slug]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function FullServiceBrokerNotFound() {
+  return (
+    <RouteNotFound
+      iconName="briefcase"
+      title="Broker Not Found"
+      description="We couldn't find that full-service broker. They may have been renamed or removed."
+      primaryCta={{ href: "/brokers", label: "Compare Brokers" }}
+      secondaryCta={{ href: "/best", label: "Best-Of Rankings" }}
+    />
+  );
+}

--- a/app/certificate/[number]/not-found.tsx
+++ b/app/certificate/[number]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function CertificateNotFound() {
+  return (
+    <RouteNotFound
+      iconName="award"
+      title="Certificate Not Found"
+      description="We couldn't find a certificate with that number. It may have been revoked or entered incorrectly."
+      primaryCta={{ href: "/academy", label: "Visit Academy" }}
+      secondaryCta={{ href: "/courses", label: "Browse Courses" }}
+    />
+  );
+}

--- a/app/clubs/[clubId]/not-found.tsx
+++ b/app/clubs/[clubId]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function ClubNotFound() {
+  return (
+    <RouteNotFound
+      iconName="users"
+      title="Club Not Found"
+      description="We couldn't find that club. It may have been renamed or removed."
+      primaryCta={{ href: "/clubs", label: "Browse Clubs" }}
+      secondaryCta={{ href: "/", label: "Go Home" }}
+    />
+  );
+}

--- a/app/consultations/[slug]/not-found.tsx
+++ b/app/consultations/[slug]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function ConsultationNotFound() {
+  return (
+    <RouteNotFound
+      iconName="message-circle"
+      title="Consultation Not Found"
+      description="We couldn't find that consultation. It may have been renamed or removed."
+      primaryCta={{ href: "/advisors", label: "Browse Advisors" }}
+      secondaryCta={{ href: "/find-advisor", label: "Find an Advisor" }}
+    />
+  );
+}

--- a/app/costs/[slug]/not-found.tsx
+++ b/app/costs/[slug]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function CostNotFound() {
+  return (
+    <RouteNotFound
+      iconName="dollar-sign"
+      title="Page Not Found"
+      description="We couldn't find that cost guide. It may have been renamed or removed."
+      primaryCta={{ href: "/costs", label: "Browse Cost Guides" }}
+      secondaryCta={{ href: "/", label: "Go Home" }}
+    />
+  );
+}

--- a/app/courses/[slug]/not-found.tsx
+++ b/app/courses/[slug]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function CourseNotFound() {
+  return (
+    <RouteNotFound
+      iconName="book-open"
+      title="Course Not Found"
+      description="We couldn't find that course. It may have been renamed or removed."
+      primaryCta={{ href: "/courses", label: "Browse Courses" }}
+      secondaryCta={{ href: "/academy", label: "Visit Academy" }}
+    />
+  );
+}

--- a/app/etfs/[ticker]/not-found.tsx
+++ b/app/etfs/[ticker]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function EtfTickerNotFound() {
+  return (
+    <RouteNotFound
+      iconName="trending-up"
+      title="ETF Not Found"
+      description="We couldn't find that ETF. The ticker may have changed or the fund may have been delisted."
+      primaryCta={{ href: "/etfs", label: "Browse ETFs" }}
+      secondaryCta={{ href: "/best", label: "Best-Of Rankings" }}
+    />
+  );
+}

--- a/app/etfs/vs/[slugs]/not-found.tsx
+++ b/app/etfs/vs/[slugs]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function EtfVsNotFound() {
+  return (
+    <RouteNotFound
+      iconName="scale"
+      title="ETF Not Found"
+      description="We couldn't find that ETF comparison. One or more funds may have been renamed or delisted."
+      primaryCta={{ href: "/etfs", label: "Browse ETFs" }}
+      secondaryCta={{ href: "/best", label: "Best-Of Rankings" }}
+    />
+  );
+}

--- a/app/events/[id]/not-found.tsx
+++ b/app/events/[id]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function EventNotFound() {
+  return (
+    <RouteNotFound
+      iconName="calendar"
+      title="Event Not Found"
+      description="We couldn't find that event. It may have ended or been removed."
+      primaryCta={{ href: "/events", label: "Browse Events" }}
+      secondaryCta={{ href: "/", label: "Go Home" }}
+    />
+  );
+}

--- a/app/expert/[slug]/not-found.tsx
+++ b/app/expert/[slug]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function ExpertNotFound() {
+  return (
+    <RouteNotFound
+      iconName="user-check"
+      title="Expert Not Found"
+      description="We couldn't find that expert profile. They may have been renamed or removed."
+      primaryCta={{ href: "/advisors", label: "Browse Advisors" }}
+      secondaryCta={{ href: "/find-advisor", label: "Find an Advisor" }}
+    />
+  );
+}

--- a/app/find-advisor/[location]/not-found.tsx
+++ b/app/find-advisor/[location]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function FindAdvisorLocationNotFound() {
+  return (
+    <RouteNotFound
+      iconName="map-pin"
+      title="Location Not Found"
+      description="We couldn't find advisors for that location. It may have been renamed or removed."
+      primaryCta={{ href: "/find-advisor", label: "Find an Advisor" }}
+      secondaryCta={{ href: "/advisors", label: "Browse Advisors" }}
+    />
+  );
+}

--- a/app/firm/[slug]/not-found.tsx
+++ b/app/firm/[slug]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function FirmNotFound() {
+  return (
+    <RouteNotFound
+      iconName="building"
+      title="Firm Not Found"
+      description="We couldn't find that advice firm. They may have been renamed or removed."
+      primaryCta={{ href: "/find-advisor", label: "Find an Advisor" }}
+      secondaryCta={{ href: "/advisors", label: "Browse Advisors" }}
+    />
+  );
+}

--- a/app/foreign-investment/compare/[pair]/not-found.tsx
+++ b/app/foreign-investment/compare/[pair]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function ForeignInvestmentPairNotFound() {
+  return (
+    <RouteNotFound
+      iconName="globe"
+      title="Comparison Not Found"
+      description="We couldn't find that country comparison. One or more countries may have been renamed or removed."
+      primaryCta={{ href: "/foreign-investment", label: "Foreign Investment Hub" }}
+      secondaryCta={{ href: "/", label: "Go Home" }}
+    />
+  );
+}

--- a/app/foreign-investment/from/[country]/not-found.tsx
+++ b/app/foreign-investment/from/[country]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function ForeignInvestmentCountryNotFound() {
+  return (
+    <RouteNotFound
+      iconName="globe"
+      title="Country Not Found"
+      description="We couldn't find a foreign-investment guide for that country. It may have been renamed or removed."
+      primaryCta={{ href: "/foreign-investment", label: "Foreign Investment Hub" }}
+      secondaryCta={{ href: "/", label: "Go Home" }}
+    />
+  );
+}

--- a/app/foreign-investment/journey/[country]/not-found.tsx
+++ b/app/foreign-investment/journey/[country]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function ForeignInvestmentJourneyNotFound() {
+  return (
+    <RouteNotFound
+      iconName="globe"
+      title="Country Not Found"
+      description="We couldn't find an investment journey for that country. It may have been renamed or removed."
+      primaryCta={{ href: "/foreign-investment", label: "Foreign Investment Hub" }}
+      secondaryCta={{ href: "/", label: "Go Home" }}
+    />
+  );
+}

--- a/app/glossary/[term]/not-found.tsx
+++ b/app/glossary/[term]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function GlossaryTermNotFound() {
+  return (
+    <RouteNotFound
+      iconName="book-open"
+      title="Term Not Found"
+      description="We couldn't find that glossary term. It may have been renamed or removed."
+      primaryCta={{ href: "/glossary", label: "Browse Glossary" }}
+      secondaryCta={{ href: "/articles", label: "Read Articles" }}
+    />
+  );
+}

--- a/app/grants/[state]/not-found.tsx
+++ b/app/grants/[state]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function GrantsStateNotFound() {
+  return (
+    <RouteNotFound
+      iconName="landmark"
+      title="State Not Found"
+      description="We couldn't find grants for that state or territory. It may have been renamed or removed."
+      primaryCta={{ href: "/grants", label: "Browse Grants" }}
+      secondaryCta={{ href: "/property", label: "Property Hub" }}
+    />
+  );
+}

--- a/app/health-scores/[slug]/not-found.tsx
+++ b/app/health-scores/[slug]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function HealthScoreNotFound() {
+  return (
+    <RouteNotFound
+      iconName="activity"
+      title="Health Score Not Found"
+      description="We couldn't find that health score. It may have been renamed or removed."
+      primaryCta={{ href: "/health-scores", label: "Browse Health Scores" }}
+      secondaryCta={{ href: "/", label: "Go Home" }}
+    />
+  );
+}

--- a/app/how-to/transfer-from/[broker_slug]/not-found.tsx
+++ b/app/how-to/transfer-from/[broker_slug]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function TransferFromNotFound() {
+  return (
+    <RouteNotFound
+      iconName="arrow-left-right"
+      title="Broker Not Found"
+      description="We couldn't find a transfer guide for that broker. They may have been renamed or removed."
+      primaryCta={{ href: "/switch", label: "Switch Brokers" }}
+      secondaryCta={{ href: "/brokers", label: "Compare Brokers" }}
+    />
+  );
+}

--- a/app/investing-for/[occupation]/not-found.tsx
+++ b/app/investing-for/[occupation]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function InvestingForOccupationNotFound() {
+  return (
+    <RouteNotFound
+      iconName="briefcase"
+      title="Guide Not Found"
+      description="We couldn't find an investing guide for that occupation. It may have been renamed or removed."
+      primaryCta={{ href: "/", label: "Go Home" }}
+      secondaryCta={{ href: "/articles", label: "Read Articles" }}
+    />
+  );
+}

--- a/app/investing/[city]/not-found.tsx
+++ b/app/investing/[city]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function InvestingCityNotFound() {
+  return (
+    <RouteNotFound
+      iconName="map-pin"
+      title="City Not Found"
+      description="We couldn't find an investing guide for that city. It may have been renamed or removed."
+      primaryCta={{ href: "/", label: "Go Home" }}
+      secondaryCta={{ href: "/articles", label: "Read Articles" }}
+    />
+  );
+}

--- a/app/just/[event]/not-found.tsx
+++ b/app/just/[event]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function JustEventNotFound() {
+  return (
+    <RouteNotFound
+      iconName="party-popper"
+      title="Page Not Found"
+      description="We couldn't find a guide for that life event. It may have been renamed or removed."
+      primaryCta={{ href: "/", label: "Go Home" }}
+      secondaryCta={{ href: "/articles", label: "Read Articles" }}
+    />
+  );
+}

--- a/app/lead-magnets/[slug]/not-found.tsx
+++ b/app/lead-magnets/[slug]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function LeadMagnetNotFound() {
+  return (
+    <RouteNotFound
+      iconName="download"
+      title="Resource Not Found"
+      description="We couldn't find that resource. It may have been renamed or removed."
+      primaryCta={{ href: "/", label: "Go Home" }}
+      secondaryCta={{ href: "/articles", label: "Read Articles" }}
+    />
+  );
+}

--- a/app/learn/[path]/not-found.tsx
+++ b/app/learn/[path]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function LearnPathNotFound() {
+  return (
+    <RouteNotFound
+      iconName="book-open"
+      title="Lesson Not Found"
+      description="We couldn't find that learning path. It may have been renamed or removed."
+      primaryCta={{ href: "/courses", label: "Browse Courses" }}
+      secondaryCta={{ href: "/academy", label: "Visit Academy" }}
+    />
+  );
+}

--- a/app/listings/[slug]/not-found.tsx
+++ b/app/listings/[slug]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function ListingNotFound() {
+  return (
+    <RouteNotFound
+      iconName="store"
+      title="Listing Not Found"
+      description="We couldn't find that listing. It may have been renamed or removed."
+      primaryCta={{ href: "/listings", label: "Browse Listings" }}
+      secondaryCta={{ href: "/", label: "Go Home" }}
+    />
+  );
+}

--- a/app/lists/[slug]/not-found.tsx
+++ b/app/lists/[slug]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function ListNotFound() {
+  return (
+    <RouteNotFound
+      iconName="list"
+      title="List Not Found"
+      description="We couldn't find that list. It may have been renamed or removed."
+      primaryCta={{ href: "/lists", label: "Browse Lists" }}
+      secondaryCta={{ href: "/", label: "Go Home" }}
+    />
+  );
+}

--- a/app/marketplace/[intent]/not-found.tsx
+++ b/app/marketplace/[intent]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function MarketplaceIntentNotFound() {
+  return (
+    <RouteNotFound
+      iconName="store"
+      title="Category Not Found"
+      description="We couldn't find that marketplace category. It may have been renamed or removed."
+      primaryCta={{ href: "/marketplace", label: "Visit Marketplace" }}
+      secondaryCta={{ href: "/providers", label: "Browse Providers" }}
+    />
+  );
+}

--- a/app/newsletter/[edition]/not-found.tsx
+++ b/app/newsletter/[edition]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function NewsletterEditionNotFound() {
+  return (
+    <RouteNotFound
+      iconName="mail"
+      title="Edition Not Found"
+      description="We couldn't find that newsletter edition. It may have been renamed or removed."
+      primaryCta={{ href: "/newsletter", label: "Newsletter Archive" }}
+      secondaryCta={{ href: "/articles", label: "Read Articles" }}
+    />
+  );
+}

--- a/app/office-hours/[id]/not-found.tsx
+++ b/app/office-hours/[id]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function OfficeHoursNotFound() {
+  return (
+    <RouteNotFound
+      iconName="clock"
+      title="Session Not Found"
+      description="We couldn't find that office-hours session. It may have ended or been removed."
+      primaryCta={{ href: "/office-hours", label: "Browse Office Hours" }}
+      secondaryCta={{ href: "/advisors", label: "Browse Advisors" }}
+    />
+  );
+}

--- a/app/persona/[type]/not-found.tsx
+++ b/app/persona/[type]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function PersonaTypeNotFound() {
+  return (
+    <RouteNotFound
+      iconName="user"
+      title="Persona Not Found"
+      description="We couldn't find a guide for that investor persona. It may have been renamed or removed."
+      primaryCta={{ href: "/", label: "Go Home" }}
+      secondaryCta={{ href: "/articles", label: "Read Articles" }}
+    />
+  );
+}

--- a/app/pro/research/[slug]/not-found.tsx
+++ b/app/pro/research/[slug]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function ProResearchNotFound() {
+  return (
+    <RouteNotFound
+      iconName="file-text"
+      title="Research Not Found"
+      description="We couldn't find that Pro research piece. It may have been renamed or removed."
+      primaryCta={{ href: "/pro/research", label: "Browse Pro Research" }}
+      secondaryCta={{ href: "/research", label: "All Research" }}
+    />
+  );
+}

--- a/app/property/buyer-agents/[slug]/not-found.tsx
+++ b/app/property/buyer-agents/[slug]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function BuyerAgentNotFound() {
+  return (
+    <RouteNotFound
+      iconName="user-check"
+      title="Buyer's Agent Not Found"
+      description="We couldn't find that buyer's agent. They may have been renamed or removed."
+      primaryCta={{ href: "/property/buyer-agents", label: "Browse Buyer's Agents" }}
+      secondaryCta={{ href: "/property", label: "Property Hub" }}
+    />
+  );
+}

--- a/app/property/listings/[slug]/not-found.tsx
+++ b/app/property/listings/[slug]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function PropertyListingNotFound() {
+  return (
+    <RouteNotFound
+      iconName="home"
+      title="Listing Not Found"
+      description="We couldn't find that property listing. It may have been sold or removed."
+      primaryCta={{ href: "/property/listings", label: "Browse Listings" }}
+      secondaryCta={{ href: "/property", label: "Property Hub" }}
+    />
+  );
+}

--- a/app/property/suburbs/[slug]/not-found.tsx
+++ b/app/property/suburbs/[slug]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function SuburbProfileNotFound() {
+  return (
+    <RouteNotFound
+      iconName="map-pin"
+      title="Suburb Not Found"
+      description="We couldn't find that suburb profile. It may have been renamed or removed."
+      primaryCta={{ href: "/property/suburbs", label: "Browse Suburbs" }}
+      secondaryCta={{ href: "/property", label: "Property Hub" }}
+    />
+  );
+}

--- a/app/providers/[slug]/not-found.tsx
+++ b/app/providers/[slug]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function ProviderNotFound() {
+  return (
+    <RouteNotFound
+      iconName="building"
+      title="Provider Not Found"
+      description="We couldn't find that provider. They may have been renamed or removed."
+      primaryCta={{ href: "/providers", label: "Browse Providers" }}
+      secondaryCta={{ href: "/marketplace", label: "Visit Marketplace" }}
+    />
+  );
+}

--- a/app/questions/[slug]/not-found.tsx
+++ b/app/questions/[slug]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function QuestionNotFound() {
+  return (
+    <RouteNotFound
+      iconName="help-circle"
+      title="Question Not Found"
+      description="We couldn't find that question. It may have been removed."
+      primaryCta={{ href: "/questions", label: "Browse Questions" }}
+      secondaryCta={{ href: "/articles", label: "Read Articles" }}
+    />
+  );
+}

--- a/app/reports/[slug]/not-found.tsx
+++ b/app/reports/[slug]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function ReportNotFound() {
+  return (
+    <RouteNotFound
+      iconName="file-text"
+      title="Report Not Found"
+      description="We couldn't find that report. It may have been renamed or removed."
+      primaryCta={{ href: "/reports", label: "Browse Reports" }}
+      secondaryCta={{ href: "/articles", label: "Read Articles" }}
+    />
+  );
+}

--- a/app/research/[slug]/not-found.tsx
+++ b/app/research/[slug]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function ResearchNotFound() {
+  return (
+    <RouteNotFound
+      iconName="file-text"
+      title="Research Not Found"
+      description="We couldn't find that research piece. It may have been renamed or removed."
+      primaryCta={{ href: "/research", label: "Browse Research" }}
+      secondaryCta={{ href: "/articles", label: "Read Articles" }}
+    />
+  );
+}

--- a/app/reviewers/[slug]/not-found.tsx
+++ b/app/reviewers/[slug]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function ReviewerNotFound() {
+  return (
+    <RouteNotFound
+      iconName="user-check"
+      title="Reviewer Not Found"
+      description="We couldn't find that reviewer profile. They may have been renamed or removed."
+      primaryCta={{ href: "/articles", label: "Read Articles" }}
+      secondaryCta={{ href: "/", label: "Go Home" }}
+    />
+  );
+}

--- a/app/switch-scripts/[broker-slug]/not-found.tsx
+++ b/app/switch-scripts/[broker-slug]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function SwitchScriptNotFound() {
+  return (
+    <RouteNotFound
+      iconName="file-text"
+      title="Script Not Found"
+      description="We couldn't find a switch script for that broker. They may have been renamed or removed."
+      primaryCta={{ href: "/switch", label: "Switch Brokers" }}
+      secondaryCta={{ href: "/brokers", label: "Compare Brokers" }}
+    />
+  );
+}

--- a/app/switch/[type]/not-found.tsx
+++ b/app/switch/[type]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function SwitchTypeNotFound() {
+  return (
+    <RouteNotFound
+      iconName="arrow-left-right"
+      title="Switch Guide Not Found"
+      description="We couldn't find that switch guide. It may have been renamed or removed."
+      primaryCta={{ href: "/switch", label: "Switch Brokers" }}
+      secondaryCta={{ href: "/brokers", label: "Compare Brokers" }}
+    />
+  );
+}

--- a/app/tag/[slug]/not-found.tsx
+++ b/app/tag/[slug]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function TagNotFound() {
+  return (
+    <RouteNotFound
+      iconName="tag"
+      title="Tag Not Found"
+      description="We couldn't find that tag. It may have been renamed or removed."
+      primaryCta={{ href: "/articles", label: "Read Articles" }}
+      secondaryCta={{ href: "/", label: "Go Home" }}
+    />
+  );
+}

--- a/app/teams/[slug]/not-found.tsx
+++ b/app/teams/[slug]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function TeamNotFound() {
+  return (
+    <RouteNotFound
+      iconName="users"
+      title="Team Not Found"
+      description="We couldn't find that team. They may have been renamed or removed."
+      primaryCta={{ href: "/teams", label: "Browse Teams" }}
+      secondaryCta={{ href: "/find-advisor", label: "Find an Advisor" }}
+    />
+  );
+}

--- a/app/topic/[slug]/not-found.tsx
+++ b/app/topic/[slug]/not-found.tsx
@@ -1,0 +1,13 @@
+import RouteNotFound from "@/components/RouteNotFound";
+
+export default function TopicNotFound() {
+  return (
+    <RouteNotFound
+      iconName="hash"
+      title="Topic Not Found"
+      description="We couldn't find that topic. It may have been renamed or removed."
+      primaryCta={{ href: "/articles", label: "Read Articles" }}
+      secondaryCta={{ href: "/", label: "Go Home" }}
+    />
+  );
+}

--- a/components/RouteNotFound.tsx
+++ b/components/RouteNotFound.tsx
@@ -1,0 +1,73 @@
+import Link from "next/link";
+import Icon from "@/components/Icon";
+
+interface CtaLink {
+  href: string;
+  label: string;
+}
+
+interface RouteNotFoundProps {
+  iconName: string;
+  title: string;
+  description: string;
+  primaryCta: CtaLink;
+  secondaryCta: CtaLink;
+  popular?: CtaLink[];
+}
+
+// Shared not-found primitive for co-located per-segment not-found.tsx boundaries.
+// Without a boundary in the route chain, `notFound()` falls back to the root
+// boundary, which the @netlify/plugin-nextjs runtime serves as a 500 ("Server
+// Error") instead of a graceful not-found page. Mirrors the layout that
+// app/compare/[versus]/not-found.tsx pioneered so every dynamic route degrades
+// the same way.
+export default function RouteNotFound({
+  iconName,
+  title,
+  description,
+  primaryCta,
+  secondaryCta,
+  popular,
+}: RouteNotFoundProps) {
+  return (
+    <div className="min-h-[50vh] flex items-center justify-center px-4 py-12">
+      <div className="text-center max-w-md">
+        <div className="w-16 h-16 rounded-full bg-slate-100 flex items-center justify-center mx-auto mb-4">
+          <Icon name={iconName} size={28} className="text-slate-300" />
+        </div>
+        <h1 className="text-xl font-bold text-slate-900 mb-2">{title}</h1>
+        <p className="text-sm text-slate-500 mb-6">{description}</p>
+        <div className="flex flex-col sm:flex-row items-center justify-center gap-3 mb-8">
+          <Link
+            href={primaryCta.href}
+            className="w-full sm:w-auto px-5 py-2.5 bg-slate-900 text-white text-sm font-semibold rounded-lg hover:bg-slate-800 transition-colors text-center"
+          >
+            {primaryCta.label}
+          </Link>
+          <Link
+            href={secondaryCta.href}
+            className="w-full sm:w-auto px-5 py-2.5 border border-slate-200 text-slate-700 text-sm font-semibold rounded-lg hover:bg-slate-50 transition-colors text-center"
+          >
+            {secondaryCta.label}
+          </Link>
+        </div>
+        {popular && popular.length > 0 ? (
+          <div className="border-t border-slate-100 pt-5">
+            <p className="text-xs font-semibold text-slate-400 uppercase tracking-wide mb-3">Popular links</p>
+            <div className="flex flex-wrap justify-center gap-2">
+              {popular.map((link) => (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  className="px-3 py-1.5 rounded-full bg-slate-50 hover:bg-slate-100 text-xs font-medium text-slate-600 transition-colors"
+                >
+                  {link.label}
+                </Link>
+              ))}
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Dynamic routes that call \`notFound()\` had no co-located \`not-found.tsx\` in their chain, so the Netlify Next.js runtime served the root boundary as a 500 instead of a graceful 404. This adds a shared \`RouteNotFound\` primitive plus thin per-segment boundaries.

- A-01: Add shared \`components/RouteNotFound.tsx\` server component (mirrors \`app/compare/[versus]/not-found.tsx\`, reuses \`components/Icon\`).
- A-02: not-found.tsx for high-traffic public SEO content routes (glossary, etfs, etfs/vs, best-for, brokers/full-service, authors, reviewers, tag, topic, research, reports, pro/research).
- A-03: not-found.tsx for advisor / firm / teams / marketplace routes (advisors, firm, teams, find-advisor, expert, consultations, providers, marketplace, questions, learn, academy, courses).
- A-04: not-found.tsx for property, grants and city/occupation programmatic-SEO routes (property/listings, property/buyer-agents, property/suburbs, grants, investing, investing-for, [suburb]/property-investing, how-to/transfer-from, switch, switch-scripts, just, persona).
- A-05: not-found.tsx for foreign-investment country/pair routes (from, compare, journey) — pure UI, no lib/country-mode imports.
- A-06: not-found.tsx for id/number-keyed public detail routes (afsl, certificate, advisor-jobs, events, office-hours, clubs, lead-magnets, lists, newsletter, listings, alerts, health-scores, costs).
- A-07: not-found.tsx for authenticated account detail routes (account/plans/[id], account/life-events/[eventId]) with in-app CTAs.

Tier A