### PR TITLE
fix(brokers): fall back to initials avatar for placeholder/empty broker logos

### DIFF
--- a/__tests__/components/BrokerLogo.test.tsx
+++ b/__tests__/components/BrokerLogo.test.tsx
@@ -67,6 +67,51 @@ describe("BrokerLogo", () => {
     expect(img?.getAttribute("src")).toBe("https://x/logo.png");
   });
 
+  it("falls back to the initials avatar for the placeholder sentinel URL", () => {
+    const { container } = render(
+      <BrokerLogo
+        broker={{
+          ...baseBroker,
+          logo_url: "https://images.unsplash.com/placeholder",
+        }}
+      />,
+    );
+    // No image is routed through the optimizer — only the letter fallback shows.
+    expect(container.querySelector("img")).toBeNull();
+    expect(screen.getByText("S")).toBeInTheDocument();
+  });
+
+  it("treats the placeholder sentinel with a query string as unusable", () => {
+    const { container } = render(
+      <BrokerLogo
+        broker={{
+          ...baseBroker,
+          logo_url: "https://images.unsplash.com/placeholder?w=64&fit=crop",
+        }}
+      />,
+    );
+    expect(container.querySelector("img")).toBeNull();
+    expect(screen.getByText("S")).toBeInTheDocument();
+  });
+
+  it("falls back to the initials avatar for an empty/whitespace logo_url", () => {
+    const { container } = render(
+      <BrokerLogo broker={{ ...baseBroker, logo_url: "   " }} />,
+    );
+    expect(container.querySelector("img")).toBeNull();
+    expect(screen.getByText("S")).toBeInTheDocument();
+  });
+
+  it("trims surrounding whitespace from an otherwise valid logo_url", () => {
+    const { container } = render(
+      <BrokerLogo
+        broker={{ ...baseBroker, logo_url: "  https://x/logo.png  " }}
+      />,
+    );
+    const img = container.querySelector("img");
+    expect(img?.getAttribute("src")).toBe("https://x/logo.png");
+  });
+
   it("size=sm applies the small container classes", () => {
     const { container } = render(
       <BrokerLogo broker={baseBroker} size="sm" />,

--- a/components/BrokerLogo.tsx
+++ b/components/BrokerLogo.tsx
@@ -36,6 +36,28 @@ const SIZES = {
   xl: { container: "w-16 h-16", text: "text-lg", img: 64 },
 };
 
+/**
+ * Known sentinel/placeholder logo URLs that exist in some broker data but
+ * 404 when routed through the Next image optimizer (e.g. the mirror dataset
+ * ships `images.unsplash.com/placeholder`). Match these case-insensitively and
+ * substring-wise so query strings or sizing params don't slip past the guard.
+ */
+const PLACEHOLDER_LOGO_SENTINELS = ["images.unsplash.com/placeholder"];
+
+/**
+ * A logo URL is only usable if it's a non-empty string that isn't a known
+ * placeholder sentinel. Empty/whitespace/sentinel URLs fall back to the
+ * initials avatar up front rather than sending a doomed request through the
+ * image optimizer.
+ */
+function isUsableLogoUrl(url: string | undefined): url is string {
+  if (!url) return false;
+  const trimmed = url.trim();
+  if (trimmed === "") return false;
+  const lower = trimmed.toLowerCase();
+  return !PLACEHOLDER_LOGO_SENTINELS.some((sentinel) => lower.includes(sentinel));
+}
+
 function LetterFallback({ broker, s }: { broker: BrokerLogoProps["broker"]; s: (typeof SIZES)["md"] }) {
   return (
     <div
@@ -56,8 +78,9 @@ export default function BrokerLogo({
   const s = SIZES[size];
   const [imgError, setImgError] = useState(false);
 
-  if (broker.logo_url && !imgError) {
-    const isIco = broker.logo_url.endsWith(".ico");
+  if (isUsableLogoUrl(broker.logo_url) && !imgError) {
+    const logoUrl = broker.logo_url.trim();
+    const isIco = logoUrl.endsWith(".ico");
 
     // ICO files: use native <img> since Next.js Image doesn't handle ICO well
     if (isIco) {
@@ -65,7 +88,7 @@ export default function BrokerLogo({
         <div className={`${s.container} rounded-lg overflow-hidden shrink-0 bg-white border border-slate-100 ${className}`}>
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
-            src={broker.logo_url}
+            src={logoUrl}
             alt={`${broker.name} logo`}
             width={s.img}
             height={s.img}
@@ -81,7 +104,7 @@ export default function BrokerLogo({
     return (
       <div className={`${s.container} rounded-lg overflow-hidden shrink-0 bg-white border border-slate-100 ${className}`}>
         <Image
-          src={broker.logo_url}
+          src={logoUrl}
           alt={`${broker.name} logo`}
           width={s.img}
           height={s.img}


### PR DESCRIPTION
## What

`BrokerLogo` now renders the initials/monogram avatar up front when `logo_url` is missing, empty/whitespace, or a known placeholder sentinel (`images.unsplash.com/placeholder`), instead of routing a doomed URL through the Next image optimizer.

Bots found broker logos in the mirror dataset pointing at the literal sentinel `images.unsplash.com/placeholder`, which 404s through the optimizer on `/versus` and broker pages. The component previously only fell back on a runtime `onError` or a missing `logo_url`, so the broken request was still fired.

New `isUsableLogoUrl()` guard:
- rejects missing / empty / whitespace-only URLs
- rejects the placeholder sentinel (matched case-insensitively + substring-wise so query strings/sizing params don't slip past)
- trims surrounding whitespace from otherwise-valid URLs

Existing good logos (PNG via next/image, `.ico` via native `<img>`) keep working, and the runtime `onError` fallback is retained as a second line of defense.

Focused tests added in `__tests__/components/BrokerLogo.test.tsx` for the sentinel (plain + with query string), empty/whitespace, and whitespace-trimming cases.

**Tier B** (component refactor + additive tests).