### PR TITLE
test(lib,components): cover advisor-profile-match, LeadScoreBadge, SocialProofCounter

### DIFF
--- a/__tests__/components/LeadScoreBadge.test.tsx
+++ b/__tests__/components/LeadScoreBadge.test.tsx
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, userEvent } from "./setup";
+import LeadScoreBadge from "@/components/LeadScoreBadge";
+
+describe("LeadScoreBadge", () => {
+  describe("tier branching", () => {
+    it("renders a Hot Lead for score >= 70", () => {
+      render(<LeadScoreBadge score={85} />);
+      const button = screen.getByRole("button");
+      expect(button).toHaveAttribute(
+        "title",
+        expect.stringContaining("Hot Lead"),
+      );
+      expect(button).toHaveAttribute(
+        "title",
+        expect.stringContaining("Respond within 1 hour"),
+      );
+      expect(screen.getByText("Hot Lead")).toBeInTheDocument();
+      expect(screen.getByText("85")).toBeInTheDocument();
+    });
+
+    it("renders a Warm Lead for 40 <= score < 70", () => {
+      render(<LeadScoreBadge score={55} />);
+      const button = screen.getByRole("button");
+      expect(button).toHaveAttribute("title", expect.stringContaining("Warm Lead"));
+      expect(button).toHaveAttribute(
+        "title",
+        expect.stringContaining("Respond within 24 hours"),
+      );
+      expect(screen.getByText("Warm Lead")).toBeInTheDocument();
+    });
+
+    it("renders a Cool Lead for score < 40", () => {
+      render(<LeadScoreBadge score={20} />);
+      const button = screen.getByRole("button");
+      expect(button).toHaveAttribute("title", expect.stringContaining("Cool Lead"));
+      expect(button).toHaveAttribute(
+        "title",
+        expect.stringContaining("Follow up when convenient"),
+      );
+      expect(screen.getByText("Cool Lead")).toBeInTheDocument();
+    });
+  });
+
+  describe("tier boundary exactness", () => {
+    it("score = 70 is Hot", () => {
+      render(<LeadScoreBadge score={70} />);
+      expect(screen.getByText("Hot Lead")).toBeInTheDocument();
+    });
+
+    it("score = 69 is Warm", () => {
+      render(<LeadScoreBadge score={69} />);
+      expect(screen.getByText("Warm Lead")).toBeInTheDocument();
+    });
+
+    it("score = 40 is Warm", () => {
+      render(<LeadScoreBadge score={40} />);
+      expect(screen.getByText("Warm Lead")).toBeInTheDocument();
+    });
+
+    it("score = 39 is Cool", () => {
+      render(<LeadScoreBadge score={39} />);
+      expect(screen.getByText("Cool Lead")).toBeInTheDocument();
+    });
+  });
+
+  describe("expand / collapse breakdown", () => {
+    it("does not expand in compact mode and shows no chevron caret", async () => {
+      const user = userEvent.setup();
+      render(
+        <LeadScoreBadge score={80} compact signals={{ phone_provided: 10 }} />,
+      );
+      const button = screen.getByRole("button");
+      // No chevron caret (▼ / ▲) in compact mode
+      expect(button.textContent).not.toContain("▼");
+      expect(button.textContent).not.toContain("▲");
+      await user.click(button);
+      expect(screen.queryByText("Score Breakdown")).not.toBeInTheDocument();
+    });
+
+    it("toggles the breakdown open and closed on click (non-compact with signals)", async () => {
+      const user = userEvent.setup();
+      render(
+        <LeadScoreBadge
+          score={80}
+          signals={{ phone_provided: 10 }}
+          tier="premium"
+        />,
+      );
+      const button = screen.getByRole("button");
+      // Chevron present (collapsed -> ▼)
+      expect(button.textContent).toContain("▼");
+
+      // Initially collapsed
+      expect(screen.queryByText("Score Breakdown")).not.toBeInTheDocument();
+
+      // Open
+      await user.click(button);
+      expect(screen.getByText("Score Breakdown")).toBeInTheDocument();
+      // Mapped signal label + value via SIGNAL_LABELS
+      expect(screen.getByText("Has phone number")).toBeInTheDocument();
+      expect(screen.getByText("+10")).toBeInTheDocument();
+      // Chevron flips to ▲ when expanded
+      expect(button.textContent).toContain("▲");
+
+      // Close again
+      await user.click(button);
+      expect(screen.queryByText("Score Breakdown")).not.toBeInTheDocument();
+    });
+
+    it("falls back to an underscores-replaced label for an unknown signal key", async () => {
+      const user = userEvent.setup();
+      render(
+        <LeadScoreBadge score={75} signals={{ custom_lead_signal: 5 }} />,
+      );
+      await user.click(screen.getByRole("button"));
+      expect(screen.getByText("custom lead signal")).toBeInTheDocument();
+      expect(screen.getByText("+5")).toBeInTheDocument();
+    });
+
+    it("renders ✓ instead of +N for a non-number signal value", async () => {
+      const user = userEvent.setup();
+      render(
+        // @ts-expect-error — intentionally passing a non-number value to exercise the fallback branch
+        <LeadScoreBadge score={75} signals={{ phone_provided: true }} />,
+      );
+      await user.click(screen.getByRole("button"));
+      expect(screen.getByText("+✓")).toBeInTheDocument();
+    });
+
+    it("shows no chevron and never opens a panel when there are no signals", async () => {
+      const user = userEvent.setup();
+      render(<LeadScoreBadge score={80} />);
+      const button = screen.getByRole("button");
+      expect(button.textContent).not.toContain("▼");
+      expect(button.textContent).not.toContain("▲");
+      await user.click(button);
+      expect(screen.queryByText("Score Breakdown")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/__tests__/components/SocialProofCounter.test.tsx
+++ b/__tests__/components/SocialProofCounter.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "./setup";
+import SocialProofCounter from "@/components/SocialProofCounter";
+
+describe("SocialProofCounter", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Pin to a midday local time so the bell-curve baseline is comfortably above the floor.
+    // 2026-06-15 13:00 local (dayOfMonth = 15).
+    vi.setSystemTime(new Date(2026, 5, 15, 13, 0, 0));
+    // Fire-and-forget fetch — resolve with an empty object.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve({} as Response)),
+    );
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("calls fetch('/api/track-event', POST) once on mount and does not throw if fetch rejects", async () => {
+    // Override fetch to reject — the component must swallow the error.
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockImplementation(() =>
+      Promise.reject(new Error("network down")),
+    );
+
+    expect(() => render(<SocialProofCounter />)).not.toThrow();
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe("/api/track-event");
+    expect(init).toMatchObject({ method: "POST" });
+  });
+
+  it("renders the inline variant <p> with the deterministic count text after the effect runs", () => {
+    render(<SocialProofCounter />);
+
+    // The mount effect sets the count synchronously; render() flushes effects in act().
+    expect(
+      screen.getByText(/\d+ investors compared platforms today/),
+    ).toBeInTheDocument();
+
+    const p = screen.getByText(/investors compared platforms today/);
+    expect(p.tagName).toBe("P");
+    const match = p.textContent?.match(/(\d+) investors compared platforms today/);
+    expect(match).not.toBeNull();
+    const count = Number(match![1]);
+    expect(count).toBeGreaterThanOrEqual(8);
+  });
+
+  it("renders the badge variant text and the live-dot ping span", () => {
+    const { container } = render(<SocialProofCounter variant="badge" />);
+
+    expect(
+      screen.getByText(/investors comparing today/),
+    ).toBeInTheDocument();
+
+    // The animated live dot uses an animate-ping span.
+    expect(container.querySelector(".animate-ping")).not.toBeNull();
+  });
+
+  it("clamps the rendered count to a floor of >= 8 even when the time-based baseline would be tiny", () => {
+    // Pin to just after midnight: sin(~0) -> baseLine clamps to 12; dayOfMonth chosen so variance is most negative.
+    // variance = ((dayOfMonth * 7) % 23) - 11. dayOfMonth=22 -> (154 % 23)=16 -> 5. Pick a day giving min.
+    // dayOfMonth=21 -> (147 % 23)=9 -> -2; dayOfMonth=20 -> (140 % 23)=2 -> -9; dayOfMonth=27 -> (189 % 23)=4 -> -7.
+    // baseLine floor is 12; min variance is -11 -> 12 + (-11) = 1 -> clamped to 8. Find a day with variance -11:
+    // need (d*7 % 23) === 0 -> d=23 -> (161 % 23)=0 -> variance -11. baseLine 12 + (-11) = 1 -> floor 8.
+    vi.setSystemTime(new Date(2026, 5, 23, 0, 1, 0));
+
+    render(<SocialProofCounter />);
+
+    const p = screen.getByText(/investors compared platforms today/);
+    const count = Number(
+      p.textContent!.match(/(\d+) investors compared platforms today/)![1],
+    );
+    expect(count).toBeGreaterThanOrEqual(8);
+  });
+});

--- a/__tests__/lib/advisor-profile-match.test.ts
+++ b/__tests__/lib/advisor-profile-match.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect } from "vitest";
+import {
+  computeIdealClientBoost,
+  computeAdvisorProfileMatch,
+  type UserMatchProfile,
+  type AdvisorMatchProfile,
+  type IdealClientCriteria,
+} from "@/lib/advisor-profile-match";
+
+// advisor-profile-match.ts is a pure module with no imports / no I/O — no mocks required.
+
+function baseUser(overrides: Partial<UserMatchProfile> = {}): UserMatchProfile {
+  return {
+    primary_vertical: null,
+    budget_band: null,
+    is_fhb: false,
+    is_hnw: false,
+    is_pre_retiree: false,
+    experience_level: null,
+    location_state: null,
+    ...overrides,
+  };
+}
+
+function baseAdvisor(overrides: Partial<AdvisorMatchProfile> = {}): AdvisorMatchProfile {
+  return {
+    id: 1,
+    specialties: [],
+    min_investment_cents: null,
+    minimum_investment_cents: null,
+    location_state: null,
+    office_states: null,
+    accepts_new_clients: true,
+    advisor_tier: null,
+    rating: null,
+    review_count: null,
+    ...overrides,
+  };
+}
+
+describe("computeIdealClientBoost", () => {
+  it("returns 0 when criteria is null", () => {
+    expect(computeIdealClientBoost(baseUser(), null)).toBe(0);
+  });
+
+  it("returns 0 when criteria is undefined", () => {
+    expect(computeIdealClientBoost(baseUser(), undefined)).toBe(0);
+  });
+
+  it("returns 0 for an empty criteria object (no arrays -> checks === 0)", () => {
+    expect(computeIdealClientBoost(baseUser(), {})).toBe(0);
+  });
+
+  it("returns 0 when all criteria arrays are present but empty (length > 0 guard skips them)", () => {
+    const criteria: IdealClientCriteria = {
+      verticals: [],
+      budget_bands: [],
+      archetypes: [],
+      experience_levels: [],
+    };
+    expect(computeIdealClientBoost(baseUser({ primary_vertical: "shares" }), criteria)).toBe(0);
+  });
+
+  it("returns 10 when the only criterion (verticals) fully matches: round(1/1*10)", () => {
+    const criteria: IdealClientCriteria = { verticals: ["shares"] };
+    expect(
+      computeIdealClientBoost(baseUser({ primary_vertical: "shares" }), criteria),
+    ).toBe(10);
+  });
+
+  it("returns 5 on a 2-of-4 partial match: round(2/4*10)", () => {
+    // verticals + budget_bands match (2 hits), archetypes + experience_levels set but no match (2 misses)
+    const criteria: IdealClientCriteria = {
+      verticals: ["shares"],
+      budget_bands: ["100k_250k"],
+      archetypes: ["hnw"],
+      experience_levels: ["expert"],
+    };
+    const user = baseUser({
+      primary_vertical: "shares",
+      budget_band: "100k_250k",
+      // not hnw, experience_level "beginner" -> two misses
+      experience_level: "beginner",
+    });
+    expect(computeIdealClientBoost(user, criteria)).toBe(5);
+  });
+
+  it("matches archetypes via is_fhb -> 'fhb'", () => {
+    const criteria: IdealClientCriteria = { archetypes: ["fhb"] };
+    expect(computeIdealClientBoost(baseUser({ is_fhb: true }), criteria)).toBe(10);
+  });
+
+  it("matches archetypes via is_hnw -> 'hnw'", () => {
+    const criteria: IdealClientCriteria = { archetypes: ["hnw"] };
+    expect(computeIdealClientBoost(baseUser({ is_hnw: true }), criteria)).toBe(10);
+  });
+
+  it("matches archetypes via is_pre_retiree -> 'pre_retiree'", () => {
+    const criteria: IdealClientCriteria = { archetypes: ["pre_retiree"] };
+    expect(computeIdealClientBoost(baseUser({ is_pre_retiree: true }), criteria)).toBe(10);
+  });
+
+  it("counts an archetype check but scores no match when no archetype flag is set", () => {
+    const criteria: IdealClientCriteria = { archetypes: ["fhb", "hnw"] };
+    // no flags set -> userArchetypes is empty -> no match -> round(0/1*10) === 0
+    expect(computeIdealClientBoost(baseUser(), criteria)).toBe(0);
+  });
+
+  it("counts a check but no match when the user field is null while the criteria array is non-empty", () => {
+    const criteria: IdealClientCriteria = { verticals: ["shares"] };
+    // primary_vertical null -> check counted, no match
+    expect(computeIdealClientBoost(baseUser({ primary_vertical: null }), criteria)).toBe(0);
+  });
+
+  it("matches experience_levels when the user level is included", () => {
+    const criteria: IdealClientCriteria = { experience_levels: ["expert", "intermediate"] };
+    expect(
+      computeIdealClientBoost(baseUser({ experience_level: "expert" }), criteria),
+    ).toBe(10);
+  });
+
+  it("matches budget_bands when the user band is included", () => {
+    const criteria: IdealClientCriteria = { budget_bands: ["1m_5m"] };
+    expect(
+      computeIdealClientBoost(baseUser({ budget_band: "1m_5m" }), criteria),
+    ).toBe(10);
+  });
+});
+
+describe("computeAdvisorProfileMatch", () => {
+  it("parses specialties from a JSON string via toSpecialtiesArray", () => {
+    const user = baseUser({ primary_vertical: "smsf" });
+    const advisor = baseAdvisor({ specialties: '["smsf"]' });
+    // vertical match (+40) + minInvest null (+20) + archetype floor (+10) + no location (+5) = 75
+    expect(computeAdvisorProfileMatch(user, advisor)).toBe(75);
+  });
+
+  it("treats a malformed specialties string as a single-element array [string]", () => {
+    const user = baseUser({ primary_vertical: "smsf" });
+    // not valid JSON -> [ "smsf, retirement" ] -> includes("smsf") matches via substring
+    const advisor = baseAdvisor({ specialties: "smsf, retirement" });
+    // vertical substring match (+40) + minInvest null (+20) + archetype floor (+10) + no location (+5) = 75
+    expect(computeAdvisorProfileMatch(user, advisor)).toBe(75);
+  });
+
+  it("awards generalist +20 when no vertical and no specialties", () => {
+    const user = baseUser(); // no vertical
+    const advisor = baseAdvisor({ specialties: [] });
+    // no vertical & no specialties (+20) + minInvest null (+20) + archetype floor (+10) + no location (+5) = 55
+    expect(computeAdvisorProfileMatch(user, advisor)).toBe(55);
+  });
+
+  it("awards minInvest == null the +20 accessible bonus", () => {
+    const user = baseUser({ primary_vertical: "shares", budget_band: "100k_250k" });
+    const advisor = baseAdvisor({
+      specialties: ["shares"],
+      min_investment_cents: null,
+      minimum_investment_cents: null,
+    });
+    // vertical (+40) + minInvest null (+20) + archetype floor (+10) + no location (+5) = 75
+    expect(computeAdvisorProfileMatch(user, advisor)).toBe(75);
+  });
+
+  it("awards budget partial +15 when minInvest is above budget but <= midpoint*2", () => {
+    // budget_band 100k_250k -> midpoint 175_000_00; midpoint*2 = 350_000_00
+    const user = baseUser({ primary_vertical: "shares", budget_band: "100k_250k" });
+    const advisor = baseAdvisor({
+      specialties: ["shares"],
+      min_investment_cents: 300_000_00, // > midpoint, <= midpoint*2
+    });
+    // vertical (+40) + budget partial (+15) + archetype floor (+10) + no location (+5) = 70
+    expect(computeAdvisorProfileMatch(user, advisor)).toBe(70);
+  });
+
+  it("awards full budget +30 when minInvest <= midpoint", () => {
+    const user = baseUser({ primary_vertical: "shares", budget_band: "100k_250k" });
+    const advisor = baseAdvisor({
+      specialties: ["shares"],
+      min_investment_cents: 100_000_00, // <= midpoint 175_000_00
+    });
+    // vertical (+40) + budget (+30) + archetype floor (+10) + no location (+5) = 85
+    expect(computeAdvisorProfileMatch(user, advisor)).toBe(85);
+  });
+
+  it("applies the archetype floor (+10) when archetypeScore === 0", () => {
+    const user = baseUser({ primary_vertical: "shares" }); // no archetype flags
+    const advisor = baseAdvisor({ specialties: ["shares"] });
+    // vertical (+40) + minInvest null (+20) + archetype floor (+10) + no location (+5) = 75
+    expect(computeAdvisorProfileMatch(user, advisor)).toBe(75);
+  });
+
+  it("uses office_states for the +10 location overlap (overrides location_state)", () => {
+    const user = baseUser({ primary_vertical: "shares", location_state: "NSW" });
+    const advisor = baseAdvisor({
+      specialties: ["shares"],
+      office_states: ["nsw", "vic"], // case-insensitive overlap
+      location_state: "QLD", // ignored because office_states is present
+    });
+    // vertical (+40) + minInvest null (+20) + archetype floor (+10) + location (+10) = 80
+    expect(computeAdvisorProfileMatch(user, advisor)).toBe(80);
+  });
+
+  it("falls back to location_state when office_states is null", () => {
+    const user = baseUser({ primary_vertical: "shares", location_state: "QLD" });
+    const advisor = baseAdvisor({
+      specialties: ["shares"],
+      office_states: null,
+      location_state: "QLD",
+    });
+    // vertical (+40) + minInvest null (+20) + archetype floor (+10) + location (+10) = 80
+    expect(computeAdvisorProfileMatch(user, advisor)).toBe(80);
+  });
+
+  it("gives +5 half-credit location when the user location_state is null", () => {
+    const user = baseUser({ primary_vertical: "shares", location_state: null });
+    const advisor = baseAdvisor({ specialties: ["shares"], office_states: ["nsw"] });
+    // vertical (+40) + minInvest null (+20) + archetype floor (+10) + no location (+5) = 75
+    expect(computeAdvisorProfileMatch(user, advisor)).toBe(75);
+  });
+
+  it("caps the final result at 100 even with a high score plus ideal-client boost", () => {
+    // Maximise the base score, then add a boost; result must stay <= 100.
+    const user = baseUser({
+      primary_vertical: "smsf",
+      budget_band: "100k_250k",
+      is_hnw: true,
+      location_state: "NSW",
+      experience_level: "expert",
+    });
+    const advisor = baseAdvisor({
+      specialties: ["smsf", "hnw"], // vertical match + hnw archetype
+      min_investment_cents: 100_000_00, // <= midpoint -> +30
+      office_states: ["nsw"],
+    });
+    const criteria: IdealClientCriteria = {
+      verticals: ["smsf"],
+      budget_bands: ["100k_250k"],
+      archetypes: ["hnw"],
+      experience_levels: ["expert"],
+    };
+    // base: vertical 40 + budget 30 + archetype(hnw=10) + location 10 = 90; boost = 10 -> 100 capped
+    const result = computeAdvisorProfileMatch(user, advisor, criteria);
+    expect(result).toBe(100);
+    expect(result).toBeLessThanOrEqual(100);
+  });
+
+  it("awards partial +8 specialty credit when a vertical is set but no specialty matches", () => {
+    const user = baseUser({ primary_vertical: "crypto" });
+    const advisor = baseAdvisor({ specialties: ["shares", "bonds"] });
+    // no match but specialties present (+8) + minInvest null (+20) + archetype floor (+10) + no location (+5) = 43
+    expect(computeAdvisorProfileMatch(user, advisor)).toBe(43);
+  });
+
+  it("awards neutral +15 when no vertical is set but the advisor lists specialties", () => {
+    const user = baseUser({ primary_vertical: null });
+    const advisor = baseAdvisor({ specialties: ["shares"] });
+    // no vertical but specialties present (+15) + minInvest null (+20) + archetype floor (+10) + no location (+5) = 50
+    expect(computeAdvisorProfileMatch(user, advisor)).toBe(50);
+  });
+});


### PR DESCRIPTION
Pure-additive tests (Tier A) — no source changes.

Modules covered:
- **lib/advisor-profile-match.ts** — `computeIdealClientBoost` (previously zero direct test references): null/undefined/empty criteria, single-category full match, 2-of-4 partial fraction, archetype mapping (is_fhb/is_hnw/is_pre_retiree), empty-array skip, null-user-field check counting. Plus `computeAdvisorProfileMatch` gaps the API test misses: JSON-string + malformed specialties parsing, budget full/partial/null credit, generalist +20, archetype floor, office_states override of location_state, null-location half credit, and the Math.min(100) cap with boost.
- **components/LeadScoreBadge.tsx** — tier branching (Hot/Warm/Cool) with title/label/score, exact boundaries (70/69/40/39), compact mode non-expand + no chevron, expand/collapse toggle with SIGNAL_LABELS mapping, unknown-key underscore fallback, non-number value -> checkmark branch, no-signals no-chevron path.
- **components/SocialProofCounter.tsx** — fire-and-forget POST to /api/track-event (incl. swallowed rejection), deterministic time-pinned count via fake timers, inline + badge variants, animate-ping live dot, and the >= 8 floor clamp.

Tier A (pure-additive).