### PR TITLE
fix(a11y): label placeholder-only form & search inputs

### DIFF
--- a/app/get-matched/GetMatchedClient.tsx
+++ b/app/get-matched/GetMatchedClient.tsx
@@ -818,6 +818,7 @@ function ActionPlanScreen({
               <input
                 type="email"
                 placeholder="you@example.com"
+                aria-label="Email address"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 className="flex-1 border border-slate-300 rounded-lg px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"

--- a/app/learn/NewsletterCta.tsx
+++ b/app/learn/NewsletterCta.tsx
@@ -52,6 +52,7 @@ export default function NewsletterCta() {
           name="email"
           required
           placeholder="you@example.com"
+          aria-label="Email address"
           className="flex-1 rounded-lg border border-slate-300 px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
         />
         <button

--- a/app/property/listings/[slug]/PropertyEnquiryForm.tsx
+++ b/app/property/listings/[slug]/PropertyEnquiryForm.tsx
@@ -120,6 +120,7 @@ export default function PropertyEnquiryForm({
         <input
           type="text"
           placeholder="Full name *"
+          aria-label="Full name"
           required
           maxLength={200}
           value={form.user_name}
@@ -129,6 +130,7 @@ export default function PropertyEnquiryForm({
         <input
           type="email"
           placeholder="Email address *"
+          aria-label="Email address"
           required
           maxLength={254}
           value={form.user_email}
@@ -138,6 +140,7 @@ export default function PropertyEnquiryForm({
         <input
           type="tel"
           placeholder="Phone number"
+          aria-label="Phone number"
           value={form.user_phone}
           onChange={(e) => setForm({ ...form, user_phone: e.target.value })}
           className="w-full px-3 py-2.5 text-sm border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-500/30 focus:border-amber-500"
@@ -145,12 +148,14 @@ export default function PropertyEnquiryForm({
         <input
           type="text"
           placeholder="Country"
+          aria-label="Country"
           value={form.user_country}
           onChange={(e) => setForm({ ...form, user_country: e.target.value })}
           className="w-full px-3 py-2.5 text-sm border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-500/30 focus:border-amber-500"
         />
         <select
           value={form.investment_budget}
+          aria-label="Investment budget"
           onChange={(e) => setForm({ ...form, investment_budget: e.target.value })}
           className="w-full px-3 py-2.5 text-sm border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-500/30 focus:border-amber-500 text-slate-600"
         >
@@ -161,6 +166,7 @@ export default function PropertyEnquiryForm({
         </select>
         <select
           value={form.timeline}
+          aria-label="Timeline"
           onChange={(e) => setForm({ ...form, timeline: e.target.value })}
           className="w-full px-3 py-2.5 text-sm border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-500/30 focus:border-amber-500 text-slate-600"
         >
@@ -171,6 +177,7 @@ export default function PropertyEnquiryForm({
         </select>
         <textarea
           placeholder="Message (optional)"
+          aria-label="Message"
           rows={3}
           maxLength={5000}
           value={form.user_message}

--- a/app/property/suburbs/SuburbsClient.tsx
+++ b/app/property/suburbs/SuburbsClient.tsx
@@ -104,6 +104,7 @@ export default function SuburbsClient() {
             <input
               type="text"
               placeholder="Search suburb name..."
+              aria-label="Search suburbs"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               className="w-full pl-9 pr-4 py-2 text-sm border border-slate-200 rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-amber-500/30 focus:border-amber-500"

--- a/app/quiz/_components/QuizInlineEmailCapture.tsx
+++ b/app/quiz/_components/QuizInlineEmailCapture.tsx
@@ -87,6 +87,7 @@ export default function QuizInlineEmailCapture({ onSubmit, status }: Props) {
         <input
           type="text"
           placeholder="First name (optional)"
+          aria-label="First name"
           autoComplete="given-name"
           value={name}
           onChange={(e) => setName(e.target.value)}

--- a/app/score/ScoreClient.tsx
+++ b/app/score/ScoreClient.tsx
@@ -418,6 +418,7 @@ export default function ScoreClient() {
                 <input
                   type="email"
                   placeholder="you@example.com"
+                  aria-label="Email address"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   onKeyDown={(e) => e.key === "Enter" && handleEmailCapture()}

--- a/app/smsf/checklist/SmsfChecklistClient.tsx
+++ b/app/smsf/checklist/SmsfChecklistClient.tsx
@@ -128,6 +128,7 @@ export default function SmsfChecklistClient() {
               name="email"
               required
               placeholder="you@example.com"
+              aria-label="Email address"
               className="flex-1 rounded-lg border border-slate-300 px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
             />
             <button

--- a/app/versus/VersusHubSearch.tsx
+++ b/app/versus/VersusHubSearch.tsx
@@ -79,6 +79,7 @@ export default function VersusHubSearch({ brokers }: VersusHubSearchProps) {
               <input
                 type="text"
                 placeholder="Search platforms..."
+                aria-label="Search for first platform"
                 value={searchA}
                 onChange={(e) => setSearchA(e.target.value)}
                 onFocus={() => setFocusA(true)}
@@ -140,6 +141,7 @@ export default function VersusHubSearch({ brokers }: VersusHubSearchProps) {
               <input
                 type="text"
                 placeholder="Search platforms..."
+                aria-label="Search for second platform"
                 value={searchB}
                 onChange={(e) => setSearchB(e.target.value)}
                 onFocus={() => setFocusB(true)}

--- a/components/HubOnboardingShell.tsx
+++ b/components/HubOnboardingShell.tsx
@@ -151,6 +151,7 @@ function HubResultPanel({
               <input
                 type="text"
                 placeholder="Your name (optional)"
+                aria-label="Your name"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 className="flex-1 min-w-0 rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-emerald-500"
@@ -160,6 +161,7 @@ function HubResultPanel({
               <input
                 type="email"
                 placeholder="Your email address"
+                aria-label="Email address"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 required

--- a/components/IdealClientBuilder.tsx
+++ b/components/IdealClientBuilder.tsx
@@ -183,6 +183,7 @@ export default function IdealClientBuilder() {
           rows={3}
           maxLength={500}
           placeholder="Describe your ideal client in your own words…"
+          aria-label="Describe your ideal client"
           value={criteria.description ?? ""}
           onChange={(e) => set("description", e.target.value || undefined)}
         />

--- a/components/foreign-investment/CountryLeadForm.tsx
+++ b/components/foreign-investment/CountryLeadForm.tsx
@@ -135,6 +135,7 @@ export default function CountryLeadForm({
         <input
           type="text"
           placeholder="Your name (optional)"
+          aria-label="Your name"
           value={name}
           onChange={(e) => setName(e.target.value)}
           className="w-full px-3 py-2 rounded-lg border border-slate-300 text-sm focus:outline-none focus:ring-2 focus:ring-amber-300"
@@ -144,6 +145,7 @@ export default function CountryLeadForm({
           type="email"
           required
           placeholder="Your email"
+          aria-label="Email address"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           className="w-full px-3 py-2 rounded-lg border border-slate-300 text-sm focus:outline-none focus:ring-2 focus:ring-amber-300"
@@ -156,6 +158,7 @@ export default function CountryLeadForm({
               <select
                 key={field.name}
                 value={val}
+                aria-label={field.label}
                 onChange={(e) => setExtra((s) => ({ ...s, [field.name]: e.target.value }))}
                 required={field.required}
                 className="w-full px-3 py-2 rounded-lg border border-slate-300 text-sm bg-white focus:outline-none focus:ring-2 focus:ring-amber-300"
@@ -174,6 +177,7 @@ export default function CountryLeadForm({
               key={field.name}
               type={field.type ?? "text"}
               required={field.required}
+              aria-label={field.label}
               placeholder={field.placeholder ?? field.label}
               value={val}
               onChange={(e) => setExtra((s) => ({ ...s, [field.name]: e.target.value }))}


### PR DESCRIPTION
WCAG 1.3.1/4.1.2/3.3.2: add aria-labels to inputs that previously had only placeholder text.

- A-13: PropertyEnquiryForm — aria-labels on name/email/phone/country/budget/timeline/message (honeypots & consent untouched)
- A-14: CountryLeadForm — aria-labels on name, email, and mapped extraFields select/input (field.label)
- A-15: VersusHubSearch — aria-labels on both platform-search inputs (first/second platform)
- A-16: HubOnboardingShell — aria-labels on name and email inputs
- A-17: GetMatchedClient — aria-label on save-plan email input
- A-18: NewsletterCta, SmsfChecklistClient, IdealClientBuilder, QuizInlineEmailCapture, ScoreClient, SuburbsClient — aria-label on each placeholder-only field

Tier A