### PR TITLE
fix: harden fee & WHT string parsing against NaN and precision loss

### DIFF
--- a/__tests__/lib/fi-data-server.test.ts
+++ b/__tests__/lib/fi-data-server.test.ts
@@ -50,6 +50,7 @@ import {
   getChangeLog,
   getDefaultWHT,
 } from "@/lib/fi-data-server";
+import { DEFAULT_WHT } from "@/lib/foreign-investment-data";
 
 beforeEach(() => {
   dbData = null;
@@ -396,8 +397,68 @@ describe("getDefaultWHT", () => {
       },
     ];
     const result = await getDefaultWHT();
-    // parseInt("N/A") → NaN → falls back to DEFAULT_WHT.dividendUnfranked
-    expect(typeof result.dividendUnfranked).toBe("number");
+    // "N/A" has no numeric token → falls back to DEFAULT_WHT.dividendUnfranked
+    expect(result.dividendUnfranked).toBe(DEFAULT_WHT.dividendUnfranked);
     expect(Number.isFinite(result.dividendUnfranked)).toBe(true);
+  });
+
+  it("preserves decimal rates (12.5% must not truncate to 12)", async () => {
+    dbData = [
+      {
+        id: "wh-1",
+        income_type: "Dividends (unfranked)",
+        standard_rate: "12.5%",
+        with_dta_typical: "",
+        notes: null,
+        color: "red",
+        sort_order: 1,
+      },
+      {
+        id: "wh-2",
+        income_type: "Interest (bank deposits, bonds)",
+        standard_rate: "7.5%",
+        with_dta_typical: "",
+        notes: null,
+        color: "amber",
+        sort_order: 2,
+      },
+    ];
+    const result = await getDefaultWHT();
+    // parseInt() used to truncate these to 12 / 7.
+    expect(result.dividendUnfranked).toBe(12.5);
+    expect(result.interest).toBe(7.5);
+  });
+
+  it("keeps a legitimate 0% rate instead of falling back to the default", async () => {
+    dbData = [
+      {
+        id: "wh-1",
+        income_type: "Dividends (unfranked)",
+        standard_rate: "0%",
+        with_dta_typical: "",
+        notes: null,
+        color: "green",
+        sort_order: 1,
+      },
+    ];
+    const result = await getDefaultWHT();
+    // The old `|| DEFAULT_WHT` guard discarded a real parsed 0.
+    expect(result.dividendUnfranked).toBe(0);
+  });
+
+  it("parses the numeric prefix of free-text rates like '30% on unfranked portion'", async () => {
+    dbData = [
+      {
+        id: "wh-1",
+        income_type: "Dividends (unfranked)",
+        standard_rate: "30% on unfranked portion",
+        with_dta_typical: "",
+        notes: null,
+        color: "red",
+        sort_order: 1,
+      },
+    ];
+    const result = await getDefaultWHT();
+    expect(result.dividendUnfranked).toBe(30);
   });
 });

--- a/__tests__/lib/switching.test.ts
+++ b/__tests__/lib/switching.test.ts
@@ -323,6 +323,21 @@ describe("parseFee", () => {
     const result = parseFee("$1,000");
     expect(result.flat).toBe(1000);
   });
+
+  it("returns zero for malformed dollar/percent tokens (no NaN leak)", () => {
+    // "$." used to match the loose /\$([\d.]+)/ → parseFloat(".") → NaN.
+    expect(parseFee("$.")).toEqual({ flat: 0, pct: 0 });
+    // ".%" used to match /([\d.]+)%/ → parseFloat(".") → NaN.
+    expect(parseFee(".%")).toEqual({ flat: 0, pct: 0 });
+  });
+
+  it("parses a sane value from multi-dot junk like '1.2.3%'", () => {
+    // The tightened regex stops at the first valid number; result must
+    // be finite (the old loose regex captured "1.2.3" → parseFloat 1.2).
+    const result = parseFee("1.2.3%");
+    expect(Number.isFinite(result.pct)).toBe(true);
+    expect(result.flat).toBe(0);
+  });
 });
 
 // ─── calcBrokerSaving ─────────────────────────────────────────────────────────
@@ -353,6 +368,17 @@ describe("calcBrokerSaving", () => {
       targetAsxFee: "$9.50",
     });
     expect(result.annualDifference).toBeGreaterThan(0);
+  });
+
+  it("keeps annualDifference finite when one broker has a garbage fee string", () => {
+    const result = calcBrokerSaving({
+      ...baseInputs,
+      currentAsxFee: "$.",
+      targetAsxFee: "$9.50",
+    });
+    expect(Number.isFinite(result.annualDifference)).toBe(true);
+    expect(Number.isFinite(result.currentAnnualCost)).toBe(true);
+    expect(Number.isFinite(result.targetAnnualCost)).toBe(true);
   });
 
   it("negative annualDifference means target costs more (no saving)", () => {

--- a/lib/fi-data-server.ts
+++ b/lib/fi-data-server.ts
@@ -359,13 +359,24 @@ export async function getDefaultWHT(): Promise<{ dividendUnfranked: number; divi
   const unfranked = rates.find((r) => r.income_type === "Dividends (unfranked)");
   const interest = rates.find((r) => r.income_type === "Interest (bank deposits, bonds)");
 
+  // standard_rate is free text ("30%", "0%", "12.5%", "30% on unfranked
+  // portion"). parseInt() truncates decimals (12.5 → 12) and the old
+  // `|| DEFAULT` guard threw away a legitimately-parsed 0 (a real "0%"
+  // rate), falling back to the default instead. pct() preserves decimals
+  // and treats a real 0 as a valid result, only falling back on garbage.
+  const pct = (s: string, fallback: number): number => {
+    const m = s.match(/(\d+(?:\.\d+)?)/);
+    const n = m?.[1] !== undefined ? parseFloat(m[1]) : NaN;
+    return Number.isFinite(n) ? n : fallback;
+  };
+
   return {
     dividendUnfranked: unfranked
-      ? parseInt(unfranked.standard_rate.replace("%", "")) || DEFAULT_WHT.dividendUnfranked
+      ? pct(unfranked.standard_rate, DEFAULT_WHT.dividendUnfranked)
       : DEFAULT_WHT.dividendUnfranked,
     dividendFullyFranked: 0,
     interest: interest
-      ? parseInt(interest.standard_rate.replace("%", "")) || DEFAULT_WHT.interest
+      ? pct(interest.standard_rate, DEFAULT_WHT.interest)
       : DEFAULT_WHT.interest,
     royalties: DEFAULT_WHT.royalties,
   };

--- a/lib/switching/savings.ts
+++ b/lib/switching/savings.ts
@@ -24,15 +24,21 @@ export function parseFee(feeStr: string | null | undefined): {
 } {
   if (!feeStr) return { flat: 0, pct: 0 };
   const s = feeStr.replace(/,/g, "").trim();
-  const pctMatch = s.match(/([\d.]+)%/);
+  // Tightened regexes (\d+(?:\.\d+)?) mirror parseFeeNumeric in
+  // lib/price-snapshots.ts — a loose [\d.]+ matches malformed tokens
+  // like "." or "1.2.3", which parseFloat then turns into NaN or a
+  // silently-truncated value that flows into the calculator UI.
+  const pctMatch = s.match(/(\d+(?:\.\d+)?)\s*%/);
   if (pctMatch) {
-    const pctRaw = pctMatch[1];
-    return { flat: 0, pct: parseFloat(pctRaw ?? "0") / 100 };
+    const n = parseFloat(pctMatch[1] ?? "0");
+    if (!Number.isFinite(n)) return { flat: 0, pct: 0 };
+    return { flat: 0, pct: n / 100 };
   }
-  const flatMatch = s.match(/\$([\d.]+)/);
+  const flatMatch = s.match(/\$\s*(\d+(?:\.\d+)?)/);
   if (flatMatch) {
-    const flatRaw = flatMatch[1];
-    return { flat: parseFloat(flatRaw ?? "0"), pct: 0 };
+    const n = parseFloat(flatMatch[1] ?? "0");
+    if (!Number.isFinite(n)) return { flat: 0, pct: 0 };
+    return { flat: n, pct: 0 };
   }
   // "$0", "free", "0" all collapse to zero
   if (s === "0" || s.toLowerCase().includes("free") || s === "$0") {


### PR DESCRIPTION
Hardens two string-as-number parsers in the #1313/#1316/#1326 class.

- D-05: tighten parseFee() in lib/switching/savings.ts (\d+(?:\.\d+)? regexes + Number.isFinite guards) so malformed tokens like "$." / ".%" / "1.2.3%" no longer leak NaN through calcBrokerSaving into the switching-calculator UI; adds regression tests + a finite-annualDifference assertion.
- D-06: fix getDefaultWHT() in lib/fi-data-server.ts via a pct() helper that preserves decimals (12.5% no longer truncates to 12) and keeps a legitimate 0% rate (the old `|| DEFAULT` discarded it); adds tests for decimals, 0%, free-text prefixes, and garbage fallback.

Both mirror the robust parseFeeNumeric in lib/price-snapshots.ts. No callers' return shapes changed.

Tier A