### PR TITLE
test(getmatched,directory): unit-test action-plan helpers + FilterPill/FilterPopover

### DIFF
--- a/__tests__/components/directory/FilterPill.test.tsx
+++ b/__tests__/components/directory/FilterPill.test.tsx
@@ -1,0 +1,201 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { FilterPill, FilterPopover } from "@/components/directory/FilterPill";
+
+vi.mock("@/components/Icon", () => ({
+  default: ({ name, ...rest }: { name: string; [key: string]: unknown }) => (
+    <span data-testid={`icon-${name}`} {...rest} />
+  ),
+}));
+
+// Generous timeout: the first jsdom render in a worker can take >5s under heavy
+// concurrent-CI machine load (the default testTimeout). The test bodies are all
+// synchronous — this only guards against environment-setup contention, not slow logic.
+describe("FilterPill", { timeout: 20000 }, () => {
+  const baseProps = {
+    icon: "map-pin",
+    label: "State",
+    active: false,
+    open: false,
+    onClick: () => {},
+  };
+
+  it("renders the label and the named icon", () => {
+    render(<FilterPill {...baseProps} />);
+    expect(screen.getByText("State")).toBeInTheDocument();
+    expect(screen.getByTestId("icon-map-pin")).toBeInTheDocument();
+  });
+
+  it("calls onClick when clicked", () => {
+    const onClick = vi.fn();
+    render(<FilterPill {...baseProps} onClick={onClick} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("active=true uses amber active classes and aria-expanded reflects the open prop", () => {
+    render(<FilterPill {...baseProps} active open />);
+    const btn = screen.getByRole("button");
+    expect(btn).toHaveAttribute("aria-expanded", "true");
+    expect(btn.className).toContain("border-amber-400");
+    expect(btn.className).toContain("bg-amber-50");
+    expect(btn.className).toContain("text-amber-800");
+  });
+
+  it("active=false uses slate classes and aria-expanded reflects open=false", () => {
+    render(<FilterPill {...baseProps} active={false} open={false} />);
+    const btn = screen.getByRole("button");
+    expect(btn).toHaveAttribute("aria-expanded", "false");
+    expect(btn.className).toContain("border-slate-200");
+    expect(btn.className).toContain("text-slate-700");
+    expect(btn.className).not.toContain("border-amber-400");
+  });
+
+  it("aria-expanded tracks `open` independently of `active`", () => {
+    // active but closed
+    const { rerender } = render(<FilterPill {...baseProps} active open={false} />);
+    expect(screen.getByRole("button")).toHaveAttribute("aria-expanded", "false");
+    // inactive but open
+    rerender(<FilterPill {...baseProps} active={false} open />);
+    expect(screen.getByRole("button")).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("renders a '· value' suffix when value is provided", () => {
+    render(<FilterPill {...baseProps} value="NSW" />);
+    expect(screen.getByText("· NSW")).toBeInTheDocument();
+  });
+
+  it("renders no value suffix when value is absent", () => {
+    render(<FilterPill {...baseProps} />);
+    expect(screen.queryByText(/·/)).not.toBeInTheDocument();
+  });
+
+  it("disabled=true sets the disabled attribute and clicking does not fire onClick", () => {
+    const onClick = vi.fn();
+    render(<FilterPill {...baseProps} disabled onClick={onClick} />);
+    const btn = screen.getByRole("button");
+    expect(btn).toBeDisabled();
+    fireEvent.click(btn);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("rotates the chevron only when open", () => {
+    const { rerender } = render(<FilterPill {...baseProps} open={false} />);
+    expect(screen.getByTestId("icon-chevron-down").className).not.toContain("rotate-180");
+
+    rerender(<FilterPill {...baseProps} open />);
+    expect(screen.getByTestId("icon-chevron-down").className).toContain("rotate-180");
+  });
+});
+
+describe("FilterPopover", { timeout: 20000 }, () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("renders nothing when open=false", () => {
+    const { container } = render(
+      <FilterPopover open={false} onClose={() => {}} label="State filter">
+        <p>panel body</p>
+      </FilterPopover>,
+    );
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByText("panel body")).not.toBeInTheDocument();
+  });
+
+  it("renders a dialog with aria-label and children when open=true", () => {
+    render(
+      <FilterPopover open onClose={() => {}} label="State filter">
+        <p>panel body</p>
+      </FilterPopover>,
+    );
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-label", "State filter");
+    expect(screen.getByText("panel body")).toBeInTheDocument();
+  });
+
+  it("fires onClose when Escape is pressed", () => {
+    const onClose = vi.fn();
+    render(
+      <FilterPopover open onClose={onClose} label="State filter">
+        <p>body</p>
+      </FilterPopover>,
+    );
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire onClose for non-Escape keys", () => {
+    const onClose = vi.fn();
+    render(
+      <FilterPopover open onClose={onClose} label="State filter">
+        <p>body</p>
+      </FilterPopover>,
+    );
+    fireEvent.keyDown(document, { key: "Enter" });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("fires onClose on a mousedown OUTSIDE the positioned wrapper", () => {
+    const onClose = vi.fn();
+    // Render inside a positioned wrapper so ref.current.parentElement is the boundary.
+    render(
+      <div className="relative" data-testid="wrapper">
+        <FilterPopover open onClose={onClose} label="State filter">
+          <button>option</button>
+        </FilterPopover>
+      </div>,
+    );
+    // mousedown on body (outside the wrapper) -> close
+    fireEvent.mouseDown(document.body);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT fire onClose on a mousedown INSIDE the popover", () => {
+    const onClose = vi.fn();
+    render(
+      <div className="relative" data-testid="wrapper">
+        <FilterPopover open onClose={onClose} label="State filter">
+          <button>option</button>
+        </FilterPopover>
+      </div>,
+    );
+    // mousedown on a child node inside the popover -> stay open
+    fireEvent.mouseDown(screen.getByText("option"));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fire onClose on a mousedown on a SIBLING inside the same wrapper (e.g. the trigger)", () => {
+    const onClose = vi.fn();
+    render(
+      <div className="relative" data-testid="wrapper">
+        <button data-testid="trigger">State</button>
+        <FilterPopover open onClose={onClose} label="State filter">
+          <button>option</button>
+        </FilterPopover>
+      </div>,
+    );
+    // The boundary is the wrapper, which also holds the trigger pill.
+    fireEvent.mouseDown(screen.getByTestId("trigger"));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("removes its document listeners on unmount (no onClose after teardown)", () => {
+    const onClose = vi.fn();
+    const { unmount } = render(
+      <div className="relative">
+        <FilterPopover open onClose={onClose} label="State filter">
+          <button>option</button>
+        </FilterPopover>
+      </div>,
+    );
+    unmount();
+    fireEvent.keyDown(document, { key: "Escape" });
+    fireEvent.mouseDown(document.body);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/lib/getmatched/action-plans-helpers.test.ts
+++ b/__tests__/lib/getmatched/action-plans-helpers.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi } from "vitest";
+
+// The module imports createAdminClient at module scope (for the async DB fns).
+// We only exercise the PURE helpers here, but the import must not blow up, so
+// stub the admin client via vi.hoisted.
+const { mockCreateAdminClient } = vi.hoisted(() => ({
+  mockCreateAdminClient: vi.fn(() => ({})),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: mockCreateAdminClient,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}));
+
+import { toggleChecklistItem, newShareToken } from "@/lib/getmatched/action-plans";
+import type { ChecklistItem } from "@/lib/getmatched/types";
+
+describe("toggleChecklistItem", () => {
+  const base = (): ChecklistItem[] => [
+    { label: "Open account", done: false },
+    { label: "Fund account", done: true },
+    { label: "Place first trade", done: false },
+  ];
+
+  it("flips done at the given index and leaves all others untouched", () => {
+    const input = base();
+    const out = toggleChecklistItem(input, 0);
+
+    expect(out[0]?.done).toBe(true);
+    // Other items unchanged in value
+    expect(out[1]?.done).toBe(true);
+    expect(out[2]?.done).toBe(false);
+    expect(out[1]?.label).toBe("Fund account");
+    expect(out[2]?.label).toBe("Place first trade");
+  });
+
+  it("toggles a true item back to false", () => {
+    const out = toggleChecklistItem(base(), 1);
+    expect(out[1]?.done).toBe(false);
+  });
+
+  it("treats undefined done as falsy and flips it to true", () => {
+    const input: ChecklistItem[] = [{ label: "No flag set" }];
+    const out = toggleChecklistItem(input, 0);
+    expect(out[0]?.done).toBe(true);
+  });
+
+  it("returns a NEW array and a NEW object at the toggled index (immutability)", () => {
+    const input = base();
+    const out = toggleChecklistItem(input, 0);
+
+    expect(out).not.toBe(input);
+    expect(out[0]).not.toBe(input[0]); // toggled item is a fresh object
+    // The original array and its items are not mutated.
+    expect(input[0]?.done).toBe(false);
+  });
+
+  it("keeps untouched items as the SAME object references (only the target is replaced)", () => {
+    const input = base();
+    const out = toggleChecklistItem(input, 0);
+    expect(out[1]).toBe(input[1]);
+    expect(out[2]).toBe(input[2]);
+  });
+
+  it("returns an equivalent copy with nothing toggled for an out-of-range positive index", () => {
+    const input = base();
+    const out = toggleChecklistItem(input, 99);
+
+    expect(out).not.toBe(input);
+    expect(out).toEqual(input);
+    expect(out.map((i) => i.done)).toEqual([false, true, false]);
+  });
+
+  it("returns an equivalent copy with nothing toggled for a negative index", () => {
+    const input = base();
+    const out = toggleChecklistItem(input, -1);
+
+    expect(out).not.toBe(input);
+    expect(out).toEqual(input);
+  });
+
+  it("returns an empty array for an empty checklist", () => {
+    const out = toggleChecklistItem([], 0);
+    expect(out).toEqual([]);
+    expect(out).toHaveLength(0);
+  });
+});
+
+describe("newShareToken", () => {
+  it("returns a 48-char lowercase hex string (randomBytes(24).toString('hex'))", () => {
+    const token = newShareToken();
+    expect(token).toHaveLength(48);
+    expect(token).toMatch(/^[0-9a-f]{48}$/);
+  });
+
+  it("returns a different token on each call (uniqueness)", () => {
+    const tokens = new Set(
+      Array.from({ length: 50 }, () => newShareToken()),
+    );
+    expect(tokens.size).toBe(50);
+  });
+});


### PR DESCRIPTION
Pure-additive tests — two new files, no source changes. **Tier A (pure-additive).**

## Modules covered

### \`lib/getmatched/action-plans.ts\` — \`__tests__/lib/getmatched/action-plans-helpers.test.ts\`
- \`toggleChecklistItem\` (pure): flips \`done\` at the given index, leaves all other items untouched; returns a NEW array with a NEW object at the toggled index while keeping untouched items as the same references; treats \`undefined\` done as falsy; out-of-range (negative / >= length) returns an equivalent untouched copy; empty array returns empty array.
- \`newShareToken\`: 48-char lowercase hex (\`randomBytes(24).toString('hex')\`) + uniqueness across 50 calls.
- The module imports \`createAdminClient\` at module scope (for the async DB fns); stubbed via \`vi.hoisted\` so the file loads. These helpers were previously only *mocked* inside the get-matched API route tests, never unit-tested.

### \`components/directory/FilterPill.tsx\` — \`__tests__/components/directory/FilterPill.test.tsx\`
- \`FilterPill\`: renders label + icon; \`onClick\`; active (amber) vs inactive (slate) classes; \`aria-expanded\` tracks \`open\` independently of \`active\`; \`· value\` suffix present/absent; \`disabled\` sets the attribute and suppresses \`onClick\`; chevron \`rotate-180\` only when open.
- \`FilterPopover\`: null when closed; \`role=dialog\` + \`aria-label\` + children when open; Escape closes (non-Escape keys ignored); outside-mousedown closes while inside-popover and sibling-trigger mousedowns (the \`.relative\` parent-element close boundary) keep it open; document listeners removed on unmount.

\`@/components/Icon\` is mocked to a testid span. Per-suite 20s timeouts guard the jsdom first-render against heavy concurrent-CI machine load (test bodies are synchronous).