### PR TITLE
fix(telemetry): send Core Web Vitals to /api/web-vitals (was 400ing on /api/track-event)

### DIFF
--- a/__tests__/components/WebVitals.test.tsx
+++ b/__tests__/components/WebVitals.test.tsx
@@ -26,6 +26,10 @@ vi.mock("next/web-vitals", () => ({
   },
 }));
 
+vi.mock("@/lib/session", () => ({
+  getSessionId: () => "sid-test",
+}));
+
 import WebVitals from "@/components/WebVitals";
 
 const fetchMock = vi.fn();
@@ -71,7 +75,7 @@ describe("WebVitals", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("POSTs to /api/track-event in production", () => {
+  it("POSTs to the dedicated /api/web-vitals beacon in production", () => {
     vi.stubEnv("NODE_ENV", "production");
     Object.defineProperty(window, "location", {
       configurable: true,
@@ -87,24 +91,21 @@ describe("WebVitals", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
 
     const [url, init] = fetchMock.mock.calls[0]!;
-    expect(url).toBe("/api/track-event");
+    expect(url).toBe("/api/web-vitals");
     expect(init.method).toBe("POST");
     expect(init.keepalive).toBe(true);
 
+    // Shape must match app/api/web-vitals/route.ts's VitalsBody validation.
     const body = JSON.parse(init.body);
     expect(body).toEqual({
-      event_type: "web_vital",
-      page: "/some/path",
-      metadata: {
-        metric: "LCP",
-        value: 1234.57, // rounded to 2dp
-        rating: "good",
-        id: "id-1",
-      },
+      metric: "LCP",
+      value: 1234.567, // raw value — route stores the sample as-is
+      page_path: "/some/path",
+      session_id: "sid-test",
     });
   });
 
-  it("rounds the metric value to 2 decimal places", () => {
+  it("sends the raw (unrounded) metric value the route expects", () => {
     vi.stubEnv("NODE_ENV", "production");
     render(<WebVitals />);
     capturedCallback?.({
@@ -116,7 +117,8 @@ describe("WebVitals", () => {
     const body = JSON.parse(
       fetchMock.mock.calls[0]?.[1]?.body as string,
     );
-    expect(body.metadata.value).toBe(0.12);
+    expect(body.value).toBe(0.123456789);
+    expect(typeof body.value).toBe("number");
   });
 
   it("swallows a fetch rejection without throwing", async () => {

--- a/components/WebVitals.tsx
+++ b/components/WebVitals.tsx
@@ -2,19 +2,26 @@
 
 import { useReportWebVitals } from "next/web-vitals";
 import { logger } from "@/lib/logger";
+import { getSessionId } from "@/lib/session";
 
 const log = logger("web-vitals");
 
 /**
- * Reports Core Web Vitals (CLS, LCP, INP, FCP, TTFB) to our own
- * /api/track-event endpoint. Logged in development for debugging.
+ * Reports Core Web Vitals (CLS, LCP, INP, FCP, TTFB) to our dedicated
+ * /api/web-vitals beacon endpoint. Logged in development for debugging.
  *
  * Mounted via components/LayoutSideEffects.tsx (lazy-loaded after
  * hydration so this telemetry doesn't compete with LCP work).
+ *
+ * The beacon body shape ({ metric, value, page_path, session_id }) is
+ * validated server-side by app/api/web-vitals/route.ts. We previously
+ * POSTed to /api/track-event with event_type "web_vital", which that
+ * route's ALLOWED_EVENTS never permitted — every beacon 400'd and all
+ * field data was dropped.
  */
 export default function WebVitals() {
   useReportWebVitals((metric) => {
-    const { name, value, id, rating } = metric;
+    const { name, value, rating } = metric;
 
     // Log in development for debugging (logger filters debug-level out in prod)
     if (process.env.NODE_ENV === "development") {
@@ -25,22 +32,20 @@ export default function WebVitals() {
       });
     }
 
-    // Send to our own analytics endpoint (non-blocking).
+    // Send to our dedicated web-vitals beacon (non-blocking, keepalive so
+    // it survives page-transition unloads). Send the raw value — the route
+    // stores the sample as-is and classifies the rating server-side.
     // Previously also dispatched to `window.gtag` when present — GA4
     // was removed in TT-04 and the branch was dead code from then on.
     if (process.env.NODE_ENV === "production") {
-      fetch("/api/track-event", {
+      fetch("/api/web-vitals", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          event_type: "web_vital",
-          page: window.location.pathname,
-          metadata: {
-            metric: name,
-            value: Math.round(value * 100) / 100,
-            rating,
-            id,
-          },
+          metric: name,
+          value,
+          page_path: window.location.pathname,
+          session_id: getSessionId(),
         }),
         keepalive: true,
       }).catch(() => {});


### PR DESCRIPTION
## What

`components/WebVitals.tsx` POSTed Core Web Vitals beacons (LCP/INP/CLS/FCP/TTFB) to `/api/track-event` with `event_type: "web_vital"`. That route's `ALLOWED_EVENTS` set never included `web_vital`, so every beacon returned **400** and all field-data CWV samples were silently dropped.

This points the beacon at the **dedicated** `app/api/web-vitals/route.ts` and sends the exact body its `VitalsBody` validation accepts:

```jsonc
{ "metric": "LCP", "value": 1234.567, "page_path": "/some/path", "session_id": "<first-party sid>" }
```

- Sends the **raw** (unrounded) `value` — the route stores the sample as-is and classifies the rating server-side via `classifyVital`.
- `session_id` reuses the existing first-party `getSessionId()` helper (`lib/session.ts`); the route hashes it (`session_hash`) for coarse grouping.
- Kept **fire-and-forget + keepalive** so the beacon survives page-transition unloads.
- Dev-debug logging unchanged.

The metric names from `next/web-vitals` (LCP/INP/CLS/FCP/TTFB) already match the route's `isValidMetric` allow-list, and `value`/`page_path` are always populated, so beacons now pass validation instead of 400ing.

## Tests

Updated `__tests__/components/WebVitals.test.tsx` to assert the new URL + payload shape (mocks `@/lib/session`), including a case proving the raw numeric value is sent. 6/6 pass.

## Verify
- `npx vitest run __tests__/components/WebVitals.test.tsx` → 6 passed
- `npx eslint --max-warnings 0 components/WebVitals.tsx __tests__/components/WebVitals.test.tsx` → clean (exit 0)

Tier B (non-API-surface telemetry fix + updated component test).