### PR TITLE
test(lib,ui): cover api-latency sampling and ProgressBar a11y

### DIFF
--- a/__tests__/components/ui/ProgressBar.test.tsx
+++ b/__tests__/components/ui/ProgressBar.test.tsx
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import { ProgressBar } from "@/components/ui/ProgressBar";
+
+import { render, screen } from "../setup";
+
+function getFillWidth(): string {
+  const bar = screen.getByRole("progressbar");
+  const fill = bar.firstElementChild as HTMLElement | null;
+  return fill?.style.width ?? "";
+}
+
+describe("ProgressBar", () => {
+  it("renders 50% for step 2 of 4 with correct label and aria attributes", () => {
+    render(<ProgressBar currentStep={2} totalSteps={4} />);
+
+    expect(screen.getByText("Step 2 of 4")).toBeInTheDocument();
+    expect(screen.getByText("50%")).toBeInTheDocument();
+
+    const bar = screen.getByRole("progressbar");
+    expect(bar).toHaveAttribute("aria-valuenow", "2");
+    expect(bar).toHaveAttribute("aria-valuemin", "1");
+    expect(bar).toHaveAttribute("aria-valuemax", "4");
+    expect(bar).toHaveAttribute("aria-label", "Step 2 of 4");
+
+    expect(getFillWidth()).toBe("50%");
+    // First test in the file absorbs jsdom + React module-warmup; give it head-room
+    // under concurrent CI/swarm load. Assertions are unchanged.
+  }, 20000);
+
+  it("rounds 33.33% down to 33% for step 1 of 3 (label + fill width)", () => {
+    render(<ProgressBar currentStep={1} totalSteps={3} />);
+
+    expect(screen.getByText("33%")).toBeInTheDocument();
+    expect(getFillWidth()).toBe("33%");
+  });
+
+  it("hides the label row when showLabel=false but still renders the progressbar with aria", () => {
+    render(<ProgressBar currentStep={2} totalSteps={4} showLabel={false} />);
+
+    expect(screen.queryByText("Step 2 of 4")).toBeNull();
+    expect(screen.queryByText("50%")).toBeNull();
+
+    const bar = screen.getByRole("progressbar");
+    expect(bar).toHaveAttribute("aria-valuenow", "2");
+    expect(bar).toHaveAttribute("aria-valuemax", "4");
+    expect(bar).toHaveAttribute("aria-label", "Step 2 of 4");
+    expect(getFillWidth()).toBe("50%");
+  });
+
+  it("appends className to the root element", () => {
+    const { container } = render(
+      <ProgressBar currentStep={1} totalSteps={4} className="my-custom-class" />,
+    );
+
+    const root = container.firstElementChild as HTMLElement;
+    expect(root).toHaveClass("my-custom-class");
+    expect(root).toHaveClass("space-y-2");
+  });
+
+  it("renders 100% when currentStep equals totalSteps", () => {
+    render(<ProgressBar currentStep={4} totalSteps={4} />);
+
+    expect(screen.getByText("100%")).toBeInTheDocument();
+    expect(getFillWidth()).toBe("100%");
+
+    const bar = screen.getByRole("progressbar");
+    expect(bar).toHaveAttribute("aria-valuenow", "4");
+    expect(bar).toHaveAttribute("aria-valuemax", "4");
+  });
+});

--- a/__tests__/lib/api-latency.test.ts
+++ b/__tests__/lib/api-latency.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockInsert, mockFrom, mockCreateAdminClient, mockWarn } = vi.hoisted(() => {
+  const mockInsert = vi.fn();
+  const mockFrom = vi.fn(() => ({ insert: mockInsert }));
+  const mockCreateAdminClient = vi.fn(() => ({ from: mockFrom }));
+  const mockWarn = vi.fn();
+  return { mockInsert, mockFrom, mockCreateAdminClient, mockWarn };
+});
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: mockCreateAdminClient,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: () => ({ warn: mockWarn, info: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}));
+
+import { recordLatencySample, withLatencySample } from "@/lib/api-latency";
+
+beforeEach(() => {
+  mockInsert.mockReset();
+  mockInsert.mockResolvedValue({ error: null });
+  mockFrom.mockClear();
+  mockCreateAdminClient.mockClear();
+  mockWarn.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("withLatencySample", () => {
+  it("does not sample when rate=0 (Math.random()>=0 always) and passes handler result through", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0); // 0 < 0 === false -> no sample
+    const sentinel = { ok: true };
+    const handler = vi.fn().mockResolvedValue(sentinel);
+
+    const wrapped = withLatencySample("/api/no-sample", handler, { rate: 0 });
+    const result = await wrapped();
+
+    expect(result).toBe(sentinel);
+    expect(handler).toHaveBeenCalledOnce();
+    expect(mockCreateAdminClient).not.toHaveBeenCalled();
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("samples when rate=1 (Math.random()<1) and inserts route_path/status/duration_ms once", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.5); // 0.5 < 1 -> sample
+    const nowSpy = vi.spyOn(performance, "now");
+    nowSpy.mockReturnValueOnce(1000).mockReturnValueOnce(1042.4); // start, end
+    const handler = vi.fn().mockResolvedValue({ value: 1 });
+
+    const wrapped = withLatencySample("/api/sampled", handler, { rate: 1 });
+    await wrapped();
+    await Promise.resolve(); // flush fire-and-forget microtask
+
+    expect(mockInsert).toHaveBeenCalledOnce();
+    expect(mockInsert).toHaveBeenCalledWith({
+      route_path: "/api/sampled",
+      duration_ms: 42, // Math.round(1042.4 - 1000)
+      status: 200,
+    });
+  });
+
+  it("reads status from a Response handler result (404 captured)", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    vi.spyOn(performance, "now").mockReturnValue(0);
+    const response = new Response("nope", { status: 404 });
+    const handler = vi.fn().mockResolvedValue(response);
+
+    const wrapped = withLatencySample("/api/not-found", handler, { rate: 1 });
+    const result = await wrapped();
+    await Promise.resolve();
+
+    expect(result).toBe(response);
+    expect(mockInsert).toHaveBeenCalledOnce();
+    expect(mockInsert.mock.calls[0]?.[0]).toMatchObject({ status: 404 });
+  });
+
+  it("defaults status to 200 for a non-Response handler result", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    vi.spyOn(performance, "now").mockReturnValue(0);
+    const handler = vi.fn().mockResolvedValue({ plain: "object" });
+
+    const wrapped = withLatencySample("/api/plain", handler, { rate: 1 });
+    await wrapped();
+    await Promise.resolve();
+
+    expect(mockInsert.mock.calls[0]?.[0]).toMatchObject({ status: 200 });
+  });
+
+  it("returns the handler result regardless of insert resolution (fire-and-forget)", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    vi.spyOn(performance, "now").mockReturnValue(0);
+    // Insert never resolves — the wrapped fn must still resolve with the result.
+    mockInsert.mockReturnValue(new Promise(() => {}));
+    const sentinel = { id: "abc" };
+    const handler = vi.fn().mockResolvedValue(sentinel);
+
+    const wrapped = withLatencySample("/api/ff", handler, { rate: 1 });
+    const result = await wrapped();
+
+    expect(result).toBe(sentinel);
+  });
+
+  it("rounds duration via Math.round and records a non-negative value", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    vi.spyOn(performance, "now")
+      .mockReturnValueOnce(10.2) // start
+      .mockReturnValueOnce(20.9); // end -> 10.7 -> round 11
+    const handler = vi.fn().mockResolvedValue(undefined);
+
+    const wrapped = withLatencySample("/api/round", handler, { rate: 1 });
+    await wrapped();
+    await Promise.resolve();
+
+    const arg = mockInsert.mock.calls[0]?.[0] as { duration_ms: number };
+    expect(arg.duration_ms).toBe(11);
+    expect(arg.duration_ms).toBeGreaterThanOrEqual(0);
+  });
+
+  it("uses the default 1% sample rate when no rate option is provided", async () => {
+    // Math.random() = 0.5 -> 0.5 < 0.01 === false -> no sample at default rate
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const handler = vi.fn().mockResolvedValue("x");
+
+    const wrapped = withLatencySample("/api/default", handler);
+    await wrapped();
+    await Promise.resolve();
+
+    expect(mockInsert).not.toHaveBeenCalled();
+
+    // Math.random() = 0.005 -> 0.005 < 0.01 === true -> sample
+    (Math.random as ReturnType<typeof vi.fn>).mockReturnValue(0.005);
+    vi.spyOn(performance, "now").mockReturnValue(0);
+    await wrapped();
+    await Promise.resolve();
+
+    expect(mockInsert).toHaveBeenCalledOnce();
+  });
+});
+
+describe("recordLatencySample", () => {
+  it("early-returns without inserting when durationMs < 0", async () => {
+    await recordLatencySample("/api/neg", -1, 200);
+    expect(mockCreateAdminClient).not.toHaveBeenCalled();
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("early-returns without inserting when durationMs > 600000", async () => {
+    await recordLatencySample("/api/huge", 600_001, 200);
+    expect(mockCreateAdminClient).not.toHaveBeenCalled();
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("inserts for a valid duration", async () => {
+    await recordLatencySample("/api/cron-job", 1234, 200);
+    expect(mockCreateAdminClient).toHaveBeenCalledOnce();
+    expect(mockFrom).toHaveBeenCalledWith("api_latency_samples");
+    expect(mockInsert).toHaveBeenCalledWith({
+      route_path: "/api/cron-job",
+      duration_ms: 1234,
+      status: 200,
+    });
+  });
+
+  it("catches and logs an insert error without throwing", async () => {
+    mockInsert.mockRejectedValue(new Error("boom"));
+
+    await expect(recordLatencySample("/api/err", 100, 500)).resolves.toBeUndefined();
+    expect(mockWarn).toHaveBeenCalledOnce();
+    expect(mockWarn.mock.calls[0]?.[0]).toBe("latency sample insert failed");
+    expect(mockWarn.mock.calls[0]?.[1]).toMatchObject({ route: "/api/err", err: "boom" });
+  });
+});


### PR DESCRIPTION
Pure-additive tests. Tier A (pure-additive).

Modules covered:
- `lib/api-latency.ts` (previously **0 references / fully untested**) — `withLatencySample` (sampling gate via `Math.random` at rate 0/1/default-1%, status read from `Response.status` vs default 200 for non-Response, `Math.round` duration, fire-and-forget insert returns handler result regardless of insert resolution) and `recordLatencySample` (durationMs<0 and >600000 early-return with no insert, valid insert shape, insert error caught + logged without throwing).
- `components/ui/ProgressBar.tsx` — percentage math (50% / 100%), `Math.round` rounding (33.33→33), progressbar role + `aria-valuenow/min/max` + `aria-label`, inner fill `width` style, `showLabel=false` hides label row but keeps progressbar, `className` passthrough.

Verify: `npm test -- __tests__/lib/api-latency.test.ts __tests__/components/ui/ProgressBar.test.tsx` → 16 passed (2 files). `eslint --max-warnings 0` clean.