### PR TITLE
fix(billing): gate auto-recharge success notification on PaymentIntent status

### DIFF
--- a/__tests__/lib/briefs/auto-recharge.test.ts
+++ b/__tests__/lib/briefs/auto-recharge.test.ts
@@ -1,0 +1,297 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Hoisted mocks ────────────────────────────────────────────────────
+// vi.mock factories are hoisted above all const/let, so any shared spies
+// they reference must be declared via vi.hoisted (per CLAUDE.md).
+const {
+  mockEnqueueUserNotification,
+  mockPaymentIntentsCreate,
+  mockCreateAdminClient,
+  mockGetStripe,
+} = vi.hoisted(() => ({
+  mockEnqueueUserNotification: vi.fn(),
+  mockPaymentIntentsCreate: vi.fn(),
+  mockCreateAdminClient: vi.fn(),
+  mockGetStripe: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: mockCreateAdminClient,
+}));
+
+vi.mock("@/lib/stripe", () => ({
+  getStripe: mockGetStripe,
+}));
+
+vi.mock("@/lib/user-notifications", () => ({
+  enqueueUserNotification: mockEnqueueUserNotification,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+import { maybeAutoRecharge } from "@/lib/briefs/auto-recharge";
+
+// ── Test helpers ─────────────────────────────────────────────────────
+
+const AUTH_USER_ID = "auth-user-abc";
+const PRO_ID = 42;
+
+/** A professionals row that passes every eligibility gate (auto-recharge
+ *  enabled, saved card, balance below threshold, no cooldown active). */
+function eligibleProRow() {
+  return {
+    id: PRO_ID,
+    email: "pro@example.com",
+    name: "Test Pro",
+    auth_user_id: AUTH_USER_ID,
+    credit_balance_cents: 100, // 1 credit — below threshold
+    auto_recharge_enabled: true,
+    auto_recharge_threshold_credits: 5,
+    auto_recharge_pack_slug: "starter", // real isCredit pack
+    stripe_customer_id: "cus_123",
+    stripe_default_payment_method: "pm_123",
+    auto_recharge_last_attempted_at: null,
+  };
+}
+
+/**
+ * Build a fake admin client that:
+ *  - returns `proRow` for the professionals.select(...).eq().maybeSingle()
+ *  - no-ops the professionals.update() timestamp stamp
+ *  - returns a topup row id for advisor_credit_topups.insert().select().single()
+ *  - returns `proRow` again for the catch-block re-fetch (select.eq.maybeSingle)
+ */
+function makeAdminClient(proRow: ReturnType<typeof eligibleProRow> | null) {
+  const from = vi.fn((table: string) => {
+    if (table === "professionals") {
+      return {
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            maybeSingle: vi.fn(async () => ({ data: proRow })),
+          })),
+        })),
+        update: vi.fn(() => ({
+          eq: vi.fn(async () => ({ data: null, error: null })),
+        })),
+      };
+    }
+    if (table === "advisor_credit_topups") {
+      return {
+        insert: vi.fn(() => ({
+          select: vi.fn(() => ({
+            single: vi.fn(async () => ({ data: { id: 999 }, error: null })),
+          })),
+        })),
+      };
+    }
+    throw new Error(`unexpected table ${table}`);
+  });
+  return { from };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv("STRIPE_SECRET_KEY", "sk_test_x");
+  mockGetStripe.mockReturnValue({
+    paymentIntents: { create: mockPaymentIntentsCreate },
+  });
+  mockCreateAdminClient.mockReturnValue(makeAdminClient(eligibleProRow()));
+  mockEnqueueUserNotification.mockResolvedValue(true);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+/** Flush the `void notifyProInbox(...)` microtask so its enqueue runs. */
+async function flush() {
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+function notifiedKinds(): string[] {
+  return mockEnqueueUserNotification.mock.calls.map((c) => c[0].kind);
+}
+
+// ── PaymentIntent status branches (the core of the fix) ──────────────
+
+describe("maybeAutoRecharge — notification gated on PaymentIntent status", () => {
+  it("status=succeeded → enqueues topup_succeeded only", async () => {
+    mockPaymentIntentsCreate.mockResolvedValue({ status: "succeeded" });
+
+    await maybeAutoRecharge(PRO_ID);
+    await flush();
+
+    expect(mockPaymentIntentsCreate).toHaveBeenCalledTimes(1);
+    expect(mockEnqueueUserNotification).toHaveBeenCalledTimes(1);
+    const call = mockEnqueueUserNotification.mock.calls[0][0];
+    expect(call.kind).toBe("topup_succeeded");
+    expect(call.authUserId).toBe(AUTH_USER_ID);
+    expect(call.body).toMatch(/topped up/i);
+    // never a failure on success
+    expect(notifiedKinds()).not.toContain("topup_failed");
+  });
+
+  it("status=requires_action → enqueues topup_failed (action required), NOT success", async () => {
+    mockPaymentIntentsCreate.mockResolvedValue({ status: "requires_action" });
+
+    await maybeAutoRecharge(PRO_ID);
+    await flush();
+
+    expect(mockEnqueueUserNotification).toHaveBeenCalledTimes(1);
+    const call = mockEnqueueUserNotification.mock.calls[0][0];
+    expect(call.kind).toBe("topup_failed");
+    expect(call.body).toMatch(/verification|updating|update your payment/i);
+    expect(notifiedKinds()).not.toContain("topup_succeeded");
+  });
+
+  it("status=requires_payment_method → enqueues topup_failed, NOT success", async () => {
+    mockPaymentIntentsCreate.mockResolvedValue({
+      status: "requires_payment_method",
+    });
+
+    await maybeAutoRecharge(PRO_ID);
+    await flush();
+
+    expect(mockEnqueueUserNotification).toHaveBeenCalledTimes(1);
+    expect(notifiedKinds()).toEqual(["topup_failed"]);
+    expect(notifiedKinds()).not.toContain("topup_succeeded");
+  });
+
+  it("status=processing → suppresses ALL notifications (no false success, no failure)", async () => {
+    mockPaymentIntentsCreate.mockResolvedValue({ status: "processing" });
+
+    await maybeAutoRecharge(PRO_ID);
+    await flush();
+
+    expect(mockPaymentIntentsCreate).toHaveBeenCalledTimes(1);
+    expect(mockEnqueueUserNotification).not.toHaveBeenCalled();
+  });
+
+  it("status=requires_capture (other non-terminal) → suppresses all notifications", async () => {
+    mockPaymentIntentsCreate.mockResolvedValue({ status: "requires_capture" });
+
+    await maybeAutoRecharge(PRO_ID);
+    await flush();
+
+    expect(mockEnqueueUserNotification).not.toHaveBeenCalled();
+  });
+
+  it("status=canceled → suppresses all notifications", async () => {
+    mockPaymentIntentsCreate.mockResolvedValue({ status: "canceled" });
+
+    await maybeAutoRecharge(PRO_ID);
+    await flush();
+
+    expect(mockEnqueueUserNotification).not.toHaveBeenCalled();
+  });
+
+  it("regression: a non-succeeded clean return must never fire topup_succeeded", async () => {
+    // This is the exact defect the fix closes: a non-throwing create()
+    // that did NOT settle previously fired an optimistic success.
+    for (const status of [
+      "processing",
+      "requires_action",
+      "requires_payment_method",
+      "requires_capture",
+      "canceled",
+    ]) {
+      mockEnqueueUserNotification.mockClear();
+      mockPaymentIntentsCreate.mockResolvedValue({ status });
+      await maybeAutoRecharge(PRO_ID);
+      await flush();
+      expect(notifiedKinds()).not.toContain("topup_succeeded");
+    }
+  });
+});
+
+// ── Throw path (hard decline) still routes to the catch failure inbox ─
+
+describe("maybeAutoRecharge — hard-decline throw path", () => {
+  it("create() throws → catch enqueues topup_failed, never success", async () => {
+    mockPaymentIntentsCreate.mockRejectedValue(
+      Object.assign(new Error("Your card was declined."), {
+        type: "StripeCardError",
+      }),
+    );
+
+    await maybeAutoRecharge(PRO_ID);
+    await flush();
+
+    expect(mockEnqueueUserNotification).toHaveBeenCalledTimes(1);
+    expect(notifiedKinds()).toEqual(["topup_failed"]);
+    expect(notifiedKinds()).not.toContain("topup_succeeded");
+  });
+});
+
+// ── Eligibility gates — no charge, no notification ───────────────────
+
+describe("maybeAutoRecharge — eligibility gates short-circuit before charging", () => {
+  it("auto_recharge_enabled=false → no charge, no notification", async () => {
+    const row = eligibleProRow();
+    row.auto_recharge_enabled = false;
+    mockCreateAdminClient.mockReturnValue(makeAdminClient(row));
+
+    await maybeAutoRecharge(PRO_ID);
+    await flush();
+
+    expect(mockPaymentIntentsCreate).not.toHaveBeenCalled();
+    expect(mockEnqueueUserNotification).not.toHaveBeenCalled();
+  });
+
+  it("balance at/above threshold → no charge", async () => {
+    const row = eligibleProRow();
+    row.credit_balance_cents = 1000; // 10 credits >= threshold 5
+    mockCreateAdminClient.mockReturnValue(makeAdminClient(row));
+
+    await maybeAutoRecharge(PRO_ID);
+    await flush();
+
+    expect(mockPaymentIntentsCreate).not.toHaveBeenCalled();
+    expect(mockEnqueueUserNotification).not.toHaveBeenCalled();
+  });
+
+  it("recent attempt within cooldown → no charge", async () => {
+    const row = eligibleProRow();
+    row.auto_recharge_last_attempted_at = new Date().toISOString();
+    mockCreateAdminClient.mockReturnValue(makeAdminClient(row));
+
+    await maybeAutoRecharge(PRO_ID);
+    await flush();
+
+    expect(mockPaymentIntentsCreate).not.toHaveBeenCalled();
+    expect(mockEnqueueUserNotification).not.toHaveBeenCalled();
+  });
+
+  it("missing saved payment method → no charge", async () => {
+    const row = eligibleProRow();
+    row.stripe_default_payment_method = null as unknown as string;
+    mockCreateAdminClient.mockReturnValue(makeAdminClient(row));
+
+    await maybeAutoRecharge(PRO_ID);
+    await flush();
+
+    expect(mockPaymentIntentsCreate).not.toHaveBeenCalled();
+    expect(mockEnqueueUserNotification).not.toHaveBeenCalled();
+  });
+
+  it("no auth_user_id → success status still charges but enqueues nothing (no inbox target)", async () => {
+    const row = eligibleProRow();
+    row.auth_user_id = null;
+    mockCreateAdminClient.mockReturnValue(makeAdminClient(row));
+    mockPaymentIntentsCreate.mockResolvedValue({ status: "succeeded" });
+
+    await maybeAutoRecharge(PRO_ID);
+    await flush();
+
+    expect(mockPaymentIntentsCreate).toHaveBeenCalledTimes(1);
+    // notifyProInbox returns early when auth_user_id is null
+    expect(mockEnqueueUserNotification).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/lib/briefs/auto-recharge.test.ts
+++ b/__tests__/lib/briefs/auto-recharge.test.ts
@@ -45,7 +45,19 @@ const PRO_ID = 42;
 
 /** A professionals row that passes every eligibility gate (auto-recharge
  *  enabled, saved card, balance below threshold, no cooldown active). */
-function eligibleProRow() {
+function eligibleProRow(): {
+  id: number;
+  email: string;
+  name: string;
+  auth_user_id: string | null;
+  credit_balance_cents: number;
+  auto_recharge_enabled: boolean;
+  auto_recharge_threshold_credits: number;
+  auto_recharge_pack_slug: string;
+  stripe_customer_id: string;
+  stripe_default_payment_method: string | null;
+  auto_recharge_last_attempted_at: string | null;
+} {
   return {
     id: PRO_ID,
     email: "pro@example.com",
@@ -271,7 +283,7 @@ describe("maybeAutoRecharge — eligibility gates short-circuit before charging"
 
   it("missing saved payment method → no charge", async () => {
     const row = eligibleProRow();
-    row.stripe_default_payment_method = null as unknown as string;
+    row.stripe_default_payment_method = null;
     mockCreateAdminClient.mockReturnValue(makeAdminClient(row));
 
     await maybeAutoRecharge(PRO_ID);

--- a/lib/briefs/auto-recharge.ts
+++ b/lib/briefs/auto-recharge.ts
@@ -138,7 +138,7 @@ export async function maybeAutoRecharge(professionalId: number): Promise<void> {
 
     // Off-session PaymentIntent — Stripe charges the saved card without
     // user intervention. The webhook handler grants credits on success.
-    await stripe.paymentIntents.create({
+    const intent = await stripe.paymentIntents.create({
       amount: pack.priceCents,
       currency: "aud",
       customer: pro.stripe_customer_id,
@@ -161,19 +161,68 @@ export async function maybeAutoRecharge(professionalId: number): Promise<void> {
       professionalId,
       pack: pack.slug,
       amountCents: pack.priceCents,
+      intentStatus: intent.status,
     });
 
     // ── In-app inbox (C1 / mm06) ────────────────────────────────────
-    // The Stripe payment_intent is off_session + confirm:true above —
-    // a clean return means the charge succeeded and the webhook will
-    // grant credits asynchronously. We notify "succeeded" optimistically;
-    // any later refund / dispute lands its own row via the refund
-    // webhook handler.
-    void notifyProInbox(
-      pro,
-      "topup_succeeded",
-      `${pack.leads} credits topped up via auto-recharge (A$${(pack.priceCents / 100).toFixed(0)}).`,
-    );
+    // Gate the notification on the ACTUAL PaymentIntent status. A
+    // non-throwing return from `paymentIntents.create({confirm:true})`
+    // does NOT mean money settled: Stripe only THROWS for hard declines
+    // / authentication_required. It returns normally with status
+    // `processing`, `requires_action`, or `requires_payment_method` when
+    // the charge is pending or needs more from the cardholder. Firing
+    // "topup_succeeded" on a clean return therefore falsely tells the pro
+    // their balance topped up when it has not.
+    //
+    // - succeeded → real settlement; notify "succeeded".
+    // - requires_action / requires_payment_method → off-session step-up
+    //   (e.g. 3DS) or a card problem the pro must resolve; notify
+    //   "failed" with an action-required message so they take action.
+    // - processing (or any other non-terminal status) → no money has
+    //   settled yet; suppress the notification and let the asynchronous
+    //   webhook / reconciliation surface the eventual outcome. Do NOT
+    //   claim success.
+    //
+    // ⚠️ KNOWN LATENT GAP (founder + payments review — see PR body): even
+    // a genuinely `succeeded` raw PaymentIntent has no registered handler
+    // that grants the advisor_credit_topup credits. `checkout.session.
+    // completed` (the comment's stated design) never fires for a raw
+    // PaymentIntent, and the `payment_intent.succeeded` handler early-
+    // returns unless metadata.kind === "marketplace_payment". So the
+    // "succeeded" notification is presently still optimistic about the
+    // credit grant. Wiring the credit-grant path (Checkout Session in
+    // payment mode, or an advisor_credit_topup branch in a
+    // payment_intent.succeeded handler) is the load-bearing companion fix
+    // and is intentionally NOT done here — it is money-movement and needs
+    // explicit founder + payments sign-off.
+    if (intent.status === "succeeded") {
+      void notifyProInbox(
+        pro,
+        "topup_succeeded",
+        `${pack.leads} credits topped up via auto-recharge (A$${(pack.priceCents / 100).toFixed(0)}).`,
+      );
+    } else if (
+      intent.status === "requires_action" ||
+      intent.status === "requires_payment_method"
+    ) {
+      log.warn("auto-recharge needs cardholder action", {
+        professionalId,
+        intentStatus: intent.status,
+      });
+      void notifyProInbox(
+        pro,
+        "topup_failed",
+        "We couldn't complete your auto-recharge — your card needs verification or updating. Top up manually or update your payment method.",
+      );
+    } else {
+      // processing / requires_capture / canceled / unknown — the charge
+      // has not settled. Do not assert success; stay silent and let the
+      // webhook / reconciliation surface the eventual outcome.
+      log.info("auto-recharge pending (no success notification)", {
+        professionalId,
+        intentStatus: intent.status,
+      });
+    }
   } catch (err) {
     // Common failures: card declined, auth required, customer deleted.
     // Stripe surfaces these as `StripeCardError` — we log and let the


### PR DESCRIPTION
⚠️ **HELD — client-money / off-session card-charge sensitive. Requires FOUNDER + LEGAL/payments sign-off before merge. Do NOT merge autonomously.**

## Finding ref
Bug-hunt finding: *"Auto-recharge fires 'top-up succeeded' inbox notification before the off-session PaymentIntent status is confirmed"* — `lib/briefs/auto-recharge.ts` (P2, tier HELD).

## Defect (confirmed on current main)
`maybeAutoRecharge` discarded the return of `stripe.paymentIntents.create({ off_session: true, confirm: true })` and fired a `topup_succeeded` inbox notification on any non-throwing return. Stripe only **throws** for hard declines / `authentication_required`; it returns **normally** with status `processing`, `requires_action`, or `requires_payment_method` when the charge has **not** settled. So a pro whose card needs 3DS step-up or settles asynchronously was told *"N credits topped up (A$X)"* while their balance was unchanged and no credits were granted — and the catch-block failure inbox path was never reached for these non-throwing non-success statuses.

## Fix in this PR (notification gating only — surgical)
Capture the PaymentIntent and gate the notification on `pi.status`:
- `succeeded` → `topup_succeeded`
- `requires_action` / `requires_payment_method` → `topup_failed` with action-required copy ("card needs verification or updating")
- `processing` / any other non-terminal status → **no notification** (let the webhook / reconciliation surface the eventual outcome; never claim success)

Reuses the existing `topup_failed` notification kind (already in the `UserNotificationKind` CHECK-constraint) so **no DB migration is required**.

## ⚠️ Companion fix intentionally NOT done here (needs founder + payments)
The finding also confirms a more severe latent gap in the same flow: **no registered webhook grants `advisor_credit_topup` credits for a raw PaymentIntent.** `checkout.session.completed` (the design the inline comment assumes) never fires for a raw PaymentIntent, and the `payment_intent.succeeded` handler early-returns unless `metadata.kind === "marketplace_payment"`. So even a genuinely `succeeded` charge currently grants no credits and leaves the `advisor_credit_topups` row `pending`. Wiring the credit-grant path (Checkout Session in payment mode, or an `advisor_credit_topup` branch in a `payment_intent.succeeded` handler that calls `recordLedgerEntry`) is money-movement and is **left for founder + payments review**. This is documented inline in the code and is why even the `succeeded` notification remains optimistic about the credit grant for now.

## Test coverage (`__tests__/lib/briefs/auto-recharge.test.ts`, 13 tests, all green)
- Per-status branches: `succeeded` → success only; `requires_action` & `requires_payment_method` → `topup_failed`, never success; `processing` / `requires_capture` / `canceled` → **no** notification.
- Regression loop: no non-succeeded clean return ever fires `topup_succeeded`.
- Hard-decline throw path still routes to the catch failure inbox.
- Eligibility gates (disabled / above threshold / cooldown / missing payment method) short-circuit before charging; missing `auth_user_id` charges but enqueues nothing.

## Verify
- `npx vitest run __tests__/lib/briefs/auto-recharge.test.ts` → 13 passed
- `npx eslint lib/briefs/auto-recharge.ts __tests__/lib/briefs/auto-recharge.test.ts` → clean
- `tsc --noEmit` → no errors in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
