### PR TITLE
test(components): cover Money formatter and EligibilityQuizSkipBanner

### DIFF
--- a/__tests__/components/EligibilityQuizSkipBanner.test.tsx
+++ b/__tests__/components/EligibilityQuizSkipBanner.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, waitFor, userEvent } from "./setup";
+import EligibilityQuizSkipBanner from "@/components/EligibilityQuizSkipBanner";
+import { INTENT_COUNTRY_COOKIE } from "@/lib/intent-context";
+
+const DISMISS_KEY = "iv-quiz-skip-banner-dismissed";
+
+/** Clear every cookie currently set on the jsdom document. */
+function clearAllCookies() {
+  for (const c of document.cookie.split("; ")) {
+    const name = c.split("=")[0];
+    if (name) document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`;
+  }
+}
+
+function setIntentCookie(value: string) {
+  document.cookie = `${INTENT_COUNTRY_COOKIE}=${value}; path=/`;
+}
+
+describe("EligibilityQuizSkipBanner", () => {
+  beforeEach(() => {
+    clearAllCookies();
+    sessionStorage.clear();
+  });
+
+  it("renders nothing when there is no intent-country cookie", async () => {
+    render(<EligibilityQuizSkipBanner />);
+    // Give the mount effect a chance to run, then assert absence.
+    await waitFor(() => {
+      expect(screen.queryByTestId("quiz-skip-banner")).toBeNull();
+    });
+  });
+
+  it("renders the banner for a known cookie value (uk) with country display, pitch, and CTA href", async () => {
+    setIntentCookie("uk");
+    render(<EligibilityQuizSkipBanner />);
+
+    const banner = await screen.findByTestId("quiz-skip-banner");
+    expect(banner).toBeInTheDocument();
+
+    // Country display text — "UK" derived from the "UK investors" label.
+    expect(banner.textContent).toContain("We see you");
+    expect(banner.textContent).toContain("UK");
+
+    // UK-specific pitch mentions pensions.
+    expect(banner.textContent).toMatch(/pension/i);
+
+    // CTA href matches the configured UK route exactly.
+    const cta = screen.getByTestId("quiz-skip-banner-cta");
+    expect(cta).toHaveAttribute(
+      "href",
+      "/advisors/international-tax-specialists?specialty=UK%20Pension%20Transfer&country=uk",
+    );
+  });
+
+  it("renders nothing for an unknown/garbage cookie value", async () => {
+    setIntentCookie("zz-not-a-country");
+    render(<EligibilityQuizSkipBanner />);
+    await waitFor(() => {
+      expect(screen.queryByTestId("quiz-skip-banner")).toBeNull();
+    });
+  });
+
+  it("hides the banner and sets the sessionStorage dismiss flag when dismissed", async () => {
+    setIntentCookie("uk");
+    render(<EligibilityQuizSkipBanner />);
+
+    const dismiss = await screen.findByTestId("quiz-skip-banner-dismiss");
+    expect(dismiss).toHaveTextContent(/Take the quiz instead/i);
+
+    await userEvent.click(dismiss);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("quiz-skip-banner")).toBeNull();
+    });
+    expect(sessionStorage.getItem(DISMISS_KEY)).toBe("1");
+  });
+
+  it("never renders when the dismiss flag is already set before mount, even with a valid cookie", async () => {
+    sessionStorage.setItem(DISMISS_KEY, "1");
+    setIntentCookie("uk");
+    render(<EligibilityQuizSkipBanner />);
+
+    // Allow the mount effect to run.
+    await waitFor(() => {
+      expect(screen.queryByTestId("quiz-skip-banner")).toBeNull();
+    });
+  });
+
+  it("shows a country-specific pitch — US mentions FATCA", async () => {
+    setIntentCookie("us");
+    render(<EligibilityQuizSkipBanner />);
+
+    const banner = await screen.findByTestId("quiz-skip-banner");
+    expect(banner.textContent).toContain("FATCA");
+
+    const cta = screen.getByTestId("quiz-skip-banner-cta");
+    expect(cta).toHaveAttribute(
+      "href",
+      "/advisors/international-tax-specialists?specialty=FATCA-Aware%20US%20Expat%20Planning&country=us",
+    );
+  });
+});

--- a/__tests__/components/Money.test.tsx
+++ b/__tests__/components/Money.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { render } from "./setup";
+import Money from "@/components/Money";
+
+/**
+ * Currency formatting via Intl varies slightly across Node ICU builds
+ * (NBSP vs regular space, "CN¥" vs "¥"). We assert on digit + symbol
+ * substrings and tolerant regexes rather than exact strings.
+ */
+
+describe("Money", () => {
+  it("renders a single AUD span for amounts < 1M with no intentCountry", () => {
+    const { container } = render(<Money amount={50_000} />);
+    const spans = container.querySelectorAll("span");
+    // Only the wrapper span — no secondary currency span.
+    expect(spans).toHaveLength(1);
+    expect(container.textContent).toMatch(/A?\$\s?50,000/);
+    expect(container.textContent).not.toContain("≈");
+  });
+
+  it("defaults to compact notation for amounts >= 1M", () => {
+    const { container } = render(<Money amount={1_500_000} />);
+    // ICU may prefix the AUD symbol as "$" or "A$" depending on the build.
+    expect(container.textContent).toMatch(/A?\$\s?1\.5M/);
+    // Compact means no grouped full digits.
+    expect(container.textContent).not.toContain("1,500,000");
+  });
+
+  it("renders standard grouped digits when compact={false} on a >= 1M amount", () => {
+    const { container } = render(<Money amount={1_500_000} compact={false} />);
+    expect(container.textContent).toContain("1,500,000");
+    expect(container.textContent).not.toMatch(/1\.5M/);
+  });
+
+  it("renders compact when compact={true} on a < 1M amount (explicit override)", () => {
+    const { container } = render(<Money amount={50_000} compact />);
+    // 50,000 in compact en-AU is "$50K" or "$50.0K" depending on ICU.
+    expect(container.textContent).toMatch(/A?\$\s?50(\.0)?K/);
+    expect(container.textContent).not.toContain("50,000");
+  });
+
+  it("renders both AUD primary and a secondary CNY span for intentCountry='cn'", () => {
+    const { container } = render(<Money amount={1_500_000} intentCountry="cn" />);
+    const text = container.textContent ?? "";
+
+    // Primary AUD still present.
+    expect(text).toMatch(/A?\$\s?1\.5M/);
+
+    // Secondary marked with the approx symbol and the CNY symbol.
+    expect(text).toContain("≈");
+    expect(text).toContain("¥");
+
+    // 1.5M AUD * 4.7 = 7.05M CNY. zh-CN compact ICU renders this with the
+    // native 万 (10k) grouping ("705万") rather than a Latin "M" suffix.
+    // Assert the ¥ symbol sits immediately before the converted digits.
+    expect(text).toMatch(/¥\s?705/);
+
+    // The secondary span carries an explanatory title attribute.
+    const titled = container.querySelector("span[title]");
+    expect(titled).not.toBeNull();
+    const title = titled?.getAttribute("title") ?? "";
+    expect(title).toContain("CNY");
+    expect(title).toContain("not a settlement rate");
+  });
+
+  it("renders only the AUD span when intentCountry is null", () => {
+    const { container } = render(<Money amount={500_000} intentCountry={null} />);
+    expect(container.textContent).not.toContain("≈");
+    expect(container.querySelector("span[title]")).toBeNull();
+    expect(container.querySelectorAll("span")).toHaveLength(1);
+  });
+
+  it("renders only the AUD span for an unmapped intent code", () => {
+    // 'xx' is not in the APPROX_FX_PER_AUD table.
+    const { container } = render(
+      // @ts-expect-error — intentionally passing an unmapped code to exercise the fallback.
+      <Money amount={500_000} intentCountry="xx" />,
+    );
+    expect(container.textContent).not.toContain("≈");
+    expect(container.querySelector("span[title]")).toBeNull();
+  });
+
+  it("applies the className prop to the wrapper span", () => {
+    const { container } = render(
+      <Money amount={50_000} className="text-emerald-600 font-bold" />,
+    );
+    const wrapper = container.firstElementChild;
+    expect(wrapper?.tagName).toBe("SPAN");
+    expect(wrapper).toHaveClass("text-emerald-600");
+    expect(wrapper).toHaveClass("font-bold");
+  });
+});


### PR DESCRIPTION
Pure-additive component tests (jsdom). Tier A (pure-additive).

Modules covered:
- `components/Money.tsx` — AUD-primary currency formatter. Cases: <1M single-span standard format, >=1M compact default, explicit `compact={false}` grouped digits, explicit `compact` override on <1M, `intentCountry='cn'` dual AUD+CNY render with title disclaimer, `intentCountry={null}` and unmapped-code fallbacks, `className` passthrough. Currency assertions use tolerant digit+symbol regexes (Intl compact notation is ICU-build dependent).
- `components/EligibilityQuizSkipBanner.tsx` — client cookie/sessionStorage banner. Cases: no cookie -> nothing, known cookie (uk) renders display+pension pitch+exact CTA href, garbage cookie rejected, dismiss hides banner and sets `iv-quiz-skip-banner-dismissed=1`, pre-set dismiss flag suppresses render, US cookie pitch mentions FATCA.

Verify: `npm test -- __tests__/components/Money.test.tsx __tests__/components/EligibilityQuizSkipBanner.test.tsx` -> 14 passed.