### PR TITLE
feat(seo): HowTo/FAQ JSON-LD + answer-first intros on SMSF/gold/FIRB/property guides

### DIFF
--- a/app/foreign-investment/guides/buy-property-australia-foreigner/page.tsx
+++ b/app/foreign-investment/guides/buy-property-australia-foreigner/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import type { Metadata } from "next";
-import { breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
+import { breadcrumbJsonLd, SITE_URL, absoluteUrl } from "@/lib/seo";
+import { faqJsonLd, howToJsonLd } from "@/lib/schema-markup";
 import { FIRB_FEES, STATE_SURCHARGES } from "@/lib/firb-data";
 import { FIRB_DISCLAIMER } from "@/lib/compliance";
 import SectionHeading from "@/components/SectionHeading";
@@ -136,6 +137,36 @@ const FAQS = [
 ];
 
 function BuyPropertyAustralieForeignerPageInner({ fxProviders }: { fxProviders: FxProvider[] | null }) {
+  const faqLd = faqJsonLd(FAQS.map((f) => ({ q: f.question, a: f.answer })));
+
+  // HowTo JSON-LD built from the rendered purchase steps, with step/page URLs
+  // patched to this guide (not /how-to/).
+  const howToLd = howToJsonLd({
+    slug: "buy-property-australia-foreigner",
+    h1: "How to Buy Property in Australia as a Foreigner",
+    intro:
+      "A step-by-step process for foreign buyers: confirm eligibility, choose an eligible (new or off-the-plan) property, engage a lawyer, obtain FIRB approval, arrange finance, budget for stamp duty surcharges, open an Australian bank account, then exchange and settle.",
+    steps: STEPS.map((s) => ({ heading: s.title, body: s.description })),
+  });
+  const howTo = {
+    ...howToLd,
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": absoluteUrl("/foreign-investment/guides/buy-property-australia-foreigner"),
+    },
+    step: howToLd.step?.map(
+      (
+        s: { "@type": string; position: number; name: string; text: string; url: string },
+        i: number,
+      ) => ({
+        ...s,
+        url: absoluteUrl(
+          `/foreign-investment/guides/buy-property-australia-foreigner#step-${i + 1}`,
+        ),
+      }),
+    ),
+  };
+
   return (
     <div className="bg-white min-h-screen">
       <script
@@ -151,6 +182,16 @@ function BuyPropertyAustralieForeignerPageInner({ fxProviders }: { fxProviders: 
           ),
         }}
       />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(howTo) }}
+      />
+      {faqLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
+        />
+      )}
 
       {/* ── 2025–2027 Established Dwelling Ban Alert ── */}
       <div className="bg-red-50 border-b-2 border-red-200">

--- a/app/foreign-investment/guides/firb-application-guide/page.tsx
+++ b/app/foreign-investment/guides/firb-application-guide/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import type { Metadata } from "next";
-import { breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
+import { breadcrumbJsonLd, SITE_URL, absoluteUrl } from "@/lib/seo";
+import { faqJsonLd, howToJsonLd } from "@/lib/schema-markup";
 import { FIRB_FEES, FIRB_PROCESS_STEPS, FIRB_FAQS, WHO_NEEDS_FIRB } from "@/lib/firb-data";
 import { FIRB_DISCLAIMER } from "@/lib/compliance";
 import SectionHeading from "@/components/SectionHeading";
@@ -65,6 +66,36 @@ const APPROVAL_CONDITIONS = [
 ];
 
 export default function FirbApplicationGuidePage() {
+  const faqLd = faqJsonLd(
+    FIRB_FAQS.map((f) => ({ q: f.question, a: f.answer })),
+  );
+
+  // HowTo JSON-LD built from the rendered FIRB process steps, with step/page
+  // URLs patched to this guide (not /how-to/).
+  const howToLd = howToJsonLd({
+    slug: "firb-application-guide",
+    h1: "FIRB Application: Complete Step-by-Step Guide",
+    intro:
+      "Every foreign person buying Australian property must obtain FIRB approval. The process runs in five steps — engage a solicitor, identify an eligible property, submit the online application, await the decision, then proceed to purchase.",
+    steps: FIRB_PROCESS_STEPS.map((s) => ({ heading: s.title, body: s.description })),
+  });
+  const howTo = {
+    ...howToLd,
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": absoluteUrl("/foreign-investment/guides/firb-application-guide"),
+    },
+    step: howToLd.step?.map(
+      (
+        s: { "@type": string; position: number; name: string; text: string; url: string },
+        i: number,
+      ) => ({
+        ...s,
+        url: absoluteUrl(`/foreign-investment/guides/firb-application-guide#step-${i + 1}`),
+      }),
+    ),
+  };
+
   return (
     <div className="bg-white min-h-screen">
       <script
@@ -80,6 +111,16 @@ export default function FirbApplicationGuidePage() {
           ),
         }}
       />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(howTo) }}
+      />
+      {faqLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
+        />
+      )}
 
       {/* ── Ban reminder ── */}
       <div className="bg-amber-50 border-b border-amber-200">
@@ -117,8 +158,7 @@ export default function FirbApplicationGuidePage() {
               <span className="text-amber-600">Complete Step-by-Step Guide</span>
             </h1>
             <p className="text-sm md:text-base text-slate-600 leading-relaxed mb-6">
-              Every foreign person buying Australian property must obtain FIRB approval. This guide covers exactly
-              what to submit, how much it costs, how long it takes, and what happens after you apply.
+              Every foreign person buying Australian property must obtain FIRB approval. The process runs in five steps — engage a solicitor, identify an eligible property, submit the application online, await the decision, then proceed to purchase — takes around 30 days for standard processing, and costs $14,100 in fees for a property up to $1M. This guide covers exactly what to submit, the full fee schedule, processing times, and what happens after you apply.
             </p>
             <div className="grid grid-cols-3 gap-3">
               {[

--- a/app/invest/gold/page.tsx
+++ b/app/invest/gold/page.tsx
@@ -1,9 +1,31 @@
 import Link from "next/link";
 import type { Metadata } from "next";
 import Icon from "@/components/Icon";
-import { breadcrumbJsonLd, SITE_URL, SITE_NAME, CURRENT_YEAR } from "@/lib/seo";
+import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR, absoluteUrl } from "@/lib/seo";
+import { howToJsonLd } from "@/lib/schema-markup";
 
 export const revalidate = 3600;
+
+// The four ordered methods walked through on this page — single source for both
+// the HowTo JSON-LD steps and to keep the schema in lockstep with the DOM copy.
+const GOLD_METHODS = [
+  {
+    title: "Physical Bullion",
+    body: "Own the gold directly as bars, coins, or via an allocated storage account. The Perth Mint, being Western Australian Government-guaranteed, is the gold standard for Australian physical gold; ABC Bullion and The Gold Bullion Company are established dealers.",
+  },
+  {
+    title: "Gold ETFs (ASX-Listed)",
+    body: "The simplest route for most investors — buy and sell like a share through any broker. ASX-listed physical gold ETFs include GOLD (iShares), PMGOLD (Perth Mint, government-guaranteed vault) and QAU (BetaShares, AUD-hedged); you own a pro-rata share of vaulted gold without storage hassle.",
+  },
+  {
+    title: "ASX-Listed Gold Miners",
+    body: "Direct equity in gold mining companies such as NST (Northern Star), EVN (Evolution Mining) and NEM (Newmont) — typically more volatile than physical gold, but with operational leverage to the gold price. Buy through any ASX broker; mining equities carry exploration and management risks beyond gold price exposure.",
+  },
+  {
+    title: "Perth Mint Certificate Programme",
+    body: "Designed for larger investors (typically $10,000+) seeking allocated gold storage backed by the Western Australian Government. Unlike an ETF, a PMCP certificate is a direct legal claim on specific gold held in the Perth Mint vault — not a fund unit.",
+  },
+];
 
 export const metadata: Metadata = {
   title: `How to Invest in Gold in Australia (${CURRENT_YEAR}) — Physical, ETFs & ASX Miners`,
@@ -25,12 +47,30 @@ export default function GoldPage() {
     { name: "Gold & Precious Metals" },
   ]);
 
-  const webPage = {
-    "@context": "https://schema.org",
-    "@type": "WebPage",
-    name: `How to Invest in Gold in Australia (${CURRENT_YEAR})`,
-    url: `${SITE_URL}/invest/gold`,
-    publisher: { "@type": "Organization", name: SITE_NAME, url: SITE_URL },
+  // HowTo JSON-LD built from the four ordered methods using the canonical
+  // builder, with step/page URLs patched to this page (not /how-to/).
+  const howToLd = howToJsonLd({
+    slug: "invest-in-gold",
+    h1: `How to Invest in Gold in Australia (${CURRENT_YEAR})`,
+    intro:
+      "Four ways to invest in gold in Australia: physical bullion via the Perth Mint, ASX-listed gold ETFs (GOLD, PMGOLD, QAU), ASX-listed gold miners (NST, EVN, NEM), and the Perth Mint Certificate Programme.",
+    steps: GOLD_METHODS.map((m) => ({ heading: m.title, body: m.body })),
+  });
+  const howTo = {
+    ...howToLd,
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": absoluteUrl("/invest/gold"),
+    },
+    step: howToLd.step?.map(
+      (
+        s: { "@type": string; position: number; name: string; text: string; url: string },
+        i: number,
+      ) => ({
+        ...s,
+        url: absoluteUrl(`/invest/gold#method-${i + 1}`),
+      }),
+    ),
   };
 
   return (
@@ -41,7 +81,7 @@ export default function GoldPage() {
       />
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(howTo) }}
       />
 
       {/* Hero */}
@@ -71,7 +111,7 @@ export default function GoldPage() {
             How to Invest in Gold in Australia
           </h1>
           <p className="text-lg text-slate-600 leading-relaxed max-w-2xl">
-            Australia produces more gold than almost any other country. Whether you want physical bullion, ETFs, ASX-listed miners, or the government-backed Perth Mint Certificate Programme — here is everything you need to know.
+            There are four ways to invest in gold in Australia: physical bullion via the Perth Mint, ASX-listed gold ETFs (GOLD, PMGOLD, QAU), ASX-listed gold miners (NST, EVN, NEM), and the Perth Mint Certificate Programme — and investment-grade bullion is GST-free. Below is how each method works, what it costs, and who it suits.
           </p>
         </div>
       </section>

--- a/app/smsf/setup/page.tsx
+++ b/app/smsf/setup/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR, absoluteUrl } from "@/lib/seo";
+import { howToJsonLd } from "@/lib/schema-markup";
 import HubAdvisorCTA from "@/components/HubAdvisorCTA";
 import AdvisorPrompt from "@/components/AdvisorPrompt";
 import { createClient } from "@/lib/supabase/server";
@@ -47,9 +48,36 @@ export default async function SmsfSetupPage() {
     { name: "SMSF", url: absoluteUrl("/smsf") },
     { name: "Setup", url: absoluteUrl("/smsf/setup") },
   ]);
+
+  // Build HowTo JSON-LD from the 7 setup steps using the canonical builder,
+  // then patch step/page URLs to this page (not /how-to/) per its real location.
+  const howToLd = howToJsonLd({
+    slug: "smsf-setup",
+    h1: `How to Set Up an SMSF in Australia (${CURRENT_YEAR} Guide)`,
+    intro:
+      "The complete 7-step process to establish a self-managed super fund in Australia, from choosing a trustee structure to engaging an SMSF accountant.",
+    steps: SETUP_STEPS.map((s) => ({ heading: s.title, body: s.body })),
+  });
+  const howTo = {
+    ...howToLd,
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": absoluteUrl("/smsf/setup"),
+    },
+    step: howToLd.step?.map(
+      (
+        s: { "@type": string; position: number; name: string; text: string; url: string },
+        i: number,
+      ) => ({
+        ...s,
+        url: absoluteUrl(`/smsf/setup#step-${i + 1}`),
+      }),
+    ),
+  };
   return (
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(howTo) }} />
       <div className="bg-white min-h-screen">
         <section className="bg-slate-900 text-white py-10 md:py-14">
           <div className="container-custom">
@@ -64,7 +92,7 @@ export default async function SmsfSetupPage() {
               How to Set Up an SMSF in Australia ({CURRENT_YEAR} Guide)
             </h1>
             <p className="text-base md:text-lg text-slate-300 leading-relaxed max-w-3xl mb-6">
-              The complete 7-step setup, with realistic cost ranges and the trustee-structure decision that drives most of the downstream complexity.
+              Setting up an SMSF takes seven steps — choose a trustee structure, create the trust deed, register with the ATO, open a dedicated bank account, document an investment strategy, roll over existing super, and engage an SMSF accountant — and costs $800–$3,500 depending on whether you use individual or corporate trustees. Below is the full process, the trustee-structure decision that drives most downstream complexity, and the realistic cost ranges.
             </p>
             <div className="grid grid-cols-2 md:grid-cols-4 gap-3 max-w-4xl">
               {[

--- a/app/smsf/wind-up/page.tsx
+++ b/app/smsf/wind-up/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { SITE_URL, CURRENT_YEAR, UPDATED_LABEL, absoluteUrl, breadcrumbJsonLd } from "@/lib/seo";
-import { faqJsonLd } from "@/lib/schema-markup";
+import { faqJsonLd, howToJsonLd } from "@/lib/schema-markup";
 import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
 
 export const revalidate = 86400;
@@ -159,11 +159,41 @@ export default function SmsfWindUpPage() {
   ]);
   const faq = faqJsonLd(FAQS);
 
+  // HowTo JSON-LD built from the rendered wind-up steps, with step/page URLs
+  // patched to this page (not /how-to/).
+  const howToLd = howToJsonLd({
+    slug: "smsf-wind-up",
+    h1: `How to Wind Up an SMSF in Australia (${CURRENT_YEAR} Guide)`,
+    intro:
+      "The formal process to wind up a self-managed super fund: pass a trustee resolution, notify the ATO, realise assets, pay liabilities, pay or rollover member benefits, lodge the final annual return, and close accounts and cancel the ABN/TFN.",
+    steps: WIND_UP_STEPS.map((s) => ({ heading: s.title, body: s.body })),
+  });
+  const howTo = {
+    ...howToLd,
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": absoluteUrl("/smsf/wind-up"),
+    },
+    step: howToLd.step?.map(
+      (
+        s: { "@type": string; position: number; name: string; text: string; url: string },
+        i: number,
+      ) => ({
+        ...s,
+        url: absoluteUrl(`/smsf/wind-up#step-${i + 1}`),
+      }),
+    ),
+  };
+
   return (
     <>
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(howTo) }}
       />
       {faq && (
         <script
@@ -197,10 +227,11 @@ export default function SmsfWindUpPage() {
               How to Wind Up an SMSF in Australia ({CURRENT_YEAR} Guide)
             </h1>
             <p className="text-base md:text-lg text-slate-300 leading-relaxed max-w-3xl mb-6">
-              Winding up an SMSF is a formal process with specific ATO notification requirements,
-              tax events, and compliance steps. Done incorrectly it can trigger unexpected CGT
-              bills, ongoing levies, and penalties. This guide covers every step — from the
-              trustee resolution through to cancelling the fund&apos;s ABN.
+              Winding up an SMSF takes seven steps — pass a trustee resolution, notify the ATO,
+              realise assets, pay all liabilities, pay or rollover member benefits, lodge the final
+              annual return, then close the bank accounts and cancel the ABN/TFN — and typically
+              costs $2,000–$6,000+ over a 3–12 month timeline. Done incorrectly it can trigger
+              unexpected CGT bills, ongoing levies, and penalties; this guide covers every step.
             </p>
             <div className="grid grid-cols-2 md:grid-cols-4 gap-3 max-w-4xl">
               {[


### PR DESCRIPTION
Adds procedural/Q&A structured data (GEO program) to four step-by-step guides that rendered their content to the DOM but emitted no machine-readable step list or FAQ — giving AI answer engines and Google rich results a citation target.

Items (Tier A):
- **GEO-01** `app/smsf/setup` — HowTo over the 7 SETUP_STEPS; answer-first lead (7 steps + $800–$3,500 cost in sentence one).
- **GEO-02** `app/invest/gold` — HowTo over the 4 methods; replaced the hand-rolled WebPage object with the typed `howToJsonLd` builder; answer-first lead (four ways named, GST-free bullion).
- **GEO-03** `app/foreign-investment/guides/firb-application-guide` — FAQPage (FIRB_FAQS) + HowTo (FIRB_PROCESS_STEPS); answer-first lead with 30-day / $14,100 figures up front.
- **GEO-04** `app/foreign-investment/guides/buy-property-australia-foreigner` — FAQPage (FAQS) + HowTo (STEPS).
- **GEO-05** `app/smsf/wind-up` — HowTo over WIND_UP_STEPS alongside the existing FAQPage; answer-first lead.

All HowTo blocks reuse `lib/schema-markup.howToJsonLd` and patch step/page URLs to each page's own canonical URL (not `/how-to/`), matching the established `app/switch/[type]` pattern; FAQ blocks reuse `faqJsonLd` (`{q, a}` shape). No hand-rolled JSON-LD or disclaimers; compliance/ban copy untouched.

Verify: `npx eslint --fix --max-warnings 0` clean on all 5 files. Full `tsc` OOMs on this host (>8 GB needed); CI authoritative — code mirrors the type-checked switch-page pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)