### PR TITLE
test(lib): extend seo, verticals, schema-markup, sponsorship coverage

### DIFF
--- a/__tests__/lib/schema-markup.test.ts
+++ b/__tests__/lib/schema-markup.test.ts
@@ -20,6 +20,8 @@ import {
   howToJsonLd,
   personCredentialJsonLd,
   personJsonLd,
+  blogPostingJsonLd,
+  governmentServiceJsonLd,
 } from "@/lib/schema-markup";
 
 describe("articleJsonLd", () => {
@@ -1411,5 +1413,109 @@ describe("personJsonLd", () => {
     expect(out.knowsAbout).toBeDefined();
     expect(out.interactionStatistic).toBeDefined();
     expect((out.interactionStatistic as Bag[])).toHaveLength(2);
+  });
+});
+
+/* ─── TEST-11: blogPostingJsonLd ─── */
+
+describe("blogPostingJsonLd", () => {
+  const base = {
+    postId: 42,
+    advisorSlug: "jane-advisor",
+    body: "x".repeat(300),
+    postType: "market-update",
+    publishedAt: "2026-01-15T00:00:00.000Z",
+    authorName: "Jane Advisor",
+    authorSlug: "jane-author",
+  };
+
+  it("emits BlogPosting with url /advisor/{advisorSlug}/insights/{postId}", () => {
+    const out = blogPostingJsonLd(base) as Bag;
+    expect(out["@context"]).toBe("https://schema.org");
+    expect(out["@type"]).toBe("BlogPosting");
+    expect(out.url).toBe("https://invest.com.au/advisor/jane-advisor/insights/42");
+  });
+
+  it("derives headline (110) / description (160) from body, keeps full articleBody", () => {
+    const out = blogPostingJsonLd(base) as Bag;
+    expect((out.headline as string)).toHaveLength(110);
+    expect((out.description as string)).toHaveLength(160);
+    expect(out.articleBody).toBe(base.body);
+  });
+
+  it("sets keywords to postType and datePublished === dateModified === publishedAt", () => {
+    const out = blogPostingJsonLd(base) as Bag;
+    expect(out.keywords).toBe("market-update");
+    expect(out.datePublished).toBe(base.publishedAt);
+    expect(out.dateModified).toBe(base.publishedAt);
+  });
+
+  it("author Person uses /advisor/{authorSlug}; image omitted when authorPhotoUrl null/undefined", () => {
+    const out = blogPostingJsonLd(base) as Bag;
+    const author = out.author as Bag;
+    expect(author["@type"]).toBe("Person");
+    expect(author.name).toBe("Jane Advisor");
+    expect(author.url).toBe("https://invest.com.au/advisor/jane-author");
+    expect(author.image).toBeUndefined();
+
+    const outNull = blogPostingJsonLd({ ...base, authorPhotoUrl: null }) as Bag;
+    expect((outNull.author as Bag).image).toBeUndefined();
+  });
+
+  it("includes author image when authorPhotoUrl present", () => {
+    const out = blogPostingJsonLd({ ...base, authorPhotoUrl: "https://cdn.example/jane.jpg" }) as Bag;
+    expect((out.author as Bag).image).toBe("https://cdn.example/jane.jpg");
+  });
+
+  it("publisher is the Organization and mainEntityOfPage.@id matches url", () => {
+    const out = blogPostingJsonLd(base) as Bag;
+    expect((out.publisher as Bag)["@type"]).toBe("Organization");
+    expect((out.mainEntityOfPage as Bag)["@id"]).toBe(out.url);
+  });
+});
+
+/* ─── TEST-11: governmentServiceJsonLd ─── */
+
+describe("governmentServiceJsonLd", () => {
+  const base = {
+    name: "ROPS pension transfer",
+    description: "Transfer a UK pension to an Australian QROPS.",
+    serviceType: "Tax concession",
+    countryName: "United Kingdom",
+    sourceName: "HMRC ROPS notification list",
+    sourceUrl: "https://www.gov.uk/rops",
+    pagePath: "/foreign-investment/united-kingdom",
+  };
+
+  it("emits GovernmentService with passed-through serviceType", () => {
+    const out = governmentServiceJsonLd(base) as Bag;
+    expect(out["@context"]).toBe("https://schema.org");
+    expect(out["@type"]).toBe("GovernmentService");
+    expect(out.name).toBe(base.name);
+    expect(out.serviceType).toBe("Tax concession");
+  });
+
+  it("areaServed is a Country with the country name", () => {
+    const out = governmentServiceJsonLd(base) as Bag;
+    expect(out.areaServed).toEqual({ "@type": "Country", name: "United Kingdom" });
+  });
+
+  it("provider is a GovernmentOrganization carrying sourceName/sourceUrl", () => {
+    const out = governmentServiceJsonLd(base) as Bag;
+    expect(out.provider).toEqual({
+      "@type": "GovernmentOrganization",
+      name: "HMRC ROPS notification list",
+      url: "https://www.gov.uk/rops",
+    });
+  });
+
+  it("mainEntityOfPage is the absolute page URL", () => {
+    const out = governmentServiceJsonLd(base) as Bag;
+    expect(out.mainEntityOfPage).toBe("https://invest.com.au/foreign-investment/united-kingdom");
+  });
+
+  it("audience.audienceType is 'Cross-border investor'", () => {
+    const out = governmentServiceJsonLd(base) as Bag;
+    expect(out.audience).toEqual({ "@type": "Audience", audienceType: "Cross-border investor" });
   });
 });

--- a/__tests__/lib/seo.test.ts
+++ b/__tests__/lib/seo.test.ts
@@ -16,8 +16,13 @@ import {
   articleAuthorJsonLd,
   dealOfferJsonLd,
   dealsHubJsonLd,
+  brokerProductJsonLd,
+  reviewerPersonJsonLd,
+  courseJsonLd,
+  howToJsonLd,
+  qaPageJsonLd,
 } from "@/lib/seo";
-import type { TeamMember, Broker } from "@/lib/types";
+import type { TeamMember, Broker, Course } from "@/lib/types";
 
 describe("constants", () => {
   it("SITE_NAME is set", () => {
@@ -396,5 +401,306 @@ describe("dealsHubJsonLd", () => {
     const jsonLd = dealsHubJsonLd([]);
     expect(jsonLd.numberOfItems).toBe(0);
     expect(jsonLd.itemListElement).toEqual([]);
+  });
+});
+
+/* ─── TEST-06: brokerProductJsonLd / reviewerPersonJsonLd / courseJsonLd ─── */
+
+describe("brokerProductJsonLd", () => {
+  const base = { name: "TestBroker", slug: "test-broker" };
+
+  it("emits FinancialProduct with a #product @id anchored to the broker URL", () => {
+    const jsonLd = brokerProductJsonLd(base);
+    expect(jsonLd["@context"]).toBe("https://schema.org");
+    expect(jsonLd["@type"]).toBe("FinancialProduct");
+    expect(jsonLd.url).toBe(absoluteUrl("/broker/test-broker"));
+    expect(jsonLd["@id"]).toBe(`${absoluteUrl("/broker/test-broker")}#product`);
+  });
+
+  it("classifies a crypto broker as a Cryptocurrency Exchange", () => {
+    const jsonLd = brokerProductJsonLd({ ...base, is_crypto: true });
+    expect(jsonLd.category).toBe("Cryptocurrency Exchange");
+  });
+
+  it("classifies platform_type robo_advisor as Robo-Advisor", () => {
+    const jsonLd = brokerProductJsonLd({ ...base, platform_type: "robo_advisor" });
+    expect(jsonLd.category).toBe("Robo-Advisor");
+  });
+
+  it("classifies platform_type super_fund as Superannuation Fund", () => {
+    const jsonLd = brokerProductJsonLd({ ...base, platform_type: "super_fund" });
+    expect(jsonLd.category).toBe("Superannuation Fund");
+  });
+
+  it("defaults to Share Trading Platform for anything else", () => {
+    const jsonLd = brokerProductJsonLd({ ...base, platform_type: "share_broker" });
+    expect(jsonLd.category).toBe("Share Trading Platform");
+    expect(brokerProductJsonLd(base).category).toBe("Share Trading Platform");
+  });
+
+  it("prefers is_crypto over platform_type when both set", () => {
+    const jsonLd = brokerProductJsonLd({ ...base, is_crypto: true, platform_type: "robo_advisor" });
+    expect(jsonLd.category).toBe("Cryptocurrency Exchange");
+  });
+
+  it("includes aggregateRating only when review_count > 0", () => {
+    const withRatings = brokerProductJsonLd({ ...base, rating: 4.2, review_count: 12 });
+    expect(withRatings.aggregateRating).toBeDefined();
+    expect(withRatings.aggregateRating?.ratingValue).toBe(4.2);
+    expect(withRatings.aggregateRating?.reviewCount).toBe(12);
+
+    expect(brokerProductJsonLd({ ...base, rating: 4.2, review_count: 0 }).aggregateRating).toBeUndefined();
+    expect(brokerProductJsonLd(base).aggregateRating).toBeUndefined();
+  });
+
+  it("clamps ratingValue to a floor of 1 for 0 / undefined / negative", () => {
+    expect(brokerProductJsonLd({ ...base, rating: 0, review_count: 3 }).aggregateRating?.ratingValue).toBe(1);
+    expect(brokerProductJsonLd({ ...base, rating: -5, review_count: 3 }).aggregateRating?.ratingValue).toBe(1);
+    expect(brokerProductJsonLd({ ...base, review_count: 3 }).aggregateRating?.ratingValue).toBe(1);
+  });
+
+  it("includes additionalProperty only when regulated_by set", () => {
+    const regulated = brokerProductJsonLd({ ...base, regulated_by: "ASIC" });
+    expect(regulated.additionalProperty).toEqual({
+      "@type": "PropertyValue",
+      name: "Regulated By",
+      value: "ASIC",
+    });
+    expect(brokerProductJsonLd(base).additionalProperty).toBeUndefined();
+  });
+
+  it("includes provider.foundingDate only when year_founded set", () => {
+    const founded = brokerProductJsonLd({ ...base, year_founded: 2010 });
+    expect(founded.provider.foundingDate).toBe("2010");
+    expect(brokerProductJsonLd(base).provider.foundingDate).toBeUndefined();
+  });
+});
+
+describe("reviewerPersonJsonLd", () => {
+  const member: TeamMember = {
+    id: 7,
+    slug: "jane-reviewer",
+    full_name: "Jane Reviewer",
+    role: "expert_reviewer",
+    linkedin_url: "https://linkedin.com/in/jane",
+    status: "active",
+    created_at: "2024-01-01",
+    updated_at: "2024-01-01",
+  };
+
+  it("uses the /reviewers/ path (not /authors/)", () => {
+    const jsonLd = reviewerPersonJsonLd(member);
+    expect(jsonLd.url).toBe(absoluteUrl("/reviewers/jane-reviewer"));
+    expect(jsonLd.url).not.toContain("/authors/");
+  });
+
+  it("sets jobTitle via formatRole", () => {
+    const jsonLd = reviewerPersonJsonLd(member);
+    expect(jsonLd.jobTitle).toBe(formatRole("expert_reviewer"));
+    expect(jsonLd.jobTitle).toBe("Expert Reviewer");
+  });
+
+  it("includes sameAs only when linkedin_url set", () => {
+    expect(reviewerPersonJsonLd(member).sameAs).toEqual(["https://linkedin.com/in/jane"]);
+    const noLinkedin: TeamMember = { ...member, linkedin_url: undefined };
+    expect(reviewerPersonJsonLd(noLinkedin).sameAs).toBeUndefined();
+  });
+
+  it("carries SITE_NAME / SITE_URL on the worksFor Organization", () => {
+    const jsonLd = reviewerPersonJsonLd(member);
+    expect(jsonLd.worksFor).toEqual({
+      "@type": "Organization",
+      name: SITE_NAME,
+      url: SITE_URL,
+    });
+  });
+});
+
+describe("courseJsonLd", () => {
+  const base: Course = {
+    id: 1,
+    slug: "investing-101",
+    title: "Investing 101",
+    description: "Learn the basics.",
+    price: 9900,
+    currency: "AUD",
+    revenue_share_percent: 0,
+    level: "beginner",
+    status: "published",
+    featured: false,
+    sort_order: 0,
+    created_at: "2024-01-01",
+    updated_at: "2024-01-01",
+  };
+
+  it("formats offers.price as dollars from cents", () => {
+    expect(courseJsonLd(base, 10, 3).offers.price).toBe("99.00");
+    expect(courseJsonLd({ ...base, price: 12345 }, 10, 3).offers.price).toBe("123.45");
+    expect(courseJsonLd({ ...base, price: 0 }, 10, 3).offers.price).toBe("0.00");
+  });
+
+  it("maps educationalLevel from level", () => {
+    expect(courseJsonLd({ ...base, level: "beginner" }, 1, 1).educationalLevel).toBe("Beginner");
+    expect(courseJsonLd({ ...base, level: "intermediate" }, 1, 1).educationalLevel).toBe("Intermediate");
+    expect(courseJsonLd({ ...base, level: "advanced" }, 1, 1).educationalLevel).toBe("Advanced");
+  });
+
+  it("includes instructor only when creator set", () => {
+    const creator: TeamMember = {
+      id: 2,
+      slug: "the-creator",
+      full_name: "The Creator",
+      role: "course_creator",
+      status: "active",
+      created_at: "2024-01-01",
+      updated_at: "2024-01-01",
+    };
+    const withCreator = courseJsonLd({ ...base, creator }, 1, 1) as ReturnType<typeof courseJsonLd> & {
+      instructor?: { "@type": string; name: string; url: string };
+    };
+    expect(withCreator.instructor).toEqual({
+      "@type": "Person",
+      name: "The Creator",
+      url: absoluteUrl("/authors/the-creator"),
+    });
+    const noCreator = courseJsonLd(base, 1, 1) as Record<string, unknown>;
+    expect(noCreator.instructor).toBeUndefined();
+  });
+
+  it("includes courseWorkload only when estimated_hours set", () => {
+    const withHours = courseJsonLd({ ...base, estimated_hours: 4.4 }, 1, 1);
+    expect(withHours.hasCourseInstance.courseWorkload).toBe("PT4H");
+    const noHours = courseJsonLd(base, 1, 1);
+    expect(noHours.hasCourseInstance.courseWorkload).toBeUndefined();
+  });
+
+  it("sets numberOfCredits to totalModules and inLanguage to en-AU", () => {
+    const jsonLd = courseJsonLd(base, 12, 5);
+    expect(jsonLd.numberOfCredits).toBe(5);
+    expect(jsonLd.inLanguage).toBe("en-AU");
+    expect(jsonLd["@type"]).toBe("Course");
+  });
+});
+
+/* ─── TEST-13: seo howToJsonLd / qaPageJsonLd ─── */
+
+describe("howToJsonLd (seo)", () => {
+  const guide = {
+    slug: "open-a-brokerage-account",
+    h1: "How to open a brokerage account",
+    intro: "A short walkthrough.",
+    steps: [
+      { heading: "Pick a broker", body: "Compare fees and features." },
+      { heading: "Sign up", body: "x".repeat(600) },
+    ],
+  };
+
+  it("emits HowTo with totalTime and AUD-zero estimatedCost", () => {
+    const jsonLd = howToJsonLd(guide);
+    expect(jsonLd["@type"]).toBe("HowTo");
+    expect(jsonLd.totalTime).toBe("PT10M");
+    expect(jsonLd.estimatedCost).toEqual({
+      "@type": "MonetaryAmount",
+      currency: "AUD",
+      value: "0",
+    });
+  });
+
+  it("numbers steps from 1 and anchors step urls", () => {
+    const jsonLd = howToJsonLd(guide);
+    expect(jsonLd.step[0].position).toBe(1);
+    expect(jsonLd.step[1].position).toBe(2);
+    expect(jsonLd.step[0].url).toBe(absoluteUrl("/how-to/open-a-brokerage-account#step-1"));
+    expect(jsonLd.step[1].url).toBe(absoluteUrl("/how-to/open-a-brokerage-account#step-2"));
+  });
+
+  it("truncates step text to 500 chars", () => {
+    const jsonLd = howToJsonLd(guide);
+    expect(jsonLd.step[1].text).toHaveLength(500);
+  });
+
+  it("sets dateModified to today's ISO date and author to REVIEW_AUTHOR", () => {
+    const jsonLd = howToJsonLd(guide);
+    expect(jsonLd.dateModified).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(jsonLd.author.name).toBe("invest.com.au Research Team");
+  });
+});
+
+describe("qaPageJsonLd (seo)", () => {
+  it("uses acceptedAnswer when an answer is accepted", () => {
+    const jsonLd = qaPageJsonLd(
+      [
+        {
+          question: "Is X safe?",
+          answers: [
+            { answer: "Not accepted.", is_accepted: false },
+            { answer: "Yes, regulated.", is_accepted: true, display_name: "Jane" },
+          ],
+        },
+      ],
+      "Broker Q&A",
+      "/ignored",
+    );
+    expect(jsonLd["@type"]).toBe("QAPage");
+    expect(jsonLd.name).toBe("Broker Q&A");
+    const q = jsonLd.mainEntity[0] as Record<string, { text: string; author: { name: string } }>;
+    expect(q.acceptedAnswer.text).toBe("Yes, regulated.");
+    expect(q.acceptedAnswer.author.name).toBe("Jane");
+    expect((jsonLd.mainEntity[0] as Record<string, unknown>).suggestedAnswer).toBeUndefined();
+  });
+
+  it("falls back to 'Editorial Team' author when display_name missing", () => {
+    const jsonLd = qaPageJsonLd(
+      [{ question: "Q?", answers: [{ answer: "A.", is_accepted: true }] }],
+      "Page",
+      "/x",
+    );
+    const q = jsonLd.mainEntity[0] as Record<string, { author: { name: string } }>;
+    expect(q.acceptedAnswer.author.name).toBe("Editorial Team");
+  });
+
+  it("uses suggestedAnswer for all answers when none accepted", () => {
+    const jsonLd = qaPageJsonLd(
+      [
+        {
+          question: "Q?",
+          answers: [
+            { answer: "A1.", is_accepted: false, display_name: "Bob" },
+            { answer: "A2.", is_accepted: false },
+          ],
+        },
+      ],
+      "Page",
+      "/x",
+    );
+    const q = jsonLd.mainEntity[0] as Record<string, unknown>;
+    expect(q.acceptedAnswer).toBeUndefined();
+    const suggested = q.suggestedAnswer as { text: string; author: { name: string } }[];
+    expect(suggested).toHaveLength(2);
+    expect(suggested[0]).toEqual({
+      "@type": "Answer",
+      text: "A1.",
+      author: { "@type": "Person", name: "Bob" },
+    });
+    expect(suggested[1].author.name).toBe("Editorial Team");
+  });
+
+  it("emits neither answer key when there are no answers", () => {
+    const jsonLd = qaPageJsonLd(
+      [{ question: "Q?", answers: [] }],
+      "Page",
+      "/x",
+    );
+    const q = jsonLd.mainEntity[0] as Record<string, unknown>;
+    expect(q.acceptedAnswer).toBeUndefined();
+    expect(q.suggestedAnswer).toBeUndefined();
+    expect(q.name).toBe("Q?");
+  });
+
+  it("ignores the third arg — pageName drives name", () => {
+    const a = qaPageJsonLd([], "The Page Name", "/path-a");
+    const b = qaPageJsonLd([], "The Page Name", "/path-b-different");
+    expect(a.name).toBe("The Page Name");
+    expect(a).toEqual(b);
   });
 });

--- a/__tests__/lib/seo.test.ts
+++ b/__tests__/lib/seo.test.ts
@@ -643,7 +643,7 @@ describe("qaPageJsonLd (seo)", () => {
     );
     expect(jsonLd["@type"]).toBe("QAPage");
     expect(jsonLd.name).toBe("Broker Q&A");
-    const q = jsonLd.mainEntity[0] as Record<string, { text: string; author: { name: string } }>;
+    const q = jsonLd.mainEntity[0] as unknown as Record<string, { text: string; author: { name: string } }>;
     expect(q.acceptedAnswer.text).toBe("Yes, regulated.");
     expect(q.acceptedAnswer.author.name).toBe("Jane");
     expect((jsonLd.mainEntity[0] as Record<string, unknown>).suggestedAnswer).toBeUndefined();
@@ -655,7 +655,7 @@ describe("qaPageJsonLd (seo)", () => {
       "Page",
       "/x",
     );
-    const q = jsonLd.mainEntity[0] as Record<string, { author: { name: string } }>;
+    const q = jsonLd.mainEntity[0] as unknown as Record<string, { author: { name: string } }>;
     expect(q.acceptedAnswer.author.name).toBe("Editorial Team");
   });
 

--- a/__tests__/lib/sponsorship.test.ts
+++ b/__tests__/lib/sponsorship.test.ts
@@ -1,10 +1,12 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import type { Broker } from "@/lib/types";
 import {
   boostFeaturedPartner,
   isSponsored,
   sortWithSponsorship,
   getSponsorSortPriority,
+  getPlacementWinners,
+  applyQuizSponsorBoost,
 } from "@/lib/sponsorship";
 
 /** Minimal broker factory for testing */
@@ -152,5 +154,120 @@ describe("boostFeaturedPartner", () => {
     const brokers = [makeBroker({ slug: "a" })];
     const result = boostFeaturedPartner(brokers, 0, { raw: true });
     expect(result).not.toBe(brokers);
+  });
+});
+
+/* ─── TEST-12: getPlacementWinners ─── */
+
+describe("getPlacementWinners", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function stubFetch(impl: () => Promise<Partial<Response>> | Partial<Response>) {
+    const mock = vi.fn(impl as never);
+    vi.stubGlobal("fetch", mock);
+    return mock;
+  }
+
+  it("builds a placement-only query when no broker slugs given", async () => {
+    const mock = stubFetch(() => ({ ok: true, json: async () => ({ winners: [] }) }));
+    await getPlacementWinners("homepage-hero");
+    const url = String(mock.mock.calls[0]![0]);
+    expect(url).toContain("/api/marketplace/allocation?");
+    expect(url).toContain("placement=homepage-hero");
+    expect(url).not.toContain("brokers=");
+  });
+
+  it("adds a brokers CSV param only when brokerSlugs non-empty", async () => {
+    const mock = stubFetch(() => ({ ok: true, json: async () => ({ winners: [] }) }));
+    await getPlacementWinners("hero", ["cmc", "stake"]);
+    const url = String(mock.mock.calls[0]![0]);
+    // URLSearchParams encodes the comma in the CSV value.
+    expect(decodeURIComponent(url)).toContain("brokers=cmc,stake");
+  });
+
+  it("maps data.winners to the PlacementWinner shape", async () => {
+    stubFetch(() => ({
+      ok: true,
+      json: async () => ({
+        winners: [
+          { broker_slug: "cmc", campaign_id: 9, inventory_type: "featured", rate_cents: 1500, extra: "drop me" },
+        ],
+      }),
+    }));
+    const result = await getPlacementWinners("hero");
+    expect(result).toEqual([
+      { broker_slug: "cmc", campaign_id: 9, inventory_type: "featured", rate_cents: 1500 },
+    ]);
+  });
+
+  it("returns [] when the response is not ok", async () => {
+    stubFetch(() => ({ ok: false, json: async () => ({ winners: [{ broker_slug: "x" }] }) }));
+    expect(await getPlacementWinners("hero")).toEqual([]);
+  });
+
+  it("returns [] when data.winners is missing", async () => {
+    stubFetch(() => ({ ok: true, json: async () => ({}) }));
+    expect(await getPlacementWinners("hero")).toEqual([]);
+  });
+
+  it("returns [] when fetch throws (no rejection bubbles up)", async () => {
+    stubFetch(() => {
+      throw new Error("network down");
+    });
+    await expect(getPlacementWinners("hero")).resolves.toEqual([]);
+  });
+});
+
+/* ─── TEST-12: applyQuizSponsorBoost goal-applicability branch ─── */
+
+describe("applyQuizSponsorBoost goal branch", () => {
+  // isApplicableToBrokerGoal is private — exercise it indirectly. A sponsored
+  // crypto exchange is applicable to goal "crypto" but NOT to goal "super".
+  function row(broker: Broker | null) {
+    return { broker };
+  }
+  const sponsoredCrypto = makeBroker({
+    slug: "sponsored-crypto",
+    sponsorship_tier: "featured_partner",
+    is_crypto: true,
+    platform_type: "crypto_exchange",
+  });
+  const plain = (slug: string) => makeBroker({ slug, sponsorship_tier: null });
+
+  it("does not swap a featured_partner that is not applicable to the goal", () => {
+    const items = [row(plain("a")), row(plain("b")), row(sponsoredCrypto)];
+    const result = applyQuizSponsorBoost(items, 1, 5, "super");
+    expect(result.map((r) => r.broker?.slug)).toEqual(["a", "b", "sponsored-crypto"]);
+  });
+
+  it("swaps an applicable featured_partner up by one within [minRank,maxRank]", () => {
+    const items = [row(plain("a")), row(plain("b")), row(sponsoredCrypto)];
+    const result = applyQuizSponsorBoost(items, 1, 5, "crypto");
+    // idx 2 swaps with idx 1.
+    expect(result.map((r) => r.broker?.slug)).toEqual(["a", "sponsored-crypto", "b"]);
+  });
+
+  it("does not swap when the applicable partner is already first (idx < 1)", () => {
+    const items = [row(sponsoredCrypto), row(plain("b")), row(plain("c"))];
+    // minRank 0 lets idx 0 match, but idx < 1 short-circuits the swap.
+    const result = applyQuizSponsorBoost(items, 0, 5, "crypto");
+    expect(result.map((r) => r.broker?.slug)).toEqual(["sponsored-crypto", "b", "c"]);
+  });
+
+  it("does not swap when the partner sits outside [minRank,maxRank]", () => {
+    const items = [row(plain("a")), row(plain("b")), row(plain("c")), row(sponsoredCrypto)];
+    // maxRank 2 excludes idx 3.
+    const result = applyQuizSponsorBoost(items, 1, 2, "crypto");
+    expect(result.map((r) => r.broker?.slug)).toEqual(["a", "b", "c", "sponsored-crypto"]);
+  });
+
+  it("does not mutate the original array (spread copy)", () => {
+    const items = [row(plain("a")), row(plain("b")), row(sponsoredCrypto)];
+    const snapshot = items.map((r) => r.broker?.slug);
+    const result = applyQuizSponsorBoost(items, 1, 5, "crypto");
+    expect(result).not.toBe(items);
+    expect(items.map((r) => r.broker?.slug)).toEqual(snapshot);
   });
 });

--- a/__tests__/lib/verticals.test.ts
+++ b/__tests__/lib/verticals.test.ts
@@ -3,6 +3,7 @@ import {
   VERTICALS,
   getVerticalBySlug,
   getAllVerticalSlugs,
+  getRelatedVerticals,
   type HubAudience,
   type HubConfig,
   type LeadQueueRoute,
@@ -365,5 +366,66 @@ describe("HubAudience union exhaustiveness", () => {
       "startup-investor",
     ];
     expect(expected).toHaveLength(6);
+  });
+});
+
+/* ─── TEST-07: getRelatedVerticals ─── */
+
+describe("getRelatedVerticals", () => {
+  // Data-driven against the live VERTICALS export — no hardcoded counts so the
+  // assertions survive new verticals being added.
+  const PILLAR_SHORT_LABELS: Record<string, string> = {
+    "share-trading": "Share Trading",
+    crypto: "Crypto",
+    savings: "Savings",
+    super: "Super",
+    cfd: "CFD & Forex",
+    "term-deposits": "Term Deposits",
+    "robo-advisors": "Robo-Advisors",
+    "property-platforms": "Property Platforms",
+    "research-tools": "Research Tools",
+    alternatives: "Alternative Assets",
+    "business-finance": "Business Finance",
+  };
+
+  const firstSlug = VERTICALS[0]!.slug;
+
+  it("excludes the passed currentSlug and returns all-but-one verticals", () => {
+    const related = getRelatedVerticals(firstSlug);
+    expect(related).toHaveLength(VERTICALS.length - 1);
+    expect(related.every((r) => r.slug !== firstSlug)).toBe(true);
+  });
+
+  it("preserves the source order of the remaining verticals", () => {
+    const related = getRelatedVerticals(firstSlug);
+    const expectedSlugs = VERTICALS.filter((v) => v.slug !== firstSlug).map((v) => v.slug);
+    expect(related.map((r) => r.slug)).toEqual(expectedSlugs);
+  });
+
+  it("resolves label via PILLAR_SHORT_LABELS, falling back to the raw slug", () => {
+    const related = getRelatedVerticals("__none__");
+    for (const r of related) {
+      const expected = PILLAR_SHORT_LABELS[r.slug] ?? r.slug;
+      expect(r.label).toBe(expected);
+    }
+  });
+
+  it("derives tagline from the first stat as `value label.toLowerCase()`", () => {
+    const related = getRelatedVerticals("__none__");
+    const bySlug = new Map(VERTICALS.map((v) => [v.slug, v]));
+    for (const r of related) {
+      const v = bySlug.get(r.slug)!;
+      const firstStat = v.stats[0];
+      const expected = firstStat
+        ? `${firstStat.value} ${firstStat.label.toLowerCase()}`
+        : "";
+      expect(r.tagline).toBe(expected);
+    }
+  });
+
+  it("returns ALL verticals when the slug does not match any", () => {
+    const related = getRelatedVerticals("does-not-exist");
+    expect(related).toHaveLength(VERTICALS.length);
+    expect(related.map((r) => r.slug)).toEqual(VERTICALS.map((v) => v.slug));
   });
 });


### PR DESCRIPTION
Adds behaviour tests for previously untested exported lib builders/helpers.

Items (Tier A):
- TEST-06 — seo.ts brokerProductJsonLd (category branching, rating clamp, conditional aggregateRating/additionalProperty/foundingDate, #product @id), reviewerPersonJsonLd (/reviewers path, formatRole, conditional sameAs, worksFor), courseJsonLd (cents->dollars price, educationalLevel map, conditional instructor/courseWorkload, numberOfCredits, inLanguage)
- TEST-07 — verticals.ts getRelatedVerticals (data-driven off live VERTICALS: exclusion, label via PILLAR_SHORT_LABELS with slug fallback, tagline from first stat, non-existent slug returns all)
- TEST-11 — schema-markup.ts blogPostingJsonLd (insights url, headline/description slices, keywords, date equality, author url + image omission via compact, publisher/mainEntityOfPage) and governmentServiceJsonLd (GovernmentService type, areaServed Country, provider GovernmentOrganization, mainEntityOfPage absoluteUrl, audience, serviceType passthrough)
- TEST-12 — sponsorship.ts getPlacementWinners (fetch stubbed: query building, winner mapping, [] on !ok / missing winners / throw) and applyQuizSponsorBoost goal-applicability branch (indirectly exercising private isApplicableToBrokerGoal: no-swap when inapplicable, swap-up when applicable in range, idx<1 no-op, out-of-range no-op, no mutation)
- TEST-13 — seo.ts howToJsonLd (step numbering/urls, 500-char truncation, PT10M, AUD-0 cost, today ISO dateModified, REVIEW_AUTHOR) and qaPageJsonLd (acceptedAnswer vs suggestedAnswer vs neither, Editorial Team fallback, third-arg unused)

Verify: npm test -- (all four files) -> 353 passed. eslint --fix --max-warnings 0 clean.