### PR TITLE
refactor(auth): migrate callers to /auth/login?next= from /account/login?redirect=

### DIFF
--- a/__tests__/lib/portal-gate.test.ts
+++ b/__tests__/lib/portal-gate.test.ts
@@ -55,6 +55,17 @@ describe("enforcePortalKind", () => {
     expect(mockSetActiveKind).not.toHaveBeenCalled();
   });
 
+  it("redirects an unauthenticated visitor to /auth/login?next= the portal path (A-19 migration)", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    await expect(enforcePortalKind("advisor")).rejects.toThrow(/REDIRECT/);
+    // Must point at the real sign-in route (/auth/login?next=), not the legacy
+    // /account/login?redirect= URL that only existed as a next.config.ts hop.
+    expect(mockRedirect).toHaveBeenCalledWith(
+      `/auth/login?next=${encodeURIComponent("/advisor-portal")}`,
+    );
+    expect(mockGetActiveKind).not.toHaveBeenCalled();
+  });
+
   it("allows the happy path (active matches + holds the kind)", async () => {
     mockGetActiveKind.mockResolvedValue("investor");
     mockGetKindsForUser.mockResolvedValue([{ kind: "investor" }]);

--- a/app/account/alerts/page.tsx
+++ b/app/account/alerts/page.tsx
@@ -22,7 +22,7 @@ export default async function AccountAlertsPage() {
   } = await supabase.auth.getUser();
 
   if (!user) {
-    redirect("/account/login?redirect=/account/alerts");
+    redirect("/auth/login?next=/account/alerts");
   }
 
   const email = user.email ?? "";

--- a/app/account/annual-check/page.tsx
+++ b/app/account/annual-check/page.tsx
@@ -210,7 +210,7 @@ export default async function AnnualCheckPage() {
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) {
-    redirect("/account/login?redirect=/account/annual-check");
+    redirect("/auth/login?next=/account/annual-check");
   }
 
   const investorProfile = await getInvestorProfile(user.id).catch(() => null);

--- a/app/account/bookmarks/page.tsx
+++ b/app/account/bookmarks/page.tsx
@@ -27,7 +27,7 @@ export default async function AccountBookmarksPage() {
   } = await supabase.auth.getUser();
 
   if (!user) {
-    redirect("/account/login?redirect=/account/bookmarks");
+    redirect("/auth/login?next=/account/bookmarks");
   }
 
   const items: BookmarkRow[] = await listBookmarks(user.id);

--- a/app/account/goals/page.tsx
+++ b/app/account/goals/page.tsx
@@ -17,7 +17,7 @@ export default async function GoalsPage() {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) {
-    redirect("/account/login?redirect=/account/goals");
+    redirect("/auth/login?next=/account/goals");
   }
 
   const { data } = await supabase

--- a/app/account/holdings/page.tsx
+++ b/app/account/holdings/page.tsx
@@ -27,7 +27,7 @@ export default async function HoldingsPage() {
   } = await supabase.auth.getUser();
 
   if (!user) {
-    redirect("/account/login?redirect=/account/holdings");
+    redirect("/auth/login?next=/account/holdings");
   }
 
   // Fetch holdings + broker fee table + sharesight connection in parallel.

--- a/app/account/investor-profile/page.tsx
+++ b/app/account/investor-profile/page.tsx
@@ -16,7 +16,7 @@ export default async function InvestorProfilePage() {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) {
-    redirect("/account/login?redirect=/account/investor-profile");
+    redirect("/auth/login?next=/account/investor-profile");
   }
 
   const [profile, tokensRes] = await Promise.all([

--- a/app/account/listings/page.tsx
+++ b/app/account/listings/page.tsx
@@ -48,7 +48,7 @@ export default async function AccountListingsPage({
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) {
-    redirect("/account/login?redirect=/account/listings");
+    redirect("/auth/login?next=/account/listings");
   }
 
   const listings = await listListingsForOwner(user.id);

--- a/app/account/lists/page.tsx
+++ b/app/account/lists/page.tsx
@@ -20,7 +20,7 @@ export default async function AccountListsPage() {
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) {
-    redirect("/account/login?redirect=/account/lists");
+    redirect("/auth/login?next=/account/lists");
   }
 
   const { data } = await supabase

--- a/app/account/my-saves/page.tsx
+++ b/app/account/my-saves/page.tsx
@@ -118,7 +118,7 @@ export default async function MySavesPage() {
   } = await supabase.auth.getUser();
 
   if (!user) {
-    redirect("/account/login?redirect=/account/my-saves");
+    redirect("/auth/login?next=/account/my-saves");
   }
 
   const admin = createAdminClient();

--- a/app/account/net-worth/page.tsx
+++ b/app/account/net-worth/page.tsx
@@ -58,7 +58,7 @@ export default async function NetWorthPage() {
   const {
     data: { user },
   } = await supabase.auth.getUser();
-  if (!user) redirect("/account/login?redirect=/account/net-worth");
+  if (!user) redirect("/auth/login?next=/account/net-worth");
 
   const [holdingsRes, goalsRes, manualBalancesRes] = await Promise.all([
     supabase

--- a/app/account/notifications/page.tsx
+++ b/app/account/notifications/page.tsx
@@ -25,7 +25,7 @@ export default async function AccountNotificationsPage() {
   } = await supabase.auth.getUser();
 
   if (!user) {
-    redirect("/account/login?redirect=/account/notifications");
+    redirect("/auth/login?next=/account/notifications");
   }
 
   const { data } = await supabase

--- a/app/account/property-holdings/page.tsx
+++ b/app/account/property-holdings/page.tsx
@@ -19,7 +19,7 @@ export default async function PropertyHoldingsPage() {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) {
-    redirect("/account/login?redirect=/account/property-holdings");
+    redirect("/auth/login?next=/account/property-holdings");
   }
 
   const { data } = await supabase

--- a/app/account/quizzes/page.tsx
+++ b/app/account/quizzes/page.tsx
@@ -26,7 +26,7 @@ export default async function AccountQuizHistoryPage() {
   } = await supabase.auth.getUser();
 
   if (!user) {
-    redirect("/account/login?redirect=/account/quizzes");
+    redirect("/auth/login?next=/account/quizzes");
   }
 
   const rows = await listForUser(user.id);

--- a/app/account/refer/page.tsx
+++ b/app/account/refer/page.tsx
@@ -20,7 +20,7 @@ export default async function AccountReferPage() {
   const {
     data: { user },
   } = await supabase.auth.getUser();
-  if (!user) redirect("/account/login?redirect=/account/refer");
+  if (!user) redirect("/auth/login?next=/account/refer");
 
   const link = await getOrCreateLink(user.id);
   const shareUrl = `${SITE_URL}/api/ref/${link.share_token}`;

--- a/app/account/reviews/page.tsx
+++ b/app/account/reviews/page.tsx
@@ -51,7 +51,7 @@ export default async function AccountReviewsPage() {
   } = await supabase.auth.getUser();
 
   if (!user?.email) {
-    redirect("/account/login?redirect=/account/reviews");
+    redirect("/auth/login?next=/account/reviews");
   }
 
   const admin = createAdminClient();

--- a/app/account/select-workspace/page.tsx
+++ b/app/account/select-workspace/page.tsx
@@ -28,7 +28,7 @@ export default async function SelectWorkspacePage() {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) {
-    redirect("/account/login?redirect=/account/select-workspace");
+    redirect("/auth/login?next=/account/select-workspace");
   }
 
   const memberships = await getKindsForUser(user.id);

--- a/app/account/startup-thesis/page.tsx
+++ b/app/account/startup-thesis/page.tsx
@@ -29,7 +29,7 @@ export default async function StartupThesisPage() {
     data: { user },
   } = await supabase.auth.getUser();
 
-  if (!user) redirect("/account/login?redirect=/account/startup-thesis");
+  if (!user) redirect("/auth/login?next=/account/startup-thesis");
 
   const { data } = await supabase
     .from("investor_profiles")

--- a/app/account/term-deposits/page.tsx
+++ b/app/account/term-deposits/page.tsx
@@ -21,7 +21,7 @@ export default async function TermDepositsPage() {
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) {
-    redirect("/account/login?redirect=/account/term-deposits");
+    redirect("/auth/login?next=/account/term-deposits");
   }
 
   const { data } = await supabase

--- a/app/account/timeline/page.tsx
+++ b/app/account/timeline/page.tsx
@@ -43,7 +43,7 @@ export default async function AccountTimelinePage() {
   const {
     data: { user },
   } = await supabase.auth.getUser();
-  if (!user) redirect("/account/login?redirect=/account/timeline");
+  if (!user) redirect("/auth/login?next=/account/timeline");
 
   const items = await loadTimeline({
     authUserId: user.id,

--- a/app/account/upgrade/business/page.tsx
+++ b/app/account/upgrade/business/page.tsx
@@ -18,7 +18,7 @@ export default async function BusinessUpgradePage({ searchParams }: PageProps) {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) {
-    redirect("/account/login?redirect=/account/upgrade/business");
+    redirect("/auth/login?next=/account/upgrade/business");
   }
 
   const params = await searchParams;

--- a/app/account/upgrade/page.tsx
+++ b/app/account/upgrade/page.tsx
@@ -137,7 +137,7 @@ export default async function AccountUpgradeHubPage() {
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) {
-    redirect("/account/login?redirect=/account/upgrade");
+    redirect("/auth/login?next=/account/upgrade");
   }
 
   const memberships = await getKindsForUser(user.id);

--- a/app/account/verified/page.tsx
+++ b/app/account/verified/page.tsx
@@ -20,7 +20,7 @@ export default async function VerifiedProductsPage() {
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) {
-    redirect("/account/login?redirect=/account/verified");
+    redirect("/auth/login?next=/account/verified");
   }
 
   const { data } = await supabase

--- a/app/account/watchlist/page.tsx
+++ b/app/account/watchlist/page.tsx
@@ -21,7 +21,7 @@ export default async function WatchlistPage() {
   } = await supabase.auth.getUser();
 
   if (!user) {
-    redirect("/account/login?redirect=/account/watchlist");
+    redirect("/auth/login?next=/account/watchlist");
   }
 
   const [watchlistRes, investorProfile] = await Promise.all([

--- a/app/admin/listings/moderation/page.tsx
+++ b/app/admin/listings/moderation/page.tsx
@@ -32,7 +32,7 @@ export default async function ListingsModerationPage() {
   } = await supabase.auth.getUser();
 
   if (!user || !user.email) {
-    redirect("/account/login?redirect=/admin/listings/moderation");
+    redirect("/auth/login?next=/admin/listings/moderation");
   }
   if (!getAdminEmails().includes(user.email.toLowerCase())) {
     redirect("/account");

--- a/app/admin/outcomes/page.tsx
+++ b/app/admin/outcomes/page.tsx
@@ -25,7 +25,7 @@ interface ScoreRow {
 
 export default async function AdminOutcomesPage() {
   const guard = await requireAdmin();
-  if (!guard.ok) redirect("/account/login");
+  if (!guard.ok) redirect("/auth/login");
 
   const admin = createAdminClient();
   const { data: rows } = await admin

--- a/app/advisor-portal/webhooks/page.tsx
+++ b/app/advisor-portal/webhooks/page.tsx
@@ -23,7 +23,7 @@ export default async function AdvisorPortalWebhooksPage() {
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) {
-    redirect("/account/login?redirect=/advisor-portal/webhooks");
+    redirect("/auth/login?next=/advisor-portal/webhooks");
   }
 
   const admin = createAdminClient();

--- a/app/business-portal/layout.tsx
+++ b/app/business-portal/layout.tsx
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
  *   1. Workspace-kind isolation (enforcePortalKind) — a multi-kind user must
  *      deliberately switch into the business workspace; this prevents reaching
  *      the business portal while active in another kind (audit §5 #14).
- *   2. Authenticated user (else → /account/login)
+ *   2. Authenticated user (else → /auth/login)
  *   3. Active or pending business_accounts row (else → /account/upgrade/business)
  */
 export default async function BusinessPortalLayout({
@@ -32,7 +32,7 @@ export default async function BusinessPortalLayout({
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) {
-    redirect("/account/login?redirect=/business-portal");
+    redirect("/auth/login?next=/business-portal");
   }
 
   const businessId = await requireBusinessSession();

--- a/app/business-portal/page.tsx
+++ b/app/business-portal/page.tsx
@@ -34,7 +34,7 @@ export default async function BusinessPortalPage() {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) {
-    redirect("/account/login?redirect=/business-portal");
+    redirect("/auth/login?next=/business-portal");
   }
 
   const { data } = await supabase

--- a/app/fire-calculator/FireCalculatorClient.tsx
+++ b/app/fire-calculator/FireCalculatorClient.tsx
@@ -428,7 +428,7 @@ function SaveGoalButton({
   if (status === "signin") {
     return (
       <p className="mt-3 text-xs text-slate-500">
-        <Link href="/account/login?redirect=/fire-calculator" className="underline">
+        <Link href="/auth/login?next=/fire-calculator" className="underline">
           Sign in
         </Link>{" "}
         to save this FIRE goal to your account.

--- a/app/firm-portal/analytics/page.tsx
+++ b/app/firm-portal/analytics/page.tsx
@@ -57,7 +57,7 @@ export default async function FirmAnalyticsPage() {
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) {
-    redirect("/account/login?redirect=/firm-portal/analytics");
+    redirect("/auth/login?next=/firm-portal/analytics");
   }
 
   const admin = createAdminClient();

--- a/app/firm-portal/billing/page.tsx
+++ b/app/firm-portal/billing/page.tsx
@@ -25,7 +25,7 @@ export default async function FirmBillingPage() {
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) {
-    redirect("/account/login?redirect=/firm-portal/billing");
+    redirect("/auth/login?next=/firm-portal/billing");
   }
 
   const admin = createAdminClient();

--- a/app/firm-portal/jobs/page.tsx
+++ b/app/firm-portal/jobs/page.tsx
@@ -33,7 +33,7 @@ export default async function FirmJobsPage() {
   } = await supabase.auth.getUser();
 
   if (!user) {
-    redirect("/account/login?redirect=/firm-portal/jobs");
+    redirect("/auth/login?next=/firm-portal/jobs");
   }
 
   const admin = createAdminClient();

--- a/app/firm-portal/performance/page.tsx
+++ b/app/firm-portal/performance/page.tsx
@@ -39,7 +39,7 @@ export default async function FirmPerformancePage() {
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) {
-    redirect("/account/login?redirect=/firm-portal/performance");
+    redirect("/auth/login?next=/firm-portal/performance");
   }
 
   const admin = createAdminClient();

--- a/app/invest/startups/for-you/page.tsx
+++ b/app/invest/startups/for-you/page.tsx
@@ -22,7 +22,7 @@ export default async function StartupsForYouPage() {
   const {
     data: { user },
   } = await supabase.auth.getUser();
-  if (!user) redirect("/account/login?redirect=/invest/startups/for-you");
+  if (!user) redirect("/auth/login?next=/invest/startups/for-you");
 
   // Fetch thesis, wholesale cert, and open rounds in parallel
   const [profileRes, certRes, roundsRes] = await Promise.all([

--- a/app/listings/new/ListingNewClient.tsx
+++ b/app/listings/new/ListingNewClient.tsx
@@ -115,7 +115,7 @@ export default function ListingNewClient() {
         });
         if (createRes.status === 401) {
           router.push(
-            `/account/login?redirect=${encodeURIComponent("/listings/new")}`,
+            `/auth/login?next=${encodeURIComponent("/listings/new")}`,
           );
           return;
         }

--- a/app/lists/[slug]/ListFollowButton.tsx
+++ b/app/lists/[slug]/ListFollowButton.tsx
@@ -14,7 +14,7 @@ export default function ListFollowButton({ slug, initialFollowing, isAuthenticat
 
   const toggle = async () => {
     if (!isAuthenticated) {
-      window.location.href = `/account/login?redirect=/lists/${slug}`;
+      window.location.href = `/auth/login?next=/lists/${slug}`;
       return;
     }
     setBusy(true);

--- a/app/pros/availability/page.tsx
+++ b/app/pros/availability/page.tsx
@@ -25,7 +25,7 @@ export default async function ProsAvailabilityPage() {
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) {
-    redirect("/account/login?redirect=/pros/availability");
+    redirect("/auth/login?next=/pros/availability");
   }
 
   const admin = createAdminClient();

--- a/app/pros/billing/page.tsx
+++ b/app/pros/billing/page.tsx
@@ -50,7 +50,7 @@ export default async function ProsBillingPage() {
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) {
-    redirect("/account/login?redirect=/pros/billing");
+    redirect("/auth/login?next=/pros/billing");
   }
 
   // Use the admin client to find the matching professionals row. The

--- a/app/pros/connect/page.tsx
+++ b/app/pros/connect/page.tsx
@@ -22,7 +22,7 @@ export default async function ProsConnectPage() {
   const {
     data: { user },
   } = await supabase.auth.getUser();
-  if (!user) redirect("/account/login?redirect=/pros/connect");
+  if (!user) redirect("/auth/login?next=/pros/connect");
 
   const admin = createAdminClient();
   const { data: pro } = await admin

--- a/app/pros/settings/intake/page.tsx
+++ b/app/pros/settings/intake/page.tsx
@@ -25,7 +25,7 @@ export default async function ProsIntakeSettingsPage() {
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) {
-    redirect("/account/login?redirect=/pros/settings/intake");
+    redirect("/auth/login?next=/pros/settings/intake");
   }
 
   const admin = createAdminClient();

--- a/app/pros/settings/pricing-tier/page.tsx
+++ b/app/pros/settings/pricing-tier/page.tsx
@@ -28,7 +28,7 @@ export default async function ProsPricingTierPage() {
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) {
-    redirect("/account/login?redirect=/pros/settings/pricing-tier");
+    redirect("/auth/login?next=/pros/settings/pricing-tier");
   }
 
   const admin = createAdminClient();

--- a/app/rba-poll/PollWidget.tsx
+++ b/app/rba-poll/PollWidget.tsx
@@ -209,7 +209,7 @@ export default function PollWidget({ poll, isAuthenticated }: Props) {
 
       {!isAuthenticated && isOpen && (
         <p className="text-sm text-slate-500 mb-4 text-center">
-          <a href="/account/login" className="text-violet-600 font-semibold hover:underline">
+          <a href="/auth/login" className="text-violet-600 font-semibold hover:underline">
             Sign in
           </a>{" "}
           to predict the RBA decision.

--- a/app/rba-poll/page.tsx
+++ b/app/rba-poll/page.tsx
@@ -268,7 +268,7 @@ export default async function RbaPollPage() {
             )}
             {!userId && (
               <p className="text-xs text-slate-400 mt-4 border-t border-slate-100 pt-3">
-                <Link href="/account/login" className="text-violet-600 font-semibold hover:underline">
+                <Link href="/auth/login" className="text-violet-600 font-semibold hover:underline">
                   Sign in
                 </Link>{" "}
                 to track your accuracy.

--- a/app/startup-portal/data-room/page.tsx
+++ b/app/startup-portal/data-room/page.tsx
@@ -9,7 +9,7 @@ async function getDataRoomData() {
   const {
     data: { user },
   } = await supabase.auth.getUser();
-  if (!user) redirect("/account/login?redirect=/startup-portal/data-room");
+  if (!user) redirect("/auth/login?next=/startup-portal/data-room");
 
   const { data: profile } = await supabase
     .from("startup_profiles")

--- a/app/startup-portal/esic-verification/page.tsx
+++ b/app/startup-portal/esic-verification/page.tsx
@@ -11,7 +11,7 @@ export default async function EsicVerificationPage() {
     data: { user },
   } = await supabase.auth.getUser();
 
-  if (!user) redirect("/account/login?redirect=/startup-portal/esic-verification");
+  if (!user) redirect("/auth/login?next=/startup-portal/esic-verification");
 
   const { data: profile } = await supabase
     .from("startup_profiles")

--- a/app/startup-portal/investors/page.tsx
+++ b/app/startup-portal/investors/page.tsx
@@ -5,7 +5,7 @@ import { redirect } from "next/navigation";
 export default async function StartupPortalInvestorsPage() {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
-  if (!user) redirect("/account/login?redirect=/startup-portal/investors");
+  if (!user) redirect("/auth/login?next=/startup-portal/investors");
 
   const { data: profile } = await supabase
     .from("startup_profiles")

--- a/app/startup-portal/page.tsx
+++ b/app/startup-portal/page.tsx
@@ -5,7 +5,7 @@ import { redirect } from "next/navigation";
 async function getStartupDashboardData() {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
-  if (!user) redirect("/account/login?redirect=/startup-portal");
+  if (!user) redirect("/auth/login?next=/startup-portal");
 
   const { data: profile } = await supabase
     .from("startup_profiles")

--- a/app/startup-portal/profile/page.tsx
+++ b/app/startup-portal/profile/page.tsx
@@ -5,7 +5,7 @@ import { redirect } from "next/navigation";
 export default async function StartupPortalProfilePage() {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
-  if (!user) redirect("/account/login?redirect=/startup-portal/profile");
+  if (!user) redirect("/auth/login?next=/startup-portal/profile");
 
   const { data: profile } = await supabase
     .from("startup_profiles")

--- a/app/startup-portal/round/page.tsx
+++ b/app/startup-portal/round/page.tsx
@@ -11,7 +11,7 @@ function centsToAud(cents: number): string {
 export default async function StartupPortalRoundPage() {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
-  if (!user) redirect("/account/login?redirect=/startup-portal/round");
+  if (!user) redirect("/auth/login?next=/startup-portal/round");
 
   const { data: profile } = await supabase
     .from("startup_profiles")

--- a/app/startup-signup/page.tsx
+++ b/app/startup-signup/page.tsx
@@ -377,7 +377,7 @@ export default function StartupSignupPage() {
 
         <p className="text-center text-xs text-gray-400 mt-6">
           Already have an account?{" "}
-          <Link href="/account/login" className="text-blue-600 hover:underline">Sign in</Link>
+          <Link href="/auth/login" className="text-blue-600 hover:underline">Sign in</Link>
         </p>
       </div>
     </div>

--- a/app/teams/[slug]/dashboard/page.tsx
+++ b/app/teams/[slug]/dashboard/page.tsx
@@ -57,7 +57,7 @@ export default async function TeamDashboardPage({ params }: PageProps) {
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) {
-    redirect(`/account/login?redirect=/teams/${slug}/dashboard`);
+    redirect(`/auth/login?next=/teams/${slug}/dashboard`);
   }
 
   const admin = createAdminClient();

--- a/app/teams/[slug]/inbox/page.tsx
+++ b/app/teams/[slug]/inbox/page.tsx
@@ -56,13 +56,13 @@ export default async function SquadInboxPage({ params, searchParams }: PageProps
   const page = Number.isFinite(rawPage) && rawPage > 0 ? rawPage : 1;
   const offset = (page - 1) * PAGE_SIZE;
 
-  // 1. Auth — redirect unauthenticated to /account/login.
+  // 1. Auth — redirect unauthenticated to /auth/login.
   const supabase = await createClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) {
-    redirect(`/account/login?redirect=/teams/${slug}/inbox`);
+    redirect(`/auth/login?next=/teams/${slug}/inbox`);
   }
 
   // 2. Resolve calling professional + team membership.

--- a/app/teams/[slug]/quote-builder/page.tsx
+++ b/app/teams/[slug]/quote-builder/page.tsx
@@ -31,7 +31,7 @@ export default async function QuoteBuilderPage({ params, searchParams }: PagePro
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) {
-    redirect(`/account/login?redirect=/teams/${slug}/quote-builder?brief=${briefId}`);
+    redirect(`/auth/login?next=/teams/${slug}/quote-builder?brief=${briefId}`);
   }
 
   const admin = createAdminClient();

--- a/app/teams/[slug]/settings/intake/page.tsx
+++ b/app/teams/[slug]/settings/intake/page.tsx
@@ -33,7 +33,7 @@ export default async function TeamIntakeSettingsPage({
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) {
-    redirect(`/account/login?redirect=/teams/${slug}/settings/intake`);
+    redirect(`/auth/login?next=/teams/${slug}/settings/intake`);
   }
 
   const admin = createAdminClient();

--- a/app/teams/[slug]/settings/ops/page.tsx
+++ b/app/teams/[slug]/settings/ops/page.tsx
@@ -26,7 +26,7 @@ export default async function TeamOpsSettingsPage({
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) {
-    redirect(`/account/login?redirect=/teams/${slug}/settings/ops`);
+    redirect(`/auth/login?next=/teams/${slug}/settings/ops`);
   }
 
   const admin = createAdminClient();

--- a/components/UserVerifiedBadge.tsx
+++ b/components/UserVerifiedBadge.tsx
@@ -96,7 +96,7 @@ export default function UserVerifiedBadge({ productType, productRef, initialCoun
 
       {!loading && !user && (
         <Link
-          href={`/account/login?redirect=${encodeURIComponent(typeof window !== "undefined" ? window.location.pathname : "/")}`}
+          href={`/auth/login?next=${encodeURIComponent(typeof window !== "undefined" ? window.location.pathname : "/")}`}
           className="text-xs text-slate-500 hover:text-violet-700 underline-offset-2 hover:underline"
         >
           Sign in to verify

--- a/lib/portal-gate.ts
+++ b/lib/portal-gate.ts
@@ -62,7 +62,7 @@ export async function enforcePortalKind(expected: WorkspaceKind): Promise<void> 
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) {
-    redirect(`/account/login?redirect=${encodeURIComponent(currentPortalPath(expected))}`);
+    redirect(`/auth/login?next=${encodeURIComponent(currentPortalPath(expected))}`);
   }
 
   const [active, memberships] = await Promise.all([


### PR DESCRIPTION
## What

Mechanical 1:1 migration (worklist A-19, **Tier A**). Replaces every internal use of the legacy `/account/login?redirect=…` URL with the canonical `/auth/login?next=…`, across 57 source files (server `redirect()` guards, `<Link href>` / `window.location` CTAs, and `encodeURIComponent` cases).

## Why

`/account/login` is not a real route — it only resolves via two catch-all rules in `next.config.ts` that rewrite it to `/auth/login?next=`. So every logged-out visitor to a gated page paid an extra HTTP redirect hop. The config comment itself says "Internal callers should migrate to `/auth/login?next=` over time." This does that, removing the hop.

- `next.config.ts` catch-all rules are **left untouched** — old bookmarks / external links still resolve.
- `/auth/login` (`LoginClient.tsx`) reads `searchParams.get("next")`, so the deep-link redirect target is preserved 1:1.
- Added a `portal-gate.test.ts` case asserting the unauthenticated path now redirects to `/auth/login?next=…` (locks the migration against regression).

## Verify

- `grep -rln "/account/login" app components lib | grep -v next.config.ts` → no results.
- `npx vitest run __tests__/lib/portal-gate.test.ts` → 8 passed.
- `npx eslint --max-warnings 0` on changed files → clean (2 pre-existing unrelated warnings in files I only touched the login line of).