### PR TITLE
fix(advisor): use FREE_LEAD_LIMIT for topup free-lead allowance

### DIFF
--- a/__tests__/api/advisor-auth-topup.test.ts
+++ b/__tests__/api/advisor-auth-topup.test.ts
@@ -30,6 +30,7 @@ vi.mock("@/lib/url", () => ({
 
 vi.mock("@/lib/advisor-billing", () => ({
   DEFAULT_TOPUP_CENTS: 20000,
+  FREE_LEAD_LIMIT: 3,
 }));
 
 const mockCustomerCreate = vi.fn();
@@ -47,6 +48,7 @@ vi.mock("@/lib/stripe", () => ({
 
 import { POST, GET } from "@/app/api/advisor-auth/topup/route";
 import { isRateLimited } from "@/lib/rate-limit";
+import { FREE_LEAD_LIMIT } from "@/lib/advisor-billing"; // mocked above to 3
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -388,7 +390,8 @@ describe("GET /api/advisor-auth/topup", () => {
     expect(json.balance_cents).toBe(50000);
     expect(json.lifetime_credit_cents).toBe(100000);
     expect(json.free_leads_used).toBe(1);
-    expect(json.free_leads_remaining).toBe(1);
+    // FREE_LEAD_LIMIT (3) - free_leads_used (1) = 2
+    expect(json.free_leads_remaining).toBe(2);
     expect(json.lead_price_cents).toBe(4900);
     expect(json.topups).toHaveLength(1);
   });
@@ -419,8 +422,56 @@ describe("GET /api/advisor-auth/topup", () => {
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.balance_cents).toBe(0);
-    expect(json.free_leads_remaining).toBe(2);
+    // No professional row: free_leads_used defaults 0, so FREE_LEAD_LIMIT (3) - 0 = 3
+    expect(json.free_leads_remaining).toBe(3);
     expect(json.lead_price_cents).toBe(4900);
     expect(json.topups).toEqual([]);
+  });
+
+  it("derives free_leads_remaining from FREE_LEAD_LIMIT, not a hardcoded literal", async () => {
+    // Pins the allowance to the shared constant (=3) so it stays consistent with
+    // billing-summary and the advisor-portal UI. With zero free leads used, a
+    // fresh advisor must see the full FREE_LEAD_LIMIT allowance.
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "u-1", email: "advisor@test.com" } },
+    });
+    mockAdminFrom.mockImplementation((table: string) => {
+      const b = createChainableBuilder(table, supabaseCalls);
+      if (table === "professionals") {
+        let callCount = 0;
+        b.maybeSingle = vi.fn(() => {
+          callCount++;
+          if (callCount === 1) {
+            return Promise.resolve({ data: { id: 42 }, error: null });
+          }
+          return Promise.resolve({ data: null, error: null });
+        });
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: {
+              credit_balance_cents: 0,
+              lifetime_credit_cents: 0,
+              lifetime_lead_spend_cents: 0,
+              free_leads_used: 0,
+              lead_price_cents: 4900,
+            },
+            error: null,
+          }),
+        );
+      }
+      if (table === "advisor_credit_topups") {
+        b.limit = vi.fn(() => Promise.resolve({ data: [], error: null }));
+      }
+      return b;
+    });
+
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.free_leads_used).toBe(0);
+    // Must equal FREE_LEAD_LIMIT (3), the single source of truth — not the old
+    // hardcoded 2 — so this endpoint agrees with billing-summary and the portal.
+    expect(json.free_leads_remaining).toBe(FREE_LEAD_LIMIT);
+    expect(json.free_leads_remaining).toBe(3);
   });
 });

--- a/app/api/advisor-auth/topup/route.ts
+++ b/app/api/advisor-auth/topup/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { getStripe } from "@/lib/stripe";
 import { getSiteUrl } from "@/lib/url";
-import { DEFAULT_TOPUP_CENTS } from "@/lib/advisor-billing";
+import { DEFAULT_TOPUP_CENTS, FREE_LEAD_LIMIT } from "@/lib/advisor-billing";
 import { isRateLimited } from "@/lib/rate-limit";
 import { requireAdvisorSession } from "@/lib/require-advisor-session";
 import { getPack } from "@/lib/advisor-credit-packs";
@@ -155,7 +155,7 @@ export async function GET(request: NextRequest) {
     lifetime_credit_cents: pro?.lifetime_credit_cents || 0,
     lifetime_spend_cents: pro?.lifetime_lead_spend_cents || 0,
     free_leads_used: pro?.free_leads_used || 0,
-    free_leads_remaining: Math.max(0, 2 - (pro?.free_leads_used || 0)),
+    free_leads_remaining: Math.max(0, FREE_LEAD_LIMIT - (pro?.free_leads_used || 0)),
     lead_price_cents: pro?.lead_price_cents || 4900,
     topups: topups || [],
   });


### PR DESCRIPTION
## What

GET `/api/advisor-auth/topup` computed `free_leads_remaining` from a hardcoded literal `2`, while the canonical `FREE_LEAD_LIMIT` constant in `lib/advisor-billing.ts` is `3`. Every other surface that reports remaining free leads uses 3 (`billing-summary/route.ts`, `BillingTab.tsx`, `DashboardTab.tsx`), so this endpoint disagreed by one and ignored the named constant entirely.

This swaps the literal for the shared `FREE_LEAD_LIMIT` constant (added to the existing `@/lib/advisor-billing` import).

## Scope / safety

- **Display-only.** The value feeds no credit grant or charge — it is a read-only field in a GET endpoint.
- The actual free-lead billing gate lives in `app/api/advisor-enquiry/route.ts` (a separate, intentionally-distinct value) and is **left untouched** — changing it would be money-movement.
- Added a focused test pinning `free_leads_remaining` to `FREE_LEAD_LIMIT`, and updated two existing assertions that locked in the old 2-based numbers.

**Tier A** (single-source-of-truth display fix, no money movement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)