### PR TITLE
refactor(seo): migrate hand-rolled FAQPage to faqJsonLd + answer-first leads on etfs/tax hubs

### DIFF
--- a/app/etfs/bonds/page.tsx
+++ b/app/etfs/bonds/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR, UPDATED_LABEL } from "@/lib/seo";
+import { faqJsonLd } from "@/lib/schema-markup";
 import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
 import SectionHeading from "@/components/SectionHeading";
 
@@ -238,20 +239,18 @@ export default function BondETFsPage() {
     { name: "Bond & Fixed Income ETFs" },
   ]);
 
-  const faqSchema = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: FAQS.map((f) => ({
-      "@type": "Question",
-      name: f.question,
-      acceptedAnswer: { "@type": "Answer", text: f.answer },
-    })),
-  };
+  const faqSchema = faqJsonLd(
+    FAQS.map((f) => ({ q: f.question, a: f.answer })),
+  );
 
   return (
     <div className="bg-white min-h-screen">
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+      {faqSchema && (
+
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+
+      )}
 
       {/* Hero */}
       <section className="relative bg-white border-b border-slate-100 overflow-hidden py-8 md:py-12">

--- a/app/etfs/international/page.tsx
+++ b/app/etfs/international/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR, UPDATED_LABEL } from "@/lib/seo";
+import { faqJsonLd } from "@/lib/schema-markup";
 import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
 import SectionHeading from "@/components/SectionHeading";
 
@@ -236,20 +237,18 @@ export default function InternationalETFsPage() {
     { name: "International ETFs" },
   ]);
 
-  const faqSchema = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: FAQS.map((f) => ({
-      "@type": "Question",
-      name: f.question,
-      acceptedAnswer: { "@type": "Answer", text: f.answer },
-    })),
-  };
+  const faqSchema = faqJsonLd(
+    FAQS.map((f) => ({ q: f.question, a: f.answer })),
+  );
 
   return (
     <div className="bg-white min-h-screen">
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+      {faqSchema && (
+
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+
+      )}
 
       {/* Hero */}
       <section className="relative bg-white border-b border-slate-100 overflow-hidden py-8 md:py-12">

--- a/app/etfs/page.tsx
+++ b/app/etfs/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR, UPDATED_LABEL } from "@/lib/seo";
+import { faqJsonLd, speakableWebPageJsonLd } from "@/lib/schema-markup";
 import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
 import SectionHeading from "@/components/SectionHeading";
 
@@ -184,20 +185,26 @@ export default function ETFHubPage() {
     { name: "ETF Hub" },
   ]);
 
-  const faqSchema = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: ETF_FAQS.map((f) => ({
-      "@type": "Question",
-      name: f.question,
-      acceptedAnswer: { "@type": "Answer", text: f.answer },
-    })),
-  };
+  const faqSchema = faqJsonLd(
+    ETF_FAQS.map((f) => ({ q: f.question, a: f.answer })),
+  );
+
+  // Speakable: mark the H1 + answer-first lead as the extractable answer region
+  // so AI/voice engines surface the direct "what is an ETF" answer (mirrors the
+  // #*-short-answer pattern used on /questions/[slug]).
+  const speakableSchema = speakableWebPageJsonLd({
+    name: "Best ETFs in Australia",
+    path: "/etfs",
+    selectors: ["#etfs-title", "#etfs-short-answer"],
+  });
 
   return (
     <div className="bg-white min-h-screen">
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+      {faqSchema && (
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+      )}
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(speakableSchema) }} />
 
       {/* ── Hero ─────────────────────────────────────────────────────── */}
       <section className="relative bg-white border-b border-slate-100 overflow-hidden py-8 md:py-12">
@@ -212,10 +219,15 @@ export default function ETFHubPage() {
               <span className="w-1.5 h-1.5 bg-slate-400 rounded-full" />
               ETF Hub · {UPDATED_LABEL}
             </div>
-            <h1 className="text-2xl sm:text-3xl md:text-4xl font-extrabold leading-[1.1] mb-3 tracking-tight text-slate-900">
+            <h1 id="etfs-title" className="text-2xl sm:text-3xl md:text-4xl font-extrabold leading-[1.1] mb-3 tracking-tight text-slate-900">
               Best ETFs in Australia{" "}
               <span className="text-amber-600">({CURRENT_YEAR})</span>
             </h1>
+            <p id="etfs-short-answer" className="text-sm md:text-base text-slate-800 font-medium leading-relaxed max-w-2xl mb-3">
+              An ETF (exchange-traded fund) is a single ASX-listed investment that holds a basket of
+              shares or bonds, letting you own hundreds of companies in one low-cost trade — the
+              cheapest Australian ETFs charge just 0.04% per year.
+            </p>
             <p className="text-sm md:text-base text-slate-600 leading-relaxed max-w-2xl">
               Compare Australian ETFs by category, MER, performance, and income yield. Our independent
               analysis covers ASX 200, US market, dividend, international, bond, and sector ETFs —

--- a/app/etfs/sectors/page.tsx
+++ b/app/etfs/sectors/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR, UPDATED_LABEL } from "@/lib/seo";
+import { faqJsonLd } from "@/lib/schema-markup";
 import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
 import SectionHeading from "@/components/SectionHeading";
 
@@ -267,20 +268,18 @@ export default function SectorETFsPage() {
     { name: "Sector ETFs" },
   ]);
 
-  const faqSchema = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: FAQS.map((f) => ({
-      "@type": "Question",
-      name: f.question,
-      acceptedAnswer: { "@type": "Answer", text: f.answer },
-    })),
-  };
+  const faqSchema = faqJsonLd(
+    FAQS.map((f) => ({ q: f.question, a: f.answer })),
+  );
 
   return (
     <div className="bg-white min-h-screen">
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+      {faqSchema && (
+
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+
+      )}
 
       {/* Hero */}
       <section className="relative bg-white border-b border-slate-100 overflow-hidden py-8 md:py-12">

--- a/app/etfs/us-exposure/page.tsx
+++ b/app/etfs/us-exposure/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR, UPDATED_LABEL } from "@/lib/seo";
+import { faqJsonLd } from "@/lib/schema-markup";
 import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
 import SectionHeading from "@/components/SectionHeading";
 
@@ -163,20 +164,18 @@ export default function USExposureETFPage() {
     { name: "US Market ETFs" },
   ]);
 
-  const faqSchema = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: FAQS.map((f) => ({
-      "@type": "Question",
-      name: f.question,
-      acceptedAnswer: { "@type": "Answer", text: f.answer },
-    })),
-  };
+  const faqSchema = faqJsonLd(
+    FAQS.map((f) => ({ q: f.question, a: f.answer })),
+  );
 
   return (
     <div className="bg-white min-h-screen">
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+      {faqSchema && (
+
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+
+      )}
 
       {/* Hero */}
       <section className="relative bg-white border-b border-slate-100 overflow-hidden py-8 md:py-12">

--- a/app/global-investing/etfs/global/page.tsx
+++ b/app/global-investing/etfs/global/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR, UPDATED_LABEL } from "@/lib/seo";
+import { faqJsonLd } from "@/lib/schema-markup";
 import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
 import SectionHeading from "@/components/SectionHeading";
 
@@ -237,20 +238,18 @@ export default function GlobalInvestingGlobalETFsPage() {
     { name: "Global / Developed Markets" },
   ]);
 
-  const faqSchema = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: FAQS.map((f) => ({
-      "@type": "Question",
-      name: f.question,
-      acceptedAnswer: { "@type": "Answer", text: f.answer },
-    })),
-  };
+  const faqSchema = faqJsonLd(
+    FAQS.map((f) => ({ q: f.question, a: f.answer })),
+  );
 
   return (
     <div className="bg-white min-h-screen">
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+      {faqSchema && (
+
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+
+      )}
 
       {/* Hero */}
       <section className="relative bg-white border-b border-slate-100 overflow-hidden py-8 md:py-12">

--- a/app/global-investing/shares/us/page.tsx
+++ b/app/global-investing/shares/us/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR, UPDATED_LABEL } from "@/lib/seo";
+import { faqJsonLd } from "@/lib/schema-markup";
 import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
 import SectionHeading from "@/components/SectionHeading";
 
@@ -306,15 +307,9 @@ export default function BuyUSSharesFromAustraliaPage() {
     { name: "US Shares" },
   ]);
 
-  const faqSchema = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: FAQS.map((f) => ({
-      "@type": "Question",
-      name: f.question,
-      acceptedAnswer: { "@type": "Answer", text: f.answer },
-    })),
-  };
+  const faqSchema = faqJsonLd(
+    FAQS.map((f) => ({ q: f.question, a: f.answer })),
+  );
 
   return (
     <div className="bg-white min-h-screen">
@@ -322,10 +317,12 @@ export default function BuyUSSharesFromAustraliaPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
-      />
+      {faqSchema && (
+              <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+        />
+      )}
 
       {/* ── Hero ───────────────────────────────────────────────────────── */}
       <section className="relative bg-white border-b border-slate-100 overflow-hidden py-8 md:py-12">

--- a/app/invest/managed-funds/page.tsx
+++ b/app/invest/managed-funds/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import Image from "next/image";
 import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL, SITE_NAME, CURRENT_YEAR } from "@/lib/seo";
+import { faqJsonLd } from "@/lib/schema-markup";
 import { createClient } from "@/lib/supabase/server";
 import ContextualLeadMagnet from "@/components/ContextualLeadMagnet";
 import { SHOW_RATINGS, SHOW_EDITORIAL_BADGES, SHOW_ADVISOR_RATINGS, SHOW_ADVISOR_VERIFIED_BADGE, FACTUAL_COMPARISON_DISCLAIMER, ADVISOR_DIRECTORY_HEADING, ADVISOR_DIRECTORY_SUBTEXT } from "@/lib/compliance-config";
@@ -20,6 +21,18 @@ export const metadata: Metadata = {
 };
 
 export const revalidate = 3600;
+
+const MANAGED_FUND_FAQS = [
+  { q: "What is the difference between an index fund and a managed fund?", a: "An index fund passively tracks a market index (like the ASX 200 or S&P 500) with minimal human intervention and very low fees (0.04-0.20% MER). An actively managed fund employs fund managers who pick stocks to try to beat the benchmark, charging higher fees (0.50-1.50% MER plus potential performance fees). Over 80% of active managers underperform their index over 10 years after fees." },
+  { q: "What is the best index fund in Australia?", a: "For Australian share exposure, Betashares A200 (MER 0.04%) and iShares IOZ (MER 0.05%) are the cheapest ASX 200 trackers. For global shares, Vanguard VGS (MER 0.18%) tracks developed world markets. For an all-in-one diversified portfolio, VDHG (Vanguard, growth-tilted) and DHHF (Betashares, 100% equities) are popular single-fund solutions." },
+  { q: "What is the minimum investment for managed funds in Australia?", a: "ETF versions of index funds can be bought for the price of a single unit — as low as $30 for IOZ or $130 for A200. Unlisted managed funds typically have higher minimums: Vanguard managed funds start at $500, while many active funds require $5,000-$25,000. Some platforms like InvestSMART and Stockspot have minimums as low as $200." },
+  { q: "How are managed fund distributions taxed in Australia?", a: "Fund distributions are taxed at your marginal rate for income components, with capital gains eligible for the 50% CGT discount if the fund held the underlying assets for 12+ months. Australian equity funds pass through franking credits which reduce your tax bill. Most large funds operate under the AMIT regime, providing clear AMMA tax statements." },
+  { q: "What is the difference between an ETF and a managed fund?", a: "ETFs trade on the ASX like shares and can be bought or sold throughout the day at market price via any broker. Unlisted managed funds are bought and sold directly with the fund manager at end-of-day NAV price, typically with higher minimums and slower settlement. ETFs generally have lower fees and greater tax efficiency due to their structure." },
+  { q: "Should I choose Vanguard or Betashares?", a: "Both are excellent low-cost providers. Betashares offers the cheapest Australian share ETF (A200, 0.04% MER) while Vanguard has a broader range including unlisted managed funds and diversified options like VDHG. Betashares DHHF is a popular all-in-one alternative to Vanguard VDHG with a slightly different allocation. The fee difference between them is minimal." },
+  { q: "Can SMSFs invest in index funds?", a: "Yes, index funds and ETFs are among the most popular SMSF investments. Dividends and distributions are taxed at 15% in accumulation phase or 0% in pension phase. Franking credits from Australian equity ETFs create net tax refunds for SMSFs. Many SMSF platforms like Stake SMSF and CommSec offer low-cost access to ETFs." },
+  { q: "What is MER and why does it matter?", a: "MER (Management Expense Ratio) is the annual percentage fee charged by a fund, deducted from returns before they reach you. A 1% MER difference compounded over 30 years can reduce your final balance by 25% or more. This is why low-cost index funds (0.04-0.20% MER) consistently outperform most higher-fee active funds over the long term." },
+];
+
 
 export default async function ManagedFundsPage() {
   const supabase = await createClient();
@@ -53,20 +66,7 @@ export default async function ManagedFundsPage() {
     publisher: { "@type": "Organization", name: SITE_NAME, url: SITE_URL },
   };
 
-  const faqSchema = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: [
-      { "@type": "Question", name: "What is the difference between an index fund and a managed fund?", acceptedAnswer: { "@type": "Answer", text: "An index fund passively tracks a market index (like the ASX 200 or S&P 500) with minimal human intervention and very low fees (0.04-0.20% MER). An actively managed fund employs fund managers who pick stocks to try to beat the benchmark, charging higher fees (0.50-1.50% MER plus potential performance fees). Over 80% of active managers underperform their index over 10 years after fees." } },
-      { "@type": "Question", name: "What is the best index fund in Australia?", acceptedAnswer: { "@type": "Answer", text: "For Australian share exposure, Betashares A200 (MER 0.04%) and iShares IOZ (MER 0.05%) are the cheapest ASX 200 trackers. For global shares, Vanguard VGS (MER 0.18%) tracks developed world markets. For an all-in-one diversified portfolio, VDHG (Vanguard, growth-tilted) and DHHF (Betashares, 100% equities) are popular single-fund solutions." } },
-      { "@type": "Question", name: "What is the minimum investment for managed funds in Australia?", acceptedAnswer: { "@type": "Answer", text: "ETF versions of index funds can be bought for the price of a single unit — as low as $30 for IOZ or $130 for A200. Unlisted managed funds typically have higher minimums: Vanguard managed funds start at $500, while many active funds require $5,000-$25,000. Some platforms like InvestSMART and Stockspot have minimums as low as $200." } },
-      { "@type": "Question", name: "How are managed fund distributions taxed in Australia?", acceptedAnswer: { "@type": "Answer", text: "Fund distributions are taxed at your marginal rate for income components, with capital gains eligible for the 50% CGT discount if the fund held the underlying assets for 12+ months. Australian equity funds pass through franking credits which reduce your tax bill. Most large funds operate under the AMIT regime, providing clear AMMA tax statements." } },
-      { "@type": "Question", name: "What is the difference between an ETF and a managed fund?", acceptedAnswer: { "@type": "Answer", text: "ETFs trade on the ASX like shares and can be bought or sold throughout the day at market price via any broker. Unlisted managed funds are bought and sold directly with the fund manager at end-of-day NAV price, typically with higher minimums and slower settlement. ETFs generally have lower fees and greater tax efficiency due to their structure." } },
-      { "@type": "Question", name: "Should I choose Vanguard or Betashares?", acceptedAnswer: { "@type": "Answer", text: "Both are excellent low-cost providers. Betashares offers the cheapest Australian share ETF (A200, 0.04% MER) while Vanguard has a broader range including unlisted managed funds and diversified options like VDHG. Betashares DHHF is a popular all-in-one alternative to Vanguard VDHG with a slightly different allocation. The fee difference between them is minimal." } },
-      { "@type": "Question", name: "Can SMSFs invest in index funds?", acceptedAnswer: { "@type": "Answer", text: "Yes, index funds and ETFs are among the most popular SMSF investments. Dividends and distributions are taxed at 15% in accumulation phase or 0% in pension phase. Franking credits from Australian equity ETFs create net tax refunds for SMSFs. Many SMSF platforms like Stake SMSF and CommSec offer low-cost access to ETFs." } },
-      { "@type": "Question", name: "What is MER and why does it matter?", acceptedAnswer: { "@type": "Answer", text: "MER (Management Expense Ratio) is the annual percentage fee charged by a fund, deducted from returns before they reach you. A 1% MER difference compounded over 30 years can reduce your final balance by 25% or more. This is why low-cost index funds (0.04-0.20% MER) consistently outperform most higher-fee active funds over the long term." } },
-    ],
-  };
+  const faqSchema = faqJsonLd(MANAGED_FUND_FAQS);
 
   return (
     <div>
@@ -78,10 +78,12 @@ export default async function ManagedFundsPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
       />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
-      />
+      {faqSchema && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+        />
+      )}
 
       {/* Hero */}
       <section className="relative bg-white border-b border-slate-100 overflow-hidden py-8 md:py-12">
@@ -445,13 +447,13 @@ export default async function ManagedFundsPage() {
           <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">FAQ</p>
           <h2 className="text-2xl font-extrabold text-slate-900 mb-6">Frequently Asked Questions</h2>
           <div className="space-y-3">
-            {faqSchema.mainEntity.map((faq: { name: string; acceptedAnswer: { text: string } }) => (
-              <details key={faq.name} className="group bg-white border border-slate-200 rounded-xl">
+            {MANAGED_FUND_FAQS.map((faq) => (
+              <details key={faq.q} className="group bg-white border border-slate-200 rounded-xl">
                 <summary className="flex items-center justify-between px-5 py-4 cursor-pointer text-sm font-bold text-slate-900 hover:text-amber-600 transition-colors">
-                  {faq.name}
+                  {faq.q}
                   <svg className="w-4 h-4 text-slate-400 shrink-0 group-open:rotate-180 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" /></svg>
                 </summary>
-                <div className="px-5 pb-4 text-sm text-slate-600 leading-relaxed">{faq.acceptedAnswer.text}</div>
+                <div className="px-5 pb-4 text-sm text-slate-600 leading-relaxed">{faq.a}</div>
               </details>
             ))}
           </div>

--- a/app/invest/options-trading/page.tsx
+++ b/app/invest/options-trading/page.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 import { createClient } from "@/lib/supabase/server";
 import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL, SITE_NAME, CURRENT_YEAR } from "@/lib/seo";
+import { faqJsonLd } from "@/lib/schema-markup";
 import ContextualLeadMagnet from "@/components/ContextualLeadMagnet";
 import { SHOW_RATINGS, SHOW_EDITORIAL_BADGES, SHOW_ADVISOR_RATINGS, SHOW_ADVISOR_VERIFIED_BADGE, FACTUAL_COMPARISON_DISCLAIMER, ADVISOR_DIRECTORY_HEADING, ADVISOR_DIRECTORY_SUBTEXT } from "@/lib/compliance-config";
 
@@ -20,6 +21,18 @@ export const metadata: Metadata = {
 };
 
 export const revalidate = 3600;
+
+const OPTIONS_FAQS = [
+  { q: "How do I trade options in Australia?", a: "You can trade ASX-listed exchange-traded options (ETOs) through brokers like CommSec, Interactive Brokers, or ANZ Share Investing. For US and global options, Interactive Brokers and Saxo Markets offer access. You will need to apply for a derivatives trading account and may need to demonstrate trading experience or pass a knowledge assessment." },
+  { q: "What are ASIC's leverage limits for derivatives?", a: "ASIC capped retail CFD leverage in 2021: 30:1 for major forex pairs, 20:1 for minor forex and gold, 10:1 for other commodities, 5:1 for shares, and 2:1 for crypto. These caps apply to retail clients only — wholesale clients can access higher leverage. ASIC also mandated negative balance protection and banned binary options for retail investors." },
+  { q: "What is the difference between ETOs and CFDs?", a: "Exchange-traded options (ETOs) are standardised contracts listed on the ASX with clearing through ASX Clear, providing counterparty protection. CFDs are over-the-counter derivatives issued by the broker — you are trading against the broker, not on an exchange. ETOs have defined expiry dates and strike prices, while CFDs have no expiry and track the underlying asset price directly." },
+  { q: "Are CFDs legal in Australia?", a: "Yes, CFDs are legal in Australia but heavily regulated by ASIC since 2021. Providers must hold an AFSL, comply with leverage caps, provide negative balance protection, disclose the percentage of retail clients who lose money, and refrain from offering bonuses or inducements. Binary options, however, are banned for retail clients entirely." },
+  { q: "How much do I need to start trading options?", a: "For ASX ETOs, you can start with as little as $500-$1,000 as the cost of an option contract is the premium multiplied by 100 shares. CFD accounts can be opened with $200-$500 at most brokers. Interactive Brokers has no minimum deposit. However, trading with very small amounts limits your ability to manage risk effectively — most experienced traders recommend at least $5,000-$10,000." },
+  { q: "How are CFD profits taxed in Australia?", a: "CFD profits and losses are generally treated as ordinary income (revenue account) rather than capital gains, due to their short-term, leveraged, and speculative nature. This means the 50% CGT discount does not apply. Losses can offset other assessable income if you are classified as a trader. The ATO examines the frequency, volume, and nature of your trading to determine the appropriate treatment." },
+  { q: "What is the best options trading platform in Australia?", a: "Interactive Brokers is widely considered the best for serious options traders due to low fees (US$0.65/contract for US options), access to global exchanges, and professional-grade tools. For ASX ETOs specifically, CommSec is the most popular. CMC Markets and IG Markets are strong for CFDs. Saxo Markets offers multi-asset derivatives with professional tools." },
+  { q: "Why do most retail traders lose money on derivatives?", a: "ASIC data shows 70-80% of retail CFD and forex traders lose money. Key reasons include excessive leverage amplifying small adverse moves, overtrading driven by emotion, lack of risk management discipline, underestimating the impact of spreads and overnight funding costs, and competing against institutional traders with superior information and technology." },
+];
+
 
 export default async function OptionsDerivativesPage() {
   const supabase = await createClient();
@@ -53,20 +66,7 @@ export default async function OptionsDerivativesPage() {
     publisher: { "@type": "Organization", name: SITE_NAME, url: SITE_URL },
   };
 
-  const faqSchema = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: [
-      { "@type": "Question", name: "How do I trade options in Australia?", acceptedAnswer: { "@type": "Answer", text: "You can trade ASX-listed exchange-traded options (ETOs) through brokers like CommSec, Interactive Brokers, or ANZ Share Investing. For US and global options, Interactive Brokers and Saxo Markets offer access. You will need to apply for a derivatives trading account and may need to demonstrate trading experience or pass a knowledge assessment." } },
-      { "@type": "Question", name: "What are ASIC's leverage limits for derivatives?", acceptedAnswer: { "@type": "Answer", text: "ASIC capped retail CFD leverage in 2021: 30:1 for major forex pairs, 20:1 for minor forex and gold, 10:1 for other commodities, 5:1 for shares, and 2:1 for crypto. These caps apply to retail clients only — wholesale clients can access higher leverage. ASIC also mandated negative balance protection and banned binary options for retail investors." } },
-      { "@type": "Question", name: "What is the difference between ETOs and CFDs?", acceptedAnswer: { "@type": "Answer", text: "Exchange-traded options (ETOs) are standardised contracts listed on the ASX with clearing through ASX Clear, providing counterparty protection. CFDs are over-the-counter derivatives issued by the broker — you are trading against the broker, not on an exchange. ETOs have defined expiry dates and strike prices, while CFDs have no expiry and track the underlying asset price directly." } },
-      { "@type": "Question", name: "Are CFDs legal in Australia?", acceptedAnswer: { "@type": "Answer", text: "Yes, CFDs are legal in Australia but heavily regulated by ASIC since 2021. Providers must hold an AFSL, comply with leverage caps, provide negative balance protection, disclose the percentage of retail clients who lose money, and refrain from offering bonuses or inducements. Binary options, however, are banned for retail clients entirely." } },
-      { "@type": "Question", name: "How much do I need to start trading options?", acceptedAnswer: { "@type": "Answer", text: "For ASX ETOs, you can start with as little as $500-$1,000 as the cost of an option contract is the premium multiplied by 100 shares. CFD accounts can be opened with $200-$500 at most brokers. Interactive Brokers has no minimum deposit. However, trading with very small amounts limits your ability to manage risk effectively — most experienced traders recommend at least $5,000-$10,000." } },
-      { "@type": "Question", name: "How are CFD profits taxed in Australia?", acceptedAnswer: { "@type": "Answer", text: "CFD profits and losses are generally treated as ordinary income (revenue account) rather than capital gains, due to their short-term, leveraged, and speculative nature. This means the 50% CGT discount does not apply. Losses can offset other assessable income if you are classified as a trader. The ATO examines the frequency, volume, and nature of your trading to determine the appropriate treatment." } },
-      { "@type": "Question", name: "What is the best options trading platform in Australia?", acceptedAnswer: { "@type": "Answer", text: "Interactive Brokers is widely considered the best for serious options traders due to low fees (US$0.65/contract for US options), access to global exchanges, and professional-grade tools. For ASX ETOs specifically, CommSec is the most popular. CMC Markets and IG Markets are strong for CFDs. Saxo Markets offers multi-asset derivatives with professional tools." } },
-      { "@type": "Question", name: "Why do most retail traders lose money on derivatives?", acceptedAnswer: { "@type": "Answer", text: "ASIC data shows 70-80% of retail CFD and forex traders lose money. Key reasons include excessive leverage amplifying small adverse moves, overtrading driven by emotion, lack of risk management discipline, underestimating the impact of spreads and overnight funding costs, and competing against institutional traders with superior information and technology." } },
-    ],
-  };
+  const faqSchema = faqJsonLd(OPTIONS_FAQS);
 
   return (
     <div>
@@ -78,10 +78,12 @@ export default async function OptionsDerivativesPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
       />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
-      />
+      {faqSchema && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+        />
+      )}
 
       {/* Hero */}
       <section className="relative bg-white border-b border-slate-100 overflow-hidden py-8 md:py-12">
@@ -339,13 +341,13 @@ export default async function OptionsDerivativesPage() {
           <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">FAQ</p>
           <h2 className="text-2xl font-extrabold text-slate-900 mb-6">Frequently Asked Questions</h2>
           <div className="space-y-3">
-            {faqSchema.mainEntity.map((faq: { name: string; acceptedAnswer: { text: string } }) => (
-              <details key={faq.name} className="group bg-white border border-slate-200 rounded-xl">
+            {OPTIONS_FAQS.map((faq) => (
+              <details key={faq.q} className="group bg-white border border-slate-200 rounded-xl">
                 <summary className="flex items-center justify-between px-5 py-4 cursor-pointer text-sm font-bold text-slate-900 hover:text-amber-600 transition-colors">
-                  {faq.name}
+                  {faq.q}
                   <svg className="w-4 h-4 text-slate-400 shrink-0 group-open:rotate-180 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" /></svg>
                 </summary>
-                <div className="px-5 pb-4 text-sm text-slate-600 leading-relaxed">{faq.acceptedAnswer.text}</div>
+                <div className="px-5 pb-4 text-sm text-slate-600 leading-relaxed">{faq.a}</div>
               </details>
             ))}
           </div>

--- a/app/invest/reits/page.tsx
+++ b/app/invest/reits/page.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 import { createClient } from "@/lib/supabase/server";
 import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL, SITE_NAME, CURRENT_YEAR } from "@/lib/seo";
+import { faqJsonLd } from "@/lib/schema-markup";
 import ContextualLeadMagnet from "@/components/ContextualLeadMagnet";
 import { SHOW_RATINGS, SHOW_EDITORIAL_BADGES, SHOW_ADVISOR_RATINGS, SHOW_ADVISOR_VERIFIED_BADGE, FACTUAL_COMPARISON_DISCLAIMER, ADVISOR_DIRECTORY_HEADING, ADVISOR_DIRECTORY_SUBTEXT } from "@/lib/compliance-config";
 
@@ -20,6 +21,17 @@ export const metadata: Metadata = {
 };
 
 export const revalidate = 3600;
+
+const REIT_FAQS = [
+  { q: "What are A-REITs?", a: "Australian Real Estate Investment Trusts (A-REITs) are ASX-listed entities that own, operate, or finance income-producing real estate such as office towers, shopping centres, and industrial warehouses. They must distribute at least 90% of taxable income to unitholders, making them popular income investments with yields typically between 4-6%." },
+  { q: "How do I buy REITs on the ASX?", a: "You can buy A-REITs through any ASX broker (CommSec, Stake, CMC Markets, etc.) just like buying ordinary shares. You can purchase individual REITs like Goodman Group (GMG) or Scentre Group (SCG), or buy a REIT ETF like VAP (Vanguard Australian Property Securities) for diversified exposure with a single trade." },
+  { q: "How are REIT distributions taxed in Australia?", a: "A-REIT distributions typically contain a mix of income, capital gains, and tax-deferred (return of capital) components. The tax-deferred portion reduces your cost base rather than being taxed immediately, with CGT payable when you eventually sell your units. In an SMSF, distributions are taxed at 15% in accumulation or 0% in pension phase." },
+  { q: "What does NTA premium or discount mean for REITs?", a: "NTA (Net Tangible Assets) represents the underlying value of a REIT's property portfolio per unit. When a REIT trades above its NTA, it is at a premium, which may indicate the market values its management quality or growth prospects. Trading below NTA indicates a discount, which may signal a buying opportunity or concerns about the portfolio's future value." },
+  { q: "What is the best REIT ETF in Australia?", a: "VAP (Vanguard Australian Property Securities ETF) is the most popular A-REIT ETF with a low MER of 0.23% and exposure to around 30 A-REITs. MVA (VanEck Australian Property ETF) is another option with a slightly higher MER of 0.35%. For global REIT exposure, DJRE (BetaShares Global Real Estate ETF) covers approximately 100 REITs worldwide." },
+  { q: "How do REITs compare to direct property investment?", a: "REITs offer liquidity (buy/sell instantly on ASX), diversification across multiple properties, professional management, and low minimums (from $500 via ETFs). Direct property offers leverage via mortgage, greater control, and potential tax benefits through negative gearing. REITs avoid the hassles of property management, vacancies, and maintenance but provide no ability to add value through renovation." },
+  { q: "Can SMSFs invest in REITs?", a: "Yes, A-REITs and REIT ETFs are straightforward investments for SMSFs with no special restrictions. They are treated like any other ASX-listed investment. Distributions are taxed at 15% in accumulation phase or 0% in pension phase, making them tax-efficient income generators for SMSF portfolios." },
+  { q: "How do interest rates affect REIT prices?", a: "A-REITs are highly sensitive to interest rate movements. Rising rates increase borrowing costs for REITs and make their distribution yields less attractive relative to bonds and term deposits, typically causing REIT prices to fall. Conversely, falling rates tend to boost REIT valuations. Most A-REITs carry gearing of 25-35%, so refinancing costs directly impact profitability." },
+];
 
 export default async function ReitsPage() {
   const supabase = await createClient();
@@ -53,20 +65,7 @@ export default async function ReitsPage() {
     publisher: { "@type": "Organization", name: SITE_NAME, url: SITE_URL },
   };
 
-  const faqSchema = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: [
-      { "@type": "Question", name: "What are A-REITs?", acceptedAnswer: { "@type": "Answer", text: "Australian Real Estate Investment Trusts (A-REITs) are ASX-listed entities that own, operate, or finance income-producing real estate such as office towers, shopping centres, and industrial warehouses. They must distribute at least 90% of taxable income to unitholders, making them popular income investments with yields typically between 4-6%." } },
-      { "@type": "Question", name: "How do I buy REITs on the ASX?", acceptedAnswer: { "@type": "Answer", text: "You can buy A-REITs through any ASX broker (CommSec, Stake, CMC Markets, etc.) just like buying ordinary shares. You can purchase individual REITs like Goodman Group (GMG) or Scentre Group (SCG), or buy a REIT ETF like VAP (Vanguard Australian Property Securities) for diversified exposure with a single trade." } },
-      { "@type": "Question", name: "How are REIT distributions taxed in Australia?", acceptedAnswer: { "@type": "Answer", text: "A-REIT distributions typically contain a mix of income, capital gains, and tax-deferred (return of capital) components. The tax-deferred portion reduces your cost base rather than being taxed immediately, with CGT payable when you eventually sell your units. In an SMSF, distributions are taxed at 15% in accumulation or 0% in pension phase." } },
-      { "@type": "Question", name: "What does NTA premium or discount mean for REITs?", acceptedAnswer: { "@type": "Answer", text: "NTA (Net Tangible Assets) represents the underlying value of a REIT's property portfolio per unit. When a REIT trades above its NTA, it is at a premium, which may indicate the market values its management quality or growth prospects. Trading below NTA indicates a discount, which may signal a buying opportunity or concerns about the portfolio's future value." } },
-      { "@type": "Question", name: "What is the best REIT ETF in Australia?", acceptedAnswer: { "@type": "Answer", text: "VAP (Vanguard Australian Property Securities ETF) is the most popular A-REIT ETF with a low MER of 0.23% and exposure to around 30 A-REITs. MVA (VanEck Australian Property ETF) is another option with a slightly higher MER of 0.35%. For global REIT exposure, DJRE (BetaShares Global Real Estate ETF) covers approximately 100 REITs worldwide." } },
-      { "@type": "Question", name: "How do REITs compare to direct property investment?", acceptedAnswer: { "@type": "Answer", text: "REITs offer liquidity (buy/sell instantly on ASX), diversification across multiple properties, professional management, and low minimums (from $500 via ETFs). Direct property offers leverage via mortgage, greater control, and potential tax benefits through negative gearing. REITs avoid the hassles of property management, vacancies, and maintenance but provide no ability to add value through renovation." } },
-      { "@type": "Question", name: "Can SMSFs invest in REITs?", acceptedAnswer: { "@type": "Answer", text: "Yes, A-REITs and REIT ETFs are straightforward investments for SMSFs with no special restrictions. They are treated like any other ASX-listed investment. Distributions are taxed at 15% in accumulation phase or 0% in pension phase, making them tax-efficient income generators for SMSF portfolios." } },
-      { "@type": "Question", name: "How do interest rates affect REIT prices?", acceptedAnswer: { "@type": "Answer", text: "A-REITs are highly sensitive to interest rate movements. Rising rates increase borrowing costs for REITs and make their distribution yields less attractive relative to bonds and term deposits, typically causing REIT prices to fall. Conversely, falling rates tend to boost REIT valuations. Most A-REITs carry gearing of 25-35%, so refinancing costs directly impact profitability." } },
-    ],
-  };
+  const faqSchema = faqJsonLd(REIT_FAQS);
 
   return (
     <div>
@@ -78,10 +77,12 @@ export default async function ReitsPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(webPage) }}
       />
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
-      />
+      {faqSchema && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+        />
+      )}
 
       {/* Hero */}
       <section className="relative bg-white border-b border-slate-100 overflow-hidden py-8 md:py-12">
@@ -490,13 +491,13 @@ export default async function ReitsPage() {
           <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">FAQ</p>
           <h2 className="text-2xl font-extrabold text-slate-900 mb-6">Frequently Asked Questions</h2>
           <div className="space-y-3">
-            {faqSchema.mainEntity.map((faq: { name: string; acceptedAnswer: { text: string } }) => (
-              <details key={faq.name} className="group bg-white border border-slate-200 rounded-xl">
+            {REIT_FAQS.map((faq) => (
+              <details key={faq.q} className="group bg-white border border-slate-200 rounded-xl">
                 <summary className="flex items-center justify-between px-5 py-4 cursor-pointer text-sm font-bold text-slate-900 hover:text-amber-600 transition-colors">
-                  {faq.name}
+                  {faq.q}
                   <svg className="w-4 h-4 text-slate-400 shrink-0 group-open:rotate-180 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" /></svg>
                 </summary>
-                <div className="px-5 pb-4 text-sm text-slate-600 leading-relaxed">{faq.acceptedAnswer.text}</div>
+                <div className="px-5 pb-4 text-sm text-slate-600 leading-relaxed">{faq.a}</div>
               </details>
             ))}
           </div>

--- a/app/super/smsf/page.tsx
+++ b/app/super/smsf/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
+import { faqJsonLd } from "@/lib/schema-markup";
 import { SUPER_WARNING_SHORT, GENERAL_ADVICE_WARNING } from "@/lib/compliance";
 import SectionHeading from "@/components/SectionHeading";
 
@@ -93,20 +94,18 @@ export default function SMSFPage() {
     { name: "SMSF" },
   ]);
 
-  const faqSchema = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: SMSF_FAQS.map((f) => ({
-      "@type": "Question",
-      name: f.question,
-      acceptedAnswer: { "@type": "Answer", text: f.answer },
-    })),
-  };
+  const faqSchema = faqJsonLd(
+    SMSF_FAQS.map((f) => ({ q: f.question, a: f.answer })),
+  );
 
   return (
     <div className="bg-white min-h-screen">
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+      {faqSchema && (
+
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+
+      )}
 
       {/* ── Hero ─────────────────────────────────────────────────────── */}
       <section className="relative bg-white border-b border-slate-100 overflow-hidden py-8 md:py-12">

--- a/app/tax/page.tsx
+++ b/app/tax/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR, UPDATED_LABEL } from "@/lib/seo";
+import { faqJsonLd, speakableWebPageJsonLd } from "@/lib/schema-markup";
 import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
 import SectionHeading from "@/components/SectionHeading";
 
@@ -222,20 +223,28 @@ export default function TaxHubPage() {
     { name: "Tax Strategy Hub" },
   ]);
 
-  const faqSchema = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: FAQS.map((f) => ({
-      "@type": "Question",
-      name: f.question,
-      acceptedAnswer: { "@type": "Answer", text: f.answer },
-    })),
-  };
+  const faqSchema = faqJsonLd(
+    FAQS.map((f) => ({ q: f.question, a: f.answer })),
+  );
+
+  // Speakable: mark the H1 + answer-first lead as the extractable answer region
+  // so AI/voice engines surface the direct "how are investments taxed in
+  // Australia" answer (mirrors the #*-short-answer pattern on /questions/[slug]).
+  const speakableSchema = speakableWebPageJsonLd({
+    name: "Australian Investor Tax Guide",
+    path: "/tax",
+    selectors: ["#tax-title", "#tax-short-answer"],
+  });
 
   return (
     <div className="bg-white min-h-screen">
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+      {faqSchema && (
+
+        <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }} />
+
+      )}
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(speakableSchema) }} />
 
       {/* Hero */}
       <section className="relative bg-white border-b border-slate-100 overflow-hidden py-8 md:py-12">
@@ -250,10 +259,16 @@ export default function TaxHubPage() {
               <span className="w-1.5 h-1.5 bg-slate-400 rounded-full" />
               Tax Hub · {UPDATED_LABEL}
             </div>
-            <h1 className="text-2xl sm:text-3xl md:text-4xl font-extrabold leading-[1.1] mb-3 tracking-tight text-slate-900">
+            <h1 id="tax-title" className="text-2xl sm:text-3xl md:text-4xl font-extrabold leading-[1.1] mb-3 tracking-tight text-slate-900">
               Australian Investor{" "}
               <span className="text-amber-600">Tax Guide ({CURRENT_YEAR})</span>
             </h1>
+            <p id="tax-short-answer" className="text-sm md:text-base text-slate-800 font-medium leading-relaxed max-w-2xl mb-3">
+              In Australia, investment income (dividends, interest, rent) is added to your assessable
+              income and taxed at your marginal rate, while capital gains on assets held 12+ months
+              receive a 50% discount before tax — and franking credits offset tax already paid on
+              Australian dividends.
+            </p>
             <p className="text-sm md:text-base text-slate-600 leading-relaxed max-w-2xl">
               Everything Australian investors need to know about tax — capital gains, franking credits,
               negative gearing, crypto, super strategies, and year-end tax planning. Independent guides


### PR DESCRIPTION
## Items (Tier B)

**GEO-06** — Migrate hand-rolled inline FAQPage JSON-LD to the single-source faqJsonLd helper (lib/schema-markup.ts). Replaced inline { '@type':'FAQPage', mainEntity:[...] } objects on 12 hub pages with faqJsonLd(items.map(...)). The helper carries the shared empty-list guard (returns null) and clean output, so each render site now guards on the nullable return. Literal-array pages (reits, managed-funds, options-trading) had their Q&A extracted into named {q,a} arrays so the visible <details> list and the JSON-LD share one source. Field mapping verified against FaqItem ({q,a}).

**GEO-07** — Answer-first leads on /etfs and /tax pillar hubs. Prepended a one-sentence direct answer to each hub's core query, tagged #etfs-short-answer / #tax-short-answer and surfaced via speakableWebPageJsonLd (mirrors the #question-short-answer pattern on /questions/[slug]). Tax figures kept factual; disclaimer copy unchanged (lib/compliance.ts).

Verify: tsc --noEmit clean, eslint --fix --max-warnings 0 clean, 0 hand-rolled FAQPage objects remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)