### PR TITLE
fix(marketplace): bound conversion_value_cents to a safe int4 in postback

### DIFF
--- a/__tests__/api/marketplace-postback.test.ts
+++ b/__tests__/api/marketplace-postback.test.ts
@@ -373,4 +373,141 @@ describe("POST /api/marketplace/postback", () => {
       expect(res.status).toBe(200);
     }
   });
+
+  describe("conversion_value_cents bounds", () => {
+    // Capture the row written to conversion_events so we can assert the exact
+    // sanitised value reaches the int4 column (and the webhook payload).
+    function setupCapturingInsert() {
+      const conversionInsert = vi.fn().mockReturnThis();
+      const webhookInsert = vi.fn().mockResolvedValue({ data: null, error: null });
+      mockFrom.mockImplementation((table: string) => {
+        if (table === "broker_accounts") {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            not: vi.fn().mockReturnThis(),
+            limit: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: {
+                broker_slug: "commsec",
+                status: "active",
+                webhook_url: "https://broker.example/hook",
+              },
+              error: null,
+            }),
+          };
+        }
+        if (table === "affiliate_clicks") {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({ data: CLICK, error: null }),
+          };
+        }
+        if (table === "conversion_events") {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            insert: conversionInsert,
+            maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+            single: vi.fn().mockResolvedValue({ data: CONVERSION, error: null }),
+          };
+        }
+        if (table === "campaign_events") {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            limit: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+          };
+        }
+        if (table === "webhook_delivery_queue") {
+          return { insert: webhookInsert };
+        }
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          update: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+        };
+      });
+      return { conversionInsert, webhookInsert };
+    }
+
+    function insertedValue(conversionInsert: ReturnType<typeof vi.fn>): number {
+      const row = conversionInsert.mock.calls[0]![0] as {
+        conversion_value_cents: number;
+      };
+      return row.conversion_value_cents;
+    }
+
+    it("clamps a negative value to 0 instead of poisoning revenue totals", async () => {
+      const { conversionInsert, webhookInsert } = setupCapturingInsert();
+      const res = await POST(
+        makePost({ ...VALID_BODY, conversion_value_cents: -100000 }, VALID_API_KEY)
+      );
+      expect(res.status).toBe(200);
+      expect(insertedValue(conversionInsert)).toBe(0);
+      const wh = webhookInsert.mock.calls[0]![0] as {
+        payload: { conversion_value_cents: number };
+      };
+      expect(wh.payload.conversion_value_cents).toBe(0);
+    });
+
+    it("truncates a fractional value to an integer (int4 column)", async () => {
+      const { conversionInsert } = setupCapturingInsert();
+      const res = await POST(
+        makePost({ ...VALID_BODY, conversion_value_cents: 12.9 }, VALID_API_KEY)
+      );
+      expect(res.status).toBe(200);
+      expect(insertedValue(conversionInsert)).toBe(12);
+    });
+
+    it("coerces NaN to 0 instead of crashing the insert (500)", async () => {
+      const { conversionInsert } = setupCapturingInsert();
+      // NaN cannot be JSON-encoded, so pass a string the route coerces to NaN.
+      const res = await POST(
+        makePost({ ...VALID_BODY, conversion_value_cents: "not-a-number" }, VALID_API_KEY)
+      );
+      expect(res.status).toBe(200);
+      expect(insertedValue(conversionInsert)).toBe(0);
+    });
+
+    it("coerces a non-finite (Infinity-like) value to 0", async () => {
+      const { conversionInsert } = setupCapturingInsert();
+      // 1e400 parses to Infinity in JS; JSON.stringify emits it as null, and a
+      // numeric-overflow string also resolves to Infinity via Number().
+      const res = await POST(
+        makePost({ ...VALID_BODY, conversion_value_cents: "1e400" }, VALID_API_KEY)
+      );
+      expect(res.status).toBe(200);
+      expect(insertedValue(conversionInsert)).toBe(0);
+    });
+
+    it("clamps a value above int4 range to MAX_INT4 instead of overflowing (500)", async () => {
+      const { conversionInsert } = setupCapturingInsert();
+      const res = await POST(
+        makePost({ ...VALID_BODY, conversion_value_cents: 3_000_000_000 }, VALID_API_KEY)
+      );
+      expect(res.status).toBe(200);
+      expect(insertedValue(conversionInsert)).toBe(2_147_483_647);
+    });
+
+    it("preserves a valid numeric-string value (S2S contract)", async () => {
+      const { conversionInsert } = setupCapturingInsert();
+      const res = await POST(
+        makePost({ ...VALID_BODY, conversion_value_cents: "500" }, VALID_API_KEY)
+      );
+      expect(res.status).toBe(200);
+      expect(insertedValue(conversionInsert)).toBe(500);
+    });
+
+    it("defaults an omitted value to 0", async () => {
+      const { conversionInsert } = setupCapturingInsert();
+      const { conversion_value_cents: _omit, ...noValue } = VALID_BODY;
+      const res = await POST(makePost(noValue, VALID_API_KEY));
+      expect(res.status).toBe(200);
+      expect(insertedValue(conversionInsert)).toBe(0);
+    });
+  });
 });

--- a/app/api/marketplace/postback/route.ts
+++ b/app/api/marketplace/postback/route.ts
@@ -5,6 +5,25 @@ import { logger } from "@/lib/logger";
 
 const log = logger("postback");
 
+// conversion_value_cents is stored in a Postgres INTEGER (int4) column and only
+// feeds broker-portal analytics aggregations — it never moves money. Clamp the
+// usable range to a finite, non-negative int4 so garbage can never poison those
+// totals or crash the INSERT.
+const MAX_INT4 = 2_147_483_647;
+
+// Coerce an arbitrary postback value to a safe int4 cents amount. Accepts
+// numbers and numeric strings (S2S postbacks routinely serialise "500");
+// anything non-finite/negative/non-numeric (NaN, Infinity, "abc", -100000,
+// 12.5, 1e308, >int4) collapses to 0 rather than rejecting or overflowing,
+// preserving the documented "valid-ish postbacks are never rejected" contract.
+function safeConversionValueCents(value: unknown): number {
+  const n = typeof value === "string" ? Number(value) : value;
+  if (typeof n !== "number" || !Number.isFinite(n)) return 0;
+  const floored = Math.trunc(n);
+  if (floored < 0) return 0;
+  return Math.min(floored, MAX_INT4);
+}
+
 // Partner conversion postback. Each field is validated individually below
 // (the existing guards produce the partner-facing error messages and HTTP
 // codes); the schema is permissive and `.passthrough()` so arbitrary partner
@@ -16,9 +35,8 @@ const Body = z
     // Accept any type here — partner S2S postbacks routinely serialise every
     // field as a string (e.g. "500"). A strict `z.number()` would fail the
     // whole-body parse, collapsing click_id/event_type to undefined and
-    // returning a spurious 400 (dropping the conversion). The downstream
-    // `typeof … === "number" ? … : 0` guard already coerces a non-number to 0,
-    // matching the documented "never rejected" contract.
+    // returning a spurious 400 (dropping the conversion). `safeConversionValueCents`
+    // below sanitises this to a bounded int4 at the insert/webhook call sites.
     conversion_value_cents: z.unknown().optional(),
     metadata: z.record(z.string(), z.unknown()).optional(),
   })
@@ -70,6 +88,10 @@ export async function POST(request: NextRequest) {
   const parsedBody = Body.safeParse(raw);
   const { click_id, event_type, conversion_value_cents, metadata } =
     parsedBody.success ? parsedBody.data : {};
+
+  // Bounded, finite, non-negative int4 — used at both the insert and webhook
+  // call sites so garbage can never poison analytics or crash the INSERT.
+  const safeValueCents = safeConversionValueCents(conversion_value_cents);
 
   // Validate required fields
   if (!click_id || typeof click_id !== "string") {
@@ -153,10 +175,7 @@ export async function POST(request: NextRequest) {
       broker_slug: account.broker_slug,
       campaign_id: campaignEvent?.campaign_id || null,
       event_type,
-      conversion_value_cents:
-        typeof conversion_value_cents === "number"
-          ? conversion_value_cents
-          : 0,
+      conversion_value_cents: safeValueCents,
       metadata: metadata || {},
       source: "postback",
       ip_hash: ipHash,
@@ -209,7 +228,7 @@ export async function POST(request: NextRequest) {
           conversion_id: conversion?.id,
           click_id,
           event_type,
-          conversion_value_cents: typeof conversion_value_cents === "number" ? conversion_value_cents : 0,
+          conversion_value_cents: safeValueCents,
           metadata: metadata || {},
           timestamp: conversion?.created_at,
         },


### PR DESCRIPTION
## What

`conversion_value_cents` in the marketplace postback handler was only sanitised with a `typeof === "number"` check before being inserted into a Postgres `INTEGER` (int4) column that feeds broker-portal analytics aggregations.

Consequences before this fix:
- **Negative** values (e.g. `-100000`) passed the guard and poisoned broker reported-revenue totals across `app/broker-portal/{page,conversions/page,analytics/page}.tsx`.
- **Fractional** values truncated inconsistently against the int4 column.
- **NaN / Infinity / >int4** values passed `typeof === "number"`, overflowed/failed the INSERT, and returned a 500 — silently dropping the conversion despite the route's documented "valid-ish postbacks are never rejected" contract.

## Fix

Added `safeConversionValueCents()`: coerces numbers and numeric strings (preserving the #1313 S2S string-tolerant contract), collapses non-finite / negative / non-numeric input to `0`, truncates fractions, and clamps to `MAX_INT4`. The single sanitised value is applied at both the insert and outbound-webhook call sites.

Added focused tests for negative, fractional, NaN, Infinity-like, >int4, valid-string, and omitted inputs (asserting the exact value reaching the insert and webhook payload).

## Scope

Analytics/reporting value only — **no money movement, payout, or balance** is touched. Finding ref: marketplace postback `conversion_value_cents` bounds (P3, Tier B).

## Verify

- `npx vitest run __tests__/api/marketplace-postback.test.ts` → 23 passed
- `npx eslint --max-warnings 0` on both changed files → clean