### PR TITLE
refactor(getmatched): use anon server client for public-read top-match queries

### DIFF
--- a/__tests__/lib/getmatched/top-match-client.test.ts
+++ b/__tests__/lib/getmatched/top-match-client.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Regression guard for the service-role → anon-client swap:
+// `brokers` (anon SELECT on status='active') and `quiz_weights` (anon SELECT
+// USING TRUE) are public anon-readable tables, so top-match must use the
+// RLS-respecting anon server client — NOT the service-role admin client.
+const { mockCreateClient } = vi.hoisted(() => ({ mockCreateClient: vi.fn() }));
+
+vi.mock("@/lib/supabase/server", () => ({ createClient: mockCreateClient }));
+// If the production code ever reaches for the admin client again, importing it
+// would pull in this mock; assert it is never instantiated.
+const { mockCreateAdminClient } = vi.hoisted(() => ({ mockCreateAdminClient: vi.fn() }));
+vi.mock("@/lib/supabase/admin", () => ({ createAdminClient: mockCreateAdminClient }));
+vi.mock("@/lib/logger", () => ({
+  logger: () => ({ warn: vi.fn(), info: vi.fn(), error: vi.fn() }),
+}));
+
+import { computeTopMatch, computeTopMatches } from "@/lib/getmatched/top-match";
+
+const broker = {
+  slug: "acme",
+  name: "Acme Invest",
+  status: "active",
+  rating: 4.5,
+  logo_url: null,
+  chess_sponsored: true,
+  is_crypto: false,
+  asx_fee_value: 5,
+};
+
+const weightRow = {
+  broker_slug: "acme",
+  beginner_weight: 10,
+  low_fee_weight: 0,
+  us_shares_weight: 0,
+  smsf_weight: 0,
+  crypto_weight: 0,
+  advanced_weight: 0,
+  property_weight: 0,
+  robo_weight: 0,
+};
+
+/** Builds a supabase-like client whose `.from()` returns table-specific data. */
+function makeClient() {
+  return {
+    from: vi.fn((table: string) => {
+      const result =
+        table === "brokers"
+          ? { data: [broker], error: null }
+          : { data: [weightRow], error: null };
+      // brokers chains `.select().eq()`, quiz_weights chains `.select()`.
+      const chain = {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => Promise.resolve(result)),
+          then: (resolve: (v: unknown) => unknown) => resolve(result),
+        })),
+      };
+      return chain;
+    }),
+  };
+}
+
+describe("top-match uses the anon server client (least-privilege)", () => {
+  beforeEach(() => {
+    mockCreateClient.mockReset();
+    mockCreateAdminClient.mockReset();
+  });
+
+  it("computeTopMatch reads via createClient(), never the admin client", async () => {
+    mockCreateClient.mockResolvedValue(makeClient());
+
+    const res = await computeTopMatch({ intent: "grow" }, null);
+
+    expect(mockCreateClient).toHaveBeenCalledTimes(1);
+    expect(mockCreateAdminClient).not.toHaveBeenCalled();
+    expect(res).not.toBeNull();
+    expect(res?.slug).toBe("acme");
+  });
+
+  it("computeTopMatches reads via createClient(), never the admin client", async () => {
+    mockCreateClient.mockResolvedValue(makeClient());
+
+    const res = await computeTopMatches({ intent: "grow" }, null, 3);
+
+    expect(mockCreateClient).toHaveBeenCalledTimes(1);
+    expect(mockCreateAdminClient).not.toHaveBeenCalled();
+    expect(res.length).toBeGreaterThan(0);
+    expect(res[0]?.slug).toBe("acme");
+  });
+});

--- a/__tests__/lib/getmatched/top-match-weights.test.ts
+++ b/__tests__/lib/getmatched/top-match-weights.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi } from "vitest";
 
-// top-match.ts imports the service-role admin client at module scope; stub it
+// top-match.ts imports the anon server client at module scope; stub it
 // so importing the pure reshape helper needs no env / DB.
-vi.mock("@/lib/supabase/admin", () => ({ createAdminClient: vi.fn() }));
+vi.mock("@/lib/supabase/server", () => ({ createClient: vi.fn() }));
 
 import { reshapeWeightRow } from "@/lib/getmatched/top-match";
 

--- a/lib/getmatched/top-match.ts
+++ b/lib/getmatched/top-match.ts
@@ -11,10 +11,16 @@
  * `quiz_weights` or `brokers` can't be queried, we return null and the
  * result screen renders without the hero card (action plan + checklist
  * still display).
+ *
+ * Both reads target public anon-readable tables — `brokers` (anon SELECT on
+ * `status = 'active'`) and `quiz_weights` (anon SELECT `USING (TRUE)`) — so we
+ * use the RLS-respecting anon server client, not the service-role admin client.
+ * The only caller is the public, unauthenticated `/api/get-matched/resolve`
+ * route, where least-privilege matters: keeping RLS in the loop means a future
+ * SELECT change can't silently leak protected rows.
  */
 
-// eslint-disable-next-line no-restricted-imports -- public-read of brokers + quiz_weights; service-role legitimate because we want to bypass anon-row restrictions on weight rows.
-import { createAdminClient } from "@/lib/supabase/admin";
+import { createClient } from "@/lib/supabase/server";
 import { logger } from "@/lib/logger";
 import {
   scoreQuizResults,
@@ -115,12 +121,12 @@ export async function computeTopMatch(
   vertical: Vertical | null,
 ): Promise<TopMatch | null> {
   try {
-    const admin = createAdminClient();
+    const supabase = await createClient();
 
     // Load active brokers + their scoring weights in parallel.
     const [brokersRes, weightsRes] = await Promise.all([
-      admin.from("brokers").select("*").eq("status", "active"),
-      admin.from("quiz_weights").select("*"),
+      supabase.from("brokers").select("*").eq("status", "active"),
+      supabase.from("quiz_weights").select("*"),
     ]);
 
     if (brokersRes.error) throw brokersRes.error;
@@ -191,11 +197,11 @@ export async function computeTopMatches(
   limit = 3,
 ): Promise<TopMatch[]> {
   try {
-    const admin = createAdminClient();
+    const supabase = await createClient();
 
     const [brokersRes, weightsRes] = await Promise.all([
-      admin.from("brokers").select("*").eq("status", "active"),
-      admin.from("quiz_weights").select("*"),
+      supabase.from("brokers").select("*").eq("status", "active"),
+      supabase.from("quiz_weights").select("*"),
     ]);
     if (brokersRes.error) throw brokersRes.error;
     if (weightsRes.error) throw weightsRes.error;


### PR DESCRIPTION
## What

`computeTopMatch` / `computeTopMatches` in `lib/getmatched/top-match.ts` now read `brokers` and `quiz_weights` via `createClient()` from `lib/supabase/server` (RLS-respecting anon client) instead of the service-role `createAdminClient()`.

## Why

Both reads are fully covered by existing anon SELECT RLS policies:
- `supabase/migrations/001_initial.sql:184` — `Public read for active brokers` (`status = 'active'`), matching the exact `.eq("status","active")` query.
- `supabase/migrations/001_initial.sql:188` — `Public read quiz weights` (`USING (TRUE)`).

CLAUDE.md service-role scope explicitly lists public anon-readable tables (brokers active reads) as NOT legitimate for the admin client. The prior `eslint-disable` justification ('bypass anon-row restrictions on weight rows') was factually wrong — `quiz_weights` is `USING (TRUE)`, no restrictions to bypass.

The only caller is the public, unauthenticated `/api/get-matched/resolve` route — exactly the surface where minimizing service-role blast radius matters. Behavior is unchanged; the code already degrades gracefully (returns null/[]) on empty results.

## Finding

Audit finding: "getMatched top-match selector uses service-role admin client for public anon-readable tables" (severity P3, **Tier B**). `autoFixSafe: true`, `stillReal: true`.

## Tests

- New `__tests__/lib/getmatched/top-match-client.test.ts` — asserts both functions use `createClient()` and never instantiate the admin client.
- Updated `__tests__/lib/getmatched/top-match-weights.test.ts` mock to stub the server client.
- `__tests__/api/get-matched-resolve.test.ts` unaffected (mocks the whole top-match module).