### PR TITLE
fix(auth): guard login next param against open redirect

### DIFF
--- a/__tests__/lib/safe-next.test.ts
+++ b/__tests__/lib/safe-next.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { safeNextPath } from "@/lib/safe-next";
+
+describe("safeNextPath — open-redirect guard for the login `next` param", () => {
+  describe("accepts same-origin relative paths unchanged", () => {
+    it.each([
+      "/account",
+      "/pro",
+      "/dashboard/settings",
+      "/account?tab=billing",
+      "/path#section",
+    ])("%s", (input) => {
+      expect(safeNextPath(input)).toBe(input);
+    });
+  });
+
+  describe("rejects off-site / malicious destinations and falls back to /account", () => {
+    it.each([
+      "https://evil.example/login", // absolute http(s) URL
+      "http://evil.example/x",
+      "//evil.example/login", // protocol-relative URL
+      "//evil.example", // protocol-relative, no path
+      "javascript:alert(1)", // javascript: scheme
+      "data:text/html,<script>", // data: scheme
+      "ftp://evil.example", // other scheme
+      "evil.example/path", // bare host, no leading slash
+      "account", // relative, no leading slash
+      "", // empty string
+    ])("%s -> /account", (input) => {
+      expect(safeNextPath(input)).toBe("/account");
+    });
+  });
+
+  describe("falls back for null/undefined", () => {
+    it("null -> /account", () => {
+      expect(safeNextPath(null)).toBe("/account");
+    });
+    it("undefined -> /account", () => {
+      expect(safeNextPath(undefined)).toBe("/account");
+    });
+  });
+
+  it("honours a custom fallback", () => {
+    expect(safeNextPath("//evil.example", "/login")).toBe("/login");
+    expect(safeNextPath(null, "/home")).toBe("/home");
+  });
+});

--- a/app/auth/login/LoginClient.tsx
+++ b/app/auth/login/LoginClient.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/client";
+import { safeNextPath } from "@/lib/safe-next";
 
 type Tab = "magic-link" | "password";
 
@@ -27,7 +28,9 @@ function EyeOffIcon() {
 export default function LoginClient() {
   const searchParams = useSearchParams();
   const router = useRouter();
-  const next = searchParams.get("next") || "/account";
+  // Guard against open redirect — only same-origin relative paths are allowed
+  // for both router.push (password path) and the magic-link emailRedirectTo.
+  const next = safeNextPath(searchParams.get("next"));
   const callbackError = searchParams.get("error");
 
   const [tab, setTab] = useState<Tab>("magic-link");

--- a/lib/safe-next.ts
+++ b/lib/safe-next.ts
@@ -1,0 +1,16 @@
+/**
+ * Open-redirect guard for post-auth `next` redirect params.
+ *
+ * Only same-origin relative paths are allowed. Absolute URLs
+ * (`https://evil.example/x`), protocol-relative URLs (`//evil.example/x`),
+ * and any non-`/`-leading value fall back to a safe default.
+ *
+ * Mirrors the inline guard already used in app/auth/callback/route.ts and
+ * app/auth/auth-error/page.tsx — kept here as the single source of truth.
+ */
+export function safeNextPath(
+  next: string | null | undefined,
+  fallback = "/account"
+): string {
+  return next && next.startsWith("/") && !next.startsWith("//") ? next : fallback;
+}


### PR DESCRIPTION
## What

`app/auth/login/LoginClient.tsx` read the `next` query param directly and passed it to `router.push(next)` on a successful password login. Inputs like `next=https://evil.example/login` or the protocol-relative `next=//evil.example/login` resolve to a different origin, so Next.js performs a hard navigation off-site after authentication — a post-auth open redirect usable as a phishing/credential-harvesting amplifier.

The rest of the auth code already treats this value as untrusted (`app/auth/callback/route.ts`, `app/auth/auth-error/page.tsx` both apply `startsWith('/') && !startsWith('//')`). LoginClient's password path was the one place consuming it client-side without the guard.

## Fix

- Add `lib/safe-next.ts` (`safeNextPath`) as the single source of truth for the same-origin guard, mirroring the existing inline checks.
- Apply it where `next` is derived in `LoginClient`, covering both the `router.push` password path and the magic-link `emailRedirectTo`, while keeping the `next === "/pro"` banner check correct.
- Add `__tests__/lib/safe-next.test.ts` (18 cases): absolute URLs, `//`-prefixed, `javascript:`/`data:` schemes, bare hosts, null/undefined all fall back to `/account`; legit relative paths pass through.

## Finding

Wave 3 — "Open redirect via login `next` param in password-login path" (severity P2, Tier B). Re-verified present on current main before fixing.

## Verify

- `npx vitest run __tests__/lib/safe-next.test.ts` -> 18 passed
- `npx eslint --fix --max-warnings 0` on changed files -> clean

Tier B: security/auth-adjacent client-side navigation hardening; 15-min observation window appropriate. No money-movement, credit, advice, or grant logic touched.
