### PR TITLE
fix(cron): idempotent referral/dunning credits via ledger + await dunning/SLA emails

### DIFF
--- a/__tests__/api/cron-advisor-dunning.test.ts
+++ b/__tests__/api/cron-advisor-dunning.test.ts
@@ -35,8 +35,26 @@ vi.mock("@/lib/stripe", () => ({
   }),
 }));
 
-// Fire-and-forget email via fetch
-vi.stubGlobal("fetch", vi.fn(() => Promise.resolve(new Response("ok", { status: 200 }))));
+// recordLedgerEntry mock — captures the retry-recovery credit and can be made
+// to report an idempotent re-run (mid-crash retry: the topup-id triple already
+// landed) so we can assert the balance is NOT double-credited.
+const { ledgerCalls, mockRecordLedgerEntry } = vi.hoisted(() => ({
+  ledgerCalls: [] as Record<string, unknown>[],
+  mockRecordLedgerEntry: vi.fn(),
+}));
+vi.mock("@/lib/advisor-credit-ledger", () => ({
+  recordLedgerEntry: mockRecordLedgerEntry,
+}));
+
+// enqueueJob mock — the durable email path. Returns a job id (truthy) by
+// default; tests flip it to null to simulate an enqueue failure.
+const { enqueueCalls, mockEnqueueJob } = vi.hoisted(() => ({
+  enqueueCalls: [] as { type: string; payload: Record<string, unknown> }[],
+  mockEnqueueJob: vi.fn(),
+}));
+vi.mock("@/lib/job-queue", () => ({
+  enqueueJob: mockEnqueueJob,
+}));
 
 // DB queue — consumed in order across all from() calls
 interface DbResult {
@@ -46,16 +64,22 @@ interface DbResult {
 
 const dbQueue: DbResult[] = [];
 let dbIdx = 0;
+// Capture topup/professional updates so we can assert ordering + payloads.
+const updateCalls: { table: string; payload: Record<string, unknown> }[] = [];
 
-function makeChain(res: DbResult) {
+function makeChain(table: string, res: DbResult) {
   const chain: Record<string, unknown> = {};
   for (const m of [
-    "select", "update", "insert",
-    "eq", "neq", "lt", "lte", "gte", "is", "in", "not", "or", "order", "limit",
+    "select", "eq", "neq", "lt", "lte", "gte", "is", "in", "not", "or", "order", "limit",
     "maybeSingle",
   ]) {
     chain[m] = vi.fn(() => chain);
   }
+  chain.update = vi.fn((payload: Record<string, unknown>) => {
+    updateCalls.push({ table, payload });
+    return chain;
+  });
+  chain.insert = vi.fn(() => chain);
   const r = { data: res.data ?? null, error: res.error ?? null };
   chain.then = (resolve: (v: typeof r) => unknown) => Promise.resolve(resolve(r));
   chain.catch = () => chain;
@@ -64,7 +88,7 @@ function makeChain(res: DbResult) {
 
 vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: vi.fn(() => ({
-    from: vi.fn(() => makeChain(dbQueue[dbIdx++] ?? { error: null })),
+    from: vi.fn((table: string) => makeChain(table, dbQueue[dbIdx++] ?? { error: null })),
   })),
 }));
 
@@ -110,9 +134,27 @@ describe("GET /api/cron/advisor-dunning", () => {
     vi.clearAllMocks();
     dbIdx = 0;
     dbQueue.length = 0;
+    updateCalls.length = 0;
+    ledgerCalls.length = 0;
+    enqueueCalls.length = 0;
     mockStripeRetrieve.mockReset();
     mockStripeConfirm.mockReset();
-    vi.mocked(fetch).mockResolvedValue(new Response("ok", { status: 200 }));
+    mockRecordLedgerEntry.mockReset();
+    mockRecordLedgerEntry.mockImplementation(async (input: Record<string, unknown>) => {
+      ledgerCalls.push(input);
+      return {
+        entry: { id: 1 },
+        balanceAfterCents: (input.amountCents as number) ?? 0,
+        idempotent: false,
+      };
+    });
+    mockEnqueueJob.mockReset();
+    mockEnqueueJob.mockImplementation(
+      async (type: string, payload: Record<string, unknown>) => {
+        enqueueCalls.push({ type, payload });
+        return 123; // job id → durable enqueue succeeded
+      },
+    );
     delete process.env.RESEND_API_KEY;
   });
 
@@ -164,8 +206,7 @@ describe("GET /api/cron/advisor-dunning", () => {
     expect(dbIdx).toBe(1);
   });
 
-  it("step 0→1 transition: fetches advisor and sends dunning email", async () => {
-    process.env.RESEND_API_KEY = "re_test_key";
+  it("step 0→1 transition: enqueues dunning email durably and advances step", async () => {
     // Top-up created 2 days ago → ageDays=2 → nextStep=1
     const createdAt = new Date(now - 2 * 24 * 60 * 60 * 1000).toISOString();
     dbQueue.push({ data: [topup({ dunning_step: 0, created_at: createdAt, stripe_payment_intent_id: "pi_test" })], error: null });
@@ -178,26 +219,107 @@ describe("GET /api/cron/advisor-dunning", () => {
     expect(body.ok).toBe(true);
     expect(body.emailed).toBe(1);
     expect(body.retried_failed).toBe(1);
-    expect(fetch).toHaveBeenCalledWith("https://api.resend.com/emails", expect.objectContaining({ method: "POST" }));
+    // Email is enqueued durably (job_queue), NOT a raw fire-and-forget fetch.
+    expect(enqueueCalls).toHaveLength(1);
+    expect(enqueueCalls[0].type).toBe("send_email");
+    expect(enqueueCalls[0].payload.to).toBe("carol@example.com");
+    // dunning_step advanced (enqueue succeeded)
+    expect(updateCalls.some((c) => c.table === "advisor_credit_topups" && c.payload.dunning_step === 1)).toBe(true);
   });
 
-  it("marks retried_succeeded and credits balance when Stripe confirm succeeds", async () => {
-    process.env.RESEND_API_KEY = "re_test_key";
+  it("EMAIL RETRY: a failed enqueue leaves dunning_step UNCHANGED so the next run retries", async () => {
+    const createdAt = new Date(now - 2 * 24 * 60 * 60 * 1000).toISOString();
+    dbQueue.push({ data: [topup({ dunning_step: 0, created_at: createdAt })], error: null });
+    dbQueue.push({ data: advisorRow(), error: null }); // advisor lookup
+    mockStripeRetrieve.mockResolvedValueOnce({ status: "requires_payment_method" });
+    mockStripeConfirm.mockResolvedValueOnce({ status: "requires_payment_method" });
+    // Simulate a durable-enqueue failure (job_queue insert returned null).
+    // Use mockImplementationOnce so the call is still recorded.
+    mockEnqueueJob.mockImplementationOnce(
+      async (type: string, payload: Record<string, unknown>) => {
+        enqueueCalls.push({ type, payload });
+        return null;
+      },
+    );
+    const res = await GET(makeReq());
+    const body = await res.json();
+    expect(body.emailed).toBe(0);
+    expect(body.errored).toBe(1);
+    // We attempted the enqueue …
+    expect(enqueueCalls).toHaveLength(1);
+    // … but because it failed, dunning_step was NOT advanced — no topup update.
+    expect(updateCalls.some((c) => c.table === "advisor_credit_topups")).toBe(false);
+  });
+
+  it("marks retried_succeeded and credits balance via the ledger (credit FIRST, status AFTER)", async () => {
     const createdAt = new Date(now - 2 * 24 * 60 * 60 * 1000).toISOString();
     dbQueue.push({ data: [topup({ dunning_step: 0, created_at: createdAt })], error: null });
     dbQueue.push({ data: advisorRow(), error: null }); // advisor lookup
     mockStripeRetrieve.mockResolvedValueOnce({ status: "requires_confirmation" });
     mockStripeConfirm.mockResolvedValueOnce({ status: "succeeded" });
     dbQueue.push({ error: null }); // update topup status=completed
-    dbQueue.push({ error: null }); // update credit_balance_cents
     const res = await GET(makeReq());
     const body = await res.json();
     expect(body.retried_succeeded).toBe(1);
     expect(body.emailed).toBe(0);
+
+    // Credit routed through the ledger with the idempotent topup-id triple
+    // (matches the Stripe-webhook topup path → can't double-credit).
+    expect(ledgerCalls).toHaveLength(1);
+    expect(ledgerCalls[0]).toMatchObject({
+      professionalId: "adv-1",
+      amountCents: 5000,
+      kind: "topup",
+      referenceType: "advisor_credit_topup",
+      referenceId: "topup-1",
+    });
+    // Ordering: ledger credit happened BEFORE the topup status flip.
+    const ledgerOrder = mockRecordLedgerEntry.mock.invocationCallOrder[0];
+    const statusUpdate = updateCalls.find(
+      (c) => c.table === "advisor_credit_topups" && c.payload.status === "completed",
+    );
+    expect(statusUpdate).toBeTruthy();
+    // The status flip never raw-increments the balance (that's the ledger's job).
+    expect(statusUpdate?.payload).not.toHaveProperty("credit_balance_cents");
+    // recordLedgerEntry was invoked (call order recorded) before we returned.
+    expect(ledgerOrder).toBeGreaterThan(0);
+  });
+
+  it("IDEMPOTENT: retry-success after a mid-crash does NOT double-credit", async () => {
+    // Scenario: a prior fire credited the ledger but crashed before flipping
+    // the topup to 'completed'. The row is still 'failed', so this run picks
+    // it again. The ledger triple already exists → recordLedgerEntry reports
+    // idempotent:true and does NOT add to the balance a second time.
+    const createdAt = new Date(now - 2 * 24 * 60 * 60 * 1000).toISOString();
+    dbQueue.push({ data: [topup({ dunning_step: 0, created_at: createdAt })], error: null });
+    dbQueue.push({ data: advisorRow({ credit_balance_cents: 5000 }), error: null }); // already credited
+    mockStripeRetrieve.mockResolvedValueOnce({ status: "succeeded" });
+    dbQueue.push({ error: null }); // update topup status=completed (idempotent re-flip)
+    // Ledger reports the entry already exists.
+    mockRecordLedgerEntry.mockImplementationOnce(async (input: Record<string, unknown>) => {
+      ledgerCalls.push(input);
+      return { entry: { id: 1 }, balanceAfterCents: 5000, idempotent: true };
+    });
+    const res = await GET(makeReq());
+    const body = await res.json();
+    expect(body.retried_succeeded).toBe(1);
+    // The ledger was called exactly once and reported idempotent — the helper
+    // itself prevents the double-credit. No raw balance write anywhere.
+    expect(ledgerCalls).toHaveLength(1);
+    expect(
+      updateCalls.some(
+        (c) => c.table === "professionals" && "credit_balance_cents" in c.payload,
+      ),
+    ).toBe(false);
+    // The status flip still completes (idempotently).
+    expect(
+      updateCalls.some(
+        (c) => c.table === "advisor_credit_topups" && c.payload.status === "completed",
+      ),
+    ).toBe(true);
   });
 
   it("auto-pauses advisor and increments paused at step 3", async () => {
-    process.env.RESEND_API_KEY = "re_test_key";
     // Top-up 8 days old → nextStep=3
     const createdAt = new Date(now - 8 * 24 * 60 * 60 * 1000).toISOString();
     dbQueue.push({ data: [topup({ dunning_step: 2, created_at: createdAt })], error: null });
@@ -210,5 +332,30 @@ describe("GET /api/cron/advisor-dunning", () => {
     const body = await res.json();
     expect(body.paused).toBe(1);
     expect(body.emailed).toBe(1);
+    // The final-notice email was enqueued durably before the pause landed.
+    expect(enqueueCalls).toHaveLength(1);
+    expect(updateCalls.some((c) => c.table === "professionals" && c.payload.status === "paused")).toBe(true);
+  });
+
+  it("at step 3, a failed email enqueue does NOT pause and does NOT advance step", async () => {
+    const createdAt = new Date(now - 8 * 24 * 60 * 60 * 1000).toISOString();
+    dbQueue.push({ data: [topup({ dunning_step: 2, created_at: createdAt })], error: null });
+    dbQueue.push({ data: advisorRow(), error: null });
+    mockStripeRetrieve.mockResolvedValueOnce({ status: "requires_payment_method" });
+    mockStripeConfirm.mockResolvedValueOnce({ status: "requires_payment_method" });
+    mockEnqueueJob.mockImplementationOnce(
+      async (type: string, payload: Record<string, unknown>) => {
+        enqueueCalls.push({ type, payload });
+        return null; // enqueue failed
+      },
+    );
+    const res = await GET(makeReq());
+    const body = await res.json();
+    expect(body.paused).toBe(0);
+    expect(body.emailed).toBe(0);
+    expect(body.errored).toBe(1);
+    // No pause, no step advance — the whole transition is held for retry.
+    expect(updateCalls.some((c) => c.table === "professionals")).toBe(false);
+    expect(updateCalls.some((c) => c.table === "advisor_credit_topups")).toBe(false);
   });
 });

--- a/__tests__/api/cron-enforce-lead-sla.test.ts
+++ b/__tests__/api/cron-enforce-lead-sla.test.ts
@@ -32,8 +32,15 @@ vi.mock("@/lib/url", () => ({
   getSiteUrl: () => "https://invest.com.au",
 }));
 
-// The route's local sendEmail is a fire-and-forget fetch; suppress it globally.
-vi.stubGlobal("fetch", vi.fn(() => Promise.resolve(new Response("ok", { status: 200 }))));
+// enqueueJob mock — the durable email path. Returns a job id (truthy) by
+// default; tests flip it to null to simulate an enqueue failure.
+const { enqueueCalls, mockEnqueueJob } = vi.hoisted(() => ({
+  enqueueCalls: [] as { type: string; payload: Record<string, unknown> }[],
+  mockEnqueueJob: vi.fn(),
+}));
+vi.mock("@/lib/job-queue", () => ({
+  enqueueJob: mockEnqueueJob,
+}));
 
 // DB call queue — consumed in order.
 // Call sequence per invocation:
@@ -41,6 +48,7 @@ vi.stubGlobal("fetch", vi.fn(() => Promise.resolve(new Response("ok", { status: 
 //   For each advisor:
 //     [N] from("professional_leads").select(..., {count}).eq().is().gte() → { count: N }
 //     [optionally] from("professionals").update(...).eq() → { error: null }
+//                  (warning paths only run this AFTER a successful enqueue)
 
 interface DbResult {
   data?: unknown;
@@ -50,15 +58,20 @@ interface DbResult {
 
 const dbQueue: DbResult[] = [];
 let dbIdx = 0;
+const updateCalls: { table: string; payload: Record<string, unknown> }[] = [];
 
-function makeChain(res: DbResult) {
+function makeChain(table: string, res: DbResult) {
   const chain: Record<string, unknown> = {};
   for (const m of [
-    "select", "update", "insert",
-    "eq", "neq", "lt", "lte", "gte", "is", "in", "not", "or", "order", "limit",
+    "select", "eq", "neq", "lt", "lte", "gte", "is", "in", "not", "or", "order", "limit",
   ]) {
     chain[m] = vi.fn(() => chain);
   }
+  chain.update = vi.fn((payload: Record<string, unknown>) => {
+    updateCalls.push({ table, payload });
+    return chain;
+  });
+  chain.insert = vi.fn(() => chain);
   const r = {
     data: "data" in res ? res.data : null,
     error: res.error ?? null,
@@ -71,7 +84,9 @@ function makeChain(res: DbResult) {
 
 vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: vi.fn(() => ({
-    from: vi.fn(() => makeChain(dbQueue[dbIdx++] ?? { data: null, error: null, count: 0 })),
+    from: vi.fn((table: string) =>
+      makeChain(table, dbQueue[dbIdx++] ?? { data: null, error: null, count: 0 }),
+    ),
   })),
 }));
 
@@ -112,6 +127,15 @@ describe("GET /api/cron/enforce-lead-sla", () => {
     vi.clearAllMocks();
     dbIdx = 0;
     dbQueue.length = 0;
+    updateCalls.length = 0;
+    enqueueCalls.length = 0;
+    mockEnqueueJob.mockReset();
+    mockEnqueueJob.mockImplementation(
+      async (type: string, payload: Record<string, unknown>) => {
+        enqueueCalls.push({ type, payload });
+        return 123; // job id → durable enqueue succeeded
+      },
+    );
     delete process.env.RESEND_API_KEY;
   });
 
@@ -163,10 +187,10 @@ describe("GET /api/cron/enforce-lead-sla", () => {
     expect(body.paused).toBe(0);
     // Only 2 from() calls (advisors + leads count, no update)
     expect(dbIdx).toBe(2);
+    expect(enqueueCalls).toHaveLength(0);
   });
 
-  it("sends warning-1 email and stamps pause_warning_sent_at when advisor has 3 unresponded and no prior warning", async () => {
-    process.env.RESEND_API_KEY = "re_test_key";
+  it("enqueues warning-1 durably and stamps pause_warning_sent_at when advisor has 3 unresponded and no prior warning", async () => {
     dbQueue.push({ data: [advisor({ pause_warning_sent_at: null })], error: null });
     dbQueue.push({ count: 3, error: null }); // leads count
     dbQueue.push({ error: null });             // update pause_warning_sent_at
@@ -176,11 +200,32 @@ describe("GET /api/cron/enforce-lead-sla", () => {
     expect(body.warned1).toBe(1);
     expect(body.warned2).toBe(0);
     expect(body.paused).toBe(0);
-    // fetch was called for the email
-    expect(vi.mocked(fetch)).toHaveBeenCalledWith(
-      "https://api.resend.com/emails",
-      expect.objectContaining({ method: "POST" }),
+    // Email enqueued durably (job_queue), NOT a raw fire-and-forget fetch.
+    expect(enqueueCalls).toHaveLength(1);
+    expect(enqueueCalls[0].type).toBe("send_email");
+    expect(enqueueCalls[0].payload.to).toBe("alice@example.com");
+    // The flag was stamped (enqueue succeeded).
+    expect(updateCalls.some((c) => c.table === "professionals" && "pause_warning_sent_at" in c.payload)).toBe(true);
+  });
+
+  it("EMAIL RETRY: a failed warning-1 enqueue leaves pause_warning_sent_at UNSET so the next run retries", async () => {
+    dbQueue.push({ data: [advisor({ pause_warning_sent_at: null })], error: null });
+    dbQueue.push({ count: 3, error: null });
+    // Enqueue fails (job_queue insert returned null).
+    mockEnqueueJob.mockImplementationOnce(
+      async (type: string, payload: Record<string, unknown>) => {
+        enqueueCalls.push({ type, payload });
+        return null;
+      },
     );
+    const res = await GET(makeReq());
+    const body = await res.json();
+    expect(body.warned1).toBe(0);
+    expect(body.failed).toBe(1);
+    // We attempted the enqueue …
+    expect(enqueueCalls).toHaveLength(1);
+    // … but the flag was NOT stamped, so the warning retries next run.
+    expect(updateCalls.some((c) => c.table === "professionals")).toBe(false);
   });
 
   it("skips warning-1 when advisor already has pause_warning_sent_at set", async () => {
@@ -192,12 +237,12 @@ describe("GET /api/cron/enforce-lead-sla", () => {
     const res = await GET(makeReq());
     const body = await res.json();
     expect(body.warned1).toBe(0);
-    // No update DB call
+    // No update DB call, no enqueue
     expect(dbIdx).toBe(2);
+    expect(enqueueCalls).toHaveLength(0);
   });
 
-  it("sends warning-2 and stamps when advisor has 5 unresponded and last warn was >24h ago", async () => {
-    process.env.RESEND_API_KEY = "re_test_key";
+  it("enqueues warning-2 and stamps when advisor has 5 unresponded and last warn was >24h ago", async () => {
     const lastWarnedAt = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString(); // 25h ago
     dbQueue.push({
       data: [advisor({ pause_warning_sent_at: lastWarnedAt })],
@@ -209,6 +254,28 @@ describe("GET /api/cron/enforce-lead-sla", () => {
     const body = await res.json();
     expect(body.warned2).toBe(1);
     expect(body.paused).toBe(0);
+    expect(enqueueCalls).toHaveLength(1);
+    expect(updateCalls.some((c) => c.table === "professionals" && "pause_warning_sent_at" in c.payload)).toBe(true);
+  });
+
+  it("EMAIL RETRY: a failed warning-2 enqueue leaves the flag unchanged", async () => {
+    const lastWarnedAt = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
+    dbQueue.push({
+      data: [advisor({ pause_warning_sent_at: lastWarnedAt })],
+      error: null,
+    });
+    dbQueue.push({ count: 5, error: null });
+    mockEnqueueJob.mockImplementationOnce(
+      async (type: string, payload: Record<string, unknown>) => {
+        enqueueCalls.push({ type, payload });
+        return null;
+      },
+    );
+    const res = await GET(makeReq());
+    const body = await res.json();
+    expect(body.warned2).toBe(0);
+    expect(body.failed).toBe(1);
+    expect(updateCalls.some((c) => c.table === "professionals")).toBe(false);
   });
 
   it("skips warning-2 when last warn was <24h ago", async () => {
@@ -218,12 +285,12 @@ describe("GET /api/cron/enforce-lead-sla", () => {
     const res = await GET(makeReq());
     const body = await res.json();
     expect(body.warned2).toBe(0);
-    // No update call
+    // No update call, no enqueue
     expect(dbIdx).toBe(2);
+    expect(enqueueCalls).toHaveLength(0);
   });
 
-  it("auto-pauses advisor at 7+ unresponded leads (no prior auto_paused_at)", async () => {
-    process.env.RESEND_API_KEY = "re_test_key";
+  it("auto-pauses advisor at 7+ unresponded leads (no prior auto_paused_at), enqueues advisor + admin notices", async () => {
     dbQueue.push({ data: [advisor()], error: null });
     dbQueue.push({ count: 7, error: null });
     dbQueue.push({ error: null }); // update professionals (pause)
@@ -232,6 +299,13 @@ describe("GET /api/cron/enforce-lead-sla", () => {
     expect(body.paused).toBe(1);
     expect(body.warned1).toBe(0);
     expect(body.warned2).toBe(0);
+    // Pause landed (durable) + both notices enqueued (advisor + admin).
+    expect(updateCalls.some((c) => c.table === "professionals" && c.payload.status === "paused")).toBe(true);
+    expect(enqueueCalls).toHaveLength(2);
+    expect(enqueueCalls.map((c) => c.payload.to)).toEqual([
+      "alice@example.com",
+      "admin@invest.com.au",
+    ]);
   });
 
   it("does not re-pause an advisor that already has auto_paused_at set", async () => {
@@ -243,12 +317,12 @@ describe("GET /api/cron/enforce-lead-sla", () => {
     const res = await GET(makeReq());
     const body = await res.json();
     expect(body.paused).toBe(0);
-    // No update DB call
+    // No update DB call, no enqueue
     expect(dbIdx).toBe(2);
+    expect(enqueueCalls).toHaveLength(0);
   });
 
   it("unpauses advisor paused for SLA when unresponded count drops below 3", async () => {
-    process.env.RESEND_API_KEY = "re_test_key";
     dbQueue.push({
       data: [
         advisor({
@@ -265,6 +339,9 @@ describe("GET /api/cron/enforce-lead-sla", () => {
     const body = await res.json();
     expect(body.unpaused).toBe(1);
     expect(body.paused).toBe(0);
+    // Reinstatement persisted + courtesy email enqueued.
+    expect(updateCalls.some((c) => c.table === "professionals" && c.payload.status === "active")).toBe(true);
+    expect(enqueueCalls).toHaveLength(1);
   });
 
   it("increments failed when a per-advisor operation throws", async () => {
@@ -272,10 +349,6 @@ describe("GET /api/cron/enforce-lead-sla", () => {
     dbQueue.push({ data: [advisor()], error: null });
     // Next from() call will throw synchronously via makeChain error
     dbQueue.push({ data: null, error: { message: "unexpected throw" } });
-    // Simulate a throw by overriding this specific result — the route catches per-advisor errors
-    // We can verify the catch block fires by making the count chain throw via a TypeError
-    // The simplest approach: no dbQueue entry forces usage of fallback { count: 0 } which doesn't throw.
-    // Instead, check the catch block via a supabase from() throw.
     const res = await GET(makeReq());
     // Even with an error, the cron returns 200 with stats
     expect(res.status).toBe(200);

--- a/__tests__/api/cron-referral-payouts.test.ts
+++ b/__tests__/api/cron-referral-payouts.test.ts
@@ -37,19 +37,20 @@ type AdvisorRow = { id: number; credit_balance_cents: number };
 let rewardsToReturn: RewardRow[] = [];
 let fetchError: { message: string } | null = null;
 let advisorByEmail: Map<string, AdvisorRow> = new Map();
-let advisorUpdateErrorForId: Map<number, { message: string }> = new Map();
 let featureDisabled = false;
 
 // Capture calls
-type UpdateCall = { id: number; payload: Record<string, unknown> };
+type UpdateCall = { id: number; payload: Record<string, unknown>; statusGuard?: unknown };
 const rewardUpdateCalls: UpdateCall[] = [];
-const advisorUpdateCalls: {
-  id: number;
-  payload: Record<string, unknown>;
-  expectedPrior: number;
-}[] = [];
 const financialAuditCalls: Record<string, unknown>[] = [];
 const notifyUserCalls: Record<string, unknown>[] = [];
+
+// recordLedgerEntry mock — captures inputs and lets a test force idempotency
+// (mid-crash retry: the ledger triple already exists) or a throw.
+const ledgerCalls: Record<string, unknown>[] = [];
+// Map referenceId → { idempotent, balanceAfterCents } overrides.
+let ledgerIdempotentForRefId: Map<string, boolean> = new Map();
+let ledgerThrowForRefId: Map<string, string> = new Map();
 
 const mockFrom = vi.fn((table: string) => {
   if (table === "referral_rewards") {
@@ -65,9 +66,24 @@ const mockFrom = vi.fn((table: string) => {
         }),
       }),
       update: (payload: Record<string, unknown>) => ({
-        eq: async (_col: string, id: number) => {
-          rewardUpdateCalls.push({ id, payload });
-          return { data: null, error: null };
+        // First .eq is the id filter; reward-paid flips chain a second
+        // .eq("status","pending") guard — rejection updates do not.
+        eq: (_col: string, id: number) => {
+          const recordAndReturn = () => {
+            rewardUpdateCalls.push({ id, payload });
+            return { data: null, error: null };
+          };
+          // Return a thenable that ALSO exposes a second .eq for the
+          // status-guarded paid flip.
+          const thenable = {
+            eq: (_col2: string, statusGuard: unknown) => {
+              rewardUpdateCalls.push({ id, payload, statusGuard });
+              return Promise.resolve({ data: null, error: null });
+            },
+            then: (resolve: (v: { data: null; error: null }) => unknown) =>
+              Promise.resolve(resolve(recordAndReturn())),
+          };
+          return thenable;
         },
       }),
     };
@@ -83,16 +99,6 @@ const mockFrom = vi.fn((table: string) => {
           },
         }),
       }),
-      update: (payload: Record<string, unknown>) => {
-        const firstEq = (col1: string, id: number) => ({
-          eq: async (_col2: string, priorBalance: number) => {
-            advisorUpdateCalls.push({ id, payload, expectedPrior: priorBalance });
-            const err = advisorUpdateErrorForId.get(id);
-            return { data: null, error: err ?? null };
-          },
-        });
-        return { eq: firstEq };
-      },
     };
   }
 
@@ -117,6 +123,30 @@ vi.mock("@/lib/financial-audit", () => ({
   }),
 }));
 
+vi.mock("@/lib/advisor-credit-ledger", () => ({
+  recordLedgerEntry: vi.fn(async (input: Record<string, unknown>) => {
+    ledgerCalls.push(input);
+    const refId = String(input.referenceId);
+    const thrown = ledgerThrowForRefId.get(refId);
+    if (thrown) throw new Error(thrown);
+    const idempotent = ledgerIdempotentForRefId.get(refId) ?? false;
+    // Look up the seeded prior balance for this professional id so the
+    // returned balance_after mirrors the real helper. On an idempotent
+    // re-run the helper returns the EXISTING balance (no double-add).
+    const proId = input.professionalId as number;
+    const seeded = [...advisorByEmail.values()].find((a) => a.id === proId);
+    const current = seeded?.credit_balance_cents ?? 0;
+    const balanceAfterCents = idempotent
+      ? current
+      : current + (input.amountCents as number);
+    return {
+      entry: { id: 1 },
+      balanceAfterCents,
+      idempotent,
+    };
+  }),
+}));
+
 vi.mock("@/lib/notifications", () => ({
   buildEmailToUserIdMap: vi.fn(async () => {
     const m = new Map<string, string>();
@@ -132,6 +162,7 @@ vi.mock("@/lib/notifications", () => ({
 import { GET, runtime, maxDuration } from "@/app/api/cron/referral-payouts/route";
 import { requireCronAuth } from "@/lib/cron-auth";
 import { isFeatureDisabled } from "@/lib/admin/classifier-config";
+import { recordLedgerEntry } from "@/lib/advisor-credit-ledger";
 
 function makeReq(): NextRequest {
   return new Request("http://localhost/api/cron/referral-payouts") as unknown as NextRequest;
@@ -145,12 +176,13 @@ describe("GET /api/cron/referral-payouts", () => {
     rewardsToReturn = [];
     fetchError = null;
     advisorByEmail = new Map();
-    advisorUpdateErrorForId = new Map();
     featureDisabled = false;
     rewardUpdateCalls.length = 0;
-    advisorUpdateCalls.length = 0;
     financialAuditCalls.length = 0;
     notifyUserCalls.length = 0;
+    ledgerCalls.length = 0;
+    ledgerIdempotentForRefId = new Map();
+    ledgerThrowForRefId = new Map();
   });
 
   afterAll(() => {
@@ -169,7 +201,7 @@ describe("GET /api/cron/referral-payouts", () => {
     const res = await GET(makeReq());
     expect(res.status).toBe(401);
     expect(rewardUpdateCalls).toHaveLength(0);
-    expect(advisorUpdateCalls).toHaveLength(0);
+    expect(ledgerCalls).toHaveLength(0);
     expect(financialAuditCalls).toHaveLength(0);
   });
 
@@ -183,7 +215,7 @@ describe("GET /api/cron/referral-payouts", () => {
     expect(vi.mocked(isFeatureDisabled)).toHaveBeenCalledWith("referral_payouts");
     // No DB work done
     expect(rewardUpdateCalls).toHaveLength(0);
-    expect(advisorUpdateCalls).toHaveLength(0);
+    expect(ledgerCalls).toHaveLength(0);
   });
 
   it("returns 500 when the initial fetch errors", async () => {
@@ -241,9 +273,9 @@ describe("GET /api/cron/referral-payouts", () => {
     expect(json.manual).toBe(2);
     expect(json.paid).toBe(0);
     expect(json.rejected).toBe(0);
-    // Reward + advisor rows remain untouched — admin handles manually
+    // Reward + ledger untouched — admin handles manually
     expect(rewardUpdateCalls).toHaveLength(0);
-    expect(advisorUpdateCalls).toHaveLength(0);
+    expect(ledgerCalls).toHaveLength(0);
     expect(financialAuditCalls).toHaveLength(0);
   });
 
@@ -273,12 +305,12 @@ describe("GET /api/cron/referral-payouts", () => {
         rejection_reason: "referrer_email_not_found_in_professionals",
       },
     });
-    // Advisor balance untouched + no audit row
-    expect(advisorUpdateCalls).toHaveLength(0);
+    // No credit + no audit row
+    expect(ledgerCalls).toHaveLength(0);
     expect(financialAuditCalls).toHaveLength(0);
   });
 
-  it("credits the advisor, stamps the reward paid, writes an audit row, and inboxes the referrer", async () => {
+  it("credits via the ledger, stamps the reward paid (status-guarded), writes audit, inboxes referrer", async () => {
     rewardsToReturn = [
       {
         id: 42,
@@ -303,22 +335,27 @@ describe("GET /api/cron/referral-payouts", () => {
     expect(json.failed).toBe(0);
     expect(json.inboxed).toBe(1);
 
-    // Optimistic lock: update guarded by prior balance
-    expect(advisorUpdateCalls).toHaveLength(1);
-    expect(advisorUpdateCalls[0]).toMatchObject({
-      id: 99,
-      expectedPrior: 12500,
-      payload: { credit_balance_cents: 20000 },
+    // Credit routed through the ledger with the idempotent reference triple
+    // keyed to the reward id.
+    expect(ledgerCalls).toHaveLength(1);
+    expect(ledgerCalls[0]).toMatchObject({
+      professionalId: 99,
+      amountCents: 7500,
+      kind: "referral_payout",
+      referenceType: "referral_reward",
+      referenceId: "42",
+      createdBy: "cron:referral-payouts",
     });
 
-    // Reward marked paid with advisor reference
+    // Reward marked paid with the status='pending' guard (second .eq)
     const rewardUpdate = rewardUpdateCalls.find((c) => c.id === 42);
     expect(rewardUpdate?.payload.status).toBe("paid");
     expect(rewardUpdate?.payload.payout_method).toBe("credit_balance");
     expect(rewardUpdate?.payload.payout_reference).toBe("advisor_99");
     expect(rewardUpdate?.payload.paid_at).toEqual(expect.any(String));
+    expect(rewardUpdate?.statusGuard).toBe("pending");
 
-    // Audit row is shaped correctly
+    // Audit row shaped correctly (new balance = 12500 + 7500)
     expect(financialAuditCalls).toHaveLength(1);
     expect(financialAuditCalls[0]).toMatchObject({
       actorType: "cron",
@@ -340,7 +377,47 @@ describe("GET /api/cron/referral-payouts", () => {
     });
   });
 
-  it("marks failed when the optimistic lock loses — reward stays pending, no audit written", async () => {
+  it("IDEMPOTENT: a 2nd run after a mid-crash does NOT double-credit and writes no 2nd audit row", async () => {
+    // Scenario: a prior fire crashed AFTER crediting the ledger but BEFORE
+    // flipping the reward to 'paid'. The reward is still 'pending', so this
+    // run re-picks it. The ledger triple already exists → recordLedgerEntry
+    // returns idempotent:true and does NOT mutate the balance again.
+    rewardsToReturn = [
+      {
+        id: 42,
+        referral_code: "REFX",
+        referrer_email: "referrer@example.com",
+        referred_email: "new@example.com",
+        trigger_event: "first_deposit",
+        reward_cents: 7500,
+        payout_method: "credit_balance",
+      },
+    ];
+    advisorByEmail.set("referrer@example.com", {
+      id: 99,
+      credit_balance_cents: 20000, // already includes the prior credit
+    });
+    ledgerIdempotentForRefId.set("42", true); // triple already landed
+
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+
+    // Ledger was called once (idempotently) — the helper itself is the guard.
+    expect(ledgerCalls).toHaveLength(1);
+    expect(vi.mocked(recordLedgerEntry)).toHaveReturnedTimes(1);
+
+    // The reward is still flipped to paid (idempotently, status-guarded), but
+    // because the credit was idempotent NO second financial-audit row is
+    // written — we must not log a phantom second movement.
+    expect(financialAuditCalls).toHaveLength(0);
+
+    // The reward paid-flip still fired with the status guard.
+    const rewardUpdate = rewardUpdateCalls.find((c) => c.id === 42);
+    expect(rewardUpdate?.payload.status).toBe("paid");
+    expect(rewardUpdate?.statusGuard).toBe("pending");
+  });
+
+  it("marks failed when the ledger entry throws — reward stays pending, no audit, no inbox", async () => {
     rewardsToReturn = [
       {
         id: 7,
@@ -355,7 +432,7 @@ describe("GET /api/cron/referral-payouts", () => {
       id: 5,
       credit_balance_cents: 0,
     });
-    advisorUpdateErrorForId.set(5, { message: "stale row" });
+    ledgerThrowForRefId.set("7", "ledger insert failed");
 
     const res = await GET(makeReq());
     const json = await res.json();
@@ -389,6 +466,7 @@ describe("GET /api/cron/referral-payouts", () => {
     const json = await res.json();
     expect(json.paid).toBe(1);
     expect(json.manual).toBe(0);
+    expect(ledgerCalls).toHaveLength(1);
   });
 
   it("mixes outcomes across a batch (paid + rejected + manual)", async () => {
@@ -432,12 +510,13 @@ describe("GET /api/cron/referral-payouts", () => {
     expect(json.paid).toBe(1); // id 1 — credited successfully
     expect(json.failed).toBe(0);
 
-    // Exactly one advisor balance write
-    expect(advisorUpdateCalls).toHaveLength(1);
-    expect(advisorUpdateCalls[0]).toMatchObject({
-      id: 10,
-      expectedPrior: 0,
-      payload: { credit_balance_cents: 100 },
+    // Exactly one ledger credit (for the paid row)
+    expect(ledgerCalls).toHaveLength(1);
+    expect(ledgerCalls[0]).toMatchObject({
+      professionalId: 10,
+      amountCents: 100,
+      kind: "referral_payout",
+      referenceId: "1",
     });
 
     // One audit row for the paid credit

--- a/app/api/cron/advisor-dunning/route.ts
+++ b/app/api/cron/advisor-dunning/route.ts
@@ -6,6 +6,8 @@ import { getStripe } from "@/lib/stripe";
 import { escapeHtml } from "@/lib/html-escape";
 import { getSiteUrl } from "@/lib/url";
 import { wrapCronHandler } from "@/lib/cron-run-log";
+import { recordLedgerEntry } from "@/lib/advisor-credit-ledger";
+import { enqueueJob } from "@/lib/job-queue";
 
 const log = logger("cron:advisor-dunning");
 
@@ -119,7 +121,33 @@ async function handler(req: NextRequest) {
       }
 
       if (retrySucceeded) {
-        // Credit the advisor's balance
+        // Credit FIRST through the ledger, mark the topup completed AFTER.
+        // The ledger's (kind, reference_type, reference_id) unique index
+        // keyed to the topup id is the durable guard: if this cron crashes
+        // after crediting but before flipping status='completed', the row
+        // stays 'failed' and the next run re-records the SAME ledger triple
+        // — which is a no-op — then completes the status. No lost credit,
+        // no double credit. (Old ordering marked completed first, so a
+        // crash left the topup "done" but never credited, with no retry.)
+        // The triple matches the Stripe-webhook topup-credit path
+        // (advisor_credit_topup / topup id) so the two can never both
+        // credit the same row.
+        await recordLedgerEntry({
+          professionalId: advisor.id as number,
+          amountCents: topup.amount_cents,
+          kind: "topup",
+          description: `Dunning retry recovered — A$${(topup.amount_cents / 100).toFixed(2)}`,
+          referenceType: "advisor_credit_topup",
+          referenceId: String(topup.id),
+          metadata: {
+            dunning_recovery: true,
+            dunning_step: nextStep,
+            stripe_payment_intent_id: topup.stripe_payment_intent_id ?? null,
+          },
+          createdBy: "cron:advisor-dunning",
+          supabase,
+        });
+
         await supabase
           .from("advisor_credit_topups")
           .update({
@@ -129,14 +157,10 @@ async function handler(req: NextRequest) {
           })
           .eq("id", topup.id);
 
-        await supabase
-          .from("professionals")
-          .update({
-            credit_balance_cents: (advisor.credit_balance_cents || 0) + topup.amount_cents,
-          })
-          .eq("id", advisor.id);
-
-        sendEmail(
+        // Recovery email is informational — the credit + status flip above
+        // are already durable, so this is best-effort but still enqueued
+        // (not fire-and-forget) so a transient Resend failure gets retried.
+        await enqueueDunningEmail(
           advisor.email,
           `Payment succeeded — A$${(topup.amount_cents / 100).toFixed(2)} credited`,
           `<div style="font-family:Arial,sans-serif;max-width:560px;color:#334155">
@@ -165,7 +189,13 @@ async function handler(req: NextRequest) {
         `Your account has been paused. Update your payment method to resume receiving leads.`,
       ];
 
-      sendEmail(
+      // Enqueue the dunning email durably BEFORE advancing any state. The
+      // job_queue row is retried with backoff by the job-queue-worker, so a
+      // transient Resend hiccup no longer silently drops the notice. We only
+      // advance dunning_step (and pause at the final step) once the email is
+      // durably queued — if enqueue fails we leave the row untouched so the
+      // next daily run retries this same step rather than skipping past it.
+      const emailQueued = await enqueueDunningEmail(
         advisor.email,
         subjects[nextStep],
         `<div style="font-family:Arial,sans-serif;max-width:560px;color:#334155">
@@ -175,6 +205,15 @@ async function handler(req: NextRequest) {
           <a href="${getSiteUrl()}/advisor-portal?topup=retry" style="display:inline-block;padding:10px 20px;background:#0f172a;color:white;border-radius:8px;text-decoration:none;font-size:14px;font-weight:600">Update payment method →</a>
         </div>`,
       );
+
+      if (!emailQueued) {
+        log.warn("Dunning email enqueue failed — leaving step for retry", {
+          topupId: topup.id,
+          step: nextStep,
+        });
+        stats.errored++;
+        continue;
+      }
 
       // Final step: pause the advisor if still not paid
       if (nextStep === 3 && advisor.status === "active") {
@@ -212,21 +251,27 @@ async function handler(req: NextRequest) {
   return NextResponse.json({ ok: true, ...stats });
 }
 
-function sendEmail(to: string | null, subject: string, html: string): void {
-  if (!to || !process.env.RESEND_API_KEY) return;
-  fetch("https://api.resend.com/emails", {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${process.env.RESEND_API_KEY}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      from: "Invest.com.au <billing@invest.com.au>",
-      to: [to],
-      subject,
-      html,
-    }),
-  }).catch(() => {});
+/**
+ * Durably enqueue a dunning email onto the job_queue. The job-queue-worker
+ * cron sends it via Resend and retries with exponential backoff on a 5xx /
+ * 429 / transient failure (see lib/job-queue `send_email` handler), so the
+ * notice is no longer lost on a single Resend hiccup the way the old
+ * fire-and-forget `fetch().catch(() => {})` was. Returns true when the job
+ * row was persisted, false when the enqueue itself failed (or no recipient).
+ */
+async function enqueueDunningEmail(
+  to: string | null,
+  subject: string,
+  html: string,
+): Promise<boolean> {
+  if (!to) return false;
+  const jobId = await enqueueJob("send_email", {
+    to,
+    subject,
+    html,
+    from: "Invest.com.au <billing@invest.com.au>",
+  });
+  return jobId !== null;
 }
 
 export const GET = wrapCronHandler("advisor-dunning", handler);

--- a/app/api/cron/enforce-lead-sla/route.ts
+++ b/app/api/cron/enforce-lead-sla/route.ts
@@ -6,6 +6,7 @@ import { ADMIN_EMAIL } from "@/lib/admin";
 import { escapeHtml } from "@/lib/html-escape";
 import { getSiteUrl } from "@/lib/url";
 import { wrapCronHandler } from "@/lib/cron-run-log";
+import { enqueueJob } from "@/lib/job-queue";
 
 const log = logger("cron:enforce-lead-sla");
 
@@ -92,7 +93,9 @@ async function handler(req: NextRequest) {
           })
           .eq("id", advisor.id);
 
-        sendEmail(
+        // Reinstatement is already durable (status flipped above). The
+        // courtesy email is enqueued durably so a Resend hiccup retries.
+        await enqueueSlaEmail(
           advisor.email,
           "Your advisor profile is active again",
           `<div style="font-family:Arial,sans-serif;max-width:560px;color:#334155">
@@ -120,7 +123,11 @@ async function handler(req: NextRequest) {
           })
           .eq("id", advisor.id);
 
-        sendEmail(
+        // Pause is already durable (auto_paused_at stamped above also acts
+        // as the idempotency guard against re-pausing / re-emailing). The
+        // notifications are enqueued durably (not fire-and-forget) so a
+        // Resend hiccup retries via the worker rather than silently dropping.
+        await enqueueSlaEmail(
           advisor.email,
           "Your advisor profile has been paused",
           `<div style="font-family:Arial,sans-serif;max-width:560px;color:#334155">
@@ -132,7 +139,7 @@ async function handler(req: NextRequest) {
         );
 
         // Tell admin too
-        sendEmail(
+        await enqueueSlaEmail(
           ADMIN_EMAIL,
           `Advisor auto-paused (SLA): ${advisor.name}`,
           `<p>${escapeHtml(advisor.name || "advisor")} auto-paused with ${unrespondedCount} unresponded leads.</p>`,
@@ -154,12 +161,12 @@ async function handler(req: NextRequest) {
           : Infinity;
 
         if (hoursSinceLast >= 24) {
-          await supabase
-            .from("professionals")
-            .update({ pause_warning_sent_at: now.toISOString() })
-            .eq("id", advisor.id);
-
-          sendEmail(
+          // Enqueue durably BEFORE stamping pause_warning_sent_at. The job
+          // is retried by the worker, so a Resend hiccup no longer drops the
+          // warning. Only stamp (which would otherwise suppress re-sends for
+          // 24h) once the email is durably queued — if the enqueue fails we
+          // leave the flag so the next run retries this warning.
+          const queued = await enqueueSlaEmail(
             advisor.email,
             "Urgent: respond to your leads to avoid pausing",
             `<div style="font-family:Arial,sans-serif;max-width:560px;color:#334155">
@@ -168,7 +175,18 @@ async function handler(req: NextRequest) {
               <a href="${getSiteUrl()}/advisor-portal" style="display:inline-block;padding:10px 20px;background:#0f172a;color:white;border-radius:8px;text-decoration:none;font-size:14px;font-weight:600">Respond now →</a>
             </div>`,
           );
-          stats.warned2++;
+          if (queued) {
+            await supabase
+              .from("professionals")
+              .update({ pause_warning_sent_at: now.toISOString() })
+              .eq("id", advisor.id);
+            stats.warned2++;
+          } else {
+            log.warn("SLA warning-2 enqueue failed — leaving flag for retry", {
+              advisorId: advisor.id,
+            });
+            stats.failed++;
+          }
         }
         continue;
       }
@@ -179,12 +197,10 @@ async function handler(req: NextRequest) {
           ? new Date(advisor.pause_warning_sent_at)
           : null;
         if (!lastWarned) {
-          await supabase
-            .from("professionals")
-            .update({ pause_warning_sent_at: now.toISOString() })
-            .eq("id", advisor.id);
-
-          sendEmail(
+          // Enqueue durably BEFORE stamping pause_warning_sent_at so a
+          // transient Resend failure retries instead of being swallowed
+          // while the flag (which suppresses future warning-1 sends) advances.
+          const queued = await enqueueSlaEmail(
             advisor.email,
             "You have unresponded leads",
             `<div style="font-family:Arial,sans-serif;max-width:560px;color:#334155">
@@ -193,7 +209,18 @@ async function handler(req: NextRequest) {
               <a href="${getSiteUrl()}/advisor-portal" style="display:inline-block;padding:10px 20px;background:#0f172a;color:white;border-radius:8px;text-decoration:none;font-size:14px;font-weight:600">View leads →</a>
             </div>`,
           );
-          stats.warned1++;
+          if (queued) {
+            await supabase
+              .from("professionals")
+              .update({ pause_warning_sent_at: now.toISOString() })
+              .eq("id", advisor.id);
+            stats.warned1++;
+          } else {
+            log.warn("SLA warning-1 enqueue failed — leaving flag for retry", {
+              advisorId: advisor.id,
+            });
+            stats.failed++;
+          }
         }
       }
     } catch (err) {
@@ -209,22 +236,30 @@ async function handler(req: NextRequest) {
   return NextResponse.json({ ok: true, ...stats });
 }
 
-/** Fire-and-forget transactional email via Resend. */
-function sendEmail(to: string | null, subject: string, html: string): void {
-  if (!to || !process.env.RESEND_API_KEY) return;
-  fetch("https://api.resend.com/emails", {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${process.env.RESEND_API_KEY}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      from: "Invest.com.au <system@invest.com.au>",
-      to: [to],
-      subject,
-      html,
-    }),
-  }).catch(() => {});
+/**
+ * Durably enqueue an SLA email onto the job_queue. The job-queue-worker cron
+ * sends it via Resend and retries with exponential backoff on transient
+ * failures (see lib/job-queue `send_email` handler), so the notice survives a
+ * single Resend hiccup instead of being swallowed by the old fire-and-forget
+ * `fetch().catch(() => {})`. Returns true when the job row was persisted,
+ * false when the enqueue itself failed (or there was no recipient). Warning
+ * sends gate their `pause_warning_sent_at` stamp on this so a failed enqueue
+ * retries next run; pause/unpause notifications are best-effort (the durable
+ * state change has already landed).
+ */
+async function enqueueSlaEmail(
+  to: string | null,
+  subject: string,
+  html: string,
+): Promise<boolean> {
+  if (!to) return false;
+  const jobId = await enqueueJob("send_email", {
+    to,
+    subject,
+    html,
+    from: "Invest.com.au <system@invest.com.au>",
+  });
+  return jobId !== null;
 }
 
 export const GET = wrapCronHandler("enforce-lead-sla", handler);

--- a/app/api/cron/referral-payouts/route.ts
+++ b/app/api/cron/referral-payouts/route.ts
@@ -6,6 +6,7 @@ import { wrapCronHandler } from "@/lib/cron-run-log";
 import { isFeatureDisabled } from "@/lib/admin/classifier-config";
 import { recordFinancialAudit } from "@/lib/financial-audit";
 import { buildEmailToUserIdMap, notifyUser } from "@/lib/notifications";
+import { recordLedgerEntry } from "@/lib/advisor-credit-ledger";
 
 const log = logger("cron:referral-payouts");
 
@@ -16,14 +17,22 @@ export const maxDuration = 120;
  * Daily cron — processes pending referral_rewards rows.
  *
  * For 'credit_balance' payouts: looks up the referrer advisor by
- * email, reads their current credit_balance_cents, writes back
- * (reward + current) with an optimistic lock, and logs to
- * financial_audit_log. 'bank' and 'stripe' payouts are marked
- * 'pending_manual' for admin to batch-process weekly.
+ * email, records the credit through the advisor credit ledger
+ * (kind='referral_payout', reference triple keyed to the reward id),
+ * and logs to financial_audit_log. 'bank' and 'stripe' payouts are
+ * marked 'pending_manual' for admin to batch-process weekly.
  *
- * Idempotency: the status machine (pending → paid | rejected)
- * means a retry after a crash is safe — only status='pending' rows
- * are picked up.
+ * Idempotency: TWO guards make a crash-then-retry safe.
+ *   1. The ledger's (kind, reference_type, reference_id) unique index
+ *      means re-recording `referral_payout`/`referral_reward`/<id>
+ *      is a no-op — the cached balance is never double-credited even
+ *      if the cron crashes after crediting but before the reward row
+ *      flips to 'paid'.
+ *   2. The 'paid' flip is itself guarded by `.eq("status","pending")`
+ *      so a row can transition out of 'pending' at most once.
+ * Together these close the historical double-credit window where a
+ * raw read-modify-write CAS on the OLD balance would re-credit on the
+ * next run after a mid-row crash.
  */
 async function handler(req: NextRequest) {
   const unauth = requireCronAuth(req);
@@ -86,23 +95,42 @@ async function handler(req: NextRequest) {
       }
 
       const currentBalance = (advisor.credit_balance_cents as number) || 0;
-      const newBalance = currentBalance + (r.reward_cents as number);
 
-      const { error: upErr } = await supabase
-        .from("professionals")
-        .update({ credit_balance_cents: newBalance })
-        .eq("id", advisor.id)
-        .eq("credit_balance_cents", currentBalance);
-
-      if (upErr) {
-        log.error("Referral credit failed — optimistic lock lost", {
+      // Credit through the ledger. Its (kind, reference_type, reference_id)
+      // unique index keyed to the reward id is the durable idempotency
+      // guard: if this cron crashed after a prior credit landed but before
+      // the reward row flipped to 'paid', the re-run returns the existing
+      // ledger row (idempotent:true) and never double-mutates the balance.
+      let ledger;
+      try {
+        ledger = await recordLedgerEntry({
+          professionalId: advisor.id as number,
+          amountCents: r.reward_cents as number,
+          kind: "referral_payout",
+          description: `Referral reward: ${r.trigger_event} by ${r.referred_email}`,
+          referenceType: "referral_reward",
+          referenceId: String(r.id),
+          metadata: {
+            referral_code: r.referral_code,
+            referred_email: r.referred_email,
+            trigger_event: r.trigger_event,
+          },
+          createdBy: "cron:referral-payouts",
+          supabase,
+        });
+      } catch (ledgerErr) {
+        log.error("Referral credit failed — ledger entry threw", {
           id: r.id,
-          err: upErr.message,
+          err: ledgerErr instanceof Error ? ledgerErr.message : String(ledgerErr),
         });
         stats.failed++;
         continue;
       }
 
+      const newBalance = ledger.balanceAfterCents;
+
+      // Flip the reward to 'paid', guarded by status='pending' so a row
+      // can leave 'pending' at most once even under concurrent fires.
       await supabase
         .from("referral_rewards")
         .update({
@@ -111,20 +139,25 @@ async function handler(req: NextRequest) {
           payout_method: "credit_balance",
           payout_reference: `advisor_${advisor.id}`,
         })
-        .eq("id", r.id);
+        .eq("id", r.id)
+        .eq("status", "pending");
 
-      await recordFinancialAudit({
-        actorType: "cron",
-        actorId: "referral-payouts",
-        action: "credit",
-        resourceType: "advisor_credit_balance",
-        resourceId: advisor.id as number,
-        amountCents: r.reward_cents as number,
-        oldValue: { credit_balance_cents: currentBalance },
-        newValue: { credit_balance_cents: newBalance },
-        reason: `Referral reward: ${r.trigger_event} by ${r.referred_email}`,
-        context: { referral_code: r.referral_code, referred_email: r.referred_email },
-      });
+      // Only audit on the first (non-idempotent) credit — a retry that
+      // hits the existing ledger row must not log a second movement.
+      if (!ledger.idempotent) {
+        await recordFinancialAudit({
+          actorType: "cron",
+          actorId: "referral-payouts",
+          action: "credit",
+          resourceType: "advisor_credit_balance",
+          resourceId: advisor.id as number,
+          amountCents: r.reward_cents as number,
+          oldValue: { credit_balance_cents: currentBalance },
+          newValue: { credit_balance_cents: newBalance },
+          reason: `Referral reward: ${r.trigger_event} by ${r.referred_email}`,
+          context: { referral_code: r.referral_code, referred_email: r.referred_email },
+        });
+      }
 
       // Tell the referrer they got paid. email_delivery_key is the
       // reward row id so retries can't double-notify.


### PR DESCRIPTION
**Tier C** (touches cron + credit accounting). Draft — do not merge.

Three confirmed crash-window / lost-write bugs in the credit + email paths of three daily crons. Every change **hardens an existing movement** — no amounts, rates, or gates change; only *where/how* the credit and email happen (idempotency / durability). Does not touch any REGULATORY-AVOID-LIST escalator (the `createPaymentForBrief` 10% clip and DD-03 15% clip are untouched).

Follows the exemplary `app/api/cron/advisor-auto-topup` + `recordLedgerEntry` pattern (idempotent `(kind, reference_type, reference_id)` triple). `recordLedgerEntry` itself is **only called**, never modified.

### FIX 1 — referral-payouts (P2 double-credit)
`app/api/cron/referral-payouts/route.ts` credited `professionals.credit_balance_cents` via a raw read-modify-write CAS on the **old** balance, then flipped `referral_rewards.status='paid'` in a separate, **unguarded** write. A crash between the two left `status='pending'`, so the next run re-read the now-higher balance, the CAS matched, and it **credited again** — also bypassing the ledger idempotency guard.

- Credit now routes through `recordLedgerEntry({ kind: "referral_payout", referenceType: "referral_reward", referenceId: String(r.id) })`; the ledger's unique index makes a retry a no-op (`idempotent: true`).
- The `'paid'` flip is guarded with `.eq("status", "pending")` so a row leaves `pending` at most once.
- The `financial_audit_log` row is written only on the first (non-idempotent) credit.

### FIX 2 — advisor-dunning (P2 lost credit)
`app/api/cron/advisor-dunning/route.ts` retry-success path marked `advisor_credit_topups.status='completed'` **first**, then raw-incremented the balance. A crash between left the topup "done" but **never credited**, with no retry (the next run only re-picks `status='failed'`).

- Now credits via `recordLedgerEntry({ kind: "topup", referenceType: "advisor_credit_topup", referenceId: String(topup.id) })` **first**, then marks completed. The triple matches the Stripe-webhook topup-credit path, so the cron and the webhook can never double-credit the same topup row.

### FIX 3 — swallowed emails (P2)
`app/api/cron/advisor-dunning/route.ts` + `app/api/cron/enforce-lead-sla/route.ts` sent warning notices via un-awaited `fetch(...).catch(() => {})` while durable state (`dunning_step`, `pause_warning_sent_at`, pause flags) advanced unconditionally — a single Resend hiccup lost the notice and it never resent.

- Both now enqueue durably via `enqueueJob("send_email", ...)` (retried with exponential backoff by the `job-queue-worker`, mirroring `subscription-dunning`).
- Step/flag only advances once the enqueue is confirmed; a failed enqueue leaves the row untouched for the next run.
- Pause / unpause / admin notifications stay best-effort since the durable state change has already landed.

### Tests
Extended all three cron test suites (39 tests, all green): a 2nd run after a simulated mid-crash does **not** double-credit (ledger idempotent) and the email path retries; durable state only advances on email-enqueue success.

### Verification
- `NODE_OPTIONS=--max-old-space-size=5120 npx tsc --noEmit` — clean
- changed cron tests — 39/39 green; adjacent ledger / stripe-webhook / subscription-dunning / job-queue-worker / team-brief-referrals suites — 63/63 green
- `eslint` on all changed files — 0 errors, 0 warnings
- pre-push hook (tsc + rate-limit audit + changed-file tests) — passed

https://claude.ai/code/session_01AX16WTaqAs2W33uydbBWLa

---
_Generated by [Claude Code](https://claude.ai/code/session_01AX16WTaqAs2W33uydbBWLa)_