### PR TITLE
feat(seo): emit ItemList JSON-LD on ranked & listing pages

### DIFF
--- a/app/advisors/[type]/[state]/page.tsx
+++ b/app/advisors/[type]/[state]/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import type { Professional, ProfessionalType } from "@/lib/types";
 import type { Metadata } from "next";
-import { PROFESSIONAL_TYPE_LABELS, AU_STATES } from "@/lib/types";
+import { PROFESSIONAL_TYPE_LABELS } from "@/lib/types";
 import { absoluteUrl, breadcrumbJsonLd, CURRENT_YEAR } from "@/lib/seo";
 import AdvisorsClient from "../../AdvisorsClient";
 
@@ -158,9 +158,30 @@ export default async function AdvisorTypeLocationPage({ params }: { params: Prom
     ? `Verified ${label.toLowerCase()}s in ${loc.name}. Compare fees, reviews & specialties — request a free consultation.`
     : `Verified ${label.toLowerCase()}s in ${loc.name}. Request a free consultation — no obligation.`;
 
+  // ItemList of the local advisors, mirroring the FinancialService
+  // ListItem shape used by /find-advisor/[location] so the location
+  // ranking is citable by AI answer engines.
+  const listLd = professionals.length > 0 ? {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: `${label}s in ${loc.name}`,
+    numberOfItems: professionals.length,
+    itemListElement: professionals.slice(0, 10).map((p, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      item: {
+        "@type": "FinancialService",
+        name: p.name,
+        description: p.bio?.slice(0, 200),
+        address: { "@type": "PostalAddress", addressRegion: loc.state, addressCountry: "AU" },
+      },
+    })),
+  } : null;
+
   return (
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }} />
+      {listLd && <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(listLd) }} />}
       <AdvisorsClient
         professionals={professionals}
         initialType={professionalType}

--- a/app/advisors/[type]/page.tsx
+++ b/app/advisors/[type]/page.tsx
@@ -4,6 +4,7 @@ import type { Professional, ProfessionalType } from "@/lib/types";
 import type { Metadata } from "next";
 import { PROFESSIONAL_TYPE_LABELS } from "@/lib/types";
 import { absoluteUrl, breadcrumbJsonLd, CURRENT_YEAR } from "@/lib/seo";
+import { itemListJsonLd } from "@/lib/schema-markup";
 import AdvisorsClient from "../AdvisorsClient";
 
 export const revalidate = 1800;
@@ -587,6 +588,7 @@ export default async function AdvisorTypePage({ params }: { params: Promise<{ ty
 
   const label = PROFESSIONAL_TYPE_LABELS[professionalType];
   const faqs = TYPE_FAQS[typeSlug] || [];
+  const advisors = (professionals as Professional[]) || [];
 
   const breadcrumbLd = breadcrumbJsonLd([
     { name: "Home", url: absoluteUrl("/") },
@@ -604,12 +606,28 @@ export default async function AdvisorTypePage({ params }: { params: Promise<{ ty
     })),
   } : null;
 
+  // ItemList over the listed advisors (already sorted verified-then-rating)
+  // so the ranking is citable by AI answer engines. itemListJsonLd
+  // absoluteUrl-wraps each url, so pass site-relative paths.
+  const listLd = advisors.length > 0
+    ? itemListJsonLd(
+        `${label}s in Australia`,
+        advisors.slice(0, 10).map((p, i) => ({
+          position: i + 1,
+          name: p.name,
+          url: `/advisor/${p.slug}`,
+          description: p.bio?.slice(0, 200),
+        })),
+      )
+    : null;
+
   return (
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }} />
       {faqLd && <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }} />}
+      {listLd && <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(listLd) }} />}
       <AdvisorsClient
-        professionals={(professionals as Professional[]) || []}
+        professionals={advisors}
         initialType={professionalType}
         pageTitle={`${label}s in Australia`}
         pageDescription={TYPE_DESCRIPTIONS[typeSlug]}

--- a/app/advisors/firb-specialists/page.tsx
+++ b/app/advisors/firb-specialists/page.tsx
@@ -2,6 +2,7 @@ import { createClient } from "@/lib/supabase/server";
 import type { Professional } from "@/lib/types";
 import type { Metadata } from "next";
 import { absoluteUrl, breadcrumbJsonLd, CURRENT_YEAR } from "@/lib/seo";
+import { itemListJsonLd } from "@/lib/schema-markup";
 import AdvisorsClient from "../AdvisorsClient";
 
 export const revalidate = 1800;
@@ -88,6 +89,23 @@ export default async function FIRBSpecialistsPage() {
     })),
   };
 
+  const advisors = (professionals as Professional[]) || [];
+
+  // ItemList over the listed specialists (sorted verified-then-rating)
+  // so the directory is citable by AI answer engines. itemListJsonLd
+  // absoluteUrl-wraps each url, so pass site-relative paths.
+  const listLd = advisors.length > 0
+    ? itemListJsonLd(
+        PAGE_TITLE,
+        advisors.slice(0, 10).map((p, i) => ({
+          position: i + 1,
+          name: p.name,
+          url: `/advisor/${p.slug}`,
+          description: p.bio?.slice(0, 200),
+        })),
+      )
+    : null;
+
   return (
     <>
       <script
@@ -98,8 +116,14 @@ export default async function FIRBSpecialistsPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
       />
+      {listLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(listLd) }}
+        />
+      )}
       <AdvisorsClient
-        professionals={(professionals as Professional[]) || []}
+        professionals={advisors}
         pageTitle={PAGE_TITLE}
         pageDescription={PAGE_DESCRIPTION}
         faqs={FAQS}

--- a/app/advisors/international-tax-specialists/page.tsx
+++ b/app/advisors/international-tax-specialists/page.tsx
@@ -2,6 +2,7 @@ import { createClient } from "@/lib/supabase/server";
 import type { Professional } from "@/lib/types";
 import type { Metadata } from "next";
 import { absoluteUrl, breadcrumbJsonLd, CURRENT_YEAR } from "@/lib/seo";
+import { itemListJsonLd } from "@/lib/schema-markup";
 import AdvisorsClient from "../AdvisorsClient";
 
 export const revalidate = 1800;
@@ -88,6 +89,23 @@ export default async function InternationalTaxSpecialistsPage() {
     })),
   };
 
+  const advisors = (professionals as Professional[]) || [];
+
+  // ItemList over the listed specialists (sorted verified-then-rating)
+  // so the directory is citable by AI answer engines. itemListJsonLd
+  // absoluteUrl-wraps each url, so pass site-relative paths.
+  const listLd = advisors.length > 0
+    ? itemListJsonLd(
+        PAGE_TITLE,
+        advisors.slice(0, 10).map((p, i) => ({
+          position: i + 1,
+          name: p.name,
+          url: `/advisor/${p.slug}`,
+          description: p.bio?.slice(0, 200),
+        })),
+      )
+    : null;
+
   return (
     <>
       <script
@@ -98,8 +116,14 @@ export default async function InternationalTaxSpecialistsPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
       />
+      {listLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(listLd) }}
+        />
+      )}
       <AdvisorsClient
-        professionals={(professionals as Professional[]) || []}
+        professionals={advisors}
         pageTitle={PAGE_TITLE}
         pageDescription={PAGE_DESCRIPTION}
         faqs={FAQS}

--- a/app/advisors/migration-agents/page.tsx
+++ b/app/advisors/migration-agents/page.tsx
@@ -2,6 +2,7 @@ import { createClient } from "@/lib/supabase/server";
 import type { Professional } from "@/lib/types";
 import type { Metadata } from "next";
 import { absoluteUrl, breadcrumbJsonLd, CURRENT_YEAR } from "@/lib/seo";
+import { itemListJsonLd } from "@/lib/schema-markup";
 import AdvisorsClient from "../AdvisorsClient";
 
 export const revalidate = 1800;
@@ -88,6 +89,23 @@ export default async function MigrationAgentsPage() {
     })),
   };
 
+  const advisors = (professionals as Professional[]) || [];
+
+  // ItemList over the listed specialists (sorted verified-then-rating)
+  // so the directory is citable by AI answer engines. itemListJsonLd
+  // absoluteUrl-wraps each url, so pass site-relative paths.
+  const listLd = advisors.length > 0
+    ? itemListJsonLd(
+        PAGE_TITLE,
+        advisors.slice(0, 10).map((p, i) => ({
+          position: i + 1,
+          name: p.name,
+          url: `/advisor/${p.slug}`,
+          description: p.bio?.slice(0, 200),
+        })),
+      )
+    : null;
+
   return (
     <>
       <script
@@ -98,8 +116,14 @@ export default async function MigrationAgentsPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
       />
+      {listLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(listLd) }}
+        />
+      )}
       <AdvisorsClient
-        professionals={(professionals as Professional[]) || []}
+        professionals={advisors}
         pageTitle={PAGE_TITLE}
         pageDescription={PAGE_DESCRIPTION}
         faqs={FAQS}

--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -9,6 +9,7 @@ import LeadMagnet from "@/components/LeadMagnet";
 import Icon from "@/components/Icon";
 import JsonLd from "@/components/JsonLd";
 import { absoluteUrl, breadcrumbJsonLd } from "@/lib/seo";
+import { itemListJsonLd } from "@/lib/schema-markup";
 
 export const metadata = {
   title: "Investing Guides & Articles",
@@ -305,9 +306,25 @@ export default async function ArticlesPage({
     { name: "Guides & Articles" },
   ]);
 
+  // ItemList over the articles so the index is citable by AI answer
+  // engines. itemListJsonLd absoluteUrl-wraps each url, so pass
+  // site-relative paths. Capped at 50 to keep the payload reasonable.
+  const listLd =
+    allArticles.length > 0
+      ? itemListJsonLd(
+          "Australian Investing Articles",
+          allArticles.slice(0, 50).map((a, i) => ({
+            position: i + 1,
+            name: a.title,
+            url: `/article/${a.slug}`,
+            description: a.excerpt ?? undefined,
+          })),
+        )
+      : null;
+
   return (
     <div className="pt-5 pb-8 md:py-12">
-      <JsonLd data={breadcrumb} testId="articles-jsonld" />
+      <JsonLd data={listLd ? [breadcrumb, listLd] : breadcrumb} testId="articles-jsonld" />
       <div className="container-custom">
         <nav className="text-xs md:text-sm text-slate-500 mb-2 md:mb-4">
           <Link href="/" className="hover:text-slate-900">Home</Link>

--- a/app/best-for/[slug]/page.tsx
+++ b/app/best-for/[slug]/page.tsx
@@ -8,6 +8,7 @@ import {
   type ScenarioInput,
 } from "@/lib/best-for-scorer";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
+import { itemListJsonLd } from "@/lib/schema-markup";
 
 export const revalidate = 3600;
 
@@ -103,12 +104,37 @@ export default async function BestForPage({
     { name: scenario.h1 },
   ]);
 
+  // ItemList over the ranked top-5 so the ranking is machine-readable
+  // for AI answer engines. itemListJsonLd absoluteUrl-wraps each url,
+  // so pass site-relative paths.
+  const listLd =
+    top.length > 0
+      ? itemListJsonLd(
+          scenario.h1,
+          top.map((item) => ({
+            position: item.rank,
+            name: item.broker.name,
+            url: `/broker/${item.broker.slug}`,
+            description:
+              typeof item.broker.tagline === "string"
+                ? item.broker.tagline
+                : undefined,
+          })),
+        )
+      : null;
+
   return (
     <>
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
+      {listLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(listLd) }}
+        />
+      )}
       <div>
         <section className="bg-white border-b border-slate-100 py-8 md:py-12">
           <div className="container-custom">

--- a/app/questions/page.tsx
+++ b/app/questions/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { breadcrumbJsonLd, absoluteUrl } from "@/lib/seo";
+import { itemListJsonLd } from "@/lib/schema-markup";
 import {
   QUESTIONS,
   CATEGORY_LABELS,
@@ -36,6 +37,19 @@ const breadcrumbLd = breadcrumbJsonLd([
   { name: "Questions", url: absoluteUrl("/questions") },
 ]);
 
+// ItemList over the answered questions so the index is citable by AI
+// answer engines. itemListJsonLd absoluteUrl-wraps each url, so pass
+// site-relative paths.
+const listLd = itemListJsonLd(
+  "Australian Investing Questions Answered",
+  QUESTIONS.map((q, i) => ({
+    position: i + 1,
+    name: q.question,
+    url: `/questions/${q.slug}`,
+    description: q.shortAnswer,
+  })),
+);
+
 const CATEGORY_ORDER: QuestionCategory[] = [
   "super",
   "tax",
@@ -66,6 +80,10 @@ export default function QuestionsPage() {
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(listLd) }}
       />
       <main className="max-w-4xl mx-auto px-4 py-12">
         <header className="mb-10">


### PR DESCRIPTION
Emits `ItemList` structured data (via the shared `itemListJsonLd` helper in `lib/schema-markup.ts`, or the FinancialService ListItem shape mirroring `/find-advisor` for location pages) on ranked and listing pages so the rankings are machine-readable for AI answer engines (GEO).

- A-08: ItemList over the ranked top-5 on `/best-for/[slug]`
- A-09: ItemList over listed advisors on `/advisors/[type]`
- A-10: ItemList (FinancialService shape, addressRegion) on `/advisors/[type]/[state]`
- A-11: ItemList over specialists on `/advisors/firb-specialists`, `/advisors/migration-agents`, `/advisors/international-tax-specialists`
- A-12: ItemList on `/articles` and `/questions` index pages

Tier A