### PR TITLE
fix(ux): surface orphaned authed navigation (net-worth/alerts, account dashboard, squad + advisor + firm portal)

### DIFF
--- a/app/account/AccountClient.tsx
+++ b/app/account/AccountClient.tsx
@@ -217,6 +217,31 @@ export default function AccountClient() {
       <div className="container-custom max-w-2xl">
         <h1 className="text-2xl font-extrabold text-slate-900 mb-6">My Account</h1>
 
+        {/* Full dashboard entry — the rich NavCard hub at /account/dashboard
+            (goals, holdings, net worth, watchlist, alerts, calendar, vault…)
+            was previously only reachable via breadcrumbs. Surface it here as
+            the primary "all tools" entry point. */}
+        <Link
+          href="/account/dashboard"
+          className="group mb-6 flex items-center justify-between gap-3 rounded-xl border border-violet-200 bg-gradient-to-r from-violet-50 to-white px-5 py-4 transition-colors hover:border-violet-300"
+        >
+          <div className="flex items-center gap-3">
+            <span className="text-2xl" aria-hidden="true">🧭</span>
+            <div>
+              <p className="text-sm font-bold text-slate-900">Your dashboard</p>
+              <p className="text-xs text-slate-500 mt-0.5">
+                Goals, holdings, net worth, watchlist, alerts &amp; every tool in one place
+              </p>
+            </div>
+          </div>
+          <span className="inline-flex items-center gap-1 text-sm font-semibold text-violet-700 whitespace-nowrap">
+            Open
+            <svg className="w-4 h-4 transition-transform group-hover:translate-x-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+          </span>
+        </Link>
+
         {/* Checkout success banner */}
         {showSuccessBanner && isPro && (
           <div className="mb-6 bg-emerald-50 border border-emerald-200 rounded-xl px-4 py-3 flex items-start gap-3">
@@ -610,6 +635,12 @@ export default function AccountClient() {
             </Link>
             <Link href="/calculators" className="flex items-center gap-2 px-3 py-2 text-sm text-slate-700 bg-slate-50 rounded-lg hover:bg-slate-100 transition-colors">
               <span>🧮</span> Calculators
+            </Link>
+            <Link href="/account/net-worth" className="flex items-center gap-2 px-3 py-2 text-sm text-slate-700 bg-slate-50 rounded-lg hover:bg-slate-100 transition-colors">
+              <span>💰</span> Net Worth
+            </Link>
+            <Link href="/account/alerts" className="flex items-center gap-2 px-3 py-2 text-sm text-slate-700 bg-slate-50 rounded-lg hover:bg-slate-100 transition-colors">
+              <span>📉</span> Rate &amp; Fee Alerts
             </Link>
             <Link href="/quiz" className="flex items-center gap-2 px-3 py-2 text-sm text-slate-700 bg-slate-50 rounded-lg hover:bg-slate-100 transition-colors">
               <span>🎯</span> Platform Quiz

--- a/app/account/dashboard/page.tsx
+++ b/app/account/dashboard/page.tsx
@@ -704,7 +704,9 @@ export default async function PersonalDashboardPage() {
           <NavCard href="/account/investor-profile" emoji="🧠" label="Investor Profile" desc="Goals, experience, interests" />
           <NavCard href="/account/goals" emoji="🎯" label="Financial Goals" desc="Set targets, track progress" />
           <NavCard href="/account/holdings" emoji="💼" label="Holdings" desc="Track your portfolio positions" />
+          <NavCard href="/account/net-worth" emoji="💰" label="Net Worth" desc="Holdings + goals + manual balances" />
           <NavCard href="/account/watchlist" emoji="📈" label="Watchlist" desc="Stocks, ETFs, funds on your radar" />
+          <NavCard href="/account/alerts" emoji="📉" label="Alerts" desc="Rate & fee alerts you've set" />
           <NavCard href="/account/bookmarks" emoji="🔖" label="Reading List" desc="Saved articles and guides" />
           <NavCard href="/account/quizzes" emoji="📝" label="Quiz History" desc="Platform quiz results" />
           <NavCard href="/account/notifications" emoji="🔔" label="Notifications" desc="Email preferences and alerts" />

--- a/app/account/vault/page.tsx
+++ b/app/account/vault/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { enforcePortalKind } from "@/lib/portal-gate";
 import VaultClient from "./VaultClient";
@@ -36,8 +37,11 @@ export default async function VaultPage() {
     data: { user },
   } = await supabase.auth.getUser();
 
+  // Defense-in-depth: enforcePortalKind already redirects unauthenticated
+  // visitors above; mirror holdings/net-worth and redirect to login rather
+  // than rendering a blank page if we somehow reach here without a user.
   if (!user) {
-    return null;
+    redirect("/account/login?redirect=/account/vault");
   }
 
   const { data: rows } = await supabase

--- a/app/advisor-portal/page.tsx
+++ b/app/advisor-portal/page.tsx
@@ -276,6 +276,23 @@ export default function AdvisorPortalPage() {
             <Icon name="activity" size={16} />
             Auctions
           </Link>
+          {/* P2-4: marketplace settings (bid templates / alert prefs) and the
+              Expert Teams (Pro Squad) manager were URL-only — surface them so
+              advisors can reach them without a direct link. */}
+          <Link
+            href="/advisor-portal/marketplace"
+            className="flex items-center gap-1.5 px-3 py-3 text-sm font-medium border-b-2 border-transparent text-slate-500 hover:text-slate-700 whitespace-nowrap focus:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 focus-visible:ring-inset"
+          >
+            <Icon name="store" size={16} />
+            Marketplace
+          </Link>
+          <Link
+            href="/advisor-portal/teams"
+            className="flex items-center gap-1.5 px-3 py-3 text-sm font-medium border-b-2 border-transparent text-slate-500 hover:text-slate-700 whitespace-nowrap focus:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 focus-visible:ring-inset"
+          >
+            <Icon name="users" size={16} />
+            Expert Teams
+          </Link>
         </div>
       </div>
 

--- a/app/firm-portal/_components/FirmPortalNav.tsx
+++ b/app/firm-portal/_components/FirmPortalNav.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+/**
+ * FirmPortalNav — shared sibling navigation for the firm-admin portal
+ * (P2-5). The Performance · Billing · Jobs cross-link strip previously only
+ * existed on /firm-portal/analytics, so the other three pages had no way to
+ * reach their siblings. Lifted into app/firm-portal/layout.tsx and extended
+ * to include Analytics + active-state highlighting.
+ *
+ * Mobile-friendly: the link row scrolls horizontally (overflow-x-auto).
+ */
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import Icon from "@/components/Icon";
+
+interface NavItem {
+  href: string;
+  label: string;
+  icon: string;
+}
+
+const ITEMS: NavItem[] = [
+  { href: "/firm-portal/performance", label: "Performance", icon: "users" },
+  { href: "/firm-portal/billing", label: "Billing", icon: "credit-card" },
+  { href: "/firm-portal/jobs", label: "Jobs", icon: "briefcase" },
+  { href: "/firm-portal/analytics", label: "Analytics", icon: "bar-chart" },
+];
+
+export default function FirmPortalNav() {
+  const pathname = usePathname() ?? "";
+
+  return (
+    <div className="bg-white border-b border-slate-200">
+      <div className="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between gap-3">
+        <Link
+          href="/firm-portal/performance"
+          className="text-xs font-semibold text-slate-700 hover:text-violet-600 transition-colors whitespace-nowrap"
+        >
+          Firm Portal
+        </Link>
+        <nav
+          aria-label="Firm portal sections"
+          className="flex items-center gap-3 text-xs overflow-x-auto"
+        >
+          {ITEMS.map((item) => {
+            const isActive = pathname.startsWith(item.href);
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                aria-current={isActive ? "page" : undefined}
+                className={`flex items-center gap-1 whitespace-nowrap transition-colors ${
+                  isActive
+                    ? "text-violet-700 font-semibold"
+                    : "text-slate-500 hover:text-violet-600"
+                }`}
+              >
+                <Icon name={item.icon} size={12} />
+                {item.label}
+              </Link>
+            );
+          })}
+        </nav>
+      </div>
+    </div>
+  );
+}

--- a/app/firm-portal/analytics/page.tsx
+++ b/app/firm-portal/analytics/page.tsx
@@ -9,7 +9,6 @@
  */
 import type { Metadata } from "next";
 import { redirect } from "next/navigation";
-import Link from "next/link";
 // eslint-disable-next-line no-restricted-imports -- Firm-admin identity resolution requires email-fallback match that can't be expressed via auth.uid() RLS. No cross-user data is read at this layer — data fetching is delegated to getFirmLeadQuality which uses service-role scoped by firmId.
 import { createAdminClient } from "@/lib/supabase/admin";
 import { createClient } from "@/lib/supabase/server";
@@ -17,7 +16,6 @@ import { breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
 import { resolveFirmAdminContext } from "@/lib/firm-billing";
 import LeadQualityClient from "./LeadQualityClient";
 import type { LeadQualityReport } from "./LeadQualityClient";
-import Icon from "@/components/Icon";
 
 export const metadata: Metadata = {
   title: "Lead quality analytics — Firm Portal — Invest.com.au",
@@ -194,33 +192,8 @@ export default async function FirmAnalyticsPage() {
       />
 
       <div className="min-h-screen bg-slate-50">
-        {/* Breadcrumb nav */}
-        <div className="bg-white border-b border-slate-200">
-          <div className="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
-            <nav className="flex items-center gap-1.5 text-xs text-slate-500">
-              <Link href="/firm-portal/performance" className="hover:text-violet-600 transition-colors">
-                Firm Portal
-              </Link>
-              <span>/</span>
-              <span className="text-slate-800 font-medium">Analytics</span>
-            </nav>
-            <div className="flex items-center gap-3 text-xs">
-              <Link href="/firm-portal/performance" className="text-slate-500 hover:text-violet-600 transition-colors flex items-center gap-1">
-                <Icon name="users" size={12} />
-                Performance
-              </Link>
-              <Link href="/firm-portal/billing" className="text-slate-500 hover:text-violet-600 transition-colors flex items-center gap-1">
-                <Icon name="credit-card" size={12} />
-                Billing
-              </Link>
-              <Link href="/firm-portal/jobs" className="text-slate-500 hover:text-violet-600 transition-colors flex items-center gap-1">
-                <Icon name="briefcase" size={12} />
-                Jobs
-              </Link>
-            </div>
-          </div>
-        </div>
-
+        {/* Sibling nav (Performance · Billing · Jobs · Analytics) now lives in
+            the shared app/firm-portal/layout.tsx. */}
         <div className="max-w-5xl mx-auto px-4 py-8">
           <LeadQualityClient initial={report} />
         </div>

--- a/app/firm-portal/layout.tsx
+++ b/app/firm-portal/layout.tsx
@@ -1,0 +1,24 @@
+/**
+ * Layout for /firm-portal/* — renders the shared sibling-nav strip
+ * (Performance · Billing · Jobs · Analytics) above every firm-admin page so
+ * the four surfaces are mutually reachable (P2-5). Previously the strip lived
+ * only on /firm-portal/analytics.
+ *
+ * Thin + additive: it does NOT gate access (each page keeps its own two-stage
+ * firm-admin auth gate) and exports no metadata (each page exports its own).
+ * The /firm-portal index page redirects before this nav ever paints.
+ */
+import FirmPortalNav from "./_components/FirmPortalNav";
+
+export default function FirmPortalLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <FirmPortalNav />
+      {children}
+    </>
+  );
+}

--- a/app/teams/[slug]/_components/SquadSubNav.tsx
+++ b/app/teams/[slug]/_components/SquadSubNav.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+/**
+ * SquadSubNav — cross-navigation for the members-only Pro Squad working
+ * surfaces (P2-3). Previously each of inbox / dashboard / availability /
+ * settings·ops / settings·intake / referrals was reachable only by direct
+ * URL or a single per-page breadcrumb back to the public profile — there was
+ * no way to hop between them.
+ *
+ * Rendered by app/teams/[slug]/layout.tsx, so it wraps every /teams/[slug]/*
+ * route INCLUDING the public, indexed team profile (/teams/[slug]) and the
+ * quote-builder / topic pages. We must NOT show members-only links on those,
+ * so the bar only renders when the current path is one of the member
+ * sub-routes below. It is nav-only and does not gate access — each child page
+ * keeps its own auth/membership check.
+ */
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+interface SubNavItem {
+  segment: string; // path suffix after /teams/<slug>
+  label: string;
+}
+
+// Only these member surfaces get the sub-nav. Keep in sync with the routes
+// that actually exist under app/teams/[slug]/.
+const ITEMS: SubNavItem[] = [
+  { segment: "inbox", label: "Inbox" },
+  { segment: "dashboard", label: "Dashboard" },
+  { segment: "availability", label: "Availability" },
+  { segment: "settings/ops", label: "Ops" },
+  { segment: "settings/intake", label: "Intake" },
+  { segment: "referrals", label: "Referrals" },
+];
+
+export default function SquadSubNav() {
+  const pathname = usePathname() ?? "";
+
+  // Expect /teams/<slug>/<rest...>. Bail (render nothing) for the public
+  // profile (no <rest>) or any route that isn't a tracked member surface.
+  const match = /^\/teams\/([^/]+)\/(.+)$/.exec(pathname);
+  if (!match) return null;
+  const slug = match[1];
+  const rest = match[2];
+
+  const active = ITEMS.find(
+    (it) => rest === it.segment || rest.startsWith(`${it.segment}/`),
+  );
+  if (!active) return null;
+
+  return (
+    <nav
+      aria-label="Pro Squad sections"
+      className="bg-white border-b border-slate-200"
+    >
+      <div className="max-w-5xl mx-auto px-4 flex gap-1 overflow-x-auto">
+        {ITEMS.map((it) => {
+          const isActive = it.segment === active.segment;
+          return (
+            <Link
+              key={it.segment}
+              href={`/teams/${slug}/${it.segment}`}
+              aria-current={isActive ? "page" : undefined}
+              className={`px-3 py-3 text-sm font-medium border-b-2 transition-colors whitespace-nowrap focus:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 focus-visible:ring-inset ${
+                isActive
+                  ? "border-slate-900 text-slate-900"
+                  : "border-transparent text-slate-500 hover:text-slate-700"
+              }`}
+            >
+              {it.label}
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/app/teams/[slug]/layout.tsx
+++ b/app/teams/[slug]/layout.tsx
@@ -1,0 +1,25 @@
+/**
+ * Layout for /teams/[slug]/* — adds a shared sub-nav across the members-only
+ * Pro Squad surfaces (inbox / dashboard / availability / ops / intake /
+ * referrals) so members can move between them (P2-3).
+ *
+ * Deliberately thin: it does NOT add auth gating or metadata. Each child page
+ * (including the public, indexed /teams/[slug] profile) keeps its own
+ * auth/membership checks and its own metadata. SquadSubNav renders nothing on
+ * the public profile and other non-member routes, so this layout is purely
+ * additive and safe to wrap the whole subtree.
+ */
+import SquadSubNav from "./_components/SquadSubNav";
+
+export default function TeamSlugLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <SquadSubNav />
+      {children}
+    </>
+  );
+}


### PR DESCRIPTION
**Tier B (additive UI nav).** Surfaces authenticated pages that were reachable only by direct URL, a single deep breadcrumb, or a Pro-gated dashboard. Additive navigation only — no page logic or data-fetching changes. Each gap was confirmed against the cited files before any change; routes were verified to exist before being linked.

### What changed

- **P2-1 — Net worth + Alerts orphaned behind the Pro paywall.** `/account/net-worth` and `/account/alerts` were linked only from the Pro-gated `/pro/dashboard` (behind its `!isPro || !user` redirect). Added `NavCard`s to the investor dashboard hub (`app/account/dashboard/page.tsx`) and quick links on `/account` (`AccountClient.tsx`) so non-Pro investors can reach them.
- **P2-2 — `/account` never linked the rich dashboard hub.** `/account/dashboard` (the NavCard hub) was only reachable via three deep breadcrumbs. Added a prominent "Your dashboard — all tools in one place" entry at the top of `/account`.
- **P2-3 — Pro Squad pages had no cross-nav.** Added a shared `app/teams/[slug]/layout.tsx` rendering a client `SquadSubNav` (Inbox · Dashboard · Availability · Ops · Intake · Referrals). All six routes verified to exist. The sub-nav renders **only** on those member surfaces — it returns `null` on the public, indexed `/teams/[slug]` profile and on `quote-builder`/`topic` pages, so members-only links never leak onto the public profile. Mobile-friendly (`overflow-x-auto`), matching the existing advisor-portal tab-bar style. No prior `teams/[slug]` layout existed.
- **P2-4 — advisor-portal marketplace + teams were URL-only.** Added "Marketplace" and "Expert Teams" tabs to the advisor-portal nav, right after the AJ-1 Briefs/Auctions entries. Both routes confirmed to exist; distinct from the existing firm-admin "Team" SPA tab.
- **P2-5 — firm-portal sibling nav was inconsistent.** The Performance · Billing · Jobs strip existed only on `/analytics`. Lifted it into a shared `app/firm-portal/layout.tsx` (`FirmPortalNav`, now also including Analytics + active-state), and removed the now-duplicated strip from the analytics page (dropping its now-unused `Link`/`Icon` imports). No prior `firm-portal` layout existed.
- **Trivial — vault logged-out path.** `app/account/vault/page.tsx` returned `null` for a logged-out user; now `redirect("/account/login?redirect=/account/vault")`, mirroring holdings/net-worth (defense-in-depth; `enforcePortalKind` already redirects first).

### Layout safety

Both new layouts are thin **server components** wrapping a small `"use client"` nav child (children are not forced into a client boundary; each page keeps its own metadata/auth). Neither layout adds auth gating. There were **no pre-existing nested layouts** under `teams/[slug]` or `firm-portal`, so nothing was clobbered.

### Verification

- `tsc --noEmit` (whole project): clean.
- `eslint` on all 9 changed files: clean.
- **Full `next build`: compiled successfully** — every wrapped route (`/firm-portal/*`, `/teams/[slug]/*`) renders in the route tree under the new layouts, confirming children render and no nested layout broke.
- Existing tests for touched areas (advisor-portal / firm-portal / teams API + account dashboard-state + jsonld/metadata coverage gates): all green.

Do not merge — draft for review.

https://claude.ai/code/session_01AX16WTaqAs2W33uydbBWLa

---
_Generated by [Claude Code](https://claude.ai/code/session_01AX16WTaqAs2W33uydbBWLa)_