### PR TITLE
fix(advisor-review): cap review body/title/name/email lengths

### DIFF
--- a/__tests__/api/advisor-review.test.ts
+++ b/__tests__/api/advisor-review.test.ts
@@ -146,6 +146,39 @@ describe("POST /api/advisor-review", () => {
     expect((await POST(makeReq({ ...VALID, body: "Short review." }))).status).toBe(400);
   });
 
+  it("returns 400 when review body exceeds the max length (5000 chars)", async () => {
+    const res = await POST(makeReq({ ...VALID, body: "A".repeat(5001) }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/5000 characters or fewer/i);
+  });
+
+  it("returns 400 when title exceeds the max length (160 chars)", async () => {
+    const res = await POST(makeReq({ ...VALID, title: "T".repeat(161) }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/title/i);
+  });
+
+  it("returns 400 when reviewer_name exceeds the max length (100 chars)", async () => {
+    const res = await POST(makeReq({ ...VALID, reviewer_name: "N".repeat(101) }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/name/i);
+  });
+
+  it("returns 400 when reviewer_email exceeds the max length (200 chars)", async () => {
+    // Construct an address that is syntactically valid but over 200 chars.
+    const longEmail = `${"a".repeat(195)}@b.com`;
+    const res = await POST(makeReq({ ...VALID, reviewer_email: longEmail }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/email/i);
+  });
+
+  it("accepts a body at the max length boundary (5000 chars)", async () => {
+    setupNoEngagement();
+    setupHappyPath();
+    const res = await POST(makeReq({ ...VALID, body: "A".repeat(5000) }));
+    expect(res.status).toBe(200);
+  });
+
   it("returns 400 when used_services is not boolean", async () => {
     expect((await POST(makeReq({ ...VALID, used_services: "yes" }))).status).toBe(400);
   });

--- a/app/api/advisor-review/route.ts
+++ b/app/api/advisor-review/route.ts
@@ -16,6 +16,14 @@ function isValidRating(v: unknown): v is number {
   return typeof v === "number" && Number.isInteger(v) && v >= 1 && v <= 5;
 }
 
+// Maximum lengths for free-text fields, consistent with lib/api-schemas.ts caps.
+// Columns are unbounded TEXT, so these route-level bounds are the only backstop
+// against unbounded-payload storage abuse / layout-breaking review bodies.
+const MAX_BODY_LENGTH = 5000;
+const MAX_TITLE_LENGTH = 160;
+const MAX_NAME_LENGTH = 100;
+const MAX_EMAIL_LENGTH = 200;
+
 export async function POST(request: NextRequest) {
   const ip = request.headers.get("x-forwarded-for")?.split(",")[0] || "unknown";
   if (await isRateLimited(`advisor_review:${ip}`, 5, 60)) {
@@ -56,6 +64,20 @@ export async function POST(request: NextRequest) {
     // Minimum review length
     if (reviewBody.trim().length < 50) {
       return NextResponse.json({ error: "Review must be at least 50 characters long." }, { status: 400 });
+    }
+
+    // Maximum lengths — guard against unbounded TEXT writes (storage abuse / layout breakage)
+    if (reviewBody.trim().length > MAX_BODY_LENGTH) {
+      return NextResponse.json({ error: `Review must be ${MAX_BODY_LENGTH} characters or fewer.` }, { status: 400 });
+    }
+    if (typeof title === "string" && title.trim().length > MAX_TITLE_LENGTH) {
+      return NextResponse.json({ error: `Title must be ${MAX_TITLE_LENGTH} characters or fewer.` }, { status: 400 });
+    }
+    if (typeof reviewer_name === "string" && reviewer_name.trim().length > MAX_NAME_LENGTH) {
+      return NextResponse.json({ error: `Name must be ${MAX_NAME_LENGTH} characters or fewer.` }, { status: 400 });
+    }
+    if (typeof reviewer_email === "string" && reviewer_email.trim().length > MAX_EMAIL_LENGTH) {
+      return NextResponse.json({ error: `Email must be ${MAX_EMAIL_LENGTH} characters or fewer.` }, { status: 400 });
     }
 
     // Validate used_services


### PR DESCRIPTION
## What

The advisor-review POST (`app/api/advisor-review/route.ts`) enforced a minimum review length (< 50 chars -> 400) but never a maximum on any text field. `body`, `title`, `reviewer_name`, and `reviewer_email` all flow unbounded into `professional_reviews`, whose columns are plain unbounded TEXT with no DB-level CHECK. An unauthenticated caller could persist arbitrarily large strings (multi-MB), inflating storage and breaking advisor-page layout once approved.

This adds route-level max-length guards consistent with the caps in `lib/api-schemas.ts`:

- body <= 5000
- title <= 160
- reviewer_name <= 100
- reviewer_email <= 200

Each returns 400 on oversize. Added focused tests asserting oversized input is rejected for each field, plus a boundary test that a 5000-char body is accepted.

Not an XSS vector (email path already truncates+escapes; React renders review text as text). No money movement, auth, webhook, migration, or compliance surface touched. The optional DB CHECK suggestion from the finding is intentionally not bundled here (migration discipline — separate change).

## Finding

wave3 audit — `app/api/advisor-review/route.ts`, P3, Tier B (additive input-validation tightening on a public route).

## Verify

`npx vitest run __tests__/api/advisor-review.test.ts` -> 29 passed
`npx eslint --max-warnings 0` on both changed files -> clean