### PR TITLE
fix(consumer-webhooks): clear needs_retry on all sibling rows in a delivery group

### DIFF
--- a/__tests__/lib/consumer-webhook-dispatch.test.ts
+++ b/__tests__/lib/consumer-webhook-dispatch.test.ts
@@ -32,13 +32,17 @@ function makeChain() {
 
   // The chain accumulates filter state so maybeSingle/order can return
   // the right data.
-  const state: { table?: string; filters: [string, unknown][]; updatePatch?: Record<string, unknown>; insertRow?: Record<string, unknown> } = { filters: [] };
+  const state: { table?: string; filters: [string, unknown][]; inFilters: [string, unknown[]][]; updatePatch?: Record<string, unknown>; insertRow?: Record<string, unknown> } = { filters: [], inFilters: [] };
 
   chain.select = vi.fn((_cols?: string, _opts?: unknown) => {
     return chain;
   });
   chain.eq = vi.fn((_col: string, val: unknown) => {
     state.filters.push([_col, val]);
+    return chain;
+  });
+  chain.in = vi.fn((_col: string, vals: unknown[]) => {
+    state.inFilters.push([_col, vals]);
     return chain;
   });
   chain.gte = vi.fn(() => chain);
@@ -71,6 +75,8 @@ function makeChain() {
     if (state.updatePatch) {
       const id = state.filters.find(([col]) => col === "id")?.[1] as string | undefined;
       if (id) updatedDeliveries.push({ id, patch: state.updatePatch });
+      const inIds = state.inFilters.find(([col]) => col === "id")?.[1] as string[] | undefined;
+      if (inIds) for (const inId of inIds) updatedDeliveries.push({ id: inId, patch: state.updatePatch });
     }
     return Promise.resolve(resolve({ data: null, error: null }));
   };
@@ -98,8 +104,16 @@ vi.mock("@/lib/supabase/admin", () => ({
       // Deliveries table
       if (table === "consumer_webhook_deliveries") {
         const chain = makeChain();
+        // Preserve the update-tracking `then` from makeChain (closes over this
+        // chain's state) so .update(...).eq/.in(...) records updatedDeliveries;
+        // fall back to returning mockDeliveries for plain SELECT chains.
+        const trackingThen = chain.then as (
+          resolve: (v: { data: unknown; error: unknown }) => unknown,
+        ) => unknown;
         chain.then = (resolve: (v: { data: unknown; error: unknown }) => unknown) =>
-          Promise.resolve(resolve({ data: mockDeliveries, error: null }));
+          trackingThen((res: { data: unknown; error: unknown }) =>
+            resolve({ ...res, data: mockDeliveries }),
+          );
         // Override insert to track rows
         chain.insert = vi.fn((row: Record<string, unknown>) => {
           insertedDeliveries.push(row);
@@ -380,6 +394,75 @@ describe("retryFailedConsumerWebhooks", () => {
     expect(stats.skipped_no_secret).toBe(1);
     expect(stats.retried).toBe(0);
     expect(sender).not.toHaveBeenCalled();
+  });
+
+  it("clears needs_retry on ALL sibling rows in a group, not just the latest, on successful retry", async () => {
+    // Two byte-identical (webhook, event, payload) failures — e.g. the
+    // timestamp-less broker.updated event fired across two cron runs while the
+    // subscriber was down. Both rows are needs_retry=true in the same group.
+    const payload = { broker_slug: "commsec" };
+    mockDeliveries = [
+      {
+        id: "d-old",
+        webhook_id: "wh-1",
+        event_type: "broker.updated",
+        payload,
+        response_status: 503,
+        attempt_count: 1,
+        needs_retry: true,
+      },
+      {
+        id: "d-new",
+        webhook_id: "wh-1",
+        event_type: "broker.updated",
+        payload,
+        response_status: 503,
+        attempt_count: 1,
+        needs_retry: true,
+      },
+    ];
+    hookLookupResult = makeHook();
+    const sender = makeSender(200);
+
+    const stats = await retryFailedConsumerWebhooks(sender);
+
+    // Single group (identical key), one real retry.
+    expect(stats.groups).toBe(1);
+    expect(stats.retried).toBe(1);
+
+    // BOTH original rows must be marked needs_retry=false — not just the latest.
+    const clearedIds = updatedDeliveries
+      .filter((u) => u.patch.needs_retry === false)
+      .map((u) => u.id);
+    expect(clearedIds).toContain("d-old");
+    expect(clearedIds).toContain("d-new");
+  });
+
+  it("clears needs_retry on ALL sibling rows when a group hits the attempt cap", async () => {
+    // 5 identical-payload failures = at cap; every row must be cleared so none
+    // is left orphaned as needs_retry=true.
+    const payload = { broker_slug: "stake" };
+    mockDeliveries = Array.from({ length: 5 }, (_, i) => ({
+      id: `cap-${i}`,
+      webhook_id: "wh-1",
+      event_type: "broker.updated",
+      payload,
+      response_status: 503,
+      attempt_count: 1,
+      needs_retry: true,
+    }));
+    hookLookupResult = makeHook();
+    const sender = makeSender(200);
+
+    const stats = await retryFailedConsumerWebhooks(sender);
+
+    expect(stats.skipped_max_attempts).toBe(1);
+    const clearedIds = updatedDeliveries
+      .filter((u) => u.patch.needs_retry === false)
+      .map((u) => u.id);
+    for (let i = 0; i < 5; i++) {
+      expect(clearedIds).toContain(`cap-${i}`);
+    }
   });
 
   it("groups separate events for the same webhook_id independently", async () => {

--- a/lib/consumer-webhook-dispatch.ts
+++ b/lib/consumer-webhook-dispatch.ts
@@ -256,13 +256,18 @@ export async function retryFailedConsumerWebhooks(
 
   if (!deliveries || deliveries.length === 0) return stats;
 
-  // Group by webhook_id + event_type + payload — pick latest row per key.
+  // Group by webhook_id + event_type + payload — pick latest row per key and
+  // track every delivery id in the group so we can clear needs_retry on all of
+  // them (not just the latest) when the group is resolved. Identical payloads
+  // can recur across cron runs (e.g. the timestamp-less broker.updated event),
+  // producing multiple needs_retry=true rows in one group; clearing only the
+  // latest would orphan the siblings as permanently needs_retry=true.
   interface DeliveryGroup {
     webhookId: string;
     eventType: string;
     payload: Record<string, unknown>;
     attempts: number;
-    latestDeliveryId: string;
+    ids: string[];
   }
   const groups = new Map<string, DeliveryGroup>();
 
@@ -278,12 +283,13 @@ export async function retryFailedConsumerWebhooks(
     const key = `${d.webhook_id}|${d.event_type}|${JSON.stringify(d.payload)}`;
     const existing = groups.get(key);
     const attempts = existing ? existing.attempts + d.attempt_count : d.attempt_count;
+    const ids = existing ? [...existing.ids, d.id] : [d.id];
     groups.set(key, {
       webhookId: d.webhook_id,
       eventType: d.event_type,
       payload: d.payload,
       attempts,
-      latestDeliveryId: d.id,
+      ids,
     });
   }
 
@@ -291,12 +297,12 @@ export async function retryFailedConsumerWebhooks(
 
   for (const g of groups.values()) {
     if (g.attempts >= MAX_CONSUMER_DELIVERY_ATTEMPTS) {
-      // Mark the latest delivery row as permanently failed (stop retrying).
+      // Mark every delivery row in the group as permanently failed (stop retrying).
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       await (admin as any)
         .from("consumer_webhook_deliveries")
         .update({ needs_retry: false })
-        .eq("id", g.latestDeliveryId);
+        .in("id", g.ids);
       stats.skipped_max_attempts += 1;
       continue;
     }
@@ -314,7 +320,7 @@ export async function retryFailedConsumerWebhooks(
       await (admin as any)
         .from("consumer_webhook_deliveries")
         .update({ needs_retry: false })
-        .eq("id", g.latestDeliveryId);
+        .in("id", g.ids);
       stats.skipped_hook_gone += 1;
       continue;
     }
@@ -324,7 +330,7 @@ export async function retryFailedConsumerWebhooks(
       await (admin as any)
         .from("consumer_webhook_deliveries")
         .update({ needs_retry: false })
-        .eq("id", g.latestDeliveryId);
+        .in("id", g.ids);
       stats.skipped_no_secret += 1;
       continue;
     }
@@ -350,12 +356,13 @@ export async function retryFailedConsumerWebhooks(
     const now = new Date().toISOString();
     const newAttemptCount = g.attempts + 1;
 
-    // Mark old delivery row as no longer needing retry.
+    // Mark every old delivery row in the group as no longer needing retry —
+    // not just the latest — so recurring identical-payload siblings are cleared.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await (admin as any)
       .from("consumer_webhook_deliveries")
       .update({ needs_retry: false })
-      .eq("id", g.latestDeliveryId);
+      .in("id", g.ids);
 
     // Insert a fresh delivery row for this attempt.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## What

`retryFailedConsumerWebhooks()` in `lib/consumer-webhook-dispatch.ts` groups failed deliveries by `(webhook_id, event_type, payload)` and accumulates each group's `attempt_count`, but on every disposition path it only cleared `needs_retry` on the single latest row (`g.latestDeliveryId`), never the sibling rows in the same group.

When a producer cron emits a byte-identical payload across runs while a subscriber is down — the timestamp-less `broker.updated` event is the realistic trigger (`app/api/cron/broker-snapshot/route.ts`) — two or more `needs_retry=true` rows land in the same group. The worker summed their attempt counts but cleared only the newest, leaving the older siblings permanently `needs_retry=true`. Those orphans were re-scanned every cron run for the full 24h window and re-counted into the group total, so the group hit `MAX_CONSUMER_DELIVERY_ATTEMPTS` (5) after fewer than 5 genuine retries — premature retry exhaustion plus unbounded-within-window stale-row accumulation.

## Fix

Track every delivery id per group (`ids: string[]`) and clear `needs_retry` via `.in("id", g.ids)` on all four disposition paths (max-attempts, hook-gone/inactive, no-secret, successful retry). Removed the now-unused `latestDeliveryId` field. Added two regression tests asserting all sibling rows are cleared — on both the successful-retry and attempt-cap paths.

Data-state-only change (DB update scope). No money-movement, no auth, no webhook signing/idempotency change, no migration.

## Finding ref

Audit wave-3: "Consumer webhook retry clears only the latest delivery row's needs_retry flag, orphaning sibling failed rows in the same (webhook, event, payload) group" (P2). Implements the recommended option (1): per-group id collection + `.in(...)` update.

## Verify

- `npx vitest run __tests__/lib/consumer-webhook-dispatch.test.ts` — 18 passed (incl. 2 new regression tests)
- `npx eslint --max-warnings 0 lib/consumer-webhook-dispatch.ts __tests__/lib/consumer-webhook-dispatch.test.ts` — clean

**Tier C** (cron-invoked webhook delivery using service-role admin client).

🤖 Generated with [Claude Code](https://claude.com/claude-code)