### PR TITLE
test(lib): cover lic-data, academy, profile-display, csv-import, fallbacks, questions-data

### DIFF
--- a/__tests__/lib/academy.test.ts
+++ b/__tests__/lib/academy.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  creatorName,
+  creatorSlug,
+  creatorLogoUrl,
+  type AcademyCourse,
+} from "@/lib/academy";
+
+// Plain-object factory — the creator helpers are pure and never touch
+// Supabase, so no client mock is needed.
+function makeCourse(overrides: Partial<AcademyCourse>): AcademyCourse {
+  return {
+    id: 1,
+    slug: "course",
+    title: "Course",
+    description: null,
+    cover_image_url: null,
+    price_cents: 0,
+    status: "published",
+    creator_kind: "organisation",
+    organisation_id: null,
+    professional_id: null,
+    avg_rating: null,
+    review_count: 0,
+    cpd_hours: null,
+    created_at: "2026-01-01T00:00:00Z",
+    organisation: null,
+    professional: null,
+    ...overrides,
+  };
+}
+
+describe("academy creator helpers — organisation creator", () => {
+  const course = makeCourse({
+    creator_kind: "organisation",
+    organisation: { slug: "acme", name: "Acme Advisers", logo_url: "https://cdn/logo.png" },
+  });
+
+  it("creatorName returns the organisation name", () => {
+    expect(creatorName(course)).toBe("Acme Advisers");
+  });
+
+  it("creatorSlug returns the /providers/<slug> path", () => {
+    expect(creatorSlug(course)).toBe("/providers/acme");
+  });
+
+  it("creatorLogoUrl returns the organisation logo_url", () => {
+    expect(creatorLogoUrl(course)).toBe("https://cdn/logo.png");
+  });
+});
+
+describe("academy creator helpers — advisor creator", () => {
+  const course = makeCourse({
+    creator_kind: "advisor",
+    professional: { slug: "jane-doe", name: "Jane Doe", photo_url: "https://cdn/jane.png" },
+  });
+
+  it("creatorName returns the professional name", () => {
+    expect(creatorName(course)).toBe("Jane Doe");
+  });
+
+  it("creatorSlug returns the /advisor/<slug> path", () => {
+    expect(creatorSlug(course)).toBe("/advisor/jane-doe");
+  });
+
+  it("creatorLogoUrl returns the professional photo_url", () => {
+    expect(creatorLogoUrl(course)).toBe("https://cdn/jane.png");
+  });
+});
+
+describe("academy creator helpers — missing relation rows", () => {
+  it("organisation kind with null organisation falls back to Unknown/null/null", () => {
+    const course = makeCourse({ creator_kind: "organisation", organisation: null });
+    expect(creatorName(course)).toBe("Unknown");
+    expect(creatorSlug(course)).toBeNull();
+    expect(creatorLogoUrl(course)).toBeNull();
+  });
+
+  it("advisor kind with null professional falls back to Unknown/null/null", () => {
+    const course = makeCourse({ creator_kind: "advisor", professional: null });
+    expect(creatorName(course)).toBe("Unknown");
+    expect(creatorSlug(course)).toBeNull();
+    expect(creatorLogoUrl(course)).toBeNull();
+  });
+
+  it("creatorLogoUrl is null when the organisation has no logo_url", () => {
+    const course = makeCourse({
+      creator_kind: "organisation",
+      organisation: { slug: "acme", name: "Acme Advisers", logo_url: null },
+    });
+    expect(creatorLogoUrl(course)).toBeNull();
+  });
+});

--- a/__tests__/lib/getmatched/fallbacks.test.ts
+++ b/__tests__/lib/getmatched/fallbacks.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  getFallbackTemplate,
+  FALLBACK_TEMPLATES,
+  FALLBACK_INTENTS,
+  FALLBACK_QUESTIONS,
+} from "@/lib/getmatched/fallbacks";
+import type { RouteType } from "@/lib/getmatched/types";
+
+const ROUTES: RouteType[] = [
+  "compare",
+  "browse",
+  "individual",
+  "firm",
+  "expert_team",
+  "investor_brief",
+  "listing_brief",
+  "second_opinion",
+  "guide",
+];
+
+describe("getFallbackTemplate", () => {
+  it.each(ROUTES)("returns a defined template for route %s", (route) => {
+    const template = getFallbackTemplate(route);
+    expect(template).toBeDefined();
+    expect(template.route).toBe(route);
+  });
+
+  it("falls back to the guide template for an unknown route", () => {
+    expect(getFallbackTemplate("nonsense" as RouteType)).toBe(FALLBACK_TEMPLATES.guide);
+  });
+});
+
+describe("FALLBACK_TEMPLATES integrity", () => {
+  it("includes a guide template", () => {
+    expect(FALLBACK_TEMPLATES.guide).toBeDefined();
+  });
+
+  it("every template carries a defined route", () => {
+    for (const template of Object.values(FALLBACK_TEMPLATES)) {
+      expect(template.route).toBeDefined();
+    }
+  });
+});
+
+describe("FALLBACK_INTENTS / FALLBACK_QUESTIONS integrity", () => {
+  it("ships non-empty intents and questions", () => {
+    expect(FALLBACK_INTENTS.length).toBeGreaterThan(0);
+    expect(FALLBACK_QUESTIONS.length).toBeGreaterThan(0);
+  });
+
+  it("has unique question ids", () => {
+    const ids = FALLBACK_QUESTIONS.map((q) => q.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("has unique question slugs", () => {
+    const slugs = FALLBACK_QUESTIONS.map((q) => q.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+});

--- a/__tests__/lib/holdings/csv-import/index.test.ts
+++ b/__tests__/lib/holdings/csv-import/index.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  getCsvImportParser,
+  SUPPORTED_BROKER_SLUGS,
+  CSV_IMPORT_PARSERS,
+} from "@/lib/holdings/csv-import";
+
+// Parser-agnostic barrel/registry coverage. Per-broker parsing behaviour
+// is covered by the individual __tests__/lib/holdings/csv-import/<broker>
+// suites — we deliberately do not duplicate those assertions here.
+
+describe("csv-import registry", () => {
+  it("supports exactly the five known broker slugs", () => {
+    expect([...SUPPORTED_BROKER_SLUGS].sort()).toEqual(
+      ["commsec", "ibkr", "nabtrade", "selfwealth", "stake"]
+    );
+  });
+
+  it("registers a function parser for every supported slug", () => {
+    for (const slug of SUPPORTED_BROKER_SLUGS) {
+      expect(typeof CSV_IMPORT_PARSERS[slug]).toBe("function");
+    }
+  });
+
+  it("getCsvImportParser returns the registry entry for a slug", () => {
+    for (const slug of SUPPORTED_BROKER_SLUGS) {
+      expect(getCsvImportParser(slug)).toBe(CSV_IMPORT_PARSERS[slug]);
+    }
+  });
+
+  it("a resolved parser returns a CsvParseResult shape on empty input without throwing", () => {
+    const parse = getCsvImportParser("commsec");
+    const result = parse("");
+    expect(Array.isArray(result.rows)).toBe(true);
+    expect(Array.isArray(result.errors)).toBe(true);
+  });
+});

--- a/__tests__/lib/lic-data.test.ts
+++ b/__tests__/lib/lic-data.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+
+import { ntaPremiumDiscount, LIC_DATA, type LIC } from "@/lib/lic-data";
+
+// A minimal LIC builder so ntaPremiumDiscount cases don't depend on the
+// (intentionally fuller) seed rows in LIC_DATA.
+function makeLic(overrides: Partial<LIC>): LIC {
+  return {
+    ticker: "TEST",
+    name: "Test LIC",
+    manager: "Internal",
+    focus: "australian-shares",
+    description: "Test",
+    ntaPreTaxCents: 100,
+    ntaPostTaxCents: 100,
+    sharePriceCents: 100,
+    managementCostPct: 0.1,
+    dividendYield: 3,
+    frankingPct: 100,
+    aumMillions: 100,
+    inceptionYear: 2000,
+    highlights: [],
+    dataSource: "https://example.com",
+    dataAsOf: "2026-05-01",
+    ...overrides,
+  };
+}
+
+describe("ntaPremiumDiscount", () => {
+  it("returns a negative percentage when trading at a discount", () => {
+    // (850 - 880) / 880 * 100 = -3.4090…
+    expect(
+      ntaPremiumDiscount(makeLic({ ntaPostTaxCents: 880, sharePriceCents: 850 }))
+    ).toBeCloseTo(-3.409, 3);
+  });
+
+  it("returns a positive percentage when trading at a premium", () => {
+    // (215 - 205) / 205 * 100 = +4.878…
+    expect(
+      ntaPremiumDiscount(makeLic({ ntaPostTaxCents: 205, sharePriceCents: 215 }))
+    ).toBeGreaterThan(0);
+  });
+
+  it("returns 0 at exact parity (price === post-tax NTA)", () => {
+    expect(
+      ntaPremiumDiscount(makeLic({ ntaPostTaxCents: 500, sharePriceCents: 500 }))
+    ).toBe(0);
+  });
+
+  it("returns 0 when ntaPostTaxCents is 0 (avoids divide-by-zero)", () => {
+    expect(
+      ntaPremiumDiscount(makeLic({ ntaPostTaxCents: 0, sharePriceCents: 500 }))
+    ).toBe(0);
+  });
+
+  it("returns 0 when sharePriceCents is 0", () => {
+    expect(
+      ntaPremiumDiscount(makeLic({ ntaPostTaxCents: 500, sharePriceCents: 0 }))
+    ).toBe(0);
+  });
+
+  it("returns 0 when fields are missing/falsy", () => {
+    expect(
+      ntaPremiumDiscount(
+        makeLic({
+          ntaPostTaxCents: undefined as unknown as number,
+          sharePriceCents: undefined as unknown as number,
+        })
+      )
+    ).toBe(0);
+  });
+});
+
+describe("LIC_DATA integrity", () => {
+  it("ships the full set of seeded LICs", () => {
+    expect(LIC_DATA.length).toBeGreaterThanOrEqual(15);
+  });
+
+  it("has unique, non-empty tickers", () => {
+    const tickers = LIC_DATA.map((lic) => lic.ticker);
+    for (const ticker of tickers) {
+      expect(typeof ticker).toBe("string");
+      expect(ticker.length).toBeGreaterThan(0);
+    }
+    expect(new Set(tickers).size).toBe(tickers.length);
+  });
+
+  // Guards against string-as-number drift in the seed data.
+  const numericFields: (keyof LIC)[] = [
+    "ntaPreTaxCents",
+    "ntaPostTaxCents",
+    "sharePriceCents",
+    "managementCostPct",
+    "dividendYield",
+    "frankingPct",
+    "aumMillions",
+    "inceptionYear",
+  ];
+
+  it.each(LIC_DATA)("$ticker has finite numeric financial fields", (lic) => {
+    for (const field of numericFields) {
+      const value = lic[field];
+      expect(typeof value).toBe("number");
+      expect(Number.isFinite(value as number)).toBe(true);
+    }
+  });
+
+  it.each(LIC_DATA)("$ticker has frankingPct within 0–100", (lic) => {
+    expect(lic.frankingPct).toBeGreaterThanOrEqual(0);
+    expect(lic.frankingPct).toBeLessThanOrEqual(100);
+  });
+
+  it.each(LIC_DATA)("$ticker has a parseable dataAsOf date", (lic) => {
+    const parsed = new Date(lic.dataAsOf);
+    expect(Number.isNaN(parsed.getTime())).toBe(false);
+  });
+});

--- a/__tests__/lib/outcomes/profile-display.test.ts
+++ b/__tests__/lib/outcomes/profile-display.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+
+import { badgeToneFor } from "@/lib/outcomes/profile-display";
+
+describe("badgeToneFor", () => {
+  it("returns slate for null", () => {
+    expect(badgeToneFor(null)).toBe("slate");
+  });
+
+  it("returns slate for undefined", () => {
+    expect(badgeToneFor(undefined as unknown as number)).toBe("slate");
+  });
+
+  it("returns slate for 0", () => {
+    expect(badgeToneFor(0)).toBe("slate");
+  });
+
+  // Pin the exact >= boundaries — catches a future > vs >= regression.
+  it("returns slate just below the amber threshold (59.9)", () => {
+    expect(badgeToneFor(59.9)).toBe("slate");
+  });
+
+  it("returns amber at exactly 60", () => {
+    expect(badgeToneFor(60)).toBe("amber");
+  });
+
+  it("returns amber just below the emerald threshold (79.9)", () => {
+    expect(badgeToneFor(79.9)).toBe("amber");
+  });
+
+  it("returns emerald at exactly 80", () => {
+    expect(badgeToneFor(80)).toBe("emerald");
+  });
+
+  it("returns emerald at 100", () => {
+    expect(badgeToneFor(100)).toBe("emerald");
+  });
+
+  it("returns slate for negatives (-5)", () => {
+    expect(badgeToneFor(-5)).toBe("slate");
+  });
+});

--- a/__tests__/lib/questions-data.test.ts
+++ b/__tests__/lib/questions-data.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  QUESTIONS,
+  QUESTIONS_BY_SLUG,
+  QUESTION_CATEGORIES,
+  CATEGORY_LABELS,
+} from "@/lib/questions-data";
+
+describe("questions-data content integrity", () => {
+  it.each(QUESTIONS)("$slug has the required non-empty copy fields", (q) => {
+    expect(q.slug.length).toBeGreaterThan(0);
+    expect(q.question.length).toBeGreaterThan(0);
+    expect(q.metaTitle.length).toBeGreaterThan(0);
+    expect(q.metaDescription.length).toBeGreaterThan(0);
+    expect(q.shortAnswer.length).toBeGreaterThan(0);
+  });
+
+  it.each(QUESTIONS)("$slug has at least one fully-populated section", (q) => {
+    expect(q.sections.length).toBeGreaterThanOrEqual(1);
+    for (const section of q.sections) {
+      expect(section.heading.length).toBeGreaterThan(0);
+      expect(section.body.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("has unique slugs", () => {
+    const slugs = QUESTIONS.map((q) => q.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+});
+
+describe("QUESTIONS_BY_SLUG lookup map", () => {
+  it("indexes every question exactly once", () => {
+    expect(QUESTIONS_BY_SLUG.size).toBe(QUESTIONS.length);
+  });
+
+  it.each(QUESTIONS)("resolves $slug back to its entry", (q) => {
+    expect(QUESTIONS_BY_SLUG.get(q.slug)).toBe(q);
+  });
+});
+
+describe("category coverage", () => {
+  it.each(QUESTION_CATEGORIES)("category %s has a non-empty label", (category) => {
+    expect(CATEGORY_LABELS[category]).toBeDefined();
+    expect(CATEGORY_LABELS[category].length).toBeGreaterThan(0);
+  });
+
+  it("every question's category has a label", () => {
+    for (const q of QUESTIONS) {
+      expect(CATEGORY_LABELS[q.category]).toBeDefined();
+      expect(CATEGORY_LABELS[q.category].length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("internal link integrity", () => {
+  it.each(QUESTIONS)("$slug relatedSlugs all resolve (no dangling links)", (q) => {
+    for (const related of q.relatedSlugs) {
+      expect(QUESTIONS_BY_SLUG.has(related)).toBe(true);
+    }
+  });
+
+  it.each(QUESTIONS)("$slug relatedTools have a label and a rooted href", (q) => {
+    if (!q.relatedTools) return;
+    for (const tool of q.relatedTools) {
+      expect(tool.label.length).toBeGreaterThan(0);
+      expect(tool.href.startsWith("/")).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Pure-additive unit + data-integrity coverage for six previously-untested lib modules.

- C-01: `lib/lic-data.ts` — ntaPremiumDiscount discount/premium/parity/zero-guard cases + LIC_DATA integrity (unique tickers, finite numeric financial fields guarding string-as-number drift, frankingPct 0–100, parseable dataAsOf).
- C-02: `lib/academy.ts` — creatorName / creatorSlug / creatorLogoUrl across organisation, advisor, and null-relation fallbacks.
- C-03: `lib/outcomes/profile-display.ts` — badgeToneFor exact >= boundary pins (catches > vs >= regression).
- C-04: `lib/holdings/csv-import` barrel — slug registry, parser dispatch, CsvParseResult smoke (parser-agnostic).
- C-05: `lib/getmatched/fallbacks.ts` — getFallbackTemplate per-route + unknown-route guide fallback; intents/questions integrity.
- C-06: `lib/questions-data.ts` — per-entry copy/section integrity, unique slugs, lookup-map parity, category labels, no dangling relatedSlugs, rooted relatedTools hrefs.

Tier A