### PR TITLE
fix(a11y): focus-trap + Escape on exit-intent modals, mega-menu Escape, collapsible aria

### DIFF
--- a/__tests__/components/CollapsibleSection.test.tsx
+++ b/__tests__/components/CollapsibleSection.test.tsx
@@ -106,4 +106,56 @@ describe("CollapsibleSection", () => {
     });
     expect(screen.queryByText(/Show all/)).not.toBeInTheDocument();
   });
+
+  // ── a11y: aria-expanded / aria-controls / inert (WCAG 2.4.3, 1.3.1) ──────────
+
+  function renderCollapsed() {
+    const utils = render(
+      <CollapsibleSection collapsedHeight={100} totalCount={12} itemLabel="reviews">
+        <div data-testid="body">
+          <a href="/hidden-link">a link clipped below the fold</a>
+        </div>
+      </CollapsibleSection>,
+    );
+    const inner = utils.container.querySelector("div");
+    Object.defineProperty(inner, "scrollHeight", { configurable: true, value: 600 });
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+    return utils;
+  }
+
+  it("the collapsed toggle exposes aria-expanded=false and aria-controls", () => {
+    renderCollapsed();
+    const toggle = screen.getByRole("button", { name: /Show all 12 reviews/ });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    const controls = toggle.getAttribute("aria-controls");
+    expect(controls).toBeTruthy();
+    // aria-controls must point at the actual content container.
+    expect(document.getElementById(controls!)).toBeInTheDocument();
+  });
+
+  it("marks the clipped content inert so it is out of the tab order while collapsed", () => {
+    renderCollapsed();
+    const toggle = screen.getByRole("button", { name: /Show all 12 reviews/ });
+    const region = document.getElementById(toggle.getAttribute("aria-controls")!);
+    // React 19 renders the boolean `inert` prop as the `inert` attribute, which
+    // takes the whole clipped subtree (and its links) out of the tab order.
+    expect(region).toHaveAttribute("inert");
+  });
+
+  it("the expanded toggle exposes aria-expanded=true after Show all is clicked", () => {
+    renderCollapsed();
+    const showAll = screen.getByRole("button", { name: /Show all 12 reviews/ });
+    act(() => {
+      showAll.click();
+    });
+    const showLess = screen.getByRole("button", { name: /Show less/ });
+    expect(showLess).toHaveAttribute("aria-expanded", "true");
+    expect(showLess).toHaveAttribute("aria-controls");
+    // Once expanded, the content is no longer inert (link is reachable).
+    const controls = showLess.getAttribute("aria-controls")!;
+    const region = document.getElementById(controls)!;
+    expect(region).not.toHaveAttribute("inert");
+  });
 });

--- a/__tests__/components/ExitIntentModal.test.tsx
+++ b/__tests__/components/ExitIntentModal.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act, waitFor } from "./setup";
+import ExitIntentModal from "@/components/ExitIntentModal";
+
+// form-tracking fires sendBeacon/fetch — stub it out so the modal's
+// view/abandon instrumentation is a no-op in jsdom.
+vi.mock("@/lib/form-tracking", () => ({
+  recordFormEvent: vi.fn(),
+  getOrCreateSessionId: () => "test-session",
+}));
+
+/**
+ * Trip the desktop exit-intent trigger: cursor leaves through the very
+ * top of the viewport (clientY <= 0).
+ */
+function fireExitIntent() {
+  act(() => {
+    document.dispatchEvent(
+      new MouseEvent("mouseleave", { clientY: 0, bubbles: true }),
+    );
+  });
+}
+
+describe("ExitIntentModal — keyboard / focus a11y", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    localStorage.clear();
+    vi.clearAllMocks();
+    // fetch may be undefined in jsdom — give the submit path something safe.
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("does not render until the exit-intent trigger fires", () => {
+    render(<ExitIntentModal />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("opens the dialog when the cursor leaves through the top", () => {
+    render(<ExitIntentModal />);
+    fireExitIntent();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("gives the email input an accessible name (label, not placeholder-only)", () => {
+    render(<ExitIntentModal />);
+    fireExitIntent();
+    // getByLabelText resolves via the <label htmlFor> association.
+    const email = screen.getByLabelText(/email address/i);
+    expect(email).toBeInTheDocument();
+    expect(email).toHaveAttribute("type", "email");
+  });
+
+  it("moves focus into the dialog when it opens", async () => {
+    render(<ExitIntentModal />);
+    fireExitIntent();
+    const dialog = screen.getByRole("dialog");
+    await waitFor(() => {
+      expect(dialog.contains(document.activeElement)).toBe(true);
+    });
+  });
+
+  it("closes on Escape", async () => {
+    render(<ExitIntentModal />);
+    fireExitIntent();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    });
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+
+  it("restores focus to the triggering element after Escape closes it", async () => {
+    // A real focusable element that holds focus before the modal opens.
+    const trigger = document.createElement("button");
+    trigger.textContent = "open-trigger";
+    document.body.appendChild(trigger);
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+
+    render(<ExitIntentModal />);
+    fireExitIntent();
+
+    const dialog = screen.getByRole("dialog");
+    await waitFor(() => {
+      expect(dialog.contains(document.activeElement)).toBe(true);
+    });
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+    // Focus returns to the element that was focused before opening.
+    expect(document.activeElement).toBe(trigger);
+
+    trigger.remove();
+  });
+
+  it("traps Tab focus within the dialog (Tab past the last control wraps to the first)", async () => {
+    render(<ExitIntentModal />);
+    fireExitIntent();
+    const dialog = screen.getByRole("dialog");
+    const focusables = Array.from(
+      dialog.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      ),
+    );
+    expect(focusables.length).toBeGreaterThan(1);
+    const last = focusables[focusables.length - 1]!;
+    const first = focusables[0]!;
+    last.focus();
+    expect(document.activeElement).toBe(last);
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab" }));
+    });
+    expect(document.activeElement).toBe(first);
+  });
+});

--- a/__tests__/components/NewsletterExitIntentModal.test.tsx
+++ b/__tests__/components/NewsletterExitIntentModal.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Deliberately does NOT import ./setup — the shared setup hard-mocks
+ * next/navigation's usePathname to "/", and the newsletter modal is gated
+ * to NOT fire on the homepage. We need an eligible content path, so this
+ * file owns its own next/navigation mock (which would otherwise lose to
+ * setup's). The modal only depends on usePathname + getSessionId + fetch,
+ * so none of setup's other mocks (next/link, next/image, useUser) are needed.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import NewsletterExitIntentModal from "@/components/NewsletterExitIntentModal";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/article/best-etfs-australia",
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  useParams: () => ({}),
+}));
+
+/** Trip the desktop trigger: cursor leaves through the top (clientY <= 10). */
+function fireExitIntent() {
+  act(() => {
+    document.dispatchEvent(
+      new MouseEvent("mouseleave", { clientY: 0, bubbles: true }),
+    );
+  });
+}
+
+describe("NewsletterExitIntentModal — keyboard / focus a11y", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    localStorage.clear();
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("opens on the exit-intent trigger for an eligible content path", () => {
+    render(<NewsletterExitIntentModal />);
+    fireExitIntent();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("gives the email input an accessible name (label, not placeholder-only)", () => {
+    render(<NewsletterExitIntentModal />);
+    fireExitIntent();
+    const email = screen.getByLabelText(/email address/i);
+    expect(email).toBeInTheDocument();
+    expect(email).toHaveAttribute("type", "email");
+  });
+
+  it("moves focus into the dialog when it opens", async () => {
+    render(<NewsletterExitIntentModal />);
+    fireExitIntent();
+    const dialog = screen.getByRole("dialog");
+    await waitFor(() => {
+      expect(dialog.contains(document.activeElement)).toBe(true);
+    });
+  });
+
+  it("closes on Escape and restores focus to the trigger", async () => {
+    const trigger = document.createElement("button");
+    document.body.appendChild(trigger);
+    trigger.focus();
+
+    render(<NewsletterExitIntentModal />);
+    fireExitIntent();
+    const dialog = screen.getByRole("dialog");
+    await waitFor(() => {
+      expect(dialog.contains(document.activeElement)).toBe(true);
+    });
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+    expect(document.activeElement).toBe(trigger);
+
+    trigger.remove();
+  });
+});

--- a/components/CollapsibleSection.tsx
+++ b/components/CollapsibleSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useId } from "react";
 
 interface CollapsibleSectionProps {
   /** Max height in px when collapsed on mobile. Content beyond this is clipped with a fade. */
@@ -21,6 +21,7 @@ export default function CollapsibleSection({
   const [isExpanded, setIsExpanded] = useState(false);
   const [needsCollapse, setNeedsCollapse] = useState(false);
   const contentRef = useRef<HTMLDivElement>(null);
+  const contentId = useId();
 
   // Check if content is tall enough to need collapsing
   useEffect(() => {
@@ -41,11 +42,13 @@ export default function CollapsibleSection({
   // If content is short enough, just render normally
   if (!needsCollapse || isExpanded) {
     return (
-      <div ref={contentRef}>
+      <div ref={contentRef} id={contentId}>
         {children}
         {needsCollapse && isExpanded && (
           <button
             onClick={() => setIsExpanded(false)}
+            aria-expanded={true}
+            aria-controls={contentId}
             className="w-full mt-3 py-2.5 text-sm font-medium text-slate-500 hover:text-slate-700 transition-colors flex items-center justify-center gap-1.5"
           >
             <svg className="w-3.5 h-3.5 rotate-180" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -60,8 +63,14 @@ export default function CollapsibleSection({
 
   return (
     <div>
+      {/* `inert` keeps the clipped (visually hidden) content out of the tab
+          order and the accessibility tree while collapsed — without it,
+          links beyond `collapsedHeight` are still Tab-focusable behind
+          overflow:hidden (WCAG 2.4.3). "Show all" reveals + re-enables it. */}
       <div
         ref={contentRef}
+        id={contentId}
+        inert
         className="relative overflow-hidden"
         style={{ maxHeight: `${collapsedHeight}px` }}
       >
@@ -71,6 +80,8 @@ export default function CollapsibleSection({
       </div>
       <button
         onClick={() => setIsExpanded(true)}
+        aria-expanded={false}
+        aria-controls={contentId}
         className="w-full mt-2 py-2.5 text-sm font-semibold text-blue-700 hover:text-blue-800 bg-blue-50 hover:bg-blue-100 rounded-lg transition-colors flex items-center justify-center gap-1.5"
       >
         Show all {totalCount} {itemLabel}

--- a/components/ExitIntentModal.tsx
+++ b/components/ExitIntentModal.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import { recordFormEvent, getOrCreateSessionId } from "@/lib/form-tracking";
+import { useDialogA11y } from "@/lib/hooks/useDialogA11y";
+import { Input } from "@/components/ui/Input";
 
 /**
  * Exit-intent modal.
@@ -45,6 +47,7 @@ export default function ExitIntentModal({
   const [email, setEmail] = useState("");
   const [status, setStatus] = useState<"idle" | "sending" | "done" | "error">("idle");
   const [error, setError] = useState<string | null>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
 
   // Open handler — triggered on mouseleave top OR pagehide
   const trigger = useCallback(() => {
@@ -72,6 +75,11 @@ export default function ExitIntentModal({
     },
     [],
   );
+
+  // Escape-to-close + focus trap + initial focus + focus restoration.
+  // Escape is treated as a manual close (same as the × button).
+  const closeFromEscape = useCallback(() => dismiss("close"), [dismiss]);
+  useDialogA11y({ open, onClose: closeFromEscape, containerRef: dialogRef });
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -133,6 +141,7 @@ export default function ExitIntentModal({
 
   return (
     <div
+      ref={dialogRef}
       className="fixed inset-0 z-[9999] flex items-center justify-center bg-slate-900/70 backdrop-blur-sm px-4"
       role="dialog"
       aria-modal="true"
@@ -158,14 +167,15 @@ export default function ExitIntentModal({
           </div>
         ) : (
           <form onSubmit={submit} className="space-y-3">
-            <input
+            <Input
+              id="exit-intent-email"
+              label="Email address"
               type="email"
               required
               autoComplete="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               placeholder="you@example.com"
-              className="w-full px-3 py-2 border border-slate-300 rounded focus:ring-2 focus:ring-amber-400 focus:border-amber-400 outline-none"
             />
             {error && (
               <p role="alert" className="text-xs text-red-700">

--- a/components/NewsletterExitIntentModal.tsx
+++ b/components/NewsletterExitIntentModal.tsx
@@ -3,6 +3,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { usePathname } from "next/navigation";
 import { getSessionId } from "@/lib/session";
+import { useDialogA11y } from "@/lib/hooks/useDialogA11y";
+import { Input } from "@/components/ui/Input";
 
 /**
  * Wave 16 — Newsletter-focused exit-intent modal.
@@ -36,6 +38,7 @@ export default function NewsletterExitIntentModal({
   const [msg, setMsg] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const firedRef = useRef(false);
+  const dialogRef = useRef<HTMLDivElement>(null);
 
   const logEvent = useCallback(
     (action: "shown" | "dismissed" | "converted_subscribe" | "converted_quiz") => {
@@ -167,6 +170,9 @@ export default function NewsletterExitIntentModal({
     logEvent("dismissed");
   }, [logEvent]);
 
+  // Escape-to-close + focus trap + initial focus + focus restoration.
+  useDialogA11y({ open, onClose: dismiss, containerRef: dialogRef });
+
   const subscribe = async (e: React.FormEvent) => {
     e.preventDefault();
     setSubmitting(true);
@@ -194,6 +200,7 @@ export default function NewsletterExitIntentModal({
 
   return (
     <div
+      ref={dialogRef}
       role="dialog"
       aria-modal="true"
       aria-label="Newsletter signup"
@@ -227,13 +234,15 @@ export default function NewsletterExitIntentModal({
           </p>
         ) : (
           <form onSubmit={subscribe} className="space-y-3">
-            <input
+            <Input
+              id="newsletter-exit-email"
+              label="Email address"
               required
               type="email"
+              autoComplete="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               placeholder="you@example.com"
-              className="w-full rounded-lg border border-slate-300 px-3 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-500/40"
             />
             <button
               type="submit"

--- a/components/layout/Navigation.tsx
+++ b/components/layout/Navigation.tsx
@@ -168,6 +168,7 @@ function MegaMenuDropdown({
   const [open, setOpen] = useState(false);
   const timeout = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const ref = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
 
   const enter = useCallback(() => {
     clearTimeout(timeout.current);
@@ -178,6 +179,24 @@ function MegaMenuDropdown({
     timeout.current = setTimeout(() => setOpen(false), 120);
   }, []);
 
+  // Keyboard users must be able to dismiss the dropdown (WCAG 2.1.1).
+  // Escape closes it and returns focus to the trigger button.
+  const onKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "Escape") {
+      setOpen(false);
+      triggerRef.current?.focus();
+    }
+  }, []);
+
+  // Close when focus leaves the menu entirely (Tab past the last item).
+  // relatedTarget is the element receiving focus; if it's outside this
+  // wrapper, the menu has been tabbed out of and should collapse.
+  const onBlur = useCallback((e: React.FocusEvent<HTMLDivElement>) => {
+    if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
+      setOpen(false);
+    }
+  }, []);
+
   useEffect(() => () => clearTimeout(timeout.current), []);
 
   return (
@@ -186,8 +205,11 @@ function MegaMenuDropdown({
       className="relative"
       onMouseEnter={enter}
       onMouseLeave={leave}
+      onKeyDown={onKeyDown}
+      onBlur={onBlur}
     >
       <button
+        ref={triggerRef}
         onClick={() => setOpen((v) => !v)}
         // whitespace-nowrap prevents multi-word labels ("Find an advisor",
         // "Compare platforms", "Browse listings", "Post a job") from breaking

--- a/lib/hooks/useDialogA11y.ts
+++ b/lib/hooks/useDialogA11y.ts
@@ -1,0 +1,104 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+/**
+ * Keyboard / focus accessibility for modal dialogs.
+ *
+ * Ports the Escape-to-close + focus-trap + initial-focus + focus-restoration
+ * pattern that already lives in `components/BottomSheet.tsx` and
+ * `components/ConfirmDialog.tsx` into a single reusable hook so dialogs don't
+ * each re-implement it (WCAG 2.1.1 keyboard, 2.4.3 focus order).
+ *
+ * Usage:
+ *   const dialogRef = useRef<HTMLDivElement>(null);
+ *   useDialogA11y({ open, onClose, containerRef: dialogRef });
+ *   return open ? <div ref={dialogRef} role="dialog" aria-modal="true">…</div> : null;
+ *
+ * While `open`:
+ *   - Escape calls `onClose`.
+ *   - Tab / Shift+Tab cycle within the container (focus trap).
+ *   - The first focusable element (or `initialFocusRef`, if given) is focused.
+ *   - On close, focus returns to whatever was focused before the dialog opened.
+ */
+const FOCUSABLE_SELECTOR =
+  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+interface UseDialogA11yOptions {
+  /** Whether the dialog is currently rendered/visible. */
+  open: boolean;
+  /** Called when the user presses Escape. */
+  onClose: () => void;
+  /** Ref to the dialog container that owns the focusable elements. */
+  containerRef: React.RefObject<HTMLElement | null>;
+  /** Optional element to focus first instead of the first focusable child. */
+  initialFocusRef?: React.RefObject<HTMLElement | null>;
+}
+
+export function useDialogA11y({
+  open,
+  onClose,
+  containerRef,
+  initialFocusRef,
+}: UseDialogA11yOptions): void {
+  // Keep latest onClose without re-subscribing the listener (or re-running the
+  // focus capture/restore) every time the parent passes a new callback identity.
+  const onCloseRef = useRef(onClose);
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    // Remember what had focus so we can restore it when the dialog closes.
+    const previouslyFocused =
+      typeof document !== "undefined"
+        ? (document.activeElement as HTMLElement | null)
+        : null;
+
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onCloseRef.current();
+        return;
+      }
+      // Focus trap: cycle Tab within the container.
+      if (e.key === "Tab" && containerRef.current) {
+        const focusable = Array.from(
+          containerRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+        );
+        if (focusable.length === 0) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (!first || !last) return;
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    document.addEventListener("keydown", handleKey);
+
+    // Move focus into the dialog after it paints.
+    const focusTimer = setTimeout(() => {
+      const target =
+        initialFocusRef?.current ??
+        containerRef.current?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR) ??
+        containerRef.current;
+      target?.focus();
+    }, 0);
+
+    return () => {
+      document.removeEventListener("keydown", handleKey);
+      clearTimeout(focusTimer);
+      // Restore focus to the trigger (only if it's still in the document).
+      if (previouslyFocused && document.contains(previouslyFocused)) {
+        previouslyFocused.focus();
+      }
+    };
+  }, [open, containerRef, initialFocusRef]);
+}


### PR DESCRIPTION
## What

Closes WCAG keyboard/focus interaction gaps from the a11y audit by porting the existing Escape-to-close + focus-trap + initial-focus pattern from `components/BottomSheet.tsx` / `components/ConfirmDialog.tsx` into a small shared hook (`lib/hooks/useDialogA11y.ts`, which additionally adds focus **restoration**), then applying targeted per-component fixes.

### 1. Exit-intent modals — `ExitIntentModal.tsx` + `NewsletterExitIntentModal.tsx`
Both fire on every content page with `role=dialog`/`aria-modal`/`aria-labelledby` but had **no** Escape-to-close, focus trap, initial focus, or focus restoration (WCAG 2.4.3 Focus Order, 2.1.1 Keyboard) — a keyboard user could be stranded behind the modal. Both now wire `useDialogA11y`. Escape on `ExitIntentModal` is treated as an explicit close (same as the × button).

Their email inputs were **placeholder-only with no accessible name** (3.3.2 Labels, 4.1.2 Name/Role/Value). Replaced the raw `<input>` with the labelled `components/ui/Input.tsx` (real `<label htmlFor>`).

### 2. Mega-menu dropdowns — `Navigation.tsx` (`MegaMenuDropdown`)
Had `aria-expanded`/`aria-haspopup` but a keyboard user couldn't dismiss it and it never closed on focus-out (2.1.1). Added an Escape handler (closes + returns focus to the trigger button) and a focus-out handler (collapses when focus leaves the wrapper). Hover/click behaviour unchanged.

### 3. `CollapsibleSection.tsx`
Clipped content with `overflow:hidden` but left it **Tab-focusable while visually hidden**, and the toggle exposed no state (2.4.3, 1.3.1). The collapsed region is now `inert` (out of the tab order and a11y tree until revealed); both toggles expose `aria-expanded` + `aria-controls`.

## Tests
- `__tests__/components/ExitIntentModal.test.tsx` (new) — opens on trigger, accessible email name, initial focus into dialog, Escape closes, **focus restored to trigger**, Tab focus-trap wraps.
- `__tests__/components/NewsletterExitIntentModal.test.tsx` (new) — opens on an eligible content path, accessible email name, initial focus, Escape closes + restores focus. (Owns its own `next/navigation` mock — the shared `./setup` pins `usePathname` to `/`, where this modal is gated off.)
- `__tests__/components/CollapsibleSection.test.tsx` (extended) — toggle exposes `aria-expanded`/`aria-controls`, clipped region is `inert`, expanded toggle reports `aria-expanded=true` and drops `inert`.

## Verification
- `NODE_OPTIONS=--max-old-space-size=5120 npx tsc --noEmit` — clean
- `npx eslint --max-warnings 0 <changed>` — clean
- 19 a11y tests green; sampled sibling component tests unaffected (40 green together)
- pre-push hook (type-check + rate-limit audit + changed-file tests) passed

## Known follow-up (out of scope)
`PostcodeAutocomplete` combobox arrow-key navigation (a more involved `role=combobox`/`aria-activedescendant` pattern) is intentionally **not** in this PR.

Tier B (a11y). Draft — do not merge.

https://claude.ai/code/session_01AX16WTaqAs2W33uydbBWLa

---
_Generated by [Claude Code](https://claude.ai/code/session_01AX16WTaqAs2W33uydbBWLa)_