### PR TITLE
fix(a11y): raise disclosure/meta contrast off slate-400 + fix VerticalPillarPage heading order

### DIFF
--- a/components/ArticleSidebar.tsx
+++ b/components/ArticleSidebar.tsx
@@ -106,7 +106,7 @@ export default function ArticleSidebar({
         </div>
 
         {/* Disclaimer */}
-        <p className="text-xs text-slate-400 mt-3 leading-relaxed px-1">
+        <p className="text-xs text-slate-500 mt-3 leading-relaxed px-1">
           {ADVERTISER_DISCLOSURE_SHORT}{" "}
           <a href="/how-we-earn" className="underline hover:text-slate-600">
             Learn more

--- a/components/BrokerStickyRightRail.tsx
+++ b/components/BrokerStickyRightRail.tsx
@@ -64,7 +64,7 @@ export default function BrokerStickyRightRail({
           </svg>
         </button>
 
-        <div className="text-[0.6rem] font-bold uppercase tracking-wider text-slate-400 mb-2">
+        <div className="text-[0.6rem] font-bold uppercase tracking-wider text-slate-500 mb-2">
           Quick action
         </div>
 
@@ -114,7 +114,7 @@ export default function BrokerStickyRightRail({
           </svg>
         </a>
 
-        <p className="mt-2 text-[0.6rem] leading-tight text-slate-400">
+        <p className="mt-2 text-[0.6rem] leading-tight text-slate-500">
           {ADVERTISER_DISCLOSURE_SHORT}
         </p>
       </div>

--- a/components/DealCard.tsx
+++ b/components/DealCard.tsx
@@ -139,7 +139,7 @@ export default memo(function DealCard({
             <span className="text-xs text-amber">
               {renderStars(broker.rating || 0)}
             </span>
-            <span className="text-[0.69rem] text-slate-400">{broker.rating}/5</span>
+            <span className="text-[0.69rem] text-slate-500">{broker.rating}/5</span>
           </div>
         </div>
         {broker.deal_category && (

--- a/components/InvestListingCard.tsx
+++ b/components/InvestListingCard.tsx
@@ -154,7 +154,7 @@ export default function InvestListingCard({
         <span key={k}>
           {i > 0 && <span className="text-slate-300"> · </span>}
           <span className="font-bold text-ink-800">{formatKeyMetricValue(v)}</span>{" "}
-          <span className="text-slate-400">{k.replace(/_/g, " ")}</span>
+          <span className="text-slate-500">{k.replace(/_/g, " ")}</span>
         </span>
       ))}
     </p>

--- a/components/MobileFloatingCTA.tsx
+++ b/components/MobileFloatingCTA.tsx
@@ -63,7 +63,7 @@ export default function MobileFloatingCTA({
           {getBenefitCta(broker, context)}
         </a>
       </div>
-      <div className="px-4 pb-2 text-[0.62rem] text-slate-400 text-center">
+      <div className="px-4 pb-2 text-[0.62rem] text-slate-500 text-center">
         {ADVERTISER_DISCLOSURE_SHORT}
       </div>
     </div>

--- a/components/QASection.tsx
+++ b/components/QASection.tsx
@@ -258,7 +258,7 @@ export default function QASection({ questions, brokerSlug, brokerName, pageType:
                 </span>
                 <div className="flex-1 min-w-0">
                   <p className="font-semibold text-slate-900 text-sm">{q.question}</p>
-                  <p className="text-xs text-slate-400 mt-1">
+                  <p className="text-xs text-slate-500 mt-1">
                     Asked by {q.display_name} &middot;{" "}
                     {new Date(q.created_at).toLocaleDateString("en-AU", {
                       day: "numeric",
@@ -299,7 +299,7 @@ export default function QASection({ questions, brokerSlug, brokerName, pageType:
                               )}
                             </div>
                             <p className="text-sm text-slate-700 leading-relaxed">{a.answer}</p>
-                            <p className="text-xs text-slate-400 mt-1">
+                            <p className="text-xs text-slate-500 mt-1">
                               {a.author_slug ? (
                                 <Link
                                   href={`/authors/${a.author_slug}`}

--- a/components/SponsoredBrokerWidget.tsx
+++ b/components/SponsoredBrokerWidget.tsx
@@ -185,7 +185,7 @@ export default function SponsoredBrokerWidget({
         )}
 
         {/* Disclaimer */}
-        <p className="text-xs text-slate-400 mt-3 leading-relaxed px-1">
+        <p className="text-xs text-slate-500 mt-3 leading-relaxed px-1">
           {isCampaign ? "Sponsored placement." : ""} {ADVERTISER_DISCLOSURE_SHORT}{" "}
           <a href="/how-we-earn" className="underline hover:text-slate-600">
             Learn more

--- a/components/VerticalPillarPage.tsx
+++ b/components/VerticalPillarPage.tsx
@@ -208,7 +208,7 @@ export default function VerticalPillarPage({
               ))}
             </div>
 
-            <p className="text-[0.62rem] md:text-xs text-slate-400 mt-3">
+            <p className="text-[0.62rem] md:text-xs text-slate-500 mt-3">
               {ADVERTISER_DISCLOSURE_SHORT}
             </p>
             {hasSponsored && (
@@ -263,7 +263,7 @@ export default function VerticalPillarPage({
           )}
 
           {/* PDS / FSG / AFCA */}
-          <p className="text-[0.62rem] md:text-xs text-slate-400 leading-relaxed mb-3">
+          <p className="text-[0.62rem] md:text-xs text-slate-500 leading-relaxed mb-3">
             {PDS_CONSIDERATION} {FSG_NOTE} {AFCA_REFERENCE}
           </p>
 
@@ -309,11 +309,11 @@ export default function VerticalPillarPage({
               className={`${config.color.bg} border ${config.color.border} rounded-xl p-4 md:p-5 mb-6 md:mb-8 scroll-mt-20`}
             >
               <div className="flex items-center gap-2 mb-2">
-                <span
+                <h2
                   className={`text-xs font-bold uppercase tracking-wide ${config.color.text} ${config.color.bg} px-2 py-0.5 rounded-full`}
                 >
                   Our Top Pick
-                </span>
+                </h2>
                 {isSponsored(topPick) && <SponsorBadge broker={topPick} />}
               </div>
               <div className="flex flex-col sm:flex-row sm:items-center gap-4">
@@ -394,7 +394,7 @@ export default function VerticalPillarPage({
                             {broker.name}
                           </Link>
                           {broker.rating && (
-                            <span className="text-[0.62rem] text-slate-400">{renderStars(broker.rating)} {broker.rating}/5</span>
+                            <span className="text-[0.62rem] text-slate-500">{renderStars(broker.rating)} {broker.rating}/5</span>
                           )}
                         </div>
                       </div>
@@ -619,7 +619,7 @@ export default function VerticalPillarPage({
                       />
                       <div>
                         <div className="text-[0.62rem] font-bold text-slate-700">{article.author_name || 'Expert Contributor'}</div>
-                        <div className="text-[0.55rem] text-slate-400">{article.views ? `${article.views.toLocaleString()} views` : 'Expert article'}</div>
+                        <div className="text-[0.55rem] text-slate-500">{article.views ? `${article.views.toLocaleString()} views` : 'Expert article'}</div>
                       </div>
                     </div>
                     <h3 className="text-sm font-bold text-slate-900 group-hover:text-violet-700 transition-colors mb-1.5 line-clamp-2">{article.title}</h3>
@@ -711,7 +711,7 @@ export default function VerticalPillarPage({
                         {ra.title}
                       </h4>
                       {ra.read_time && (
-                        <span className="text-xs text-slate-400">
+                        <span className="text-xs text-slate-500">
                           {ra.read_time} min read
                         </span>
                       )}


### PR DESCRIPTION
## Items

- **A11Y-01** (Tier A) — Advertiser-disclosure copy in `text-slate-400` (~3.2:1) on light card bodies bumped to `text-slate-500` (~4.6:1, established muted token): `SponsoredBrokerWidget.tsx:188`, `BrokerStickyRightRail.tsx:67` (uppercase label) + `:117`, `ArticleSidebar.tsx:109`, `MobileFloatingCTA.tsx:66`. Required ACCC/ASIC affiliate disclosure must clear AA.
- **A11Y-02** (Tier A) — Content-bearing meta/disclosure text in `text-slate-400` on light bg bumped to `text-slate-500`: `InvestListingCard.tsx:157` (metric label), `QASection.tsx:261`+`:302` (attribution), `DealCard.tsx:142` (rating), `VerticalPillarPage.tsx:211`+`:266` (disclosures), `:397`/`:622`/`:714` (content-bearing rating/meta). Decorative separators (slate-300) and aria-hidden icons left as-is.
- **A11Y-03** (Tier B) — VerticalPillarPage heading-order skip (h1 → h3 with no intervening h2). Promoted the "Our Top Pick" section label span to an `<h2>` (visual styling unchanged); broker name stays `<h3>` nested beneath. Heading order is now h1 → h2 → h3 → h2.

## Verify

- `npx vitest run __tests__/components/ArticleSidebar.test.tsx __tests__/components/MobileFloatingCTA.test.tsx` → 19 passed
- `grep -n '<h[1-6]'` on VerticalPillarPage confirms no level skip
- eslint --fix clean on touched lines (2 pre-existing warnings on untouched lines in ArticleSidebar/DealCard, present on main)
- Class-only + one element-tag change; no TS surface impact

Tier A (A11Y-01, A11Y-02) + Tier B (A11Y-03).