### PR TITLE
fix(community): stop serializing forum author_id to the client

### DIFF
--- a/__tests__/app/community-thread-detail-page.test.tsx
+++ b/__tests__/app/community-thread-detail-page.test.tsx
@@ -1,0 +1,243 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Privacy regression test for app/community/[category]/[threadId]/page.tsx.
+ *
+ * The thread-detail server component must NOT serialize author_id (a Supabase
+ * auth.uid) into the props handed to the ThreadClient client component, because
+ * client-component props are shipped to the browser in the RSC/HTML payload and
+ * this deanonymises Investment Confessions authors. Instead it must compute
+ * ownership/moderator state server-side and pass only booleans.
+ *
+ * Finding: "Forum thread-detail page serializes author_id to the client,
+ * breaking confessions anonymity" (Tier B).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "../components/setup";
+
+const { mockFrom, mockGetUser, mockResolveAdvisorBadges, capturedProps } =
+  vi.hoisted(() => ({
+    mockFrom: vi.fn(),
+    mockGetUser: vi.fn(),
+    mockResolveAdvisorBadges: vi.fn(),
+    capturedProps: { current: null as Record<string, unknown> | null },
+  }));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue({
+    from: mockFrom,
+    auth: { getUser: mockGetUser },
+  }),
+}));
+
+vi.mock("@/lib/forum-author-badges", () => ({
+  resolveAdvisorBadges: mockResolveAdvisorBadges,
+}));
+
+vi.mock("@/lib/seo", () => ({
+  absoluteUrl: (p: string) => `https://invest.com.au${p}`,
+  breadcrumbJsonLd: () => ({}),
+}));
+
+vi.mock("@/lib/compliance", () => ({
+  GENERAL_ADVICE_WARNING: "advice warning",
+}));
+
+// Capture the props the page passes across the client boundary so we can assert
+// on the exact serialized payload.
+vi.mock("@/app/community/[category]/[threadId]/ThreadClient", () => ({
+  default: (props: Record<string, unknown>) => {
+    capturedProps.current = props;
+    return null;
+  },
+}));
+
+const AUTHOR_UUID = "11111111-1111-1111-1111-111111111111";
+const POST_AUTHOR_UUID = "22222222-2222-2222-2222-222222222222";
+const VIEWER_UUID = "33333333-3333-3333-3333-333333333333";
+
+const CATEGORY = {
+  id: "cat-1",
+  slug: "shares-etfs",
+  name: "Shares & ETFs",
+  icon: "trending-up",
+  color: "emerald",
+};
+
+const THREAD_ROW = {
+  id: "thread-1",
+  category_id: "cat-1",
+  author_id: AUTHOR_UUID,
+  author_name: "Anonymous Investor",
+  title: "My confession",
+  slug: "my-confession",
+  body: "Line one\nLine two",
+  is_pinned: false,
+  is_locked: false,
+  reply_count: 1,
+  view_count: 10,
+  vote_score: 3,
+  created_at: "2026-01-01T00:00:00.000Z",
+  updated_at: null,
+};
+
+const POST_ROW = {
+  id: "post-1",
+  thread_id: "thread-1",
+  parent_id: null,
+  author_id: POST_AUTHOR_UUID,
+  author_name: "Replier",
+  body: "A reply",
+  vote_score: 1,
+  is_removed: false,
+  created_at: "2026-01-02T00:00:00.000Z",
+  updated_at: null,
+};
+
+/**
+ * Builds a from() dispatcher that returns a query chain per table. Each leaf
+ * (single / order / in / update) resolves with the appropriate fixture.
+ */
+function makeFrom(profiles: unknown[]) {
+  return (table: string) => {
+    if (table === "forum_categories") {
+      const single = vi.fn().mockResolvedValue({ data: CATEGORY });
+      const eq2 = vi.fn().mockReturnValue({ single });
+      const eq1 = vi.fn().mockReturnValue({ eq: eq2 });
+      const select = vi.fn().mockReturnValue({ eq: eq1 });
+      return { select };
+    }
+    if (table === "forum_threads") {
+      // forum_threads is used twice: a select(...).eq().eq().single() read and
+      // an update(...).eq().then() fire-and-forget view-count bump.
+      const single = vi.fn().mockResolvedValue({ data: THREAD_ROW });
+      const eqRead2 = vi.fn().mockReturnValue({ single });
+      const eqRead1 = vi.fn().mockReturnValue({ eq: eqRead2 });
+      const select = vi.fn().mockReturnValue({ eq: eqRead1 });
+      const eqUpdate = vi.fn().mockReturnValue({
+        then: (cb: () => void) => cb(),
+      });
+      const update = vi.fn().mockReturnValue({ eq: eqUpdate });
+      return { select, update };
+    }
+    if (table === "forum_posts") {
+      const order = vi.fn().mockResolvedValue({ data: [POST_ROW] });
+      const eq2 = vi.fn().mockReturnValue({ order });
+      const eq1 = vi.fn().mockReturnValue({ eq: eq2 });
+      const select = vi.fn().mockReturnValue({ eq: eq1 });
+      return { select };
+    }
+    if (table === "forum_user_profiles") {
+      const inFn = vi.fn().mockResolvedValue({ data: profiles });
+      const select = vi.fn().mockReturnValue({ in: inFn });
+      return { select };
+    }
+    throw new Error(`unexpected table ${table}`);
+  };
+}
+
+import ThreadPage from "@/app/community/[category]/[threadId]/page";
+
+async function renderPage() {
+  render(
+    await ThreadPage({
+      params: Promise.resolve({
+        category: "shares-etfs",
+        threadId: "thread-1",
+      }),
+    })
+  );
+}
+
+describe("ThreadPage author_id serialization", () => {
+  beforeEach(() => {
+    capturedProps.current = null;
+    mockResolveAdvisorBadges.mockResolvedValue(new Map());
+    mockFrom.mockImplementation(makeFrom([]));
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+  });
+
+  it("does NOT include author_id anywhere in the serialized ThreadClient payload", async () => {
+    await renderPage();
+
+    const props = capturedProps.current;
+    expect(props).not.toBeNull();
+
+    // The whole serialized payload must be free of author_id and of the raw
+    // author UUIDs themselves.
+    const serialized = JSON.stringify(props);
+    expect(serialized).not.toContain("author_id");
+    expect(serialized).not.toContain(AUTHOR_UUID);
+    expect(serialized).not.toContain(POST_AUTHOR_UUID);
+
+    const thread = props!.thread as Record<string, unknown>;
+    const posts = props!.posts as Record<string, unknown>[];
+    expect(thread).not.toHaveProperty("author_id");
+    expect(posts[0]).not.toHaveProperty("author_id");
+
+    // The legitimate display field is still present.
+    expect(thread.author_name).toBe("Anonymous Investor");
+  });
+
+  it("passes is_own=false / isModerator=false for an anonymous viewer", async () => {
+    await renderPage();
+
+    const props = capturedProps.current!;
+    const thread = props.thread as Record<string, unknown>;
+    const posts = props.posts as Record<string, unknown>[];
+
+    expect(thread.is_own).toBe(false);
+    expect(posts[0]?.is_own).toBe(false);
+    expect(props.isModerator).toBe(false);
+  });
+
+  it("computes is_own=true for the viewer's own thread/post and isModerator from their profile", async () => {
+    // Viewer authored the thread AND is a moderator per their forum profile.
+    mockGetUser.mockResolvedValue({ data: { user: { id: AUTHOR_UUID } } });
+    mockFrom.mockImplementation(
+      makeFrom([
+        {
+          user_id: AUTHOR_UUID,
+          display_name: "Anonymous Investor",
+          reputation: 100,
+          badge: "moderator",
+          is_moderator: true,
+        },
+      ])
+    );
+
+    await renderPage();
+
+    const props = capturedProps.current!;
+    const thread = props.thread as Record<string, unknown>;
+    const posts = props.posts as Record<string, unknown>[];
+
+    expect(thread.is_own).toBe(true); // viewer === thread author
+    expect(posts[0]?.is_own).toBe(false); // viewer !== post author
+    expect(props.isModerator).toBe(true);
+
+    // Still no author_id leak even when ownership flags are true.
+    expect(JSON.stringify(props)).not.toContain("author_id");
+  });
+
+  it("isModerator is false when the viewer's profile is not a moderator", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: VIEWER_UUID } } });
+    mockFrom.mockImplementation(
+      makeFrom([
+        {
+          user_id: VIEWER_UUID,
+          display_name: "Regular",
+          reputation: 5,
+          badge: null,
+          is_moderator: false,
+        },
+      ])
+    );
+
+    await renderPage();
+
+    const props = capturedProps.current!;
+    expect(props.isModerator).toBe(false);
+    expect((props.thread as Record<string, unknown>).is_own).toBe(false);
+  });
+});

--- a/app/community/[category]/[threadId]/ThreadClient.tsx
+++ b/app/community/[category]/[threadId]/ThreadClient.tsx
@@ -22,7 +22,6 @@ interface AuthorProfile {
 interface ForumThread {
   id: string;
   category_id: string;
-  author_id: string;
   author_name: string;
   title: string;
   slug: string;
@@ -35,13 +34,15 @@ interface ForumThread {
   created_at: string;
   updated_at: string | null;
   author_profile: AuthorProfile | null;
+  // Server-computed: viewer authored this thread. Replaces comparing a
+  // serialized author_id (auth.uid) on the client.
+  is_own: boolean;
 }
 
 interface ForumPost {
   id: string;
   thread_id: string;
   parent_id: string | null;
-  author_id: string;
   author_name: string;
   body: string;
   vote_score: number;
@@ -49,12 +50,16 @@ interface ForumPost {
   created_at: string;
   updated_at: string | null;
   author_profile: AuthorProfile | null;
+  // Server-computed ownership flag (see ForumThread.is_own).
+  is_own: boolean;
 }
 
 interface ThreadClientProps {
   thread: ForumThread;
   posts: ForumPost[];
   categorySlug: string;
+  // Server-computed moderator flag for the current viewer.
+  isModerator: boolean;
 }
 
 /* ─── Helpers ─── */
@@ -220,7 +225,7 @@ function PostCard({
 }) {
   const [showReport, setShowReport] = useState(false);
   const [reported, setReported] = useState(false);
-  const isAuthor = userId === post.author_id;
+  const isAuthor = post.is_own;
   const parentPost = post.parent_id ? true : false;
 
   return (
@@ -382,6 +387,7 @@ export default function ThreadClient({
   thread,
   posts: initialPosts,
   categorySlug,
+  isModerator,
 }: ThreadClientProps) {
   const { user, loading } = useUser();
   const router = useRouter();
@@ -398,14 +404,8 @@ export default function ThreadClient({
 
   const userId = user?.id ?? null;
 
-  // Check if the user is moderator from the thread's profile data
-  const isModerator =
-    posts.some(
-      (p) =>
-        p.author_id === userId && p.author_profile?.is_moderator === true
-    ) ||
-    (thread.author_id === userId &&
-      thread.author_profile?.is_moderator === true);
+  // isModerator is computed server-side and passed in as a prop — the client
+  // no longer infers it from serialized author_ids.
 
   /* ─── Reply ─── */
 
@@ -445,6 +445,8 @@ export default function ThreadClient({
         is_removed: false,
         updated_at: null,
         author_profile: null,
+        // The viewer just authored this reply.
+        is_own: true,
       };
       setPosts((prev) => [...prev, newPost]);
       setReplyBody("");

--- a/app/community/[category]/[threadId]/page.tsx
+++ b/app/community/[category]/[threadId]/page.tsx
@@ -26,7 +26,6 @@ interface AuthorProfile {
 interface ForumThread {
   id: string;
   category_id: string;
-  author_id: string;
   author_name: string;
   title: string;
   slug: string;
@@ -39,13 +38,16 @@ interface ForumThread {
   created_at: string;
   updated_at: string | null;
   author_profile: AuthorProfile | null;
+  // Server-computed ownership flag — replaces shipping the raw author_id
+  // (a Supabase auth.uid) to the browser. See finding "Forum thread-detail
+  // page serializes author_id to the client".
+  is_own: boolean;
 }
 
 interface ForumPost {
   id: string;
   thread_id: string;
   parent_id: string | null;
-  author_id: string;
   author_name: string;
   body: string;
   vote_score: number;
@@ -53,6 +55,8 @@ interface ForumPost {
   created_at: string;
   updated_at: string | null;
   author_profile: AuthorProfile | null;
+  // Server-computed ownership flag (see ForumThread.is_own).
+  is_own: boolean;
 }
 
 interface ForumCategory {
@@ -154,20 +158,33 @@ export default async function ThreadPage({
   if (!catData) notFound();
   const category = catData as ForumCategory;
 
-  // Fetch thread
+  // Resolve the viewer once, server-side. author_id (a Supabase auth.uid) is
+  // never serialized to the client; ownership/moderator state is computed here
+  // and only booleans cross the RSC boundary.
+  const {
+    data: { user: viewer },
+  } = await supabase.auth.getUser();
+  const viewerId = viewer?.id ?? null;
+
+  // Fetch thread — explicit columns (no select("*")). author_id stays
+  // server-side only, long enough to build profileMap and ownership flags.
   const { data: threadData } = await supabase
     .from("forum_threads")
-    .select("*")
+    .select(
+      "id, category_id, author_id, author_name, title, slug, body, is_pinned, is_locked, reply_count, view_count, vote_score, created_at, updated_at"
+    )
     .eq("id", threadId)
     .eq("is_removed", false)
     .single();
 
   if (!threadData) notFound();
 
-  // Fetch posts
+  // Fetch posts — explicit columns (no select("*")), author_id server-side only.
   const { data: postsData } = await supabase
     .from("forum_posts")
-    .select("*")
+    .select(
+      "id, thread_id, parent_id, author_id, author_name, body, vote_score, is_removed, created_at, updated_at"
+    )
     .eq("thread_id", threadId)
     .eq("is_removed", false)
     .order("created_at", { ascending: true });
@@ -179,6 +196,12 @@ export default async function ThreadPage({
     for (const post of postsData) {
       authorIds.add(post.author_id);
     }
+  }
+  // Include the viewer so their own moderator flag is available even when they
+  // have not authored anything in this thread (matches the intent of the prior
+  // client-side mod check, without shipping author_ids to the browser).
+  if (viewerId != null) {
+    authorIds.add(viewerId);
   }
 
   const { data: profiles } = await supabase
@@ -204,15 +227,29 @@ export default async function ThreadPage({
     }
   }
 
+  // Strip author_id before crossing the client boundary — keep only a
+  // per-row ownership boolean so the browser never receives raw auth UUIDs.
+  const { author_id: threadAuthorId, ...threadRest } = threadData;
   const thread: ForumThread = {
-    ...threadData,
-    author_profile: profileMap[threadData.author_id] ?? null,
+    ...threadRest,
+    author_profile: profileMap[threadAuthorId] ?? null,
+    is_own: viewerId != null && threadAuthorId === viewerId,
   };
 
-  const posts: ForumPost[] = (postsData ?? []).map((post) => ({
-    ...post,
-    author_profile: profileMap[post.author_id] ?? null,
-  }));
+  const posts: ForumPost[] = (postsData ?? []).map((post) => {
+    const { author_id: postAuthorId, ...postRest } = post;
+    return {
+      ...postRest,
+      author_profile: profileMap[postAuthorId] ?? null,
+      is_own: viewerId != null && postAuthorId === viewerId,
+    };
+  });
+
+  // Moderator state for the viewer is the authoritative server-side flag from
+  // their own forum profile — computed here, never inferred client-side from
+  // other users' author_ids. Defaults to false for anonymous/non-mod viewers.
+  const isViewerModerator =
+    viewerId != null && profileMap[viewerId]?.is_moderator === true;
 
   // Increment view count (fire-and-forget)
   supabase
@@ -357,6 +394,7 @@ export default async function ThreadPage({
           thread={thread}
           posts={posts}
           categorySlug={categorySlug}
+          isModerator={isViewerModerator}
         />
       </Suspense>
       <div className="container-custom max-w-4xl pb-8">


### PR DESCRIPTION
## What

The thread-detail server component (`app/community/[category]/[threadId]/page.tsx`) ran `forum_threads.select("*")` and `forum_posts.select("*")` and spread the full DB rows into the props passed to the `ThreadClient` client component. React serializes client-component props into the RSC/HTML payload, so every author's Supabase `auth.uid` (`author_id`) was shipped to the browser of every visitor — including anonymous, unauthenticated ones — on a publicly indexed page.

Most damaging: Investment Confessions render as "Anonymous Investor" and promise "Author identity is never revealed publicly," yet the linked thread-detail page carried the real `author_id`, deanonymising the confessor.

## Fix

- Select explicit columns on both tables (no `select("*")`); `author_id` is kept server-side only, long enough to build the profile map and compute ownership.
- Resolve the viewer once server-side via `supabase.auth.getUser()`.
- Strip `author_id` before constructing the thread/post objects; pass only per-row `is_own` booleans and a server-computed `isModerator` flag to `ThreadClient`.
- `ThreadClient` drops `author_id` from its interfaces and drives `isAuthor`/`isModerator` off the server-provided booleans.
- Hardening: the viewer's own profile is included in the profile lookup so their moderator status resolves even when they haven't posted in the thread (the old client-side check only worked if the viewer had authored something here).

Added `__tests__/app/community-thread-detail-page.test.tsx` asserting `author_id` (and the raw UUIDs) never appear in the serialized `ThreadClient` payload, plus correct `is_own`/`isModerator` for anonymous, owner-moderator, and non-mod viewers.

RLS column-exposure tightening on `forum_threads`/`forum_posts` is a separate migration and intentionally out of scope here.

Finding ref: "Forum thread-detail page serializes author_id to the client, breaking confessions anonymity" — Tier B.