### PR TITLE
fix(advisor-billing): grant 3 free leads from FREE_LEAD_LIMIT; honour configured 0

### DIFF
--- a/__tests__/api/advisor-enquiry.test.ts
+++ b/__tests__/api/advisor-enquiry.test.ts
@@ -27,6 +27,10 @@ vi.mock("@/lib/email-templates", () => ({
 
 vi.mock("@/lib/advisor-billing", () => ({
   createLeadInvoice: vi.fn(() => Promise.resolve()),
+  // Canonical free-lead allowance (founder decision: 3). The route imports
+  // this constant; mock it so tests don't pull in the real module's
+  // Stripe/admin-client deps.
+  FREE_LEAD_LIMIT: 3,
 }));
 
 // ── Import route AFTER mocks ──────────────────────────────────────────────────
@@ -60,6 +64,12 @@ function setupFromMock(options: {
   leadPriceCents?: number;
   creditBalanceCents?: number;
   billingRecord?: { id: string } | null;
+  // When set, models a lead_pricing row for the advisor's category with this
+  // free_trial_leads value. Only consulted by the route when the advisor has
+  // no custom lead_price_cents. `undefined` means "no category row" (route
+  // falls back to FREE_LEAD_LIMIT); a number (incl. 0) is the configured
+  // override.
+  categoryFreeTrialLeads?: number;
 } = {}) {
   const {
     pro = PRO,
@@ -69,10 +79,27 @@ function setupFromMock(options: {
     leadPriceCents = 4900,
     creditBalanceCents = 0,
     billingRecord = { id: "bill-001" },
+    categoryFreeTrialLeads,
   } = options;
 
   mockFrom.mockImplementation((table: string) => {
     const builder = createChainableBuilder(table);
+
+    if (table === "lead_pricing") {
+      builder.single = vi.fn(() =>
+        Promise.resolve({
+          data:
+            categoryFreeTrialLeads === undefined
+              ? null
+              : {
+                  price_cents: 4900,
+                  qualified_price_cents: 9800,
+                  free_trial_leads: categoryFreeTrialLeads,
+                },
+          error: categoryFreeTrialLeads === undefined ? { code: "PGRST116" } : null,
+        })
+      );
+    }
 
     if (table === "professionals") {
       builder.single = vi.fn(() => {
@@ -261,8 +288,79 @@ describe("POST /api/advisor-enquiry", () => {
     expect(billingCalls).toHaveLength(0);
   });
 
-  it("creates billing record for paid leads (free_leads_used >= 2, has credit)", async () => {
-    setupFromMock({ freeLeadsUsed: 2, leadPriceCents: 4900, creditBalanceCents: 20000 });
+  // ── Free-lead allowance (founder decision: canonical 3) ─────────────────────
+  // The server's free-trial allowance is sourced from the shared
+  // FREE_LEAD_LIMIT constant (lib/advisor-billing) so the portal Dashboard /
+  // Billing tabs and billing-summary route — which advertise 3 — match what
+  // the server actually grants. These tests pin the granted allowance to 3 and
+  // guard the falsy-zero regression (a configured 0 must disable the trial,
+  // not silently re-enable the default).
+  function billingCallsFor() {
+    return mockFrom.mock.calls.filter(
+      (call: unknown[]) => call[0] === "advisor_billing"
+    );
+  }
+
+  describe("free-lead allowance", () => {
+    it("grants exactly 3 free leads by default — the 3rd lead (index 2) is free", async () => {
+      // No category lead_pricing row → falls back to FREE_LEAD_LIMIT (3).
+      // free_leads_used = 2 means this is the 3rd lead; 2 < 3 ⇒ free.
+      setupFromMock({ freeLeadsUsed: 2, leadPriceCents: 4900, creditBalanceCents: 20000 });
+
+      const res = await POST(enquiryRequest(VALID_BODY));
+      expect(res.status).toBe(200);
+
+      // Free lead ⇒ no advisor_billing record is written.
+      expect(billingCallsFor()).toHaveLength(0);
+    });
+
+    it("bills the 4th lead (free_leads_used = 3) once the 3-lead allowance is exhausted", async () => {
+      setupFromMock({ freeLeadsUsed: 3, leadPriceCents: 4900, creditBalanceCents: 20000 });
+
+      const res = await POST(enquiryRequest(VALID_BODY));
+      expect(res.status).toBe(200);
+
+      // Allowance exhausted ⇒ a billing record is created.
+      expect(billingCallsFor().length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("honours a configured 0 free leads (falsy-zero must NOT re-enable the default)", async () => {
+      // Admin set the category's free_trial_leads to 0 to disable the trial.
+      // With `??` (not `||`) the configured 0 wins, so the very first lead
+      // (free_leads_used = 0) is billed. leadPriceCents must be falsy so the
+      // route consults lead_pricing.
+      setupFromMock({
+        freeLeadsUsed: 0,
+        leadPriceCents: 0,
+        creditBalanceCents: 20000,
+        categoryFreeTrialLeads: 0,
+      });
+
+      const res = await POST(enquiryRequest(VALID_BODY));
+      expect(res.status).toBe(200);
+
+      // 0 < 0 is false ⇒ not free ⇒ billing record created on lead #1.
+      expect(billingCallsFor().length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("respects a category override above/below the default (free_trial_leads = 5)", async () => {
+      // Category configured for 5 free leads; the 5th lead (index 4) is free.
+      setupFromMock({
+        freeLeadsUsed: 4,
+        leadPriceCents: 0,
+        creditBalanceCents: 20000,
+        categoryFreeTrialLeads: 5,
+      });
+
+      const res = await POST(enquiryRequest(VALID_BODY));
+      expect(res.status).toBe(200);
+
+      expect(billingCallsFor()).toHaveLength(0);
+    });
+  });
+
+  it("creates billing record for paid leads (free_leads_used >= 3, has credit)", async () => {
+    setupFromMock({ freeLeadsUsed: 3, leadPriceCents: 4900, creditBalanceCents: 20000 });
 
     const req = enquiryRequest(VALID_BODY);
     const res = await POST(req);
@@ -343,7 +441,7 @@ describe("POST /api/advisor-enquiry", () => {
 
     for (const sourcePath of CROSS_BORDER_PATHS) {
       it(`charges 3× when source_page is ${sourcePath}`, async () => {
-        setupFromMock({ freeLeadsUsed: 2, leadPriceCents: 4900, creditBalanceCents: 20000 });
+        setupFromMock({ freeLeadsUsed: 3, leadPriceCents: 4900, creditBalanceCents: 20000 });
 
         const req = enquiryRequest({ ...VALID_BODY, source_page: sourcePath });
         const res = await POST(req);
@@ -358,7 +456,7 @@ describe("POST /api/advisor-enquiry", () => {
     }
 
     it("does NOT trigger international pricing for a domestic source_page", async () => {
-      setupFromMock({ freeLeadsUsed: 2, leadPriceCents: 4900, creditBalanceCents: 20000 });
+      setupFromMock({ freeLeadsUsed: 3, leadPriceCents: 4900, creditBalanceCents: 20000 });
 
       const req = enquiryRequest({ ...VALID_BODY, source_page: "/best/share-trading" });
       const res = await POST(req);

--- a/app/api/advisor-enquiry/route.ts
+++ b/app/api/advisor-enquiry/route.ts
@@ -7,6 +7,7 @@ import { notificationFooter } from "@/lib/email-templates";
 import { escapeHtml } from "@/lib/html-escape";
 import { getSiteUrl } from "@/lib/url";
 import { isValidAuPhone } from "@/lib/validate-phone";
+import { FREE_LEAD_LIMIT } from "@/lib/advisor-billing";
 import { logger } from "@/lib/logger";
 
 const log = logger("advisor-enquiry");
@@ -253,20 +254,28 @@ export async function POST(request: NextRequest) {
     const leadTier = isInternationalLead ? "international" : hasQualificationData ? "qualified" : "standard";
 
     // ── Auto-Billing (prepaid credit model) ──
-    // First 2 leads are free (trial), then deduct from credit balance
+    // First FREE_LEAD_LIMIT leads are free (trial), then deduct from credit
+    // balance. The default is sourced from the shared advisor-billing constant
+    // so the server, the portal Dashboard/Billing tabs, and billing-summary
+    // all agree (founder decision: 3 free leads). A per-category override in
+    // lead_pricing.free_trial_leads takes precedence when a row exists.
     const { data: advisor } = await supabase
       .from("professionals")
       .select("free_leads_used, lead_price_cents, credit_balance_cents, lifetime_lead_spend_cents, total_leads, low_credit_alert_sent_at, specialties, avg_response_minutes")
       .eq("id", professional_id)
       .single();
 
-    const freeTrialCount = 2; // Default, overridden below if category pricing exists
+    const freeTrialCount = FREE_LEAD_LIMIT; // Canonical default (founder decision: 3)
     const freeUsed = advisor?.free_leads_used || 0;
 
     // Get category default price if advisor has no custom price
     let categoryPrice = 4900; // ultimate fallback
     let categoryQualifiedPrice = 9800; // fallback: 2x standard
-    let categoryFreeLeads = 2;
+    // null = "no category row" (fall back to freeTrialCount). A configured 0
+    // (free trial deliberately disabled) must be honoured, so we use `??`
+    // below, not `||` — `||` would treat a legitimate 0 as falsy and silently
+    // re-enable the default free leads.
+    let categoryFreeLeads: number | null = null;
     if (!advisor?.lead_price_cents) {
       const { data: catPricing } = await supabase
         .from("lead_pricing")
@@ -280,7 +289,8 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    const isFree = freeUsed < (categoryFreeLeads || freeTrialCount);
+    const effectiveFreeLeads = categoryFreeLeads ?? freeTrialCount;
+    const isFree = freeUsed < effectiveFreeLeads;
     // Pricing tiers: international = 3x, qualified = 2x, standard = 1x
     const basePriceCents = advisor?.lead_price_cents || categoryPrice;
     const tieredCents = isFree ? 0 : (


### PR DESCRIPTION
## What

The advisor-enquiry route granted **2** free leads (`freeTrialCount = 2`, `categoryFreeLeads` default 2) while the advisor portal Dashboard/Billing tabs and the `billing-summary` route advertise **3**. An advisor told "your first 3 leads are on us" was billed on lead #3 — a surprise charge the dispute UI even blocks them from contesting.

**Founder decision: the canonical free-lead allowance is 3.**

- Source the default from the shared `FREE_LEAD_LIMIT` constant (`lib/advisor-billing`, already = 3 and already consumed by `app/api/advisor-auth/topup/route.ts`) so the server now matches the UI copy. DashboardTab/BillingTab/billing-summary already say 3 — no change needed there; they now agree with the server.
- Fix the falsy-zero bug at the `isFree` decision: `categoryFreeLeads || freeTrialCount` treated an intentionally-configured `0` (free trial disabled via `/admin/pricing`) as falsy and silently re-enabled the default. `categoryFreeLeads` now initialises to `null` and the fallback uses `??` (`effectiveFreeLeads = categoryFreeLeads ?? freeTrialCount`), so a configured `0` is honoured and a `null` "no row" still falls back.

## Tests

Added a `free-lead allowance` describe block to `__tests__/api/advisor-enquiry.test.ts`:
- grants exactly 3 free leads by default (lead #3 / `free_leads_used = 2` is free)
- bills the 4th lead once the allowance is exhausted (`free_leads_used = 3`)
- honours a configured `0` (lead #1 billed — falsy-zero regression guard)
- respects a non-default category override (`free_trial_leads = 5`)

Existing 2-free assumptions updated to the new canonical 3. All 25 tests pass; `eslint --max-warnings 0` clean.

## Finding

Audit finding: "Advisor free-lead allowance mismatch: server grants 2 (and ignores a configured 0), portal UI advertises 3" (`app/api/advisor-enquiry/route.ts`).

**Tier B.** No money-movement primitive or schema migration introduced — this changes the free/paid boundary only; the credit-ledger deduction path is unchanged.