### PR TITLE
fix(referrals): gate referral-accept on tier + balance before claiming the brief

### DIFF
--- a/__tests__/lib/advisor-credit-ledger.test.ts
+++ b/__tests__/lib/advisor-credit-ledger.test.ts
@@ -310,6 +310,90 @@ describe("recordLedgerEntry", () => {
     expect(pros[0]?.lifetime_lead_spend_cents).toBe(3900);
   });
 
+  it("rejects a lead_spend that would drive the balance below zero (NegativeBalanceError)", async () => {
+    const { recordLedgerEntry, NegativeBalanceError } = await import(
+      "@/lib/advisor-credit-ledger"
+    );
+    pros[0]!.credit_balance_cents = 100;
+    await expect(
+      recordLedgerEntry({
+        professionalId: 1,
+        amountCents: -2500, // > balance
+        kind: "lead_spend",
+        description: "overspend",
+        referenceType: "brief_accept",
+        referenceId: "500",
+      }),
+    ).rejects.toBeInstanceOf(NegativeBalanceError);
+    // No ledger row, no cache mutation.
+    expect(ledger).toHaveLength(0);
+    expect(pros[0]!.credit_balance_cents).toBe(100);
+  });
+
+  it("rejects a success_bonus_award spend that would go negative", async () => {
+    const { recordLedgerEntry, NegativeBalanceError } = await import(
+      "@/lib/advisor-credit-ledger"
+    );
+    pros[0]!.credit_balance_cents = 50;
+    await expect(
+      recordLedgerEntry({
+        professionalId: 1,
+        amountCents: -300,
+        kind: "success_bonus_award",
+        description: "success overspend",
+        referenceType: "success_charge",
+        referenceId: "9",
+      }),
+    ).rejects.toBeInstanceOf(NegativeBalanceError);
+    expect(ledger).toHaveLength(0);
+  });
+
+  it("allows a spend that lands exactly at zero", async () => {
+    const { recordLedgerEntry } = await import("@/lib/advisor-credit-ledger");
+    pros[0]!.credit_balance_cents = 2500;
+    const result = await recordLedgerEntry({
+      professionalId: 1,
+      amountCents: -2500,
+      kind: "lead_spend",
+      description: "exact",
+      referenceType: "brief_accept",
+      referenceId: "501",
+    });
+    expect(result.balanceAfterCents).toBe(0);
+    expect(pros[0]!.credit_balance_cents).toBe(0);
+  });
+
+  it("respects allowNegativeBalance opt-out for floored spend kinds", async () => {
+    const { recordLedgerEntry } = await import("@/lib/advisor-credit-ledger");
+    pros[0]!.credit_balance_cents = 100;
+    const result = await recordLedgerEntry({
+      professionalId: 1,
+      amountCents: -2500,
+      kind: "lead_spend",
+      description: "forced negative",
+      referenceType: "brief_accept",
+      referenceId: "502",
+      allowNegativeBalance: true,
+    });
+    expect(result.balanceAfterCents).toBe(-2400);
+    expect(pros[0]!.credit_balance_cents).toBe(-2400);
+  });
+
+  it("does NOT floor non-prepaid-spend kinds (chargeback_clawback may go negative)", async () => {
+    const { recordLedgerEntry } = await import("@/lib/advisor-credit-ledger");
+    pros[0]!.credit_balance_cents = 100;
+    const result = await recordLedgerEntry({
+      professionalId: 1,
+      amountCents: -500,
+      kind: "chargeback_clawback",
+      description: "clawback of already-spent credit",
+      referenceType: "stripe_charge",
+      referenceId: "ch_neg",
+    });
+    expect(result.balanceAfterCents).toBe(-400);
+    expect(pros[0]!.credit_balance_cents).toBe(-400);
+  });
+
   it("increments lifetime_credit_cents only for credit kinds", async () => {
     const { recordLedgerEntry } = await import("@/lib/advisor-credit-ledger");
     await recordLedgerEntry({

--- a/__tests__/lib/team-brief-referrals.test.ts
+++ b/__tests__/lib/team-brief-referrals.test.ts
@@ -28,6 +28,14 @@ interface BriefRow {
   accepted_by_team_id: number | null;
   accepted_by_professional_id: number | null;
   accepted_at?: string;
+  accept_credits_cost?: number | null;
+}
+interface ProRow {
+  id: number;
+  credit_balance_cents: number;
+  lifetime_credit_cents?: number;
+  lifetime_lead_spend_cents?: number;
+  pricing_tier?: "standard" | "success_only";
 }
 interface ReferralRow {
   id: number;
@@ -46,7 +54,10 @@ let members: MemberRow[] = [];
 let teams: TeamRow[] = [];
 let briefs: BriefRow[] = [];
 let referrals: ReferralRow[] = [];
+let pros: ProRow[] = [];
+let ledger: Record<string, unknown>[] = [];
 let nextReferralId = 1;
+let nextLedgerId = 1;
 
 function reset() {
   members = [
@@ -67,10 +78,21 @@ function reset() {
       id: 500,
       accepted_by_team_id: null,
       accepted_by_professional_id: null,
+      accept_credits_cost: 2,
     },
   ];
   referrals = [];
+  // Accepting pros: 200 (to_team 2) and 300 (to_team 3) funded generously by
+  // default so the existing happy-path tests pass. Per-test overrides set the
+  // balance / tier as needed.
+  pros = [
+    { id: 100, credit_balance_cents: 100_000, pricing_tier: "standard" },
+    { id: 200, credit_balance_cents: 100_000, pricing_tier: "standard" },
+    { id: 300, credit_balance_cents: 100_000, pricing_tier: "standard" },
+  ];
+  ledger = [];
   nextReferralId = 1;
+  nextLedgerId = 1;
 }
 
 // ─── Minimal Supabase admin-client chain mock ────────────────────────
@@ -181,7 +203,11 @@ function resolveRows(
           ? (briefs as unknown as Record<string, unknown>[])
           : table === "team_brief_referrals"
             ? (referrals as unknown as Record<string, unknown>[])
-            : [];
+            : table === "professionals"
+              ? (pros as unknown as Record<string, unknown>[])
+              : table === "advisor_credit_ledger"
+                ? (ledger as unknown as Record<string, unknown>[])
+                : [];
   return source.filter((row) => {
     for (const [k, v] of Object.entries(filters)) {
       if (row[k] !== v) return false;
@@ -197,6 +223,11 @@ function resolveRows(
 }
 
 function doInsert(table: string, payload: Record<string, unknown>): Record<string, unknown> | null {
+  if (table === "advisor_credit_ledger") {
+    const row = { id: nextLedgerId++, ...payload };
+    ledger.push(row);
+    return row;
+  }
   if (table === "team_brief_referrals") {
     // Enforce the UNIQUE (brief_id, to_team_id) constraint in the mock.
     const duplicate = referrals.find(
@@ -386,5 +417,156 @@ describe("team-brief-referrals", () => {
     await expect(acceptReferral(created.id, 200)).rejects.toMatchObject({
       code: "referral_not_pending",
     });
+  });
+
+  // ── Pre-charge gating (mirrors acceptBrief) ────────────────────────
+  // Regression guard for the referral-accept money divergence: the path
+  // used to claim the brief and debit with NO balance / tier check.
+
+  it("standard-tier accept charges the accepting pro the full accept cost", async () => {
+    // Cost 25 credits = 2500c; accepting pro 200 funded with 5000c.
+    briefs[0]!.accept_credits_cost = 25;
+    pros.find((p) => p.id === 200)!.credit_balance_cents = 5000;
+    const created = await createReferral({
+      briefId: 500,
+      fromTeamId: 1,
+      toTeamId: 2,
+      fromProfessionalId: 100,
+    });
+
+    const accepted = await acceptReferral(created.id, 200);
+    expect(accepted.status).toBe("accepted");
+    expect(briefs[0]!.accepted_by_team_id).toBe(2);
+
+    // The accepting pro was debited 2500c -> 2500c remaining.
+    expect(pros.find((p) => p.id === 200)!.credit_balance_cents).toBe(2500);
+    // One lead_spend ledger row was written for the accepting pro.
+    const spend = ledger.filter(
+      (r) => r["kind"] === "lead_spend" && r["professional_id"] === 200,
+    );
+    expect(spend).toHaveLength(1);
+    expect(spend[0]!["amount_cents"]).toBe(-2500);
+  });
+
+  it("rejects a standard-tier accept when balance is below the accept cost — brief stays unclaimed, zero ledger writes", async () => {
+    // Cost 25 credits = 2500c; accepting pro 200 only has 100c.
+    briefs[0]!.accept_credits_cost = 25;
+    pros.find((p) => p.id === 200)!.credit_balance_cents = 100;
+    const created = await createReferral({
+      briefId: 500,
+      fromTeamId: 1,
+      toTeamId: 2,
+      fromProfessionalId: 100,
+    });
+
+    await expect(acceptReferral(created.id, 200)).rejects.toMatchObject({
+      code: "insufficient_credits",
+    });
+
+    // The fix's whole point: the brief must NOT be claimed.
+    expect(briefs[0]!.accepted_by_team_id).toBeNull();
+    expect(briefs[0]!.accepted_by_professional_id).toBeNull();
+    // The referral must remain pending.
+    expect(referrals[0]!.status).toBe("pending");
+    // No balance movement at all — neither the spend nor the referrer payout.
+    expect(pros.find((p) => p.id === 200)!.credit_balance_cents).toBe(100);
+    expect(ledger).toHaveLength(0);
+  });
+
+  it("rejects when balance is exactly one cent short (boundary)", async () => {
+    briefs[0]!.accept_credits_cost = 25; // 2500c
+    pros.find((p) => p.id === 200)!.credit_balance_cents = 2499;
+    const created = await createReferral({
+      briefId: 500,
+      fromTeamId: 1,
+      toTeamId: 2,
+      fromProfessionalId: 100,
+    });
+    await expect(acceptReferral(created.id, 200)).rejects.toMatchObject({
+      code: "insufficient_credits",
+    });
+    expect(briefs[0]!.accepted_by_team_id).toBeNull();
+    expect(ledger).toHaveLength(0);
+  });
+
+  it("accepts when balance exactly equals the accept cost (boundary)", async () => {
+    briefs[0]!.accept_credits_cost = 25; // 2500c
+    pros.find((p) => p.id === 200)!.credit_balance_cents = 2500;
+    const created = await createReferral({
+      briefId: 500,
+      fromTeamId: 1,
+      toTeamId: 2,
+      fromProfessionalId: 100,
+    });
+    const accepted = await acceptReferral(created.id, 200);
+    expect(accepted.status).toBe("accepted");
+    expect(pros.find((p) => p.id === 200)!.credit_balance_cents).toBe(0);
+  });
+
+  it("success_only accept skips the accept-time charge entirely — no debit, brief still claimed", async () => {
+    briefs[0]!.accept_credits_cost = 25; // 2500c if charged
+    const pro200 = pros.find((p) => p.id === 200)!;
+    pro200.pricing_tier = "success_only";
+    pro200.credit_balance_cents = 0; // would fail the standard gate
+    const created = await createReferral({
+      briefId: 500,
+      fromTeamId: 1,
+      toTeamId: 2,
+      fromProfessionalId: 100,
+    });
+
+    const accepted = await acceptReferral(created.id, 200);
+    expect(accepted.status).toBe("accepted");
+    expect(briefs[0]!.accepted_by_team_id).toBe(2);
+
+    // No lead_spend on the accepting pro — they pay at outcome-submit time.
+    const spend = ledger.filter(
+      (r) => r["kind"] === "lead_spend" && r["professional_id"] === 200,
+    );
+    expect(spend).toHaveLength(0);
+    expect(pro200.credit_balance_cents).toBe(0);
+  });
+
+  it("success_only accept still pays out the referrer", async () => {
+    briefs[0]!.accept_credits_cost = 25; // 2500c basis
+    const pro200 = pros.find((p) => p.id === 200)!;
+    pro200.pricing_tier = "success_only";
+    pro200.credit_balance_cents = 0;
+    const created = await createReferral({
+      briefId: 500,
+      fromTeamId: 1,
+      toTeamId: 2,
+      fromProfessionalId: 100,
+    });
+
+    await acceptReferral(created.id, 200);
+    // Referrer (pro 100) gets 20% of the standard 2500c basis = 500c.
+    const payout = ledger.filter(
+      (r) => r["kind"] === "referral_payout" && r["professional_id"] === 100,
+    );
+    expect(payout).toHaveLength(1);
+    expect(payout[0]!["amount_cents"]).toBe(500);
+  });
+
+  it("repeat accept of an already-settled referral is idempotent — no double charge", async () => {
+    briefs[0]!.accept_credits_cost = 25; // 2500c
+    pros.find((p) => p.id === 200)!.credit_balance_cents = 5000;
+    const created = await createReferral({
+      briefId: 500,
+      fromTeamId: 1,
+      toTeamId: 2,
+      fromProfessionalId: 100,
+    });
+    await acceptReferral(created.id, 200);
+    expect(pros.find((p) => p.id === 200)!.credit_balance_cents).toBe(2500);
+
+    // A second accept of the now-accepted referral is rejected as not-pending,
+    // and crucially does NOT debit again.
+    await expect(acceptReferral(created.id, 200)).rejects.toMatchObject({
+      code: "referral_not_pending",
+    });
+    expect(pros.find((p) => p.id === 200)!.credit_balance_cents).toBe(2500);
+    const spend = ledger.filter((r) => r["kind"] === "lead_spend");
+    expect(spend).toHaveLength(1);
   });
 });

--- a/__tests__/lib/team-brief-referrals/payouts.test.ts
+++ b/__tests__/lib/team-brief-referrals/payouts.test.ts
@@ -160,6 +160,86 @@ describe("recordReferralPayout", () => {
     expect(mockRecordLedgerEntry.mock.calls[0]?.[0]).toMatchObject({ kind: "lead_spend" });
   });
 
+  it("skips the accept-time charge for success_only pros but still pays the referrer", async () => {
+    const result = await recordReferralPayout({
+      referralId: 100,
+      briefId: 500,
+      acceptCreditsCost: 25,
+      acceptingProfessionalId: 1,
+      fromProfessionalId: 2,
+      fromTeamId: 10,
+      pricingTier: "success_only",
+    });
+
+    // No accept-time debit for success_only pros.
+    expect(result.chargeCents).toBe(0);
+    // Referrer payout is still 20% of the STANDARD 2500c basis = 500c.
+    expect(result.payoutCents).toBe(500);
+
+    // Only ONE ledger write — the referral_payout. No lead_spend.
+    expect(mockRecordLedgerEntry).toHaveBeenCalledTimes(1);
+    const kinds = mockRecordLedgerEntry.mock.calls.map((c) => c[0].kind);
+    expect(kinds).not.toContain("lead_spend");
+    expect(kinds).toContain("referral_payout");
+  });
+
+  it("charges the full accept cost for standard tier (explicit) and stamps the tier in metadata", async () => {
+    await recordReferralPayout({
+      referralId: 100,
+      briefId: 500,
+      acceptCreditsCost: 25,
+      acceptingProfessionalId: 1,
+      fromProfessionalId: 2,
+      fromTeamId: 10,
+      pricingTier: "standard",
+    });
+    const spendCall = mockRecordLedgerEntry.mock.calls.find(
+      (c) => c[0].kind === "lead_spend",
+    )?.[0];
+    expect(spendCall).toMatchObject({
+      amountCents: -2500,
+      kind: "lead_spend",
+      referenceType: "brief_accept",
+      referenceId: "500",
+    });
+    expect(spendCall?.metadata).toMatchObject({ pricing_tier_at_accept: "standard" });
+  });
+
+  it("defaults to standard tier (full charge) when pricingTier is omitted", async () => {
+    const result = await recordReferralPayout({
+      referralId: 100,
+      briefId: 500,
+      acceptCreditsCost: 25,
+      acceptingProfessionalId: 1,
+      fromProfessionalId: 2,
+      fromTeamId: 10,
+    });
+    expect(result.chargeCents).toBe(2500);
+    const kinds = mockRecordLedgerEntry.mock.calls.map((c) => c[0].kind);
+    expect(kinds).toContain("lead_spend");
+  });
+
+  it("relies on the ledger idempotency triple for the accept-time charge (brief_accept, briefId)", async () => {
+    // Re-running the same payout must reuse the (lead_spend, brief_accept,
+    // briefId) triple so a retry never double-charges.
+    await recordReferralPayout({
+      referralId: 100,
+      briefId: 500,
+      acceptCreditsCost: 25,
+      acceptingProfessionalId: 1,
+      fromProfessionalId: 2,
+      fromTeamId: 10,
+      pricingTier: "standard",
+    });
+    const spendCall = mockRecordLedgerEntry.mock.calls.find(
+      (c) => c[0].kind === "lead_spend",
+    )?.[0];
+    expect(spendCall).toMatchObject({
+      referenceType: "brief_accept",
+      referenceId: "500",
+    });
+  });
+
   it("throws when there is no payout target (null fromProfessionalId AND no team members)", async () => {
     mockFrom.mockImplementation((table: string) => {
       if (table === "expert_team_members") {

--- a/app/api/referrals/[id]/accept/route.ts
+++ b/app/api/referrals/[id]/accept/route.ts
@@ -69,6 +69,8 @@ function mapStatus(code: string): number {
     case "referral_not_pending":
     case "brief_already_accepted":
       return 409;
+    case "insufficient_credits":
+      return 402;
     case "not_team_member":
       return 403;
     case "referral_not_found":

--- a/lib/advisor-credit-ledger.ts
+++ b/lib/advisor-credit-ledger.ts
@@ -81,7 +81,49 @@ export interface RecordLedgerEntryInput {
    * `createAdminClient()` for callers that don't have a context.
    */
   supabase?: SupabaseLike;
+  /**
+   * Opt OUT of the negative-balance floor for spend kinds. Defaults to
+   * `false` — i.e. the floor is enforced for the prepaid-credit spend kinds
+   * (`lead_spend`, `success_bonus_award`) and a charge that would drive
+   * `credit_balance_cents` below zero throws `NegativeBalanceError`.
+   *
+   * Set to `true` only for kinds that legitimately settle a debt that may
+   * exceed the current cached balance (e.g. a `chargeback_clawback` of a
+   * credit the pro has already spent, or `expiry` of granted-but-spent
+   * credits). Those kinds are NOT floored even when this is left `false`.
+   */
+  allowNegativeBalance?: boolean;
 }
+
+/**
+ * Thrown when a prepaid-credit spend would drive the cached balance below
+ * zero. Mirrors `lib/marketplace/wallet.ts`'s "Adjustment would result in
+ * negative balance" guard so no caller can silently over-spend.
+ */
+export class NegativeBalanceError extends Error {
+  constructor(
+    public readonly professionalId: number,
+    public readonly currentBalanceCents: number,
+    public readonly amountCents: number,
+  ) {
+    super(
+      `recordLedgerEntry: spend would drive advisor ${professionalId} below zero ` +
+        `(balance ${currentBalanceCents}c, amount ${amountCents}c)`,
+    );
+    this.name = "NegativeBalanceError";
+  }
+}
+
+/**
+ * Spend kinds whose balance must not be driven below zero unless the caller
+ * explicitly opts out via `allowNegativeBalance`. These are the prepaid-credit
+ * accept-time charges; clawbacks / expiry of already-spent credits are
+ * intentionally excluded so debt settlement still works.
+ */
+const FLOORED_SPEND_KINDS: ReadonlySet<LedgerKind> = new Set<LedgerKind>([
+  "lead_spend",
+  "success_bonus_award",
+]);
 
 export interface RecordLedgerEntryResult {
   /** The ledger row (existing one if (kind, reference_type, reference_id) triple already landed). */
@@ -138,6 +180,24 @@ export async function recordLedgerEntry(
 
   const currentBalance = pro.credit_balance_cents ?? 0;
   const newBalance = currentBalance + input.amountCents;
+
+  // ── 2b. Negative-balance floor for prepaid-credit spends ───────────
+  //      Mirrors lib/marketplace/wallet.ts: a spend that would drive the
+  //      cached balance below zero is rejected unless the caller opts out.
+  //      No ledger row is inserted and the cache is untouched, so the brief
+  //      claim that triggered the spend can be safely rolled back / aborted.
+  if (
+    input.amountCents < 0 &&
+    newBalance < 0 &&
+    !input.allowNegativeBalance &&
+    FLOORED_SPEND_KINDS.has(input.kind)
+  ) {
+    throw new NegativeBalanceError(
+      input.professionalId,
+      currentBalance,
+      input.amountCents,
+    );
+  }
 
   // ── 3. Insert the ledger row ───────────────────────────────────────
   const expiresAtIso =

--- a/lib/briefs/credits.ts
+++ b/lib/briefs/credits.ts
@@ -82,6 +82,62 @@ export async function getAcceptCost({
   return 2;
 }
 
+/**
+ * Pre-charge affordability gate, shared by `acceptBrief` (direct accept) and
+ * `acceptReferral` (accept via a team referral) so the two paths can never
+ * diverge on the money rules. Resolves the pro's pricing tier and, for the
+ * `standard` tier, checks the cached `credit_balance_cents` against the
+ * accept-time charge.
+ *
+ * Returns the data the caller needs to either (a) abort BEFORE claiming the
+ * brief when funds are short, or (b) decide whether to record the accept-time
+ * charge at all (success_only pros pay nothing at accept).
+ *
+ * NB: like `acceptBrief`, this gates on the cached balance — the authoritative
+ * floor is `recordLedgerEntry`, which rejects spend entries that would drive
+ * `credit_balance_cents` below zero.
+ */
+export interface ProChargeGate {
+  /** The pro's pricing tier at the moment of the check. */
+  tier: import("./pricing-tier").PricingTier;
+  /** Accept-time charge in cents (0 for success_only). */
+  chargeCents: number;
+  /** Whether the pro can afford `chargeCents`. Always true for success_only. */
+  sufficient: boolean;
+  /** Cached balance read for the check (cents). */
+  currentBalanceCents: number;
+}
+
+export async function resolveProChargeGate(
+  professionalId: number,
+  credits: number,
+): Promise<ProChargeGate> {
+  const admin = createAdminClient();
+  const cents = credits * CENTS_PER_CREDIT;
+
+  // success_only pros pay nothing at accept (they settle at outcome-submit).
+  const tier = await getProPricingTier(professionalId);
+
+  const { data: pro } = await admin
+    .from("professionals")
+    .select("credit_balance_cents")
+    .eq("id", professionalId)
+    .maybeSingle();
+  const currentBalanceCents = pro?.credit_balance_cents ?? 0;
+
+  if (tier !== "standard") {
+    // No accept-time charge — nothing to gate on.
+    return { tier, chargeCents: 0, sufficient: true, currentBalanceCents };
+  }
+
+  return {
+    tier,
+    chargeCents: cents,
+    sufficient: currentBalanceCents >= cents,
+    currentBalanceCents,
+  };
+}
+
 export interface AcceptBriefInput {
   briefId: number;
   professionalId: number;
@@ -142,17 +198,13 @@ export async function acceptBrief({
   const credits = row.accept_credits_cost ?? 2;
   const cents = credits * CENTS_PER_CREDIT;
 
-  // ── 2a. Resolve pricing tier (success_only pros skip the accept-time charge) ─
-  const tier = await getProPricingTier(professionalId);
-
-  // ── 2b. Standard tier: check sufficient balance up front ────────────
-  const { data: pro } = await admin
-    .from("professionals")
-    .select("credit_balance_cents")
-    .eq("id", professionalId)
-    .maybeSingle();
-  const currentBalance = pro?.credit_balance_cents ?? 0;
-  if (tier === "standard" && currentBalance < cents) {
+  // ── 2. Pre-charge gate: resolve pricing tier (success_only pros skip the
+  //      accept-time charge) and, for standard tier, check sufficient balance
+  //      up front. Shared with the referral-accept path via resolveProChargeGate.
+  const gate = await resolveProChargeGate(professionalId, credits);
+  const tier = gate.tier;
+  const currentBalance = gate.currentBalanceCents;
+  if (!gate.sufficient) {
     return {
       accepted: false,
       reason: "insufficient_credits",

--- a/lib/team-brief-referrals.ts
+++ b/lib/team-brief-referrals.ts
@@ -17,6 +17,7 @@
 // eslint-disable-next-line no-restricted-imports -- cross-team writes; service-role legitimate per CLAUDE.md.
 import { createAdminClient } from "@/lib/supabase/admin";
 import { logger } from "@/lib/logger";
+import { resolveProChargeGate } from "./briefs/credits";
 import { recordReferralPayout } from "./team-brief-referrals/payouts";
 
 const log = logger("team-brief-referrals");
@@ -227,6 +228,19 @@ export async function acceptReferral(
   }
   const acceptCreditsCost = (briefBefore.accept_credits_cost as number | null) ?? 2;
 
+  // ── Pre-charge gate (MUST run BEFORE the claim) ──────────────────────
+  // Mirror the direct-accept path (acceptBrief): resolve the pricing tier
+  // and, for standard-tier pros, reject up-front when the cached credit
+  // balance can't cover the accept-time charge. This runs before the claim
+  // and OUTSIDE the swallowed payout try/catch below, so an insufficient
+  // balance leaves the brief unclaimed and writes nothing to the ledger.
+  // success_only pros skip the accept-time charge entirely (gate.sufficient
+  // is always true for them) and pay at outcome-submit time instead.
+  const gate = await resolveProChargeGate(professionalId, acceptCreditsCost);
+  if (!gate.sufficient) {
+    throw new ReferralError("insufficient_credits");
+  }
+
   // Claim the brief for the receiving team AND stamp the accepting
   // professional so the lead spend can be attributed cleanly. Guard against
   // concurrent acceptance by another team / individual via the still-open
@@ -280,6 +294,7 @@ export async function acceptReferral(
       acceptingProfessionalId: professionalId,
       fromProfessionalId: referral.from_professional_id,
       fromTeamId: referral.from_team_id,
+      pricingTier: gate.tier,
     });
   } catch (err) {
     log.error("referral payout failed (referral still accepted)", {

--- a/lib/team-brief-referrals/payouts.ts
+++ b/lib/team-brief-referrals/payouts.ts
@@ -3,11 +3,18 @@
  * squad and the receiving squad accepts, two credit movements happen:
  *
  *   1. The accepting professional is debited the brief's accept_credits_cost
- *      (same charge they'd pay accepting directly).
+ *      — exactly mirroring the direct-accept path (`acceptBrief`). This means
+ *      the charge is gated on the pro's pricing tier: `standard` pros pay the
+ *      accept-time charge now; `success_only` pros pay $0 at accept (they
+ *      settle at outcome-submit time) so we skip the debit entirely for them.
+ *      The sufficient-balance check happens in the caller (`acceptReferral`)
+ *      BEFORE the brief is claimed; `recordLedgerEntry` additionally enforces
+ *      a hard negative-balance floor on `lead_spend`.
  *   2. The referring professional (or, if not set, the first active member
  *      of the from_team) is credited REFERRAL_PAYOUT_BPS / 10_000 of the
- *      charge — defaults to 20% (2_000 bps). Environment override:
- *      `REFERRAL_PAYOUT_BPS`.
+ *      standard charge — defaults to 20% (2_000 bps). Environment override:
+ *      `REFERRAL_PAYOUT_BPS`. The referrer is paid per the agreed rule
+ *      regardless of the accepting pro's tier.
  *
  * Both writes go through `recordLedgerEntry` so the existing idempotency
  * triple (kind, reference_type, reference_id) prevents double-charging on
@@ -18,6 +25,7 @@
 import { createAdminClient } from "@/lib/supabase/admin";
 import { recordLedgerEntry } from "@/lib/advisor-credit-ledger";
 import { CENTS_PER_CREDIT } from "@/lib/briefs/credits";
+import type { PricingTier } from "@/lib/briefs/pricing-tier";
 import { logger } from "@/lib/logger";
 
 const log = logger("referrals:payouts");
@@ -47,9 +55,18 @@ export interface RecordReferralPayoutInput {
    */
   fromProfessionalId: number | null;
   fromTeamId: number;
+  /**
+   * The accepting pro's pricing tier, resolved by the caller BEFORE the brief
+   * is claimed. `success_only` pros pay $0 at accept (they settle at
+   * outcome-submit time), so we skip the accept-time debit for them while
+   * still paying out the referrer. Defaults to `"standard"` when omitted so
+   * existing callers keep the prior behaviour.
+   */
+  pricingTier?: PricingTier;
 }
 
 export interface RecordReferralPayoutResult {
+  /** Amount actually debited from the accepting pro (0 for success_only). */
   chargeCents: number;
   payoutCents: number;
   acceptingBalanceAfterCents: number;
@@ -61,8 +78,14 @@ export async function recordReferralPayout(
   input: RecordReferralPayoutInput,
 ): Promise<RecordReferralPayoutResult> {
   const bps = getReferralPayoutBps();
-  const chargeCents = input.acceptCreditsCost * CENTS_PER_CREDIT;
-  const payoutCents = Math.floor((chargeCents * bps) / 10_000);
+  const tier: PricingTier = input.pricingTier ?? "standard";
+  // The standard accept-time charge — used both for the (possibly skipped)
+  // debit and as the basis for the referrer payout, which is paid per the
+  // agreed rule regardless of the accepting pro's tier.
+  const standardChargeCents = input.acceptCreditsCost * CENTS_PER_CREDIT;
+  // success_only pros pay $0 at accept; standard pros pay the full charge.
+  const debitCents = tier === "standard" ? standardChargeCents : 0;
+  const payoutCents = Math.floor((standardChargeCents * bps) / 10_000);
 
   const admin = createAdminClient();
 
@@ -86,19 +109,36 @@ export async function recordReferralPayout(
   }
 
   // ── Charge the accepting professional ─────────────────────────────────
-  const charge = await recordLedgerEntry({
-    professionalId: input.acceptingProfessionalId,
-    amountCents: -chargeCents,
-    kind: "lead_spend",
-    description: `Brief #${input.briefId} accept via referral #${input.referralId}`,
-    referenceType: "brief_accept",
-    referenceId: String(input.briefId),
-    metadata: {
-      referral_id: input.referralId,
-      via_referral: true,
-      credits: input.acceptCreditsCost,
-    },
-  });
+  //     Skipped entirely for success_only pros (they settle at outcome-submit
+  //     time), exactly like acceptBrief. recordLedgerEntry enforces the
+  //     negative-balance floor on lead_spend, but the caller has already
+  //     gated on sufficient balance before claiming the brief.
+  let acceptingBalanceAfterCents: number;
+  if (debitCents > 0) {
+    const charge = await recordLedgerEntry({
+      professionalId: input.acceptingProfessionalId,
+      amountCents: -debitCents,
+      kind: "lead_spend",
+      description: `Brief #${input.briefId} accept via referral #${input.referralId}`,
+      referenceType: "brief_accept",
+      referenceId: String(input.briefId),
+      metadata: {
+        referral_id: input.referralId,
+        via_referral: true,
+        credits: input.acceptCreditsCost,
+        pricing_tier_at_accept: tier,
+      },
+    });
+    acceptingBalanceAfterCents = charge.balanceAfterCents;
+  } else {
+    // No accept-time charge — read the current balance for the result.
+    const { data: pro } = await admin
+      .from("professionals")
+      .select("credit_balance_cents")
+      .eq("id", input.acceptingProfessionalId)
+      .maybeSingle();
+    acceptingBalanceAfterCents = pro?.credit_balance_cents ?? 0;
+  }
 
   // ── Pay out the referring professional (only when bps > 0) ────────────
   let referrerBalanceAfterCents = 0;
@@ -138,9 +178,9 @@ export async function recordReferralPayout(
     .eq("id", input.referralId);
 
   return {
-    chargeCents,
+    chargeCents: debitCents,
     payoutCents,
-    acceptingBalanceAfterCents: charge.balanceAfterCents,
+    acceptingBalanceAfterCents,
     referrerBalanceAfterCents,
     payoutProfessionalId,
   };


### PR DESCRIPTION
⚠️ **HELD — client-money / billing-rule sensitive. Requires FOUNDER + LEGAL sign-off before merge. Do NOT merge autonomously.**

## Finding ref
Bug-hunt wave-3 finding (P1, HELD): *"Referral-accept charges the accepting pro with no balance guard and no pricing-tier check, diverging from acceptBrief"* — `lib/team-brief-referrals/payouts.ts`.

## Defect (verified on current main)
The team-brief referral-accept path charged the accepting pro's prepaid credit balance with **no sufficient-balance guard and no pricing-tier check**, unlike the direct-accept path (`acceptBrief`, `lib/briefs/credits.ts`) which has both.

- `acceptReferral()` claimed the brief and stamped the referral `accepted` **before** calling `recordReferralPayout`, then **swallowed** payout errors. A standard-tier pro with balance below the accept cost still got the brief, and `recordLedgerEntry` (no negative floor) drove `credit_balance_cents` negative — leads accepted for free.
- `success_only` pros (pay $0 at accept, settle at outcome time) were charged the full accept cost via referral — **double-charged**.

## Fix (mirrors `lib/briefs/credits.ts` exactly)
- **Shared gate** `resolveProChargeGate()` added to `lib/briefs/credits.ts`: resolves pricing tier and, for standard tier, checks cached balance. `acceptBrief` now uses it too, so the two paths cannot diverge again.
- `acceptReferral()` runs the gate **before** the claim and **outside** the swallowed try/catch. Insufficient balance → `ReferralError('insufficient_credits')` → **402**; the brief is left **unclaimed** and **zero ledger rows** are written.
- `recordReferralPayout()` skips the accept-time debit for `success_only` while still paying the referrer on the standard basis; stamps `pricing_tier_at_accept` in metadata.
- **Defensive floor**: `recordLedgerEntry` now rejects prepaid-spend kinds (`lead_spend`, `success_bonus_award`) that would drive the balance below zero (`NegativeBalanceError`), mirroring `lib/marketplace/wallet.ts`. `chargeback_clawback` / `expiry` of already-spent credits are intentionally exempt (they settle real debt).

## Migration
None — uses existing columns only (`credit_balance_cents`, `pricing_tier`, `advisor_auctions.accept_credits_cost`, `pricing_tier_at_accept`).

## Test coverage (68 affected tests green locally)
- Standard accept debits the full cost; insufficient balance rejects with **brief unclaimed + zero ledger writes**; one-cent-short and exact-balance boundaries.
- `success_only` accept skips the charge (brief still claimed, no debit) yet still pays the referrer.
- Repeat accept of a settled referral does not double-charge.
- Ledger floor: rejects over-spend on `lead_spend` / `success_bonus_award`; allows exact-zero; `allowNegativeBalance` opt-out; clawback/expiry not floored.
- `recordReferralPayout` unit: success_only chargeCents=0 + referrer paid; standard tier full charge + tier metadata; default = standard; idempotency triple `(lead_spend, brief_accept, briefId)`.

## Why held
Balance-affecting client-money path (advisor prepaid credit funded by Stripe top-ups) touching billing-rule logic (pricing tiers, charge collection) and referrer payout, plus a change to the shared ledger helper. Tier C / HELD per merge-authorization policy — requires explicit founder + legal sign-off.
