### PR TITLE
fix(api): NaN-guard numeric query & route params before DB queries

### DIFF
--- a/__tests__/api/advisor-articles.test.ts
+++ b/__tests__/api/advisor-articles.test.ts
@@ -207,6 +207,59 @@ describe("GET /api/advisor-articles — advisor mode", () => {
   });
 });
 
+// ── NaN guards (D-04) ────────────────────────────────────────────────────────
+// advisor_articles.id / professional_id / article_id are bigint columns. A
+// non-numeric query string must be rejected with 400 before reaching .eq(),
+// otherwise parseInt('abc')=NaN sends col=eq.NaN and Postgres throws
+// "invalid input syntax for type bigint".
+
+describe("GET /api/advisor-articles — NaN guards", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+  });
+
+  it("returns 400 for non-numeric id (authed admin) and never queries with NaN", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { email: ADMIN_EMAIL } }, error: null });
+    const builder = createChainableBuilder("advisor_articles");
+    mockAdminFrom.mockReturnValue(builder);
+
+    const res = await GET(makeGet({ id: "abc" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/invalid id/i);
+    // The admin client must not have been queried with NaN
+    const eqCalls = (builder.eq as ReturnType<typeof vi.fn>).mock.calls;
+    expect(eqCalls.some((c: unknown[]) => Number.isNaN(c[1]))).toBe(false);
+    expect(eqCalls).toHaveLength(0);
+  });
+
+  it("returns 400 for non-numeric professional_id in advisor mode", async () => {
+    const builder = createChainableBuilder("advisor_articles");
+    mockServerFrom.mockReturnValue(builder);
+
+    const res = await GET(makeGet({ mode: "advisor", professional_id: "abc" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/invalid id/i);
+    const eqCalls = (builder.eq as ReturnType<typeof vi.fn>).mock.calls;
+    expect(eqCalls.some((c: unknown[]) => Number.isNaN(c[1]))).toBe(false);
+  });
+
+  it("returns 400 for non-numeric article_id in moderation_log mode", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { email: ADMIN_EMAIL } }, error: null });
+    const builder = createChainableBuilder("advisor_article_moderation_log");
+    mockAdminFrom.mockReturnValue(builder);
+
+    const res = await GET(makeGet({ mode: "moderation_log", article_id: "abc" }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/invalid id/i);
+    const eqCalls = (builder.eq as ReturnType<typeof vi.fn>).mock.calls;
+    expect(eqCalls.some((c: unknown[]) => Number.isNaN(c[1]))).toBe(false);
+  });
+});
+
 // ── POST tests ─────────────────────────────────────────────────────────────────
 
 describe("POST /api/advisor-articles", () => {

--- a/__tests__/api/community-threads.test.ts
+++ b/__tests__/api/community-threads.test.ts
@@ -177,6 +177,34 @@ describe("GET /api/community/threads", () => {
     const json = await res.json();
     expect(json.error).toMatch(/failed to fetch threads/i);
   });
+
+  // ── NaN guards (D-03) ──────────────────────────────────────────────────────
+  // Math.max(1, NaN) === NaN, so the clamps don't catch non-numeric input on
+  // their own — the route must coerce to defaults before .range().
+
+  it("coerces non-numeric page to 1 (range starts at offset 0)", async () => {
+    const chain = makeGetChain({ data: SAMPLE_THREADS, error: null, count: 1 });
+    mockAdminFrom.mockReturnValue(chain);
+    const res = await GET(makeGet({ page: "abc" }));
+    expect(res.status).toBe(200);
+    expect(chain.range).toHaveBeenCalledWith(0, 19);
+  });
+
+  it("coerces non-numeric limit to default 20", async () => {
+    const chain = makeGetChain({ data: SAMPLE_THREADS, error: null, count: 1 });
+    mockAdminFrom.mockReturnValue(chain);
+    const res = await GET(makeGet({ limit: "abc" }));
+    expect(res.status).toBe(200);
+    expect(chain.range).toHaveBeenCalledWith(0, 19);
+  });
+
+  it("coerces both non-numeric page and limit to defaults", async () => {
+    const chain = makeGetChain({ data: SAMPLE_THREADS, error: null, count: 1 });
+    mockAdminFrom.mockReturnValue(chain);
+    const res = await GET(makeGet({ limit: "abc", page: "abc" }));
+    expect(res.status).toBe(200);
+    expect(chain.range).toHaveBeenCalledWith(0, 19);
+  });
 });
 
 // ── Tests: POST ────────────────────────────────────────────────────────────────

--- a/__tests__/api/property-listings.test.ts
+++ b/__tests__/api/property-listings.test.ts
@@ -178,4 +178,54 @@ describe("GET /api/property/listings", () => {
     const json = await res.json();
     expect(json.total_pages).toBe(3);
   });
+
+  // ── NaN guards (D-02) ──────────────────────────────────────────────────────
+
+  it("coerces non-numeric page to 1 (range starts at first page)", async () => {
+    const chain = makeQueryChain([], 0);
+    mockServerFrom.mockReturnValue(chain);
+    const res = await GET(makeGet({ page: "abc" }));
+    expect(res.status).toBe(200);
+    expect(chain.range).toHaveBeenCalledWith(0, 11);
+  });
+
+  it("normalizes page=-5 to 1", async () => {
+    const chain = makeQueryChain([], 0);
+    mockServerFrom.mockReturnValue(chain);
+    const res = await GET(makeGet({ page: "-5" }));
+    expect(res.status).toBe(200);
+    expect(chain.range).toHaveBeenCalledWith(0, 11);
+  });
+
+  it("normalizes page=0 to 1", async () => {
+    const chain = makeQueryChain([], 0);
+    mockServerFrom.mockReturnValue(chain);
+    const res = await GET(makeGet({ page: "0" }));
+    expect(res.status).toBe(200);
+    expect(chain.range).toHaveBeenCalledWith(0, 11);
+  });
+
+  it("skips price_min filter when value is non-numeric", async () => {
+    const chain = makeQueryChain([], 0);
+    mockServerFrom.mockReturnValue(chain);
+    const res = await GET(makeGet({ price_min: "abc" }));
+    expect(res.status).toBe(200);
+    expect(chain.gte).not.toHaveBeenCalled();
+  });
+
+  it("skips price_max filter when value is non-numeric", async () => {
+    const chain = makeQueryChain([], 0);
+    mockServerFrom.mockReturnValue(chain);
+    const res = await GET(makeGet({ price_max: "abc" }));
+    expect(res.status).toBe(200);
+    expect(chain.lte).not.toHaveBeenCalled();
+  });
+
+  it("skips beds_min filter when value is non-numeric", async () => {
+    const chain = makeQueryChain([], 0);
+    mockServerFrom.mockReturnValue(chain);
+    const res = await GET(makeGet({ beds_min: "abc" }));
+    expect(res.status).toBe(200);
+    expect(chain.gte).not.toHaveBeenCalled();
+  });
 });

--- a/app/api/advisor-articles/route.ts
+++ b/app/api/advisor-articles/route.ts
@@ -58,8 +58,12 @@ export async function GET(request: NextRequest) {
     // Single article by ID — admin only (contains unpublished/draft content)
     const adminEmail = await verifyAdmin();
     if (!adminEmail) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    const aid = Number(articleId);
+    // advisor_articles.id is bigint — guard before .eq() so ?id=abc doesn't send
+    // id=eq.NaN and trip "invalid input syntax for type bigint".
+    if (!Number.isFinite(aid)) return NextResponse.json({ error: "Invalid id" }, { status: 400 });
     const admin = createAdminClient();
-    const { data } = await admin.from("advisor_articles").select("*").eq("id", parseInt(articleId)).single();
+    const { data } = await admin.from("advisor_articles").select("*").eq("id", aid).single();
     if (!data) return NextResponse.json({ error: "Not found" }, { status: 404 });
     return NextResponse.json(data);
   }
@@ -72,7 +76,9 @@ export async function GET(request: NextRequest) {
   }
 
   if (mode === "advisor" && sp.get("professional_id")) {
-    const { data } = await supabase.from("advisor_articles").select("id, title, slug, content, excerpt, status, category, tags, created_at, submitted_at, published_at, view_count, click_count, admin_notes, rejection_reason, pricing_tier, payment_status, price_cents").eq("professional_id", parseInt(sp.get("professional_id")!)).order("created_at", { ascending: false });
+    const pid = Number(sp.get("professional_id"));
+    if (!Number.isFinite(pid)) return NextResponse.json({ error: "Invalid id" }, { status: 400 });
+    const { data } = await supabase.from("advisor_articles").select("id, title, slug, content, excerpt, status, category, tags, created_at, submitted_at, published_at, view_count, click_count, admin_notes, rejection_reason, pricing_tier, payment_status, price_cents").eq("professional_id", pid).order("created_at", { ascending: false });
     return NextResponse.json(data || []);
   }
 
@@ -89,8 +95,10 @@ export async function GET(request: NextRequest) {
   if (mode === "moderation_log" && sp.get("article_id")) {
     const adminEmail = await verifyAdmin();
     if (!adminEmail) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    const aid = Number(sp.get("article_id"));
+    if (!Number.isFinite(aid)) return NextResponse.json({ error: "Invalid id" }, { status: 400 });
     const admin = createAdminClient();
-    const { data } = await admin.from("advisor_article_moderation_log").select("*").eq("article_id", parseInt(sp.get("article_id")!)).order("created_at", { ascending: false });
+    const { data } = await admin.from("advisor_article_moderation_log").select("*").eq("article_id", aid).order("created_at", { ascending: false });
     return NextResponse.json(data || []);
   }
 

--- a/app/api/community/threads/route.ts
+++ b/app/api/community/threads/route.ts
@@ -31,8 +31,12 @@ export async function GET(req: NextRequest) {
     const { searchParams } = req.nextUrl;
     const categorySlug = searchParams.get("category");
     const sort = searchParams.get("sort") || "recent";
-    const page = Math.max(1, parseInt(searchParams.get("page") || "1", 10));
-    const limit = Math.min(50, Math.max(1, parseInt(searchParams.get("limit") || "20", 10)));
+    // Math.max(1, NaN) === NaN, so the clamps alone don't catch ?page=abc —
+    // that would feed NaN into .range(). Coerce non-numeric input first.
+    const parsedPage = parseInt(searchParams.get("page") || "1", 10);
+    const page = Number.isFinite(parsedPage) ? Math.max(1, parsedPage) : 1;
+    const parsedLimit = parseInt(searchParams.get("limit") || "20", 10);
+    const limit = Number.isFinite(parsedLimit) ? Math.min(50, Math.max(1, parsedLimit)) : 20;
     const offset = (page - 1) * limit;
 
     const supabase = createAdminClient();

--- a/app/api/property/listings/route.ts
+++ b/app/api/property/listings/route.ts
@@ -23,7 +23,9 @@ export async function GET(request: NextRequest) {
     const foreignBuyer = searchParams.get("foreign_buyer_eligible");
     const featured = searchParams.get("featured");
     const sort = searchParams.get("sort") || "default";
-    const page = parseInt(searchParams.get("page") || "1", 10);
+    const parsedPage = parseInt(searchParams.get("page") || "1", 10);
+    // ?page=abc / ?page=-5 / ?page=0 must not feed NaN/negative offsets into .range()
+    const page = Number.isFinite(parsedPage) && parsedPage > 0 ? parsedPage : 1;
     const perPage = 12;
     const offset = (page - 1) * perPage;
 
@@ -59,9 +61,14 @@ export async function GET(request: NextRequest) {
     // Filters
     if (city && city !== "All") query = query.eq("city", city);
     if (type && type !== "All") query = query.eq("property_type", type);
-    if (priceMin) query = query.gte("price_from_cents", parseInt(priceMin, 10));
-    if (priceMax) query = query.lte("price_from_cents", parseInt(priceMax, 10));
-    if (bedsMin && bedsMin !== "0") query = query.gte("bedrooms_min", parseInt(bedsMin, 10));
+    // Only apply numeric filters when the value parses to a finite number —
+    // ?price_min=abc would otherwise push NaN into .gte()/.lte().
+    const priceMinNum = priceMin ? Number(priceMin) : NaN;
+    if (Number.isFinite(priceMinNum)) query = query.gte("price_from_cents", priceMinNum);
+    const priceMaxNum = priceMax ? Number(priceMax) : NaN;
+    if (Number.isFinite(priceMaxNum)) query = query.lte("price_from_cents", priceMaxNum);
+    const bedsMinNum = bedsMin && bedsMin !== "0" ? Number(bedsMin) : NaN;
+    if (Number.isFinite(bedsMinNum)) query = query.gte("bedrooms_min", bedsMinNum);
     if (firbApproved === "true") query = query.eq("firb_approved", true);
     if (offThePlan === "true") query = query.eq("off_the_plan", true);
     if (newDevelopment === "true") query = query.eq("new_development", true);

--- a/app/api/v1/brokers/route.ts
+++ b/app/api/v1/brokers/route.ts
@@ -118,7 +118,9 @@ export async function GET(request: NextRequest) {
   try {
     const params = request.nextUrl.searchParams;
 
-    // Parse pagination
+    // Parse pagination. `parseInt('abc')` is NaN (falsy), so the `|| 20` / `|| 0`
+    // fallbacks already coerce non-numeric input to a safe default before it can
+    // reach .range(); the `< 1` / `< 0` checks then normalise negatives.
     let limit = Math.min(parseInt(params.get("limit") || "20", 10) || 20, 100);
     if (limit < 1) limit = 20;
     let offset = parseInt(params.get("offset") || "0", 10) || 0;

--- a/app/office-hours/[id]/page.tsx
+++ b/app/office-hours/[id]/page.tsx
@@ -49,14 +49,20 @@ export async function generateMetadata({
   params: Promise<{ id: string }>;
 }): Promise<Metadata> {
   const { id } = await params;
+  const sessionId = parseInt(id, 10);
+  // advisor_office_hours.id is bigint — a non-numeric slug would send id=eq.NaN
+  // and Postgres rejects it ("invalid input syntax for type bigint"). Guard
+  // before querying, mirroring the page body below.
+  if (!Number.isInteger(sessionId) || sessionId <= 0) return { title: "Session not found" };
+
   const supabase = await createClient();
 
   const { data } = await supabase
     .from("advisor_office_hours")
     .select("title, description, professionals(name)")
-    .eq("id", parseInt(id, 10))
+    .eq("id", sessionId)
     .eq("is_published", true)
-    .single();
+    .maybeSingle();
 
   if (!data) return { title: "Session not found" };
 


### PR DESCRIPTION
Guards `parseInt`/`Number` on user-supplied numeric inputs before they reach Postgres bigint/range columns. Non-numeric input previously produced `NaN` → `id=eq.NaN` ("invalid input syntax for type bigint") or silent `range(NaN, NaN)` pagination. Same string-where-numeric class as #1313/#1316/#1326.

- D-01: office-hours `generateMetadata` guards a non-numeric id (returns "Session not found" before querying) and switches `.single()` → `.maybeSingle()` to match the page body.
- D-02: `/api/property/listings` coerces non-finite/<=0 `page` to 1 and only applies `price_min`/`price_max`/`beds_min` filters when finite; mirrored note in `/api/v1/brokers` (already NaN-safe via `|| default`). Tests added.
- D-03: `/api/community/threads` coerces non-numeric `page`/`limit` to defaults before clamps (`Math.max(1, NaN)` is `NaN`). Tests added.
- D-04: `/api/advisor-articles` returns 400 on non-numeric `id`/`professional_id`/`article_id` before `.eq()`; radix-10 parse. Tests added.

Tier B