### PR TITLE
test(lib): cover telegram, admin-mfa-env-check, intent-context-actions

### DIFF
--- a/__tests__/lib/admin-mfa-env-check.test.ts
+++ b/__tests__/lib/admin-mfa-env-check.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { mockError } = vi.hoisted(() => ({ mockError: vi.fn() }));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: mockError,
+  })),
+}));
+
+// Each case re-imports the module so the module-level `warned` Set starts
+// empty (it is not resettable from the outside).
+async function loadChecker() {
+  const mod = await import("@/lib/admin-mfa-env-check");
+  return mod.checkAdminMfaEnv;
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  mockError.mockClear();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("checkAdminMfaEnv", () => {
+  it("returns ok with no missing vars and never logs when both are set", async () => {
+    vi.stubEnv("ADMIN_MFA_COOKIE_SECRET", "cookie-secret");
+    vi.stubEnv("ADMIN_MFA_KEY", "totp-key");
+    const checkAdminMfaEnv = await loadChecker();
+
+    expect(checkAdminMfaEnv()).toEqual({ ok: true, missing: [] });
+    expect(mockError).not.toHaveBeenCalled();
+  });
+
+  it("reports ADMIN_MFA_KEY missing when only it is unset", async () => {
+    // Use empty string per CI-stub caveat: the CI env: block may set values.
+    vi.stubEnv("ADMIN_MFA_COOKIE_SECRET", "cookie-secret");
+    vi.stubEnv("ADMIN_MFA_KEY", "");
+    const checkAdminMfaEnv = await loadChecker();
+
+    expect(checkAdminMfaEnv()).toEqual({ ok: false, missing: ["ADMIN_MFA_KEY"] });
+  });
+
+  it("reports ADMIN_MFA_COOKIE_SECRET missing when only it is unset", async () => {
+    vi.stubEnv("ADMIN_MFA_COOKIE_SECRET", "");
+    vi.stubEnv("ADMIN_MFA_KEY", "totp-key");
+    const checkAdminMfaEnv = await loadChecker();
+
+    expect(checkAdminMfaEnv()).toEqual({
+      ok: false,
+      missing: ["ADMIN_MFA_COOKIE_SECRET"],
+    });
+  });
+
+  it("reports both missing in source order when neither is set", async () => {
+    vi.stubEnv("ADMIN_MFA_COOKIE_SECRET", "");
+    vi.stubEnv("ADMIN_MFA_KEY", "");
+    const checkAdminMfaEnv = await loadChecker();
+
+    expect(checkAdminMfaEnv()).toEqual({
+      ok: false,
+      missing: ["ADMIN_MFA_COOKIE_SECRET", "ADMIN_MFA_KEY"],
+    });
+    expect(mockError).toHaveBeenCalledTimes(1);
+    expect(mockError).toHaveBeenCalledWith(expect.any(String), {
+      missing: ["ADMIN_MFA_COOKIE_SECRET", "ADMIN_MFA_KEY"],
+    });
+  });
+
+  it("warns only once per process for the same missing set", async () => {
+    vi.stubEnv("ADMIN_MFA_COOKIE_SECRET", "");
+    vi.stubEnv("ADMIN_MFA_KEY", "");
+    const checkAdminMfaEnv = await loadChecker();
+
+    const first = checkAdminMfaEnv();
+    const second = checkAdminMfaEnv();
+
+    expect(first).toEqual(second);
+    expect(first.ok).toBe(false);
+    // The module-level `warned` Set dedupes the log.error across calls.
+    expect(mockError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/lib/intent-context-actions.test.ts
+++ b/__tests__/lib/intent-context-actions.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockSet, mockDelete, mockCookies } = vi.hoisted(() => {
+  const set = vi.fn();
+  const del = vi.fn();
+  return {
+    mockSet: set,
+    mockDelete: del,
+    mockCookies: vi.fn(async () => ({ set, delete: del })),
+  };
+});
+
+vi.mock("next/headers", () => ({
+  cookies: mockCookies,
+}));
+
+import {
+  setIntentCountryAction,
+  clearIntentCountryAction,
+} from "@/lib/intent-context-actions";
+import {
+  INTENT_COUNTRY_COOKIE,
+  INTENT_COUNTRY_TTL_SECONDS,
+  isKnownIntentCountry,
+} from "@/lib/intent-context";
+
+// A real, known intent code (sanity-checked against the source of truth).
+const KNOWN_CODE = "uk";
+
+beforeEach(() => {
+  mockSet.mockClear();
+  mockDelete.mockClear();
+});
+
+describe("setIntentCountryAction", () => {
+  it("uses a code that is genuinely known to the registry", () => {
+    expect(isKnownIntentCountry(KNOWN_CODE)).toBe(true);
+  });
+
+  it("early-returns for an unknown code without touching cookies", async () => {
+    expect(isKnownIntentCountry("zz")).toBe(false);
+    await setIntentCountryAction("zz");
+    expect(mockSet).not.toHaveBeenCalled();
+  });
+
+  it("sets the intent cookie with the expected options for a known code", async () => {
+    await setIntentCountryAction(KNOWN_CODE);
+    expect(mockSet).toHaveBeenCalledTimes(1);
+    expect(mockSet).toHaveBeenCalledWith(INTENT_COUNTRY_COOKIE, KNOWN_CODE, {
+      maxAge: INTENT_COUNTRY_TTL_SECONDS,
+      httpOnly: false,
+      sameSite: "lax",
+      path: "/",
+    });
+  });
+});
+
+describe("clearIntentCountryAction", () => {
+  it("deletes the intent cookie", async () => {
+    await clearIntentCountryAction();
+    expect(mockDelete).toHaveBeenCalledTimes(1);
+    expect(mockDelete).toHaveBeenCalledWith(INTENT_COUNTRY_COOKIE);
+  });
+});

--- a/__tests__/lib/telegram.test.ts
+++ b/__tests__/lib/telegram.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+import {
+  getTelegramBotToken,
+  isTelegramConfigured,
+  verifyTelegramWebhookSecret,
+  escapeMarkdownV2,
+  formatRateAlertMessage,
+  dispatchTelegramAlerts,
+} from "@/lib/telegram";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe("getTelegramBotToken", () => {
+  it("returns null when TELEGRAM_BOT_TOKEN is unset", () => {
+    // Use empty string per CI-stub caveat: the CI env: block may set a value.
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "");
+    expect(getTelegramBotToken()).toBeNull();
+  });
+
+  it("returns null for whitespace-only tokens (trimmed)", () => {
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "        ");
+    expect(getTelegramBotToken()).toBeNull();
+  });
+
+  it("returns null for tokens shorter than 10 chars after trimming", () => {
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "  123456  ");
+    expect(getTelegramBotToken()).toBeNull();
+  });
+
+  it("returns the trimmed token when it is at least 10 chars", () => {
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "  123456:abcdef  ");
+    expect(getTelegramBotToken()).toBe("123456:abcdef");
+  });
+});
+
+describe("isTelegramConfigured", () => {
+  it("is false when no token is set", () => {
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "");
+    expect(isTelegramConfigured()).toBe(false);
+  });
+
+  it("is true when a valid token is set (delegates to getTelegramBotToken)", () => {
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "123456:valid-token");
+    expect(isTelegramConfigured()).toBe(true);
+  });
+});
+
+describe("verifyTelegramWebhookSecret", () => {
+  it("returns false when TELEGRAM_WEBHOOK_SECRET is unset", () => {
+    vi.stubEnv("TELEGRAM_WEBHOOK_SECRET", "");
+    expect(verifyTelegramWebhookSecret("anything")).toBe(false);
+    expect(verifyTelegramWebhookSecret(null)).toBe(false);
+  });
+
+  it("returns false when the header does not exactly match the secret", () => {
+    vi.stubEnv("TELEGRAM_WEBHOOK_SECRET", "s3cr3t-value");
+    expect(verifyTelegramWebhookSecret("wrong")).toBe(false);
+    expect(verifyTelegramWebhookSecret(null)).toBe(false);
+    // Trailing whitespace difference must not match (strict equality).
+    expect(verifyTelegramWebhookSecret("s3cr3t-value ")).toBe(false);
+  });
+
+  it("returns true on strict equality with the configured secret", () => {
+    vi.stubEnv("TELEGRAM_WEBHOOK_SECRET", "s3cr3t-value");
+    expect(verifyTelegramWebhookSecret("s3cr3t-value")).toBe(true);
+  });
+});
+
+describe("escapeMarkdownV2", () => {
+  it("returns empty string for empty input", () => {
+    expect(escapeMarkdownV2("")).toBe("");
+  });
+
+  it("passes through text with no special characters unchanged", () => {
+    expect(escapeMarkdownV2("BetaShares A200")).toBe("BetaShares A200");
+  });
+
+  it("escapes each special character individually", () => {
+    const specials = [
+      "_",
+      "*",
+      "[",
+      "]",
+      "(",
+      ")",
+      "~",
+      "`",
+      ">",
+      "#",
+      "+",
+      "-",
+      "=",
+      "|",
+      "{",
+      "}",
+      ".",
+      "!",
+    ];
+    for (const c of specials) {
+      expect(escapeMarkdownV2(c)).toBe(`\\${c}`);
+    }
+  });
+
+  it("escapes a literal backslash to a double backslash", () => {
+    expect(escapeMarkdownV2("\\")).toBe("\\\\");
+  });
+
+  it("escapes all special characters in a single pass", () => {
+    expect(escapeMarkdownV2("_*[]()~`>#+-=|{}.!")).toBe(
+      "\\_\\*\\[\\]\\(\\)\\~\\`\\>\\#\\+\\-\\=\\|\\{\\}\\.\\!",
+    );
+  });
+
+  it("escapes a mixed real-world string", () => {
+    expect(escapeMarkdownV2("50% - rate (1.2)!")).toBe(
+      "50% \\- rate \\(1\\.2\\)\\!",
+    );
+  });
+});
+
+describe("formatRateAlertMessage", () => {
+  it("uses the up arrow for direction 'above'", () => {
+    const msg = formatRateAlertMessage({
+      metricLabel: "yield",
+      direction: "above",
+      oldRatePct: "4.0%",
+      newRatePct: "4.5%",
+      productName: "BetaShares A200",
+      deepLinkUrl: "https://invest.com.au/x",
+    });
+    expect(msg.startsWith("📈")).toBe(true);
+  });
+
+  it("uses the down arrow for direction 'below'", () => {
+    const msg = formatRateAlertMessage({
+      metricLabel: "yield",
+      direction: "below",
+      oldRatePct: "4.5%",
+      newRatePct: "4.0%",
+      productName: "BetaShares A200",
+      deepLinkUrl: "https://invest.com.au/x",
+    });
+    expect(msg.startsWith("📉")).toBe(true);
+  });
+
+  it("escapes special characters in the product name (parens)", () => {
+    const msg = formatRateAlertMessage({
+      metricLabel: "yield",
+      direction: "above",
+      oldRatePct: "4.0%",
+      newRatePct: "4.5%",
+      productName: "BetaShares (A200)",
+      deepLinkUrl: "https://invest.com.au/x",
+    });
+    expect(msg).toContain("BetaShares \\(A200\\)");
+  });
+
+  it("passes metric, old/new rate and url through escapeMarkdownV2 and renders the View link", () => {
+    const msg = formatRateAlertMessage({
+      metricLabel: "12-mo return",
+      direction: "above",
+      oldRatePct: "4.0%",
+      newRatePct: "4.5%",
+      productName: "Fund",
+      deepLinkUrl: "https://invest.com.au/etf?id=1.2",
+    });
+    // metricLabel escaped (the hyphen).
+    expect(msg).toContain("12\\-mo return");
+    // old/new escaped (the dots).
+    expect(msg).toContain("4\\.0%");
+    expect(msg).toContain("*4\\.5%*");
+    // The View link with an escaped url (the dots and ? are escaped where special).
+    expect(msg).toContain("[View →](https://invest\\.com\\.au/etf?id\\=1\\.2)");
+  });
+});
+
+describe("dispatchTelegramAlerts", () => {
+  it("is a no-op when there are no recipients (does not call fetch)", async () => {
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "123456:valid-token");
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    await dispatchTelegramAlerts([], "hi");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when Telegram is not configured (does not call fetch)", async () => {
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "");
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    await dispatchTelegramAlerts(
+      [{ chatId: 1, email: "a@b.com" }],
+      "hi",
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Adds focused unit coverage for three previously-untested lib modules.

- **TEST-01** `__tests__/lib/telegram.test.ts` — getTelegramBotToken (trim + min-length gate), isTelegramConfigured, verifyTelegramWebhookSecret (unset secret -> false; strict equality), escapeMarkdownV2 (each special char, backslash, empty, mixed string), formatRateAlertMessage (direction arrows, per-field escaping incl. escaped parens + View link), dispatchTelegramAlerts early-return no-ops.
- **TEST-02** `__tests__/lib/admin-mfa-env-check.test.ts` — checkAdminMfaEnv missing-var matrix (both set / each missing / both missing in source order) + warn-once dedupe via the module-level Set (vi.resetModules + dynamic import per case).
- **TEST-03** `__tests__/lib/intent-context-actions.test.ts` — setIntentCountryAction (unknown -> no cookie write; known -> cookies().set with TTL/httpOnly/sameSite/path) and clearIntentCountryAction delete.

Env-unset cases use `vi.stubEnv(name, "")` per the CI-stub caveat.

Tier A.

Verify: `npm test -- __tests__/lib/telegram.test.ts __tests__/lib/admin-mfa-env-check.test.ts __tests__/lib/intent-context-actions.test.ts` -> 30 passed.