### PR TITLE
fix(webhooks): drop email_id from Resend recipient fallback chain

### DIFF
--- a/__tests__/api/webhooks-resend.test.ts
+++ b/__tests__/api/webhooks-resend.test.ts
@@ -135,15 +135,34 @@ describe("POST /api/webhooks/resend", () => {
     expect(mockAdminFrom).toHaveBeenCalledWith("email_captures");
   });
 
-  it("uses email_id as fallback when to[] is absent", async () => {
+  it("does not run suppression UPDATEs when to[] is absent (email_id is a UUID, never an address)", async () => {
+    // Resend sends data.email_id as the sent-message UUID, not an email.
+    // When to[] is missing we must NOT fall back to it and key a query on it.
     const res = await POST(
       makePost({
         type: "email.bounced",
-        data: { email_id: "norecipient@test.com" },
+        data: {
+          email_id: "56761188-7520-42d8-8898-ff6fc54ce618",
+          bounce: { message: "user unknown" },
+        },
       })
     );
     expect(res.status).toBe(200);
-    expect(mockAdminFrom).toHaveBeenCalledWith("email_captures");
+    const json = await res.json();
+    expect(json.received).toBe(true);
+    // No DB suppression should be attempted on any table.
+    expect(mockAdminFrom).not.toHaveBeenCalled();
+  });
+
+  it("does not run suppression UPDATEs when to[] is empty", async () => {
+    const res = await POST(
+      makePost({
+        type: "email.complained",
+        data: { to: [], complaint: { type: "abuse" } },
+      })
+    );
+    expect(res.status).toBe(200);
+    expect(mockAdminFrom).not.toHaveBeenCalled();
   });
 
   it("handles email.delivery_delayed without DB writes", async () => {

--- a/app/api/webhooks/resend/route.ts
+++ b/app/api/webhooks/resend/route.ts
@@ -66,7 +66,11 @@ export async function POST(request: NextRequest) {
       bounce?: { message?: string };
       complaint?: { type?: string };
     };
-    const email = d.to?.[0] || d.email_id;
+    // Recipient comes ONLY from data.to[]. data.email_id is the sent-message
+    // UUID, never an email address — using it as a fallback keys the
+    // suppression UPDATEs on a value that can never match a stored email,
+    // silently no-op'ing the bounce/complaint suppression.
+    const email = d.to?.[0];
 
     if (type === "email.bounced" || type === "email.complained") {
       log.info(`Email ${type}`, {
@@ -92,6 +96,12 @@ export async function POST(request: NextRequest) {
           .from("quiz_leads")
           .update({ unsubscribed: true })
           .eq("email", email.toLowerCase());
+      } else {
+        // No recipient address on the event — we cannot suppress anyone.
+        // Surface it instead of silently dropping a real bounce/complaint.
+        log.warn(`Email ${type} received without a recipient address`, {
+          emailId: d.email_id,
+        });
       }
     } else if (type === "email.delivery_delayed") {
       log.info("Email delivery delayed", { email });


### PR DESCRIPTION
## What

`app/api/webhooks/resend/route.ts` line 69 used `const email = d.to?.[0] || d.email_id;`. In Resend's webhook payload `data.email_id` is the **sent-message UUID**, never an email address. When `data.to` is absent/empty the handler fell back to the UUID, lowercased it, and ran `.eq("email", <uuid>)` against `email_captures`, `fee_alert_subscriptions`, and `quiz_leads` — matching zero rows every time. The bounced/complaining recipient was never suppressed (deliverability + sender-reputation risk) and logs were polluted with UUIDs in the `email` field.

## Fix

- Recipient now comes only from `d.to?.[0]`. The existing `if (email)` guard skips DB writes when absent.
- Added a `log.warn` so a bounce/complaint arriving without a recipient is visible instead of silently dropped.
- Replaced the masking test (which used an email-shaped `email_id`) with one using a realistic UUID asserting **no** suppression UPDATEs run; added an empty-`to[]` case too.

## Finding ref

Bug-hunt finding for `app/api/webhooks/resend/route.ts` (P3, Tier C, stillReal=true). Implements its recommendedFix exactly.

**Tier C** (webhook handler) — body field-mapping only; no signature/idempotency change. No money-movement, no migrations.

## Verify

`npx vitest run __tests__/api/webhooks-resend.test.ts` → 12 passing. `npx eslint --max-warnings 0` clean.