### PR TITLE
perf(images): add sizes to firm + event fill images

### DIFF
--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -241,6 +241,7 @@ export default async function EventDetailPage({
                 alt={event.title}
                 fill
                 className="object-cover"
+                sizes="(max-width: 768px) 100vw, 720px"
                 priority
               />
             </div>

--- a/app/firm/[slug]/page.tsx
+++ b/app/firm/[slug]/page.tsx
@@ -143,6 +143,7 @@ export default async function FirmProfilePage({ params }: { params: Promise<{ sl
                   alt={`${typedFirm.name} banner`}
                   fill
                   className="object-cover"
+                  sizes="(max-width: 768px) 100vw, 768px"
                   priority
                 />
               </div>


### PR DESCRIPTION
Adds `sizes` to two `priority` `fill` Next.js Images that were defaulting to 100vw and over-fetching LCP bandwidth.

- **PERF-01** — Enhanced Partner hero banner (`app/firm/[slug]/page.tsx`): `sizes="(max-width: 768px) 100vw, 768px"` (matches the capped content column).
- **PERF-02** — Event detail cover image (`app/events/[id]/page.tsx`): `sizes="(max-width: 768px) 100vw, 720px"` (matches the centered max-width column).

Tier A.