### PR TITLE
fix(db): correct drift-backfill migrations to match live schema

### DIFF
--- a/supabase/migrations/20260521_careers_marketplace.sql
+++ b/supabase/migrations/20260521_careers_marketplace.sql
@@ -32,7 +32,7 @@ BEGIN;
 
 CREATE TABLE IF NOT EXISTS public.job_posts (
   id            uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
-  firm_id       uuid        NOT NULL REFERENCES public.advisor_firms(id) ON DELETE CASCADE,
+  firm_id       integer     NOT NULL REFERENCES public.advisor_firms(id) ON DELETE CASCADE,
   created_by    uuid        REFERENCES auth.users(id) ON DELETE SET NULL,
   title         text        NOT NULL CHECK (char_length(title) BETWEEN 2 AND 200),
   location      text        NOT NULL CHECK (char_length(location) BETWEEN 2 AND 100),

--- a/supabase/migrations/20260522_course_reviews.sql
+++ b/supabase/migrations/20260522_course_reviews.sql
@@ -7,7 +7,7 @@ BEGIN;
 
 CREATE TABLE IF NOT EXISTS public.course_reviews (
   id              SERIAL PRIMARY KEY,
-  course_id       UUID NOT NULL REFERENCES public.courses(id) ON DELETE CASCADE,
+  course_id       BIGINT NOT NULL REFERENCES public.courses(id) ON DELETE CASCADE,
   user_id         UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
   purchase_id     INTEGER REFERENCES public.course_purchases(id) ON DELETE SET NULL,
   rating          SMALLINT NOT NULL CHECK (rating BETWEEN 1 AND 5),

--- a/supabase/migrations/20260522_cpd_tracking.sql
+++ b/supabase/migrations/20260522_cpd_tracking.sql
@@ -42,7 +42,7 @@ CREATE TABLE IF NOT EXISTS course_certificates (
   id                 UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id            UUID        REFERENCES auth.users(id) ON DELETE SET NULL,
   professional_id    BIGINT      REFERENCES professionals(id) ON DELETE SET NULL,
-  course_id          UUID        NOT NULL REFERENCES courses(id),
+  course_id          BIGINT      NOT NULL REFERENCES courses(id),
   purchase_id        BIGINT      REFERENCES course_purchases(id),
   certificate_number TEXT        NOT NULL,
   issued_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
@@ -101,7 +101,7 @@ CREATE POLICY "User reads own certificates"
 CREATE TABLE IF NOT EXISTS cpd_credits (
   id               UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
   professional_id  BIGINT      NOT NULL REFERENCES professionals(id) ON DELETE CASCADE,
-  course_id        UUID        NOT NULL REFERENCES courses(id),
+  course_id        BIGINT      NOT NULL REFERENCES courses(id),
   purchase_id      BIGINT      REFERENCES course_purchases(id),
   certificate_id   UUID        REFERENCES course_certificates(id) ON DELETE SET NULL,
   hours_earned     NUMERIC(5,2) NOT NULL,

--- a/supabase/migrations/20260522_organisations_foundation.sql
+++ b/supabase/migrations/20260522_organisations_foundation.sql
@@ -76,17 +76,6 @@ CREATE POLICY "Organisation admin can update own org"
   USING (admin_user_id = auth.uid())
   WITH CHECK (admin_user_id = auth.uid());
 
--- Active members can also view their organisation
-DROP POLICY IF EXISTS "Organisation members can view own org" ON public.organisations;
-CREATE POLICY "Organisation members can view own org"
-  ON public.organisations FOR SELECT TO authenticated
-  USING (
-    id IN (
-      SELECT organisation_id FROM public.organisation_members
-      WHERE user_id = auth.uid() AND status = 'active'
-    )
-  );
-
 -- Service role has full access (admin routes, cron, webhooks)
 DROP POLICY IF EXISTS "Service role full access on organisations" ON public.organisations;
 CREATE POLICY "Service role full access on organisations"
@@ -167,6 +156,19 @@ CREATE POLICY "Service role full access on organisation_members"
   ON public.organisation_members FOR ALL TO service_role
   USING (true)
   WITH CHECK (true);
+
+-- Active members can also view their organisation.
+-- Defined here (not in the organisations section above) because it subqueries
+-- organisation_members, which must exist first.
+DROP POLICY IF EXISTS "Organisation members can view own org" ON public.organisations;
+CREATE POLICY "Organisation members can view own org"
+  ON public.organisations FOR SELECT TO authenticated
+  USING (
+    id IN (
+      SELECT organisation_id FROM public.organisation_members
+      WHERE user_id = auth.uid() AND status = 'active'
+    )
+  );
 
 -- ─── organisation_applications ────────────────────────────────────────────────
 

--- a/supabase/migrations/20260825150000_rba_polls.sql
+++ b/supabase/migrations/20260825150000_rba_polls.sql
@@ -60,13 +60,13 @@ CREATE POLICY "rba_polls_service_all"
 
 CREATE OR REPLACE VIEW public.rba_poll_accuracy AS
 SELECT
-  fv.voter_user_id,
+  fv.user_id,
   COUNT(*)::integer                                              AS polls_participated,
-  SUM(CASE WHEN fv.vote = rp.outcome THEN 1 ELSE 0 END)::integer AS correct_predictions,
+  SUM(CASE WHEN fv.value = rp.outcome THEN 1 ELSE 0 END)::integer AS correct_predictions,
   CASE
     WHEN COUNT(*) = 0 THEN 0.0
     ELSE ROUND(
-      100.0 * SUM(CASE WHEN fv.vote = rp.outcome THEN 1 ELSE 0 END) / COUNT(*),
+      100.0 * SUM(CASE WHEN fv.value = rp.outcome THEN 1 ELSE 0 END) / COUNT(*),
       1
     )
   END::numeric                                                   AS accuracy_pct
@@ -76,7 +76,7 @@ JOIN public.rba_polls rp
  AND fv.target_type = 'rba_poll'
 WHERE rp.status = 'revealed'
   AND rp.outcome IS NOT NULL
-GROUP BY fv.voter_user_id;
+GROUP BY fv.user_id;
 
 -- ── Seed: 3 polls (1 revealed historic, 2 upcoming) ─────────────────────────
 -- Real RBA meeting schedule (approximate). Seeded for demo / dev.
@@ -94,7 +94,10 @@ VALUES
   )
 ON CONFLICT (meeting_date) DO NOTHING;
 
-INSERT INTO public.rba_polls (meeting_date, description, status)
+-- Upcoming polls: status defaults to 'open' (column default), so it is omitted
+-- from the column list. (The original listed `status` with no matching value,
+-- which raised "INSERT has more target columns than expressions".)
+INSERT INTO public.rba_polls (meeting_date, description)
 VALUES
   ('2026-07-07', 'July 2026 RBA Board meeting — cash rate decision.'),
   ('2026-08-04', 'August 2026 RBA Board meeting — cash rate decision.')

--- a/supabase/migrations/20260828010000_investment_clubs.sql
+++ b/supabase/migrations/20260828010000_investment_clubs.sql
@@ -33,17 +33,9 @@ CREATE TABLE IF NOT EXISTS public.investment_clubs (
 ALTER TABLE public.investment_clubs ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.investment_clubs FORCE ROW LEVEL SECURITY;
 
--- Members can read their clubs (joined via club_members)
-CREATE POLICY "club_members_read_club"
-  ON public.investment_clubs FOR SELECT
-  TO authenticated
-  USING (
-    EXISTS (
-      SELECT 1 FROM public.club_members
-      WHERE club_members.club_id = investment_clubs.id
-        AND club_members.user_id = auth.uid()
-    )
-  );
+-- NOTE: the "club_members_read_club" SELECT policy on investment_clubs
+-- subqueries club_members, so it is created further down — after the
+-- club_members table exists.
 
 -- Authenticated users can create clubs
 CREATE POLICY "authenticated_insert_club"
@@ -103,6 +95,20 @@ CREATE INDEX IF NOT EXISTS club_members_club_idx
 
 CREATE INDEX IF NOT EXISTS club_members_user_idx
   ON public.club_members (user_id);
+
+-- Members can read their clubs (joined via club_members).
+-- Defined here (not in the investment_clubs section above) because it
+-- subqueries club_members, which must exist first.
+CREATE POLICY "club_members_read_club"
+  ON public.investment_clubs FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.club_members
+      WHERE club_members.club_id = investment_clubs.id
+        AND club_members.user_id = auth.uid()
+    )
+  );
 
 -- ── club_watchlist_items ──────────────────────────────────────────────────────
 

--- a/supabase/migrations/20260829000000_etf_data_moat.sql
+++ b/supabase/migrations/20260829000000_etf_data_moat.sql
@@ -73,9 +73,11 @@ CREATE POLICY "etf_distributions_service_write"
 CREATE INDEX IF NOT EXISTS etf_distributions_slug_date_idx
   ON public.etf_distributions (etf_slug, ex_date DESC);
 
+-- Plain ascending index on ex_date. A partial predicate (e.g.
+-- WHERE ex_date >= CURRENT_DATE) cannot be used here because CURRENT_DATE is
+-- not IMMUTABLE (Postgres error 42P17 on partial-index predicates).
 CREATE INDEX IF NOT EXISTS etf_distributions_future_idx
-  ON public.etf_distributions (ex_date ASC)
-  WHERE ex_date >= CURRENT_DATE;
+  ON public.etf_distributions (ex_date ASC);
 
 -- ── Seed: etf_holdings ────────────────────────────────────────────────────────
 -- Top ~15 holdings per ETF from publicly published fund disclosures.


### PR DESCRIPTION
## Summary

Seven additive-backfill migrations had bugs vs the **live** schema that prevented them from applying. Each is corrected here to be compatible with production. **The corrected SQL has already been applied to prod** (Supabase project `guggzyqceattncjwvgyc`) via `apply_migration` and verified — this PR brings the repo source into parity with what is now live.

**Tier C** (migration files). Because the corrected SQL is **already applied to prod and verified**, this PR is for source parity only — there is no new prod schema change to land on merge. Do not merge without the usual Tier C announcement.

Live facts these corrections target: `advisor_firms.id`=integer, `professionals.id`/`professionals.firm_id`=integer, `courses.id`=bigint, `course_purchases.id`=bigint, `brokers.id`=bigint, `forum_votes` columns `(id, user_id, target_type, target_id, value, created_at)`.

## Per-file corrections

1. **`20260521_careers_marketplace.sql`** — `job_posts.firm_id` `uuid` → `integer` (FK to `advisor_firms.id`, which is integer). Prod already carried the corrected table; this is a file-only fix.
2. **`20260522_course_reviews.sql`** — `course_reviews.course_id` `UUID` → `bigint` (FK to `courses.id`).
3. **`20260522_cpd_tracking.sql`** — `course_certificates.course_id` and `cpd_credits.course_id` `UUID` → `bigint`. The CPD columns added to `courses` (`cpd_hours`/`cpd_category`/`is_cpd_eligible`) are retained.
4. **`20260522_organisations_foundation.sql`** — forward-reference fix: the policy *"Organisation members can view own org"* subqueried `organisation_members` before that table existed. Moved the policy to **after** the `organisation_members` CREATE TABLE. Policy body unchanged.
5. **`20260825150000_rba_polls.sql`** — the `rba_poll_accuracy` view referenced `forum_votes.voter_user_id` / `forum_votes.vote`; live columns are `user_id` / `value`. Renamed in the view. Also fixed the upcoming-polls seed `INSERT`, whose column list named `status` with no matching value ("INSERT has more target columns than expressions") — `status` is omitted so the column default `'open'` applies. (This seed mismatch was a second defect in the same file blocking the apply; flagged for review.)
6. **`20260828010000_investment_clubs.sql`** — forward-reference fix: the `club_members_read_club` policy on `investment_clubs` subqueried `club_members` before it existed. Moved the policy to **after** the `club_members` CREATE TABLE. Policy body unchanged. (Group-invite feature.)
7. **`20260829000000_etf_data_moat.sql`** — dropped the non-IMMUTABLE `WHERE ex_date >= CURRENT_DATE` predicate from `etf_distributions_future_idx` (Postgres error `42P17`); it is now a plain btree on `ex_date`.

## Production verification (already applied)

- All 14 tables exist with RLS enabled: `course_reviews`, `course_certificates`, `cpd_credits`, `organisations`, `organisation_members`, `organisation_applications`, `rba_polls`, `investment_clubs`, `club_members`, `club_messages`, `club_watchlist_items`, `club_invitations`, `etf_holdings`, `etf_distributions`.
- `rba_poll_accuracy` view created; `SELECT` from it succeeds (confirms `forum_votes.user_id`/`value` resolve).
- FK types confirmed: `course_reviews.course_id`, `course_certificates.course_id`, `cpd_credits.course_id` all `bigint`.
- New `courses` columns present: `cpd_hours`, `cpd_category`, `is_cpd_eligible`, `avg_rating`, `review_count`, `creator_kind`, `organisation_id`.
- Forward-ref policies created: `club_members_read_club` (1), `Organisation members can view own org` (1).
- `etf_distributions_future_idx` is now `CREATE INDEX ... USING btree (ex_date)` with no WHERE predicate.
- Seeds landed: `rba_polls`=3 rows, `etf_holdings`=96, `etf_distributions`=21.

https://claude.ai/code/session_01AX16WTaqAs2W33uydbBWLa

---
_Generated by [Claude Code](https://claude.ai/code/session_01AX16WTaqAs2W33uydbBWLa)_