### PR TITLE
fix(reviews): verify broker review clients against platform leads (broker_signups has no email)

### DIFF
--- a/__tests__/api/cron-verify-review-clients.test.ts
+++ b/__tests__/api/cron-verify-review-clients.test.ts
@@ -66,4 +66,70 @@ describe("GET /api/cron/verify-review-clients", () => {
     expect(body.advisor_verified).toBe(0);
     expect(body.total_verified).toBe(0);
   });
+
+  it("verifies a broker review whose email matches a platform lead for that broker_id", async () => {
+    // Route call order: 1) user_reviews fetch, 2) leads fetch,
+    // 3) user_reviews update, 4) professional_reviews fetch (empty).
+    const updateBuilder = makeBuilder({ error: null });
+    const leadsBuilder = makeBuilder({
+      data: [{ broker_id: 7, user_email: "client@example.com" }],
+      error: null,
+    });
+
+    let call = 0;
+    mockFrom.mockImplementation((table?: string) => {
+      call += 1;
+      if (call === 1) {
+        // unverified broker reviews — review.broker_id 7 matches the lead above
+        return makeBuilder({
+          data: [{ id: 1, email: "client@example.com", broker_slug: "commsec", broker_id: 7 }],
+          error: null,
+        });
+      }
+      if (table === "leads") return leadsBuilder;
+      if (call === 3) return updateBuilder; // the user_reviews update
+      return makeBuilder({ data: [], error: null }); // advisor block: no reviews
+    });
+
+    const res = await GET(req({ authorization: `Bearer ${SECRET}` }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.broker_verified).toBe(1);
+    // Matched against the leads table, scoped to platform lead_type.
+    expect(mockFrom).toHaveBeenCalledWith("leads");
+    expect(leadsBuilder.eq).toHaveBeenCalledWith("lead_type", "platform");
+    // And the verification was written with the enquiry-match source.
+    expect(updateBuilder.update).toHaveBeenCalledWith(
+      expect.objectContaining({ is_verified_client: true, verified_via: "enquiry_match" }),
+    );
+  });
+
+  it("does not verify a broker review when no platform lead matches the broker_id", async () => {
+    let call = 0;
+    mockFrom.mockImplementation((table?: string) => {
+      call += 1;
+      if (call === 1) {
+        // review for broker_id 7 …
+        return makeBuilder({
+          data: [{ id: 1, email: "client@example.com", broker_slug: "commsec", broker_id: 7 }],
+          error: null,
+        });
+      }
+      if (table === "leads") {
+        // … but the only platform lead is for a different broker_id
+        return makeBuilder({
+          data: [{ broker_id: 99, user_email: "client@example.com" }],
+          error: null,
+        });
+      }
+      return makeBuilder({ data: [], error: null });
+    });
+
+    const res = await GET(req({ authorization: `Bearer ${SECRET}` }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.broker_verified).toBe(0);
+  });
 });

--- a/__tests__/api/reviews-verify-client.test.ts
+++ b/__tests__/api/reviews-verify-client.test.ts
@@ -117,7 +117,7 @@ describe("POST /api/reviews/verify-client", () => {
     expect(body.already_verified).toBe(true);
   });
 
-  it("verifies broker review via signup_match", async () => {
+  it("verifies broker review via enquiry_match against a platform lead", async () => {
     const reviewChain = {
       select: vi.fn().mockReturnThis(),
       eq: vi.fn().mockReturnThis(),
@@ -126,7 +126,8 @@ describe("POST /api/reviews/verify-client", () => {
         error: null,
       }),
     };
-    const signupChain = {
+    // Platform-lead lookup chain: .select().eq(lead_type).eq(broker_id).eq(user_email).limit()
+    const leadChain = {
       select: vi.fn().mockReturnThis(),
       eq: vi.fn().mockReturnThis(),
       limit: vi.fn().mockResolvedValue({ data: [{ id: 10 }] }),
@@ -137,7 +138,7 @@ describe("POST /api/reviews/verify-client", () => {
     };
     mockAdminFrom
       .mockReturnValueOnce(reviewChain)
-      .mockReturnValueOnce(signupChain)
+      .mockReturnValueOnce(leadChain)
       .mockReturnValueOnce(updateChain);
 
     const { POST } = await import("@/app/api/reviews/verify-client/route");
@@ -146,10 +147,15 @@ describe("POST /api/reviews/verify-client", () => {
 
     expect(res.status).toBe(200);
     expect(body.verified).toBe(true);
-    expect(body.verified_via).toBe("signup_match");
+    expect(body.verified_via).toBe("enquiry_match");
+    // Confirms we matched against `leads`, scoped to platform lead_type + broker_id
+    expect(mockAdminFrom).toHaveBeenNthCalledWith(2, "leads");
+    expect(leadChain.eq).toHaveBeenCalledWith("lead_type", "platform");
+    expect(leadChain.eq).toHaveBeenCalledWith("broker_id", 2);
+    expect(leadChain.eq).toHaveBeenCalledWith("user_email", "customer@example.com");
   });
 
-  it("returns verified=false when no broker signup match", async () => {
+  it("returns verified=false when no platform lead matches the broker review", async () => {
     const reviewChain = {
       select: vi.fn().mockReturnThis(),
       eq: vi.fn().mockReturnThis(),
@@ -158,14 +164,14 @@ describe("POST /api/reviews/verify-client", () => {
         error: null,
       }),
     };
-    const signupChain = {
+    const leadChain = {
       select: vi.fn().mockReturnThis(),
       eq: vi.fn().mockReturnThis(),
       limit: vi.fn().mockResolvedValue({ data: [] }),
     };
     mockAdminFrom
       .mockReturnValueOnce(reviewChain)
-      .mockReturnValueOnce(signupChain);
+      .mockReturnValueOnce(leadChain);
 
     const { POST } = await import("@/app/api/reviews/verify-client/route");
     const res = await POST(makeReq({ review_id: 1, review_type: "broker" }));
@@ -173,6 +179,28 @@ describe("POST /api/reviews/verify-client", () => {
 
     expect(res.status).toBe(200);
     expect(body.verified).toBe(false);
+    expect(body.message).toMatch(/no matching enquiry/i);
+  });
+
+  it("returns verified=false without querying leads when broker review has no broker_id", async () => {
+    const reviewChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({
+        data: { id: 1, email: "customer@example.com", broker_slug: "commsec", broker_id: null, is_verified_client: false },
+        error: null,
+      }),
+    };
+    mockAdminFrom.mockReturnValueOnce(reviewChain);
+
+    const { POST } = await import("@/app/api/reviews/verify-client/route");
+    const res = await POST(makeReq({ review_id: 1, review_type: "broker" }));
+    const body = await res.json() as Record<string, unknown>;
+
+    expect(res.status).toBe(200);
+    expect(body.verified).toBe(false);
+    // Only the review fetch should have hit the DB — no leads lookup for a null broker_id.
+    expect(mockAdminFrom).toHaveBeenCalledTimes(1);
   });
 
   it("returns 500 when broker review update fails", async () => {
@@ -184,7 +212,7 @@ describe("POST /api/reviews/verify-client", () => {
         error: null,
       }),
     };
-    const signupChain = {
+    const leadChain = {
       select: vi.fn().mockReturnThis(),
       eq: vi.fn().mockReturnThis(),
       limit: vi.fn().mockResolvedValue({ data: [{ id: 10 }] }),
@@ -195,7 +223,7 @@ describe("POST /api/reviews/verify-client", () => {
     };
     mockAdminFrom
       .mockReturnValueOnce(reviewChain)
-      .mockReturnValueOnce(signupChain)
+      .mockReturnValueOnce(leadChain)
       .mockReturnValueOnce(updateChain);
 
     const { POST } = await import("@/app/api/reviews/verify-client/route");

--- a/app/api/cron/verify-review-clients/route.ts
+++ b/app/api/cron/verify-review-clients/route.ts
@@ -15,16 +15,26 @@ export async function GET(req: NextRequest) {
   let brokerVerified = 0;
   let advisorVerified = 0;
 
-  // ── Broker reviews: match user_reviews.email against broker_signups.email ──
+  // ── Broker reviews: match user_reviews.email against platform leads ──
+  //
+  // A reviewer is a "verified client" of a broker when they submitted a
+  // platform enquiry for that broker via /api/submit-lead (lead_type =
+  // 'platform', broker_id set). This mirrors the advisor path, which matches
+  // professional_reviews.reviewer_email against professional_leads. The match
+  // key is broker_id (not broker_slug): user_reviews carries both, but the
+  // `leads` table only has broker_id, so we key on the column both share.
   //
   // Previously this loop was N+1: one Supabase query per unverified review.
   // With the platform growing this hit cron timeout (60s) once unverified
   // reviews crossed ~600 rows. The new flow:
   //   1. Fetch all unverified reviews (one query)
-  //   2. Fetch all candidate broker_signups in a single .in() (one query)
-  //   3. Build an in-memory lookup map keyed on (broker_slug,email)
+  //   2. Fetch all candidate platform leads in a single .in() (one query)
+  //   3. Build an in-memory lookup map keyed on (broker_id,email)
   //   4. Update only reviews that have a matching key
   // Reduces N+1 to O(1) Supabase round-trips on the read path.
+  //
+  // Caveat: platform leads submitted without a broker (null broker_id) never
+  // match — by design; there is no broker to attribute the review to.
   try {
     const { data: unverifiedBrokerReviews } = await supabase
       .from("user_reviews")
@@ -42,31 +52,33 @@ export async function GET(req: NextRequest) {
         ),
       );
 
-      // Single batched fetch of all candidate signups
-      const { data: candidateSignups } = await supabase
-        .from("broker_signups")
-        .select("broker_slug, email")
-        .in("email", emails);
+      // Single batched fetch of all candidate platform leads
+      const { data: candidateLeads } = await supabase
+        .from("leads")
+        .select("broker_id, user_email")
+        .eq("lead_type", "platform")
+        .not("broker_id", "is", null)
+        .in("user_email", emails);
 
-      // Build O(1) lookup keyed on slug+email
-      const matchKey = (slug: string, email: string) =>
-        `${slug}::${email.toLowerCase()}`;
+      // Build O(1) lookup keyed on broker_id+email
+      const matchKey = (brokerId: number | string, email: string) =>
+        `${brokerId}::${email.toLowerCase()}`;
       const matchedKeys = new Set(
-        (candidateSignups || []).map((s) =>
-          matchKey(s.broker_slug, s.email),
-        ),
+        (candidateLeads || [])
+          .filter((l) => l.broker_id != null && l.user_email)
+          .map((l) => matchKey(l.broker_id, l.user_email)),
       );
 
       // Update only matching reviews
       for (const review of unverifiedBrokerReviews) {
-        if (!review.email) continue;
-        if (!matchedKeys.has(matchKey(review.broker_slug, review.email))) continue;
+        if (!review.email || review.broker_id == null) continue;
+        if (!matchedKeys.has(matchKey(review.broker_id, review.email))) continue;
 
         const { error } = await supabase
           .from("user_reviews")
           .update({
             is_verified_client: true,
-            verified_via: "signup_match",
+            verified_via: "enquiry_match",
             verified_client_at: new Date().toISOString(),
           })
           .eq("id", review.id);

--- a/app/api/reviews/verify-client/route.ts
+++ b/app/api/reviews/verify-client/route.ts
@@ -80,20 +80,35 @@ export async function POST(request: NextRequest) {
         });
       }
 
-      // Check if reviewer email matches any broker_signups for the same broker
-      const { data: signupMatch } = await supabase
-        .from("broker_signups")
+      // Check if reviewer email matches any platform lead for the same broker.
+      // A platform enquiry (lead_type='platform', broker_id set) submitted via
+      // /api/submit-lead proves the reviewer is a real customer of this broker.
+      // Mirrors the advisor path (professional_leads match). We key on
+      // broker_id — `leads` has no broker_slug, and the review row carries
+      // broker_id alongside broker_slug. Reviews with a null broker_id (and
+      // leads with a null broker_id) can't be attributed, so they never match.
+      if (review.broker_id == null) {
+        return NextResponse.json({
+          success: true,
+          verified: false,
+          message: "No matching enquiry found for this reviewer",
+        });
+      }
+
+      const { data: leadMatch } = await supabase
+        .from("leads")
         .select("id")
-        .eq("broker_slug", review.broker_slug)
-        .eq("email", review.email)
+        .eq("lead_type", "platform")
+        .eq("broker_id", review.broker_id)
+        .eq("user_email", review.email)
         .limit(1);
 
-      if (signupMatch && signupMatch.length > 0) {
+      if (leadMatch && leadMatch.length > 0) {
         const { error: updateError } = await supabase
           .from("user_reviews")
           .update({
             is_verified_client: true,
-            verified_via: "signup_match",
+            verified_via: "enquiry_match",
             verified_client_at: new Date().toISOString(),
           })
           .eq("id", review_id);
@@ -112,7 +127,7 @@ export async function POST(request: NextRequest) {
         return NextResponse.json({
           success: true,
           verified: true,
-          verified_via: "signup_match",
+          verified_via: "enquiry_match",
         });
       }
 
@@ -120,7 +135,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({
         success: true,
         verified: false,
-        message: "No matching signup found for this reviewer",
+        message: "No matching enquiry found for this reviewer",
       });
     } else {
       // advisor review


### PR DESCRIPTION
## The bug

Two routes mark a review as **Verified Client** by matching the reviewer's email against a real customer of that broker/advisor:

- `app/api/cron/verify-review-clients/route.ts` — the nightly batch sweep
- `app/api/reviews/verify-client/route.ts` — the admin-gated per-review POST

The **advisor** half works: it matches `professional_reviews.reviewer_email` + `professional_id` against `professional_leads.user_email` + `professional_id` and stamps `verified_via:'enquiry_match'`.

The **broker** half was broken. It matched `user_reviews.email` + `broker_slug` against **`broker_signups.email`** — but `broker_signups` is the **affiliate-postback table and has no `email` column** (and no per-customer enquiry data). The query never matched, so *every broker review silently stayed unverified*. No error surfaced; the cron just reported `broker_verified: 0` every run.

## The fix (Option A — leads / platform)

Founder decision: verify broker reviewers against the **`leads`** table (platform enquiries), mirroring the working advisor path.

Both routes now match:

```
user_reviews.email  ==  leads.user_email
WHERE leads.lead_type = 'platform'
  AND leads.broker_id = <the review row's broker_id>
```

A platform enquiry submitted via `/api/submit-lead` (`lead_type='platform'`, `broker_id` set) proves the reviewer is a real customer of that broker — the broker analogue of the advisor's `professional_leads` match.

### Match-key switch: `broker_slug` → `broker_id`

`user_reviews` rows carry **both** `broker_slug` and `broker_id`, but the `leads` table only has `broker_id`. So the match key switches from `broker_slug` to `broker_id` — the column both tables share. Verified against the `leads` schema (`supabase/migrations/20260316_create_leads_table.sql`): columns are `lead_type` (`CHECK IN ('advisor','platform')`), `broker_id INTEGER`, `user_email TEXT NOT NULL`. The `idx_leads_email` index on `leads(user_email)` backs the batched `.in("user_email", …)` lookup in the cron sweep.

### `verified_via` value

Broker matches are now stamped `verified_via:'enquiry_match'` (was `'signup_match'`). **No constraint widening was needed** — the `user_reviews.verified_via` CHECK constraint already permits it:

```sql
CHECK (verified_via IN ('enquiry_match', 'manual', 'signup_match'))
```

(`supabase/migrations/20260411_features_11_12_14_15_16_18.sql:123`). `signup_match` no longer appears anywhere in app code — only in the migration's constraint definition — so nothing else asserted on the old value. The `VerifiedClientBadge` component renders the badge from `is_verified_client` and just formats `verified_via` for the aria-label (underscores → spaces), so `'enquiry_match'` displays cleanly with no allow-list.

### Accepted caveat

Platform leads submitted without a broker (`null broker_id`) — and reviews with a `null broker_id` — can't be attributed to a broker and never match. This is by design. The per-review POST route short-circuits to `verified:false` before querying `leads` when the review has no `broker_id`.

## Out of scope (untouched)

- The **advisor** half of both routes — unchanged, used as the template.
- `broker_signups`, its schema, and the affiliate-postback route.
- `requireCronAuth(req)` still runs first in the cron `GET` handler.

## Tests

`__tests__/api/reviews-verify-client.test.ts` and `__tests__/api/cron-verify-review-clients.test.ts`:

- Broker cases now mock the `leads` query and assert it's scoped to `lead_type='platform'` + `broker_id`, and that the write stamps `verified_via:'enquiry_match'`.
- Added a **no-match** case (lead for a different `broker_id`) and a **null-`broker_id`** case (verifies `leads` is never queried).

```
npm test -- __tests__/api/reviews-verify-client.test.ts __tests__/api/cron-verify-review-clients.test.ts
→ 23 passed
npm run type-check → clean
eslint (changed files, --max-warnings 0) → clean
```

> Tier C (cron route) — **draft, do not merge** without review.

https://claude.ai/code/session_01AX16WTaqAs2W33uydbBWLa

---
_Generated by [Claude Code](https://claude.ai/code/session_01AX16WTaqAs2W33uydbBWLa)_