### PR TITLE
fix(advisor-tiers): clamp proration daysRemaining to [0, cycleDays]

### DIFF
--- a/__tests__/lib/advisor-tiers.test.ts
+++ b/__tests__/lib/advisor-tiers.test.ts
@@ -119,6 +119,77 @@ describe("prorateUpgradeCents", () => {
     // Annual is roughly 10× monthly (12 months at ~20% discount)
     expect(annual).toBeGreaterThan(monthly);
   });
+
+  // ── clamp: daysRemaining must be bounded to [0, cycleDays] ───────────────────
+  // Regression guard for the unclamped-proration finding: an over-cycle
+  // daysRemaining (e.g. annual sub's ~365 days against a 30-day cycle) must NOT
+  // inflate the multiplier beyond 1.0, and a negative daysRemaining must NOT
+  // flip the sign.
+
+  describe("clamp — daysRemaining bounded to [0, cycleDays]", () => {
+    it("daysRemaining > cycleDays is clamped to cycleDays (multiplier capped at 1.0)", () => {
+      // free→growth monthly: full-cycle credit is the full price difference (4900).
+      const fullCycle = prorateUpgradeCents("free", "growth", 30, 30);
+      const overCycle = prorateUpgradeCents("free", "growth", 60, 30);
+      expect(overCycle).toBe(fullCycle);
+      expect(overCycle).toBe(4900); // not 9800 (the pre-fix doubled value)
+    });
+
+    it("annual downgrade with ~365 days against a 30-day cycle is capped at one cycle's credit", () => {
+      // The exact scenario from the finding: elite→pro deferred downgrade, annual,
+      // daysRemaining≈365, cycleDays=30. Pre-fix this returned ≈ -4,087,000
+      // (~$40,870 credit). Clamped, it equals the full-cycle (30/30) credit.
+      const clamped = prorateUpgradeCents("elite", "pro", 365, 30, "annual");
+      const fullCycle = prorateUpgradeCents("elite", "pro", 30, 30, "annual");
+      expect(clamped).toBe(fullCycle);
+      // Full annual cycle credit = pro annual (143000) - elite annual (479000) = -336000.
+      expect(clamped).toBe(143000 - 479000);
+      // Credit owed must never exceed the highest annual plan price the advisor
+      // could have paid (elite annual = 479000).
+      expect(Math.abs(clamped)).toBeLessThanOrEqual(479000);
+    });
+
+    it("downgrade credit ratio can never exceed 1.0 of the full price difference", () => {
+      const fullDiff = prorateUpgradeCents("elite", "free", 30, 30); // most negative possible
+      const overCycle = prorateUpgradeCents("elite", "free", 999, 30);
+      expect(overCycle).toBe(fullDiff);
+      expect(overCycle).toBeGreaterThanOrEqual(fullDiff); // not more negative than a full cycle
+    });
+
+    it("negative daysRemaining is clamped to 0 (returns 0, never sign-flipped)", () => {
+      expect(prorateUpgradeCents("free", "growth", -5, 30)).toBe(0);
+      // A downgrade with negative days must not become a positive charge.
+      expect(prorateUpgradeCents("elite", "free", -100, 30)).toBe(0);
+    });
+
+    it("daysRemaining exactly equal to cycleDays is unaffected (boundary)", () => {
+      expect(prorateUpgradeCents("free", "growth", 30, 30)).toBe(4900);
+    });
+
+    it("over-cycle never over-credits for any downgrade pair (annual + monthly)", () => {
+      const pairs: [AdvisorTier, AdvisorTier][] = [
+        ["elite", "pro"],
+        ["elite", "growth"],
+        ["elite", "free"],
+        ["pro", "growth"],
+        ["growth", "free"],
+      ];
+      for (const billing of ["monthly", "annual"] as const) {
+        for (const [from, to] of pairs) {
+          const fullCycle = prorateUpgradeCents(from, to, 30, 30, billing);
+          const overCycle = prorateUpgradeCents(from, to, 400, 30, billing);
+          // Clamped over-cycle equals the full-cycle figure exactly.
+          expect(overCycle).toBe(fullCycle);
+          // And the credit magnitude never exceeds the from-tier's full price.
+          const fromPrice =
+            billing === "annual"
+              ? getTier(from)!.annualPriceCents
+              : getTier(from)!.monthlyPriceCents;
+          expect(Math.abs(overCycle)).toBeLessThanOrEqual(fromPrice);
+        }
+      }
+    });
+  });
 });
 
 // ── isUpgrade ─────────────────────────────────────────────────────────────────

--- a/lib/advisor-tiers.ts
+++ b/lib/advisor-tiers.ts
@@ -100,6 +100,14 @@ export function getTier(id: string): TierSpec | null {
  * to plan B with N days remaining in the current billing cycle,
  * returns the cents owed today. Negative means we owe the user
  * a credit (downgrade).
+ *
+ * `daysRemaining` is clamped to `[0, cycleDays]` so the proration
+ * multiplier can never exceed 1.0 (which would inflate a downgrade
+ * credit beyond a full plan price) nor go negative (which would
+ * flip the sign). This matters most for annual subscriptions, where
+ * a caller may pass ~365 days-remaining against a 30-day cycle — an
+ * unclamped ratio of ~12x produced credits many multiples of what
+ * the advisor ever paid. See finding "Proration amount not clamped".
  */
 export function prorateUpgradeCents(
   fromTier: AdvisorTier,
@@ -113,12 +121,15 @@ export function prorateUpgradeCents(
   const to = getTier(toTier);
   if (!from || !to) return 0;
 
+  // Bound the multiplier to [0, 1] regardless of caller input.
+  const days = Math.min(Math.max(daysRemaining, 0), cycleDays);
+
   const priceKey = billing === "annual" ? "annualPriceCents" : "monthlyPriceCents";
   const fromPrice = from[priceKey];
   const toPrice = to[priceKey];
 
-  const unusedFromCredit = Math.round((fromPrice * daysRemaining) / cycleDays);
-  const proratedToCharge = Math.round((toPrice * daysRemaining) / cycleDays);
+  const unusedFromCredit = Math.round((fromPrice * days) / cycleDays);
+  const proratedToCharge = Math.round((toPrice * days) / cycleDays);
   return proratedToCharge - unusedFromCredit;
 }
 


### PR DESCRIPTION
⚠️ **HELD — client-money / balance-affecting sensitive.** Requires **FOUNDER + LEGAL sign-off** before merge. Do NOT merge autonomously.

### Finding ref
Bug-hunt wave-3: "Proration amount not clamped: daysRemaining/cycleDays ratio can exceed 1.0, inflating downgrade credit (real money owed) — esp. annual subscriptions" (P1, Tier C, `lib/advisor-tiers.ts`).

### Defect (confirmed on current main)
`prorateUpgradeCents` guarded only `cycleDays <= 0` and never bounded `daysRemaining`. The proration is `round(price * daysRemaining / cycleDays)`, so when `daysRemaining > cycleDays` the multiplier exceeds 1.0 (credit beyond a full plan price) and when `daysRemaining < 0` the sign flips.

The sole production caller — the self-service tier-**downgrade** branch of `app/api/advisor-auth/tier-upgrade/route.ts` — hardcodes `cycleDays = 30` but derives `daysRemaining` from the Stripe subscription's `current_period_end`. For an ANNUAL subscription that is ~365 days out, giving a ~12.2x multiplier. Worked example (elite→pro deferred downgrade, annual): credit ≈ **$40,870** vs the ≤ **$4,790** the advisor ever paid. The credit is written as a `tier_proration_credit` ledger row with `expiresAt: null` — a never-expiring, real-money credit.

### Fix (this PR — exactly the recommendedFix's clamp)
Clamp `daysRemaining` to `[0, cycleDays]` inside the pure function:
```ts
const days = Math.min(Math.max(daysRemaining, 0), cycleDays);
```
used in both `Math.round` expressions. This bounds the multiplier to `[0, 1]` regardless of caller, capping any single downgrade credit at one full cycle and preventing the negative-days sign flip. Pure, no DB/migration change.

### NOT included (needs founder/billing decision)
The finding's complementary caller fix — passing the **true** annual cycle length (365), so a full annual cycle credits one annual price rather than merely being capped at one cycle — is a billing-policy decision (cap-at-one-cycle vs true period-length proration) and touches the route + clawback flow. Left for founder review.

### Test coverage (added, all green — 36 tests pass)
- over-cycle `daysRemaining > cycleDays` clamps to the full-cycle figure (e.g. free→growth 60d/30d == 30d/30d == 4900, not 9800)
- exact elite→pro annual ~365d scenario: equals full annual cycle credit (−336000), magnitude ≤ elite annual price
- over-credit guard across all downgrade pairs (monthly + annual): clamped over-cycle equals full-cycle and magnitude ≤ from-tier price
- negative `daysRemaining` clamps to 0 (no sign flip, no positive charge on a downgrade)
- boundary: `daysRemaining == cycleDays` unaffected

Verify: `npx vitest run __tests__/lib/advisor-tiers.test.ts` (36 passed); `npx eslint lib/advisor-tiers.ts __tests__/lib/advisor-tiers.test.ts` clean; `tsc --noEmit` no errors.
