### PR TITLE
fix(marketplace-webhook): event idempotency + fail-closed signing secret

### DIFF
--- a/__tests__/api/marketplace-webhook.test.ts
+++ b/__tests__/api/marketplace-webhook.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { NextRequest } from "next/server";
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────
@@ -28,10 +28,7 @@ import { POST } from "@/app/api/marketplace/webhook/route";
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
-function makePost(
-  body: string,
-  signature = "test-sig"
-): NextRequest {
+function makePost(body: string, signature = "test-sig"): NextRequest {
   return new NextRequest("http://localhost/api/marketplace/webhook", {
     method: "POST",
     headers: {
@@ -42,21 +39,56 @@ function makePost(
   });
 }
 
-function makeDbChain(result: unknown = { data: null, error: null }) {
+/**
+ * A thenable Supabase query-builder stub. Every builder method returns the
+ * same chain; awaiting the chain (or calling `.maybeSingle()`) resolves to
+ * `result`. `insertResult` lets a caller distinguish the terminal result of
+ * an `.insert(...)` (used for the idempotency claim) from a `.maybeSingle()`
+ * read (used to inspect the existing idempotency row).
+ */
+function makeDbChain(
+  result: unknown = { data: null, error: null },
+  insertResult: { error: unknown } = { error: null }
+) {
   const c: Record<string, unknown> = {};
-  for (const m of ["select", "eq", "update", "insert", "limit"]) {
+  let lastWasInsert = false;
+  for (const m of ["select", "eq", "update", "limit"]) {
     c[m] = vi.fn(() => c);
   }
+  c.insert = vi.fn(() => {
+    lastWasInsert = true;
+    return c;
+  });
   c.maybeSingle = vi.fn(() => Promise.resolve(result));
-  c.then = (cb: (v: unknown) => void) => {
-    cb({ error: null });
-    return Promise.resolve({ error: null });
+  // Awaiting the chain itself resolves to insertResult after an insert,
+  // otherwise to `{ error: null }` (update / fire-and-forget paths).
+  c.then = (cb: (v: unknown) => unknown) => {
+    const v = lastWasInsert ? insertResult : { error: null };
+    lastWasInsert = false;
+    return Promise.resolve(cb(v));
   };
   return c;
 }
 
-function makeWalletTopupEvent(overrides: Record<string, unknown> = {}) {
+/**
+ * Default table router: idempotency claim succeeds (no error), everything
+ * else returns the broker-enrichment row. Individual tests override per table.
+ */
+function defaultFromRouter() {
+  return (table: string) => {
+    if (table === "stripe_webhook_events") {
+      return makeDbChain({ data: null, error: null }, { error: null });
+    }
+    return makeDbChain(
+      { data: { company_name: "CommSec", email: "admin@commsec.com.au" }, error: null },
+      { error: null }
+    );
+  };
+}
+
+function makeWalletTopupEvent(overrides: Record<string, unknown> = {}, id = "evt_wallet_1") {
   return {
+    id,
     type: "checkout.session.completed",
     data: {
       object: {
@@ -74,8 +106,9 @@ function makeWalletTopupEvent(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function makeAutoTopupEvent(overrides: Record<string, unknown> = {}) {
+function makeAutoTopupEvent(overrides: Record<string, unknown> = {}, id = "evt_auto_1") {
   return {
+    id,
     type: "payment_intent.succeeded",
     data: {
       object: {
@@ -97,8 +130,16 @@ function makeAutoTopupEvent(overrides: Record<string, unknown> = {}) {
 describe("POST /api/marketplace/webhook", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // The marketplace endpoint fails closed without its own secret. Stub it
+    // explicitly — CI's env block sets only STRIPE_WEBHOOK_SECRET, NOT the
+    // marketplace one, so without this the happy-path tests would 500.
+    vi.stubEnv("STRIPE_MARKETPLACE_WEBHOOK_SECRET", "whsec_marketplace_test");
     mockCreditWallet.mockResolvedValue({ id: "txn-1" });
-    mockAdminFrom.mockReturnValue(makeDbChain({ data: { company_name: "CommSec", email: "admin@commsec.com.au" }, error: null }));
+    mockAdminFrom.mockImplementation(defaultFromRouter());
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it("returns 400 when stripe-signature header is missing", async () => {
@@ -112,6 +153,37 @@ describe("POST /api/marketplace/webhook", () => {
     expect(json.error).toMatch(/signature/i);
   });
 
+  // ── Fail-closed secret (finding: no STRIPE_WEBHOOK_SECRET fallback) ──────────
+
+  it("returns 500 and does NOT verify when STRIPE_MARKETPLACE_WEBHOOK_SECRET is unset", async () => {
+    vi.stubEnv("STRIPE_MARKETPLACE_WEBHOOK_SECRET", "");
+    const res = await POST(makePost("{}"));
+    expect(res.status).toBe(500);
+    // Must NOT borrow the platform secret — constructEvent is never reached.
+    expect(mockConstructEvent).not.toHaveBeenCalled();
+    expect(mockCreditWallet).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fall back to STRIPE_WEBHOOK_SECRET when marketplace secret is unset", async () => {
+    vi.stubEnv("STRIPE_MARKETPLACE_WEBHOOK_SECRET", "");
+    vi.stubEnv("STRIPE_WEBHOOK_SECRET", "whsec_platform_main");
+    const res = await POST(makePost("{}"));
+    expect(res.status).toBe(500);
+    expect(mockConstructEvent).not.toHaveBeenCalled();
+  });
+
+  it("verifies against the marketplace secret (not the platform secret)", async () => {
+    vi.stubEnv("STRIPE_MARKETPLACE_WEBHOOK_SECRET", "whsec_marketplace_only");
+    vi.stubEnv("STRIPE_WEBHOOK_SECRET", "whsec_platform_main");
+    mockConstructEvent.mockReturnValue(makeWalletTopupEvent());
+    await POST(makePost("{}"));
+    expect(mockConstructEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      "whsec_marketplace_only"
+    );
+  });
+
   it("returns 400 when signature verification fails", async () => {
     mockConstructEvent.mockImplementation(() => {
       throw new Error("No signatures found");
@@ -121,6 +193,8 @@ describe("POST /api/marketplace/webhook", () => {
     const json = await res.json();
     expect(json.error).toMatch(/signature/i);
   });
+
+  // ── Happy paths ──────────────────────────────────────────────────────────────
 
   it("credits wallet on checkout.session.completed wallet_topup", async () => {
     mockConstructEvent.mockReturnValue(makeWalletTopupEvent());
@@ -133,6 +207,12 @@ describe("POST /api/marketplace/webhook", () => {
       expect.objectContaining({ type: "stripe_checkout", id: "cs_test_123" }),
       "stripe_webhook"
     );
+  });
+
+  it("claims the event in stripe_webhook_events before processing", async () => {
+    mockConstructEvent.mockReturnValue(makeWalletTopupEvent());
+    await POST(makePost("{}"));
+    expect(mockAdminFrom).toHaveBeenCalledWith("stripe_webhook_events");
   });
 
   it("updates invoice to paid with correct fields on wallet_topup", async () => {
@@ -211,10 +291,141 @@ describe("POST /api/marketplace/webhook", () => {
   });
 
   it("returns 200 for unknown event types (no-op)", async () => {
-    mockConstructEvent.mockReturnValue({ type: "charge.expired", data: { object: {} } });
+    mockConstructEvent.mockReturnValue({ id: "evt_unknown_1", type: "charge.expired", data: { object: {} } });
     const res = await POST(makePost("{}"));
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.received).toBe(true);
+  });
+
+  // ── Event-level idempotency (finding: no event-level idempotency guard) ──────
+
+  it("short-circuits a duplicate event already marked 'done' WITHOUT re-crediting", async () => {
+    mockConstructEvent.mockReturnValue(makeWalletTopupEvent({}, "evt_dup_done"));
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === "stripe_webhook_events") {
+        // INSERT collides (23505); the existing row is 'done'.
+        return makeDbChain(
+          { data: { status: "done", started_at: new Date().toISOString() }, error: null },
+          { error: { code: "23505", message: "duplicate key" } }
+        );
+      }
+      return makeDbChain(
+        { data: { company_name: "CommSec", email: "x@y.com" }, error: null },
+        { error: null }
+      );
+    });
+
+    const res = await POST(makePost("{}"));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.duplicate).toBe(true);
+    // No money movement, no audit row, no invoice update on the replay.
+    expect(mockCreditWallet).not.toHaveBeenCalled();
+    expect(mockAdminFrom).not.toHaveBeenCalledWith("admin_audit_log");
+    expect(mockAdminFrom).not.toHaveBeenCalledWith("marketplace_invoices");
+  });
+
+  it("treats an in-flight 'processing' duplicate (younger than 5 min) as in-flight, no re-credit", async () => {
+    mockConstructEvent.mockReturnValue(makeWalletTopupEvent({}, "evt_dup_inflight"));
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === "stripe_webhook_events") {
+        return makeDbChain(
+          { data: { status: "processing", started_at: new Date().toISOString() }, error: null },
+          { error: { code: "23505", message: "duplicate key" } }
+        );
+      }
+      return makeDbChain(
+        { data: { company_name: "CommSec", email: "x@y.com" }, error: null },
+        { error: null }
+      );
+    });
+
+    const res = await POST(makePost("{}"));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.inflight).toBe(true);
+    expect(mockCreditWallet).not.toHaveBeenCalled();
+    expect(mockAdminFrom).not.toHaveBeenCalledWith("admin_audit_log");
+  });
+
+  it("re-takes a STALE 'processing' duplicate (older than 5 min) and processes it once", async () => {
+    mockConstructEvent.mockReturnValue(makeWalletTopupEvent({}, "evt_dup_stale"));
+    const stale = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === "stripe_webhook_events") {
+        return makeDbChain(
+          { data: { status: "processing", started_at: stale }, error: null },
+          { error: { code: "23505", message: "duplicate key" } }
+        );
+      }
+      return makeDbChain(
+        { data: { company_name: "CommSec", email: "x@y.com" }, error: null },
+        { error: null }
+      );
+    });
+
+    const res = await POST(makePost("{}"));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.received).toBe(true);
+    expect(json.duplicate).toBeUndefined();
+    expect(json.inflight).toBeUndefined();
+    // Stale crash was re-taken → the side effects DO run this time.
+    expect(mockCreditWallet).toHaveBeenCalledTimes(1);
+    expect(mockAdminFrom).toHaveBeenCalledWith("admin_audit_log");
+  });
+
+  it("processes anyway (fail-open) when the idempotency claim errors with a non-23505 code", async () => {
+    mockConstructEvent.mockReturnValue(makeWalletTopupEvent({}, "evt_claim_err"));
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === "stripe_webhook_events") {
+        return makeDbChain(
+          { data: null, error: null },
+          { error: { code: "08006", message: "connection failure" } }
+        );
+      }
+      return makeDbChain(
+        { data: { company_name: "CommSec", email: "x@y.com" }, error: null },
+        { error: null }
+      );
+    });
+
+    const res = await POST(makePost("{}"));
+    expect(res.status).toBe(200);
+    // We do not block real events on an idempotency-table outage.
+    expect(mockCreditWallet).toHaveBeenCalledTimes(1);
+  });
+
+  it("a first delivery that 500s leaves the event re-takeable (marks 'error', does not mark 'done')", async () => {
+    mockConstructEvent.mockReturnValue(makeWalletTopupEvent({}, "evt_first_fail"));
+    mockCreditWallet.mockRejectedValue(new Error("optimistic lock failure"));
+
+    const updateStatuses: string[] = [];
+    mockAdminFrom.mockImplementation((table: string) => {
+      if (table === "stripe_webhook_events") {
+        const chain = makeDbChain({ data: null, error: null }, { error: null }) as Record<
+          string,
+          ReturnType<typeof vi.fn>
+        >;
+        const origUpdate = chain.update;
+        chain.update = vi.fn((patch: { status?: string }) => {
+          if (patch?.status) updateStatuses.push(patch.status);
+          return origUpdate(patch);
+        });
+        return chain;
+      }
+      return makeDbChain(
+        { data: { company_name: "CommSec", email: "x@y.com" }, error: null },
+        { error: null }
+      );
+    });
+
+    const res = await POST(makePost("{}"));
+    expect(res.status).toBe(500);
+    // The terminal stamp must be 'error', never 'done', so Stripe's retry
+    // can re-take the stale row and re-run the un-completed side effects.
+    expect(updateStatuses).toContain("error");
+    expect(updateStatuses).not.toContain("done");
   });
 });

--- a/app/api/marketplace/webhook/route.ts
+++ b/app/api/marketplace/webhook/route.ts
@@ -17,17 +17,99 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Missing stripe-signature" }, { status: 400 });
   }
 
+  // ── Fail-closed signature secret ──────────────────────────────────
+  // The marketplace endpoint has its OWN Stripe webhook endpoint and its
+  // OWN signing secret (STRIPE_MARKETPLACE_WEBHOOK_SECRET), distinct from
+  // the subscription endpoint's STRIPE_WEBHOOK_SECRET. Previously this
+  // handler fell back to STRIPE_WEBHOOK_SECRET when the marketplace secret
+  // was unset, which silently conflated two endpoints' trust boundaries
+  // and masked a deployment misconfiguration on a money-movement path
+  // (broker wallet credits + invoice settlement). Mirror the subscription
+  // handler: read only the marketplace secret and fail closed (500) if it
+  // is missing, rather than borrowing the platform secret.
+  const webhookSecret = process.env.STRIPE_MARKETPLACE_WEBHOOK_SECRET;
+  if (!webhookSecret) {
+    log.error("STRIPE_MARKETPLACE_WEBHOOK_SECRET not configured");
+    return NextResponse.json({ error: "Webhook not configured" }, { status: 500 });
+  }
+
   let event: Stripe.Event;
 
   try {
-    event = getStripe().webhooks.constructEvent(
-      body,
-      signature,
-      process.env.STRIPE_MARKETPLACE_WEBHOOK_SECRET || process.env.STRIPE_WEBHOOK_SECRET!
-    );
+    event = getStripe().webhooks.constructEvent(body, signature, webhookSecret);
   } catch (err) {
     log.error("Marketplace webhook signature failed", { error: err instanceof Error ? err.message : String(err) });
     return NextResponse.json({ error: "Invalid signature" }, { status: 400 });
+  }
+
+  // ── Event-level idempotency (crash-robust) ────────────────────────
+  // Stripe retries events after transient failures (any 500 below — e.g.
+  // a creditWallet optimistic-lock failure — triggers re-delivery), so the
+  // same event.id can arrive multiple times. creditWallet is already
+  // idempotent on stripe_payment_intent_id (the actual money movement is
+  // safe), but the admin_audit_log INSERT and the marketplace_invoices
+  // paid_at update are NOT — duplicate deliveries pollute the financial
+  // audit trail and drift the recorded settlement time. Claim each event
+  // in stripe_webhook_events with a processing → done state machine so a
+  // retried event.id is short-circuited, and a crashed handler's event can
+  // be re-taken after a 5-minute timeout. Mirrors app/api/stripe/webhook.
+  const idempotencyClient = createAdminClient();
+  const FIVE_MINS_AGO = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+  {
+    const { error: dedupeError } = await idempotencyClient
+      .from("stripe_webhook_events")
+      .insert({
+        event_id: event.id,
+        event_type: event.type,
+        status: "processing",
+        started_at: new Date().toISOString(),
+      });
+
+    if (dedupeError) {
+      if (dedupeError.code === "23505") {
+        // Row already exists. If it's 'done', we're finished. If it's
+        // 'processing' and younger than 5 min, another worker owns it.
+        // If 'processing' and older, we re-take it (previous worker crashed).
+        const { data: existing } = await idempotencyClient
+          .from("stripe_webhook_events")
+          .select("status, started_at")
+          .eq("event_id", event.id)
+          .maybeSingle();
+
+        if (existing?.status === "done") {
+          log.info("Duplicate marketplace webhook event ignored (already done)", {
+            eventId: event.id,
+            type: event.type,
+          });
+          return NextResponse.json({ received: true, duplicate: true });
+        }
+        if (
+          existing?.status === "processing" &&
+          existing.started_at &&
+          existing.started_at > FIVE_MINS_AGO
+        ) {
+          log.info("Duplicate marketplace webhook event ignored (in-flight)", {
+            eventId: event.id,
+            type: event.type,
+          });
+          return NextResponse.json({ received: true, inflight: true });
+        }
+        // Stale processing row — re-take it.
+        await idempotencyClient
+          .from("stripe_webhook_events")
+          .update({ status: "processing", started_at: new Date().toISOString() })
+          .eq("event_id", event.id);
+        log.warn("Retaking stale marketplace webhook event", {
+          eventId: event.id,
+          type: event.type,
+        });
+      } else {
+        log.warn("Idempotency claim failed, processing anyway", {
+          eventId: event.id,
+          error: dedupeError.message,
+        });
+      }
+    }
   }
 
   const supabase = createAdminClient();
@@ -44,6 +126,10 @@ export async function POST(request: NextRequest) {
 
           if (!brokerSlug || !amountCents) {
             log.error("Missing metadata on wallet_topup checkout", { metadata: session.metadata });
+            // Mark the event 'error' so it is not stuck in 'processing'; a
+            // re-delivery of the same (still-invalid) event will be re-taken
+            // and short-circuited the same way.
+            await markEvent(idempotencyClient, event.id, "error");
             return NextResponse.json({ error: "Missing metadata" }, { status: 400 });
           }
 
@@ -184,8 +270,35 @@ export async function POST(request: NextRequest) {
     }
   } catch (err) {
     log.error("Marketplace webhook error", { error: err instanceof Error ? err.message : String(err) });
+    // Mark the event row 'error' so a Stripe retry can re-take it via the
+    // stale-processing fallback above (the handler did NOT complete its
+    // non-idempotent side effects, so re-running is correct).
+    await markEvent(idempotencyClient, event.id, "error");
     return NextResponse.json({ error: "Webhook handler failed" }, { status: 500 });
   }
 
+  // Mark done so this event will never be re-processed by a Stripe retry.
+  await markEvent(idempotencyClient, event.id, "done");
+
   return NextResponse.json({ received: true });
+}
+
+/**
+ * Best-effort terminal status stamp for the idempotency row. Swallows
+ * errors — the event was already processed (or already failed); the stamp
+ * is only an optimisation/observability aid, not a correctness guarantee.
+ */
+async function markEvent(
+  client: ReturnType<typeof createAdminClient>,
+  eventId: string,
+  status: "done" | "error"
+): Promise<void> {
+  try {
+    await client
+      .from("stripe_webhook_events")
+      .update({ status, completed_at: new Date().toISOString() })
+      .eq("event_id", eventId);
+  } catch {
+    // swallow — terminal stamp is best-effort
+  }
 }


### PR DESCRIPTION
⚠️ HELD — client-money / webhook-signing sensitive. Requires FOUNDER + LEGAL sign-off before merge. Do NOT merge autonomously.

## Finding ref
Bug-hunt findings on `app/api/marketplace/webhook/route.ts` (two findings, both addressed):
- P2 / Tier C — "Marketplace Stripe webhook has no event-level idempotency guard (duplicate audit-log rows + paid_at overwrite on retries)"
- P3 / Tier HELD — "Marketplace Stripe webhook falls back to the main STRIPE_WEBHOOK_SECRET when the marketplace-specific secret is unset"

## What changed (`app/api/marketplace/webhook/route.ts`)

**1. Event-level idempotency claim.** Immediately after `constructEvent` succeeds, the handler now INSERTs into `stripe_webhook_events {event_id, event_type, status:'processing', started_at}` and runs a `processing → done` state machine, exactly mirroring `app/api/stripe/webhook/route.ts`:
- 23505 + existing row `done` → return `{ received: true, duplicate: true }` (no re-credit, no audit row, no invoice update).
- 23505 + `processing` younger than 5 min → return `{ received: true, inflight: true }`.
- 23505 + `processing` older than 5 min → re-take (crashed handler recovery).
- Non-23505 claim error → fail-open (process anyway; do not block real events on an idempotency-table outage).
- On handler success → mark `done`; on 500 → mark `error` so a Stripe retry can re-take the row.

This makes the previously un-deduplicated side effects fire exactly once: the `admin_audit_log` INSERT and the `marketplace_invoices` `paid_at` update. (`creditWallet` was already idempotent on `stripe_payment_intent_id`, so funds were never at risk — the harm was audit-trail duplication and settlement-timestamp drift.)

**2. Removed the signing-secret fallback (fail closed).** Replaced `STRIPE_MARKETPLACE_WEBHOOK_SECRET || STRIPE_WEBHOOK_SECRET!` with reading only `STRIPE_MARKETPLACE_WEBHOOK_SECRET`; if unset, `log.error(...)` + return 500 **before** `constructEvent` — mirroring the subscription handler. No longer borrows the platform secret, so the two endpoints' trust boundaries stay separate and a missing marketplace secret surfaces loudly instead of silently passing.

## Test coverage (`__tests__/api/marketplace-webhook.test.ts`, 23 tests, all green)
- Missing-secret → 500, `constructEvent` never called, no credit.
- No fallback to `STRIPE_WEBHOOK_SECRET` even when it is set.
- Verifies against the marketplace secret value specifically.
- Duplicate `done` → `duplicate:true`, no re-credit / no audit / no invoice update.
- In-flight `processing` (<5 min) → `inflight:true`, no re-credit.
- Stale `processing` (>5 min) → re-taken, processed exactly once.
- Non-23505 claim error → fail-open, processes once.
- First-delivery 500 → marks `error`, never `done` (so retry can re-take).
- All prior happy/edge-path tests retained and passing.

## Verification
`npx vitest run __tests__/api/marketplace-webhook.test.ts` → 23 passed. `tsc --noEmit` clean for changed files. `eslint --fix` clean. No DB migration (the `stripe_webhook_events` table already exists and is used by the subscription handler).

## Founder/legal review notes
- Removing the fallback is a behavioural change to a money-movement webhook's trust boundary. **Confirm the live Stripe endpoint/secret configuration before merge** — any environment currently relying on the fallback (marketplace secret unset, platform secret set) will start returning 500 until `STRIPE_MARKETPLACE_WEBHOOK_SECRET` is provisioned.
- Confirm the marketplace route is allowed to share the global `stripe_webhook_events` table (event ids are namespaced per Stripe account, so cross-route collisions are not expected, but worth confirming).
- Secondary hardening from the finding (adding the marketplace secret to the rotation cron `app/api/cron/check-secret-rotation` and to `lib/stripe-env-check.ts`) is intentionally **out of scope** here to keep this PR to the one sensitive file — track separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
