### PR TITLE
fix(security): IP-key the chatbot limiter + sanitize badge-widget slug

### DIFF
--- a/__tests__/api/chatbot.test.ts
+++ b/__tests__/api/chatbot.test.ts
@@ -6,6 +6,10 @@ import { NextRequest } from "next/server";
 const mockIsAllowed = vi.fn();
 vi.mock("@/lib/rate-limit-db", () => ({
   isAllowed: (...args: unknown[]) => mockIsAllowed(...args),
+  // Deterministic, IP-derived key so the IP-limiter test can hold the bucket
+  // across requests that rotate session_id.
+  ipKey: (req: { headers: Headers }) =>
+    req.headers.get("x-forwarded-for")?.split(",")[0].trim() ?? "test-ip",
 }));
 
 const mockAdminFrom = vi.fn();
@@ -26,10 +30,10 @@ import { POST } from "@/app/api/chatbot/route";
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
-function makePost(body: unknown): NextRequest {
+function makePost(body: unknown, headers: Record<string, string> = {}): NextRequest {
   return new NextRequest("http://localhost/api/chatbot", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...headers },
     body: JSON.stringify(body),
   });
 }
@@ -95,6 +99,67 @@ describe("POST /api/chatbot", () => {
     expect(res.status).toBe(429);
     const json = await res.json();
     expect(json.error).toMatch(/Too many/i);
+  });
+
+  it("checks an IP-keyed bucket so the cap survives session_id rotation (wallet-DoS guard)", async () => {
+    // Model the limiter as two independent buckets. The per-session bucket is
+    // keyed on the client-supplied session_id (and so resets when an attacker
+    // rotates it); the IP bucket is keyed on the request IP and persists across
+    // requests from the same IP regardless of session. The IP bucket starts
+    // depleted, so even a fresh session_id from the same IP must be rejected.
+    const sessionBuckets = new Map<string, number>();
+    let ipTokens = 0; // IP bucket already exhausted for this IP
+    mockIsAllowed.mockImplementation(
+      async (scope: string, key: string) => {
+        if (scope === "chatbot_ip") {
+          if (ipTokens < 1) return false;
+          ipTokens -= 1;
+          return true;
+        }
+        // per-session bucket: each distinct session gets a fresh allowance
+        const remaining = sessionBuckets.get(key) ?? 20;
+        if (remaining < 1) return false;
+        sessionBuckets.set(key, remaining - 1);
+        return true;
+      },
+    );
+
+    const ip = { "x-forwarded-for": "203.0.113.7" };
+
+    // 1st request: brand-new session_id, but the IP bucket is empty → 429.
+    const res1 = await POST(makePost({ session_id: "sess-1", message: "hi" }, ip));
+    expect(res1.status).toBe(429);
+
+    // 2nd request: DIFFERENT session_id (rotated, as an attacker would) from the
+    // SAME IP. The per-session bucket is fresh, but the IP bucket still holds →
+    // still 429. This is the property that closes the provider-bill DoS.
+    const res2 = await POST(makePost({ session_id: "sess-2", message: "hi" }, ip));
+    expect(res2.status).toBe(429);
+
+    // The IP-keyed bucket was consulted for both requests.
+    const ipCalls = mockIsAllowed.mock.calls.filter((c) => c[0] === "chatbot_ip");
+    expect(ipCalls.length).toBe(2);
+    expect(ipCalls.every((c) => c[1] === "203.0.113.7")).toBe(true);
+  });
+
+  it("allows when both IP and session buckets have capacity", async () => {
+    mockIsAllowed.mockResolvedValue(true);
+    let callCount = 0;
+    mockAdminFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return makeConversationSelectChain({ data: [], error: null });
+      return makeInsertChain({ error: null });
+    });
+    mockRespondToMessage.mockResolvedValue(CHAT_RESULT);
+
+    const res = await POST(
+      makePost({ session_id: "sess-ok", message: "hi" }, { "x-forwarded-for": "198.51.100.4" }),
+    );
+    expect(res.status).toBe(200);
+    // Both buckets were checked, IP first.
+    const scopes = mockIsAllowed.mock.calls.map((c) => c[0]);
+    expect(scopes).toContain("chatbot_ip");
+    expect(scopes).toContain("chatbot");
   });
 
   it("returns 200 with reply on success", async () => {

--- a/__tests__/api/widget-badge.test.ts
+++ b/__tests__/api/widget-badge.test.ts
@@ -130,6 +130,52 @@ describe("GET /api/widget/badge — validation", () => {
     const res = await GET(makeReq({ type: "broker", slug: "nobody" }));
     expect(res.status).toBe(404);
   });
+
+  it("sanitizes the slug so a 404 comment cannot break out of the JS comment (advisor)", async () => {
+    // The 404 body interpolates the slug into a `/* … "<slug>" … */` comment
+    // served as application/javascript. An unsanitized `*/<payload>/*` would
+    // terminate the comment early and inject executable script. After
+    // sanitization the body must contain only the single, legitimate comment
+    // terminator (the template's own `*/`) and none of the attacker's payload.
+    mockFrom.mockReturnValue(makeSingleChain(null)); // force the 404 branch
+    const res = await GET(
+      makeReq({ type: "advisor", slug: "nobody*/alert(document.domain);/*" }),
+    );
+    expect(res.status).toBe(404);
+    const body = await res.text();
+    // Exactly one `*/` — the template terminator. A breakout would add more.
+    expect(body.split("*/").length - 1).toBe(1);
+    // The echoed slug carries none of the comment/script metacharacters.
+    expect(body).not.toContain("alert(");
+    expect(body).not.toContain("document.domain");
+    expect(body).not.toContain("(");
+    expect(body).not.toContain(";");
+    // The sanitized remainder (slug charset only) is what gets echoed.
+    expect(body).toContain("nobodyalertdocumentdomain");
+  });
+
+  it("sanitizes the slug so a 404 comment cannot break out of the JS comment (broker)", async () => {
+    mockFrom.mockReturnValue(makeSingleChain(null)); // force the 404 branch
+    const res = await GET(
+      makeReq({ type: "broker", slug: "nobody*/</script><script>x/*" }),
+    );
+    expect(res.status).toBe(404);
+    const body = await res.text();
+    // Only the single legitimate comment terminator survives.
+    expect(body.split("*/").length - 1).toBe(1);
+    expect(body).not.toContain("<script>");
+    expect(body).not.toContain("</script>");
+    expect(body).not.toContain("</");
+  });
+
+  it("passes a slug-charset-only value to the DB query (injection chars stripped)", async () => {
+    const chain = makeSingleChain(null);
+    mockFrom.mockReturnValue(chain);
+    await GET(makeReq({ type: "advisor", slug: "jane*/x/*-smith" }));
+    const eqCalls = (chain.eq as ReturnType<typeof vi.fn>).mock.calls;
+    const slugCall = eqCalls.find((c) => c[0] === "slug");
+    expect(slugCall?.[1]).toBe("janex-smith");
+  });
 });
 
 describe("GET /api/widget/badge — advisor badge", () => {

--- a/app/api/chatbot/route.ts
+++ b/app/api/chatbot/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { createAdminClient } from "@/lib/supabase/admin";
-import { isAllowed } from "@/lib/rate-limit-db";
+import { isAllowed, ipKey } from "@/lib/rate-limit-db";
 import { respondToMessage, type ChatMessage } from "@/lib/chatbot";
 import { logger } from "@/lib/logger";
 
@@ -29,8 +29,11 @@ export const runtime = "nodejs";
  * Returns:
  *   { reply, retrieved: [...], flagged, flaggedReason }
  *
- * Rate limited to 20 messages per minute per session to keep
- * the provider bill bounded.
+ * Rate limited per session (20/min, UX guard) AND per IP (40/min). The
+ * IP limiter is the wallet-DoS backstop: `session_id` is client-supplied,
+ * so an anon caller can rotate it per request and defeat the per-session
+ * cap. Keying the second bucket on the request IP bounds the Anthropic
+ * provider bill regardless of how many sessions a single client spins up.
  */
 export async function POST(request: NextRequest) {
   const parsedBody = Body.safeParse(await request.json().catch(() => ({})));
@@ -47,6 +50,12 @@ export async function POST(request: NextRequest) {
   }
   if (message.length > 2000) {
     return NextResponse.json({ error: "Message too long" }, { status: 400 });
+  }
+
+  // IP-keyed backstop: caps the provider bill even when session_id is rotated
+  // per request to slip past the per-session limit below.
+  if (!(await isAllowed("chatbot_ip", ipKey(request), { max: 40, refillPerSec: 40 / 60 }))) {
+    return NextResponse.json({ error: "Too many requests." }, { status: 429 });
   }
 
   if (!(await isAllowed("chatbot", sessionId, { max: 20, refillPerSec: 20 / 60 }))) {

--- a/app/api/widget/badge/route.ts
+++ b/app/api/widget/badge/route.ts
@@ -41,7 +41,15 @@ export const revalidate = 3600;
 export async function GET(request: NextRequest) {
   const params = request.nextUrl.searchParams;
   const type = params.get("type");
-  const slug = params.get("slug")?.trim() ?? "";
+  // Sanitize slug to the slug charset before it is ever echoed back. The 404
+  // branches below interpolate it into a `/* … "${slug}" … */` JS comment
+  // served as application/javascript; an unsanitized `*/<payload>/*` would
+  // break out of the comment and inject script. Slugs are always [a-z0-9-],
+  // so stripping everything else is lossless for legitimate lookups.
+  const slug = (params.get("slug") ?? "")
+    .trim()
+    .replace(/[^a-z0-9-]/gi, "")
+    .slice(0, 100);
   const theme = params.get("theme") === "dark" ? "dark" : "light";
   const ref = params.get("ref") || "";
 


### PR DESCRIPTION
**Tier C (security)** — do not merge; founder review.

Two verified, reproduced security fixes.

## CODE FIX 1 — LLM wallet-DoS (P2) · `app/api/chatbot/route.ts`
The limiter keyed only on the client-supplied body `session_id`. An anonymous caller could rotate `session_id` on every request, so the per-session token bucket never depleted and the Anthropic provider bill was effectively uncapped (provider-bill DoS). The sibling LLM routes (`concierge`, `investor/copilot`, `calculator/explain`) all key on `ipKey(req)`.

Fix: add an IP-keyed bucket `isAllowed("chatbot_ip", ipKey(request), { max: 40, refillPerSec: 40/60 })` checked **ahead of** the per-session bucket (returns `429 "Too many requests."`). The per-session limit (20/min) stays as the UX guard. `ipKey` is imported from `@/lib/rate-limit-db` — the same module the route already imported `isAllowed` from, matching the sibling routes.

## CODE FIX 2 — script-injection primitive (P3) · `app/api/widget/badge/route.ts`
The two 404 branches interpolated the request `slug` (only `.trim()`'d) into a `/* … "${slug}" … */` JS comment served as `application/javascript`. A slug like `*/<payload>/*` terminated the comment early and broke out into executable script.

Fix: sanitize once at the read site — `(params.get("slug") ?? "").trim().replace(/[^a-z0-9-]/gi, "").slice(0, 100)`. This covers **both** 404 interpolation points and the downstream `.eq("slug", …)` DB lookup. Slugs are always `[a-z0-9-]`, so the strip is lossless for real entities.

## Tests
- `__tests__/api/chatbot.test.ts` — asserts a 2nd request from the **same IP with a different `session_id`** is still `429` (the IP bucket holds across session rotation), plus a happy-path test that both buckets are consulted (IP first). Added `ipKey` to the `@/lib/rate-limit-db` mock.
- `__tests__/api/widget-badge.test.ts` — asserts a malicious slug cannot emit an extra `*/` (only the template's own terminator survives) and that the comment/script metacharacters never reach the body or the DB query.

## Verification (local)
- `NODE_OPTIONS=--max-old-space-size=5120 npx tsc --noEmit` — clean
- `npx vitest run __tests__/api/chatbot.test.ts __tests__/api/widget-badge.test.ts` — 46 passed
- `npx eslint <changed files>` — clean
- pre-push hook (type-check + rate-limit audit + changed-file tests) — all passed

https://claude.ai/code/session_01AX16WTaqAs2W33uydbBWLa

---
_Generated by [Claude Code](https://claude.ai/code/session_01AX16WTaqAs2W33uydbBWLa)_