### PR TITLE
feat(bots): authenticated test account + sandbox flow for logged-in QA

### DIFF
--- a/__tests__/bots/personas.test.ts
+++ b/__tests__/bots/personas.test.ts
@@ -1,0 +1,73 @@
+import path from "node:path";
+import { describe, it, expect } from "vitest";
+import {
+  PHASE0_PERSONAS,
+  AI_PERSONAS,
+  AUTHED_PERSONAS,
+  type Persona,
+} from "../../bots/personas";
+
+const ALL_PERSONAS: Persona[] = [
+  ...PHASE0_PERSONAS,
+  ...AI_PERSONAS,
+  ...AUTHED_PERSONAS,
+];
+
+const AUTH_DIR = path.resolve(process.cwd(), "e2e/visual/.auth");
+
+describe("persona registry integrity", () => {
+  it("every persona has a non-empty name and description", () => {
+    for (const p of ALL_PERSONAS) {
+      expect(p.name, JSON.stringify(p)).toBeTruthy();
+      expect(p.description, p.name).toBeTruthy();
+    }
+  });
+
+  it("persona names are unique across all arrays", () => {
+    const names = ALL_PERSONAS.map((p) => p.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it("deterministic (anon) personas declare routes", () => {
+    for (const p of PHASE0_PERSONAS) {
+      expect(p.routes && p.routes.length > 0, p.name).toBe(true);
+    }
+  });
+
+  it("AI personas declare a goal", () => {
+    for (const p of AI_PERSONAS) {
+      expect(p.goal, p.name).toBeTruthy();
+    }
+  });
+});
+
+describe("authenticated personas", () => {
+  it("ships at least one authenticated persona", () => {
+    expect(AUTHED_PERSONAS.length).toBeGreaterThan(0);
+  });
+
+  it("includes the authed-investor persona", () => {
+    expect(AUTHED_PERSONAS.some((p) => p.name === "authed-investor")).toBe(true);
+  });
+
+  it("every authed persona has a storageStateFile", () => {
+    for (const p of AUTHED_PERSONAS) {
+      expect(p.storageStateFile, p.name).toBeTruthy();
+    }
+  });
+
+  it("every authed persona has routes and/or a goal to drive", () => {
+    for (const p of AUTHED_PERSONAS) {
+      const hasWork = (p.routes && p.routes.length > 0) || Boolean(p.goal);
+      expect(hasWork, p.name).toBe(true);
+    }
+  });
+
+  it("storageStateFile paths live under e2e/visual/.auth and are .json", () => {
+    for (const p of AUTHED_PERSONAS) {
+      const file = p.storageStateFile!;
+      expect(path.dirname(path.resolve(file)), p.name).toBe(AUTH_DIR);
+      expect(file.endsWith(".json"), p.name).toBe(true);
+    }
+  });
+});

--- a/bots/README.md
+++ b/bots/README.md
@@ -46,6 +46,45 @@ Then every run:
 To turn on the AI bots in CI, add a secret `BOTS_ANTHROPIC_API_KEY` (its own
 billing line) and set the `BOTS_AI_TOKEN_BUDGET` variable above 0.
 
+## Authenticated / sandbox testing
+
+By default the fleet roams **anonymous** routes. To exercise LOGGED-IN journeys
+(account dashboard, holdings, bookmarks, save-a-plan, advisor enquiry) it uses a
+dedicated test account and a captured browser session — with **zero financial
+side effects** (payments, affiliate `/go/`, leads and account writes are mocked
+by `safety/money-paths.ts`, on every target class).
+
+End-to-end flow against a **disposable sandbox/staging** target (never prod):
+
+```bash
+# 0. Point at a seeded sandbox / staging deploy (or Supabase local).
+#    NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY must target it.
+export BOTS_BASE_URL=https://my-staging.example.com
+
+# 1. Seed the dedicated bot account(s) — idempotent; safe to re-run.
+npm run bots:seed-users        # creates test-bot-buyer@invest-test.local + profile
+
+# 2. Capture its authenticated session (storageState) via the auto-login flow.
+#    Writes e2e/visual/.auth/bot-buyer.json (gitignored).
+E2E_BASE_URL=$BOTS_BASE_URL npm run screenshots:auto-login
+
+# 3. Run the fleet in sandbox mode — authed personas now activate.
+npm run bots:sandbox
+```
+
+How it stays safe to run *un*seeded: each authenticated persona
+(`AUTHED_PERSONAS` in `personas.ts`) is **skipped** unless its storageState file
+exists on disk, so a normal/CI run without seeded auth never fails on them.
+
+Destructive account operations (delete account, document removal) stay gated
+behind `BOTS_ALLOW_DESTRUCTIVE=1` *and* a `sandbox` target — leave it off unless
+you're deliberately testing teardown on throwaway data.
+
+The credentials reuse the existing test convention: the non-routable
+`*.invest-test.local` domain and the shared `TEST_USER_PASSWORD`
+(single source of truth in `e2e/visual/state-registry.ts`). No new secret is
+introduced, and the seed script never prints the password.
+
 ## Why this is safe
 
 The whole design hinges on one rule: **a bot must never trip a real-world side
@@ -141,7 +180,7 @@ bots/
 │   ├── store.ts         # collect / dedupe / aggregate                     [pure]
 │   └── report.ts        # HTML+JSON report + shard aggregation            [pure render]
 ├── ai/cost.ts           # token→USD ledger + budget guard                 [pure]
-├── personas.ts          # persona registry
+├── personas.ts          # persona registry (anon / AI / authenticated)
 ├── session.ts           # BotSession: safety + checks + findings per user
 ├── fleet.spec.ts        # entrypoint (one session per persona)
 ├── playwright.config.ts # dedicated runner config

--- a/bots/fleet.spec.ts
+++ b/bots/fleet.spec.ts
@@ -1,7 +1,8 @@
+import fs from "node:fs";
 import { test } from "@playwright/test";
 import { loadConfig } from "./config";
 import { BotSession } from "./session";
-import { PHASE0_PERSONAS, AI_PERSONAS } from "./personas";
+import { PHASE0_PERSONAS, AI_PERSONAS, AUTHED_PERSONAS } from "./personas";
 import { resolveAiKey } from "./ai/anthropic-client";
 
 /**
@@ -40,6 +41,41 @@ for (const persona of PHASE0_PERSONAS) {
 // AI-driven personas — only when AI is enabled (a budget is set AND a key is
 // present). Each pursues a goal like a real user and judges the experience.
 const aiEnabled = config.aiTokenBudget > 0 && resolveAiKey() !== null;
+
+// Authenticated personas — drive logged-in surfaces using a seeded storageState.
+// Each test SKIPS unless its storageState file exists on disk, so a normal/CI
+// run without seeded auth never fails on them. They activate after
+// `npm run bots:seed-users` + the e2e/visual auto-login capture. Money/affiliate/
+// external paths stay auto-mocked by safety/money-paths.ts.
+for (const persona of AUTHED_PERSONAS) {
+  test(`authed bot: ${persona.name}`, async ({ browser }) => {
+    const storageStateFile = persona.storageStateFile;
+    test.skip(
+      !storageStateFile || !fs.existsSync(storageStateFile),
+      `no seeded storageState for "${persona.name}" — run bots:seed-users + auto-login first`,
+    );
+
+    const session = await BotSession.create(browser, config, {
+      persona: persona.name,
+      storageStateFile,
+    });
+    try {
+      // Deterministic logged-in route sweep.
+      for (const route of persona.routes ?? []) {
+        await session.visit(route);
+        await session.audit({ links: true });
+      }
+      // If AI is enabled, also let the persona pursue its logged-in goal.
+      if (aiEnabled && persona.goal) {
+        await session.runAiGoal(persona.goal, persona.startPath ?? "/account");
+        await session.audit();
+      }
+    } finally {
+      await session.persist();
+      await session.close();
+    }
+  });
+}
 
 if (aiEnabled) {
   for (const persona of AI_PERSONAS) {

--- a/bots/personas.ts
+++ b/bots/personas.ts
@@ -3,10 +3,13 @@
  *
  * A persona is a simulated user with a goal and a route emphasis. Phase 0 ships
  * anonymous personas over public, placeholder-cred-safe routes (the same routes
- * the a11y suite trusts to render without a seeded DB). Later phases attach
- * auth states (reusing e2e/visual/state-registry.ts) and AI-driven goals so a
- * persona can roam and judge the experience, not just load a fixed list.
+ * the a11y suite trusts to render without a seeded DB). Authenticated personas
+ * attach an auth state (reusing e2e/visual/state-registry.ts) so a persona can
+ * walk logged-in pages and pursue logged-in goals — gated on the storageState
+ * existing, so unseeded runs skip them safely.
  */
+
+import { stateFile } from "../e2e/visual/state-registry";
 
 export interface Persona {
   name: string;
@@ -62,5 +65,27 @@ export const AI_PERSONAS: Persona[] = [
     description: "A visitor using the guided 'get matched' quiz.",
     startPath: "/get-matched",
     goal: "Complete the get-matched quiz as a long-term investor and reach a personalised action plan. Judge whether the result is clear and trustworthy, and flag anything broken or missing.",
+  },
+];
+
+/**
+ * Authenticated personas: each reuses a seeded storageState (captured by the
+ * e2e/visual auto-login flow) so the bot drives logged-in surfaces — account
+ * dashboard, holdings, bookmarks, save-a-plan, advisor enquiry. Money, affiliate
+ * and external paths stay auto-mocked by safety/money-paths.ts, so these run
+ * with zero financial side effects. The fleet SKIPS any persona whose
+ * storageStateFile is not present on disk, so a normal/CI run (no seeded auth)
+ * never fails on them — they activate only after `npm run bots:seed-users` +
+ * the auto-login capture.
+ */
+export const AUTHED_PERSONAS: Persona[] = [
+  {
+    name: "authed-investor",
+    description:
+      "A signed-in individual investor exploring their account, holdings and saved plans.",
+    storageStateFile: stateFile("bot-buyer"),
+    routes: ["/account", "/account/holdings", "/account/bookmarks", "/dashboard"],
+    startPath: "/account",
+    goal: "As a logged-in investor, explore your account dashboard, review your holdings and saved bookmarks, and try to save a plan or send an advisor enquiry. Note anything broken, confusing, or any missing fees/risk disclosures. (Money and external actions are mocked — do not worry about real side effects.)",
   },
 ];

--- a/e2e/visual/auto-login.spec.ts
+++ b/e2e/visual/auto-login.spec.ts
@@ -1,53 +1,21 @@
 import { test } from "@playwright/test";
-import { AUTH_STATES } from "./state-registry";
+import { AUTH_STATES, TEST_USER_PASSWORD } from "./state-registry";
 
+// Email per state; the password is shared (see TEST_USER_PASSWORD) so it stays
+// in lockstep with scripts/seed-bot-users.ts and the rest of the seed flow.
 const TEST_USERS = [
-  {
-    state: "user-individual",
-    email: "test-individual@invest-test.local",
-    password: "TestPassword123!@#",
-  },
-  {
-    state: "advisor",
-    email: "test-advisor@invest-test.local",
-    password: "TestPassword123!@#",
-  },
-  {
-    state: "broker",
-    email: "test-broker@invest-test.local",
-    password: "TestPassword123!@#",
-  },
-  {
-    state: "business",
-    email: "test-business@invest-test.local",
-    password: "TestPassword123!@#",
-  },
-  {
-    state: "advertiser",
-    email: "test-advertiser@invest-test.local",
-    password: "TestPassword123!@#",
-  },
-  {
-    state: "author",
-    email: "test-author@invest-test.local",
-    password: "TestPassword123!@#",
-  },
-  {
-    state: "admin",
-    email: "test-admin@invest-test.local",
-    password: "TestPassword123!@#",
-  },
-  {
-    state: "listing-owner",
-    email: "test-listing-owner@invest-test.local",
-    password: "TestPassword123!@#",
-  },
-  {
-    state: "firm-portal",
-    email: "test-firm-admin@invest-test.local",
-    password: "TestPassword123!@#",
-  },
-];
+  { state: "user-individual", email: "test-individual@invest-test.local" },
+  { state: "advisor", email: "test-advisor@invest-test.local" },
+  { state: "broker", email: "test-broker@invest-test.local" },
+  { state: "business", email: "test-business@invest-test.local" },
+  { state: "advertiser", email: "test-advertiser@invest-test.local" },
+  { state: "author", email: "test-author@invest-test.local" },
+  { state: "admin", email: "test-admin@invest-test.local" },
+  { state: "listing-owner", email: "test-listing-owner@invest-test.local" },
+  { state: "firm-portal", email: "test-firm-admin@invest-test.local" },
+  // Dedicated bot-fleet individual account — seeded by scripts/seed-bot-users.ts.
+  { state: "bot-buyer", email: "test-bot-buyer@invest-test.local" },
+].map((u) => ({ ...u, password: TEST_USER_PASSWORD }));
 
 const baseURL = process.env.E2E_BASE_URL ?? "http://localhost:3000";
 

--- a/e2e/visual/state-registry.ts
+++ b/e2e/visual/state-registry.ts
@@ -11,7 +11,16 @@ export interface AuthState {
 
 const AUTH_DIR = path.resolve(process.cwd(), "e2e/visual/.auth");
 
-function stateFile(name: string): string {
+/**
+ * Shared password for every seeded test account. Single source of truth so the
+ * Playwright auto-login flow and the service-role seed script (scripts/) stay in
+ * lockstep. Test-only credential against a non-routable `*.invest-test.local`
+ * domain — never a real secret. Override per-environment with TEST_USER_PASSWORD.
+ */
+export const TEST_USER_PASSWORD = process.env.TEST_USER_PASSWORD ?? "TestPassword123!@#";
+
+/** Resolve the on-disk storageState path for a named auth state. */
+export function stateFile(name: string): string {
   return path.join(AUTH_DIR, `${name}.json`);
 }
 
@@ -80,6 +89,14 @@ export const AUTH_STATES: AuthState[] = [
     loginUrl: "/advisor-portal",
     postLoginPattern: /\/advisor-portal(\/|$)/,
     storageStateFile: stateFile("firm-portal"),
+  },
+  {
+    name: "bot-buyer",
+    description:
+      "Dedicated bot-fleet individual investor — drives logged-in QA journeys (account, holdings, save-a-plan) with money auto-mocked",
+    loginUrl: "/login",
+    postLoginPattern: /\/(dashboard|account|$)/,
+    storageStateFile: stateFile("bot-buyer"),
   },
 ];
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "e2e:install": "playwright install --with-deps chromium webkit",
     "bots": "playwright test --config bots/playwright.config.ts",
     "bots:install": "playwright install --with-deps chromium",
+    "bots:seed-users": "npx tsx scripts/seed-bot-users.ts",
+    "bots:sandbox": "BOTS_TARGET_CLASS=sandbox playwright test --config bots/playwright.config.ts",
     "screenshots": "playwright test --config e2e/visual/playwright.config.ts e2e/visual/screenshots.spec.ts",
     "screenshots:seed": "node scripts/screenshots-seed.mjs",
     "screenshots:auto-seed": "node scripts/screenshots-auto-seed.mjs",

--- a/scripts/seed-bot-users.ts
+++ b/scripts/seed-bot-users.ts
@@ -1,0 +1,160 @@
+/**
+ * Bot-fleet test-account seed.
+ *
+ * Idempotently provisions the dedicated authenticated account(s) the bot fleet
+ * uses to exercise LOGGED-IN journeys (account dashboard, holdings, save-a-plan,
+ * advisor enquiry) against a disposable sandbox / staging target. Money,
+ * affiliate and external paths are auto-mocked by the fleet
+ * (`bots/safety/money-paths.ts`) — these accounts have zero financial side
+ * effects.
+ *
+ * What it does, per account:
+ *   1. `auth.admin.createUser({ email, password, email_confirm: true })`,
+ *      tolerating "already registered" so re-runs are safe.
+ *   2. upserts the matching `public.profiles` row (keyed on auth.users.id) so
+ *      the account area renders instead of showing an empty/broken state.
+ *
+ * Credentials reuse the existing test convention — the non-routable
+ * `*.invest-test.local` domain and the shared `TEST_USER_PASSWORD` from
+ * e2e/visual/state-registry.ts (single source of truth) — so the Playwright
+ * auto-login flow can sign these accounts in unchanged. No new secret is
+ * introduced and no secret is ever printed.
+ *
+ * Usage:
+ *
+ *     # Requires NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY in env for
+ *     # the target project (Supabase local or a throwaway staging branch).
+ *     npm run bots:seed-users
+ *     # or: npx tsx scripts/seed-bot-users.ts
+ *
+ * NEVER point this at production — it writes to auth.users.
+ */
+
+import { createClient } from "@supabase/supabase-js";
+import { TEST_USER_PASSWORD } from "../e2e/visual/state-registry";
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceRole = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!url || !serviceRole) {
+  console.error(
+    "Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY in env. " +
+      "Copy .env.local.example → .env.local and fill them in for the SANDBOX/STAGING " +
+      "target (never production).",
+  );
+  process.exit(1);
+}
+
+const supabase = createClient(url, serviceRole, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+/**
+ * The dedicated bot accounts. Mirror the `*.invest-test.local` convention used
+ * by e2e/visual/auto-login.spec.ts and the `bot-buyer` auth state in
+ * state-registry.ts. At minimum we ship one individual investor.
+ */
+export interface BotSeedUser {
+  email: string;
+  displayName: string;
+}
+
+export const BOT_SEED_USERS: BotSeedUser[] = [
+  {
+    email: "test-bot-buyer@invest-test.local",
+    displayName: "Bot Buyer (test individual)",
+  },
+];
+
+/** Treat Supabase's "already registered" responses as success (idempotency). */
+function isAlreadyRegistered(message: string): boolean {
+  const m = message.toLowerCase();
+  return (
+    m.includes("already registered") ||
+    m.includes("already been registered") ||
+    m.includes("already exists") ||
+    m.includes("duplicate")
+  );
+}
+
+/**
+ * Resolve a user's id by email — used when createUser reports the account
+ * already exists, so we can still upsert its profile row.
+ */
+async function findUserIdByEmail(email: string): Promise<string | null> {
+  // listUsers is paginated; the test project is tiny, but page through to be safe.
+  for (let page = 1; page <= 20; page++) {
+    const { data, error } = await supabase.auth.admin.listUsers({ page, perPage: 200 });
+    if (error) throw new Error(error.message);
+    const match = (data?.users ?? []).find((u) => u.email === email);
+    if (match) return match.id;
+    if (!data || data.users.length < 200) break;
+  }
+  return null;
+}
+
+async function seedUser(user: BotSeedUser): Promise<{ email: string; status: string }> {
+  let userId: string | null = null;
+  let status: string;
+
+  const { data, error } = await supabase.auth.admin.createUser({
+    email: user.email,
+    password: TEST_USER_PASSWORD,
+    email_confirm: true,
+  });
+
+  if (error) {
+    if (!isAlreadyRegistered(error.message)) {
+      throw new Error(`createUser(${user.email}) failed: ${error.message}`);
+    }
+    userId = await findUserIdByEmail(user.email);
+    status = "exists";
+  } else {
+    userId = data.user?.id ?? null;
+    status = "created";
+  }
+
+  if (!userId) {
+    return { email: user.email, status: `${status} (no id — profile skipped)` };
+  }
+
+  // Mirror the individual-user profile row the account area expects.
+  const { error: profileError } = await supabase.from("profiles").upsert(
+    {
+      id: userId,
+      email: user.email,
+      display_name: user.displayName,
+    },
+    { onConflict: "id" },
+  );
+  if (profileError) {
+    return { email: user.email, status: `${status} (profile upsert failed: ${profileError.message})` };
+  }
+
+  return { email: user.email, status: `${status} + profile` };
+}
+
+async function main() {
+  console.log("Seeding bot test account(s)…");
+  console.log(`  target: ${url}`);
+
+  const results: Array<{ email: string; status: string }> = [];
+  for (const user of BOT_SEED_USERS) {
+    results.push(await seedUser(user));
+  }
+
+  console.log("\nSummary:");
+  for (const r of results) {
+    console.log(`  ✓ ${r.email} — ${r.status}`);
+  }
+  console.log(
+    "\nNext: capture auth via `npm run screenshots:auto-login`, then run " +
+      "`npm run bots:sandbox`. (Password is the shared test credential — not printed.)",
+  );
+  console.log("Done.");
+}
+
+main().catch((err) => {
+  console.error("Bot-user seed failed:", err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});


### PR DESCRIPTION
## What

Gives the `bots/` fleet a **dedicated authenticated test account** + a turnkey sandbox flow so future runs can exercise **logged-in journeys** (account dashboard, holdings, bookmarks, save-a-plan, advisor enquiry) with **zero financial side effects**. Money / affiliate `/go/` / leads / account writes stay auto-mocked by `bots/safety/money-paths.ts` (untouched).

## Files

- **`scripts/seed-bot-users.ts`** (new) — idempotent service-role seed of `test-bot-buyer@invest-test.local` via `auth.admin.createUser({ email_confirm: true })`, tolerating "already registered", plus the matching `public.profiles` row so the account area renders. Fails with a helpful message if `SUPABASE_SERVICE_ROLE_KEY` is absent; never prints the password.
- **`e2e/visual/state-registry.ts`** — exports a shared `TEST_USER_PASSWORD` (single source of truth) + an exported `stateFile()`; registers the `bot-buyer` auth state.
- **`e2e/visual/auto-login.spec.ts`** — adds `bot-buyer` to `TEST_USERS`; consumes the shared password constant (de-duped the 9 inline copies).
- **`bots/personas.ts`** — new exported `AUTHED_PERSONAS` (`authed-investor`): storageState at `e2e/visual/.auth/bot-buyer.json`, logged-in routes (`/account`, `/account/holdings`, `/account/bookmarks`, `/dashboard`) + an AI goal for account/save-a-plan exploration.
- **`bots/fleet.spec.ts`** — runs `AUTHED_PERSONAS`; **`test.skip` when the storageState file is absent** (`fs.existsSync`), so normal/CI runs without seeded auth never fail. AI goal runs only when AI is enabled.
- **`package.json`** — `bots:seed-users` (`npx tsx scripts/seed-bot-users.ts`) and `bots:sandbox` (`BOTS_TARGET_CLASS=sandbox` + the bots run).
- **`bots/README.md`** — new "Authenticated / sandbox testing" section documenting the end-to-end flow; notes money is auto-mocked and destructive ops are gated behind `BOTS_ALLOW_DESTRUCTIVE`.
- **`__tests__/bots/personas.test.ts`** (new) — persona-registry integrity: every authed persona has a storageStateFile + routes/goal; names unique across all arrays; storageState paths live under `e2e/visual/.auth/`.

## Safety

- Money / affiliate / external / destructive paths remain auto-mocked on every target class — `safety/money-paths.ts` is unchanged.
- No new secret: reuses the non-routable `*.invest-test.local` domain and the shared test password.
- `.auth/*.json` is gitignored — no session is committed.
- Authed personas are storageState-gated, so this is inert until explicitly activated.

## Run steps (founder)

```bash
export BOTS_BASE_URL=https://<sandbox-or-staging>   # never prod
npm run bots:seed-users                              # seed the account (idempotent)
E2E_BASE_URL=$BOTS_BASE_URL npm run screenshots:auto-login   # capture session
npm run bots:sandbox                                 # run logged-in fleet
```

## Verify

- `npm test -- __tests__/bots/personas.test.ts` → 9 passed; full `__tests__/bots/` → 129 passed.
- `npx eslint --fix --max-warnings 0` on all changed files → clean.
- `tsc --noEmit` → exit 0, no errors in touched files.

Tier B (additive test infra). CI is authoritative.