### PR TITLE
fix(compliance): gate advisor booking payments behind a default-off kill-switch (pre-AFSL/RG-246)

### DIFF
--- a/__tests__/lib/stripe-connect/stripe-connect.test.ts
+++ b/__tests__/lib/stripe-connect/stripe-connect.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-const { mockFrom, mockPaymentIntentsCreate, mockAccountsCreate, mockAccountLinksCreate, mockAccountsRetrieve } = vi.hoisted(() => ({
+const { mockFrom, mockPaymentIntentsCreate, mockAccountsCreate, mockAccountLinksCreate, mockAccountsRetrieve, mockCheckoutSessionsCreate } = vi.hoisted(() => ({
   mockFrom: vi.fn(),
   mockPaymentIntentsCreate: vi.fn(),
   mockAccountsCreate: vi.fn(),
   mockAccountLinksCreate: vi.fn(),
   mockAccountsRetrieve: vi.fn(),
+  mockCheckoutSessionsCreate: vi.fn(),
 }));
 
 vi.mock("@/lib/supabase/admin", () => ({
@@ -17,13 +18,16 @@ vi.mock("@/lib/stripe", () => ({
     paymentIntents: { create: mockPaymentIntentsCreate },
     accounts: { create: mockAccountsCreate, retrieve: mockAccountsRetrieve },
     accountLinks: { create: mockAccountLinksCreate },
+    checkout: { sessions: { create: mockCheckoutSessionsCreate } },
   })),
 }));
 
 import {
   createPaymentForBrief,
+  createBookingCheckout,
   createConnectOnboardingLink,
   getMarketplaceTakeRateBps,
+  getSessionTakeRateBps,
   refreshConnectAccountStatus,
   handleConnectWebhook,
 } from "@/lib/stripe-connect";
@@ -165,6 +169,110 @@ describe("createPaymentForBrief", () => {
     expect(callArgs.transfer_data?.destination).toBe("acct_test");
     expect(callArgs.metadata?.kind).toBe("marketplace_payment");
     expect(callArgs.metadata?.brief_id).toBe("5");
+  });
+});
+
+describe("getSessionTakeRateBps", () => {
+  beforeEach(() => {
+    delete process.env.SESSION_BOOKING_TAKE_RATE_BPS;
+  });
+
+  it("defaults to 15% (1500 bps)", () => {
+    expect(getSessionTakeRateBps()).toBe(1500);
+  });
+
+  it("honours SESSION_BOOKING_TAKE_RATE_BPS env override", () => {
+    process.env.SESSION_BOOKING_TAKE_RATE_BPS = "1000";
+    expect(getSessionTakeRateBps()).toBe(1000);
+  });
+
+  it("clamps out-of-range values to default", () => {
+    process.env.SESSION_BOOKING_TAKE_RATE_BPS = "9999"; // > 3000 cap
+    expect(getSessionTakeRateBps()).toBe(1500);
+  });
+});
+
+describe("createBookingCheckout (pre-AFSL/RG-246 kill-switch)", () => {
+  // Advisor session-booking payments intermediate consumer→adviser money +
+  // take a 15% clip (DD-03) — RG 246 / client-money territory that must stay
+  // OFF until the AFSL lands. The rail must NOT create a checkout session
+  // unless BOOKING_PAYMENTS_ENABLED === "true". Defaults OFF.
+  beforeEach(() => {
+    delete process.env.SESSION_BOOKING_TAKE_RATE_BPS; // keep the 15% default deterministic
+  });
+
+  const baseInput = {
+    slotId: 42,
+    professionalId: 7,
+    advisorSlug: "jane-adviser",
+    advisorName: "Jane Adviser",
+    consumerEmail: "c@example.com",
+    amountCents: 30000, // $300
+    successUrl: "https://invest.com.au/booking/success",
+    cancelUrl: "https://invest.com.au/advisor/jane-adviser#book",
+  };
+
+  const connectedPro = () =>
+    mockFrom.mockImplementation(() => ({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          maybeSingle: vi.fn().mockResolvedValue({
+            data: {
+              stripe_connect_account_id: "acct_test",
+              stripe_connect_status: "active",
+              stripe_connect_payouts_enabled: true,
+              stripe_connect_charges_enabled: true,
+            },
+            error: null,
+          }),
+        }),
+      }),
+    }));
+
+  it("returns 'disabled' by default (flag unset) and never calls Stripe", async () => {
+    vi.stubEnv("BOOKING_PAYMENTS_ENABLED", "");
+    connectedPro();
+    const result = await createBookingCheckout(baseInput);
+    expect(result.unavailable).toBe("disabled");
+    expect(result.checkoutUrl).toBeNull();
+    expect(mockCheckoutSessionsCreate).not.toHaveBeenCalled();
+  });
+
+  it.each(["false", "1", "TRUE", "True", "yes", "on", " true "])(
+    "stays gated when BOOKING_PAYMENTS_ENABLED is %j (not exactly 'true')",
+    async (value) => {
+      vi.stubEnv("BOOKING_PAYMENTS_ENABLED", value);
+      connectedPro();
+      const result = await createBookingCheckout(baseInput);
+      expect(result.unavailable).toBe("disabled");
+      expect(result.checkoutUrl).toBeNull();
+      expect(mockCheckoutSessionsCreate).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not call Stripe even when STRIPE_SECRET_KEY is set, while the flag is off", async () => {
+    vi.stubEnv("BOOKING_PAYMENTS_ENABLED", "");
+    vi.stubEnv("STRIPE_SECRET_KEY", "sk_test_dummy");
+    connectedPro();
+    const result = await createBookingCheckout(baseInput);
+    expect(result.unavailable).toBe("disabled");
+    expect(mockCheckoutSessionsCreate).not.toHaveBeenCalled();
+    expect(mockFrom).not.toHaveBeenCalled(); // gate short-circuits before any DB/Stripe work
+  });
+
+  it("creates a checkout session with the 15% clip once the flag is explicitly 'true'", async () => {
+    vi.stubEnv("BOOKING_PAYMENTS_ENABLED", "true");
+    connectedPro();
+    mockCheckoutSessionsCreate.mockResolvedValue({
+      url: "https://checkout.stripe.com/c/pay/cs_test",
+    });
+    const result = await createBookingCheckout(baseInput);
+    expect(result.checkoutUrl).toBe("https://checkout.stripe.com/c/pay/cs_test");
+    const arg = mockCheckoutSessionsCreate.mock.calls[0]?.[0];
+    expect(arg.mode).toBe("payment");
+    expect(arg.payment_intent_data?.application_fee_amount).toBe(4500); // 15% of 30000
+    expect(arg.payment_intent_data?.transfer_data?.destination).toBe("acct_test");
+    expect(arg.metadata?.type).toBe("session_booking");
   });
 });
 

--- a/lib/stripe-connect/index.ts
+++ b/lib/stripe-connect/index.ts
@@ -408,13 +408,40 @@ export interface CreateBookingCheckoutInput {
 
 export interface CreateBookingCheckoutResult {
   checkoutUrl: string | null;
-  unavailable?: "no_secret" | "pro_not_connected" | "stripe_error";
+  unavailable?: "no_secret" | "pro_not_connected" | "stripe_error" | "disabled";
   detail?: string;
+}
+
+/**
+ * Advisor session bookings intermediate consumer→adviser money and take a
+ * platform clip (DD-03, 15%) — engaging RG 246 (conflicted remuneration) and
+ * client-money handling under an AFSL we do not yet hold. This booking-payment
+ * rail stays OFF until the licence lands and the RG 246 / s981A questions in
+ * `AFSL-LAWYER-BRIEF.md` are cleared: it MUST NOT create a checkout session
+ * unless `BOOKING_PAYMENTS_ENABLED` is explicitly set to "true". Defaults OFF —
+ * a missing/empty/any-other value keeps it gated. Flipping this flag on is
+ * founder + legal-gated (see `docs/strategy/REGULATORY-AVOID-LIST.md`, DD-03);
+ * do not enable pre-AFSL.
+ */
+export function areBookingPaymentsEnabled(): boolean {
+  return process.env.BOOKING_PAYMENTS_ENABLED === "true";
 }
 
 export async function createBookingCheckout(
   input: CreateBookingCheckoutInput,
 ): Promise<CreateBookingCheckoutResult> {
+  if (!areBookingPaymentsEnabled()) {
+    log.warn(
+      "createBookingCheckout blocked: booking payments disabled (pre-AFSL/RG-246)",
+      { slot_id: input.slotId },
+    );
+    return {
+      checkoutUrl: null,
+      unavailable: "disabled",
+      detail: "Booking payments are not currently available.",
+    };
+  }
+
   if (!process.env.STRIPE_SECRET_KEY) {
     return { checkoutUrl: null, unavailable: "no_secret" };
   }


### PR DESCRIPTION
## Compliance kill-switch — do NOT merge

This is a **pre-launch compliance kill-switch**, not a feature. It closes a gap where the advisor session-booking payment rail could take **real consumer payments with no off-switch**.

### The gap
`createBookingCheckout()` in `lib/stripe-connect/index.ts` had **no pre-launch feature flag**. Unlike its sibling `createPaymentForBrief()` — hard-gated behind `BRIEF_PAYMENTS_ENABLED` — a Stripe-Connect-enabled pro plus `STRIPE_SECRET_KEY` was enough to create a live Checkout session and take a consumer payment for a session booking. That intermediates consumer→adviser money and takes a 15% platform clip (DD-03), which engages **RG 246 (conflicted remuneration)** and **client-money handling (s981A)** under an AFSL we do not yet hold. Per `docs/strategy/REGULATORY-AVOID-LIST.md`, this must stay **OFF** until the licence lands.

### The fix
- New `areBookingPaymentsEnabled()` helper: returns `true` only when `process.env.BOOKING_PAYMENTS_ENABLED === "true"`. Unset / empty / any other value (`"false"`, `"1"`, `"TRUE"`, …) = **OFF**.
- Checked at the **very top** of `createBookingCheckout()`, before any Connect lookup or `checkout.sessions.create` call — mirrors the `createPaymentForBrief` gate shape exactly. Returns `{ unavailable: "disabled" }` when gated.
- The consumer-facing route (`app/api/booking/[slotId]/checkout/route.ts`) already degrades any non-`pro_not_connected` unavailable result to a 503, so the endpoint is closed transitively — no route change needed.

`createBookingCheckout` was the **only** un-gated consumer-charge entry point in `lib/stripe-connect/*`. The onboarding-link and account-status helpers create no consumer charge and are intentionally left ungated.

### Tests
Extends `__tests__/lib/stripe-connect/stripe-connect.test.ts`:
- returns `"disabled"` and never calls Stripe when the flag is unset;
- stays gated across a table of non-`"true"` values (`false`, `1`, `TRUE`, `True`, `yes`, `on`, `" true "`);
- short-circuits before any DB/Stripe work even when `STRIPE_SECRET_KEY` is set;
- (flag-on) still routes the 15% clip + transfer destination correctly.

`npm run type-check` clean; full stripe-connect suite (27 tests) green; pre-push checks passed.

### Merge gating — read before enabling
Setting `BOOKING_PAYMENTS_ENABLED=true` is **founder + legal-gated** and must not happen until the **AFSL is granted and RG 246 / s981A sign-off is recorded** (see `docs/strategy/REGULATORY-AVOID-LIST.md`, DD-03 row, and `AFSL-LAWYER-BRIEF.md`). Booking payments stay OFF until then. **Do not merge / do not flip the flag** without that explicit sign-off.

https://claude.ai/code/session_01AX16WTaqAs2W33uydbBWLa

---
_Generated by [Claude Code](https://claude.ai/code/session_01AX16WTaqAs2W33uydbBWLa)_