### PR TITLE
feat(bots): mirror target + advisor-focused personas

### DIFF
--- a/__tests__/bots/personas.test.ts
+++ b/__tests__/bots/personas.test.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { describe, it, expect } from "vitest";
 import {
   PHASE0_PERSONAS,
+  ADVISOR_PERSONAS,
   AI_PERSONAS,
   AUTHED_PERSONAS,
   type Persona,
@@ -9,11 +10,56 @@ import {
 
 const ALL_PERSONAS: Persona[] = [
   ...PHASE0_PERSONAS,
+  ...ADVISOR_PERSONAS,
   ...AI_PERSONAS,
   ...AUTHED_PERSONAS,
 ];
 
 const AUTH_DIR = path.resolve(process.cwd(), "e2e/visual/.auth");
+
+describe("ADVISOR_PERSONAS", () => {
+  it("is non-empty", () => {
+    expect(ADVISOR_PERSONAS.length).toBeGreaterThan(0);
+  });
+
+  it("every persona has a name, a description, and routes or a goal", () => {
+    for (const persona of ADVISOR_PERSONAS) {
+      expect(persona.name).toBeTruthy();
+      expect(persona.description).toBeTruthy();
+      const hasRoutes = (persona.routes?.length ?? 0) > 0;
+      const hasGoal = Boolean(persona.goal);
+      expect(hasRoutes || hasGoal).toBe(true);
+    }
+  });
+
+  it("is anonymous — no storage state (the mirror is a protected target)", () => {
+    for (const persona of ADVISOR_PERSONAS) {
+      expect(persona.storageStateFile).toBeUndefined();
+    }
+  });
+
+  it("every route targets the advisor area", () => {
+    for (const persona of ADVISOR_PERSONAS) {
+      for (const route of persona.routes ?? []) {
+        // /advisors, /advisor/<slug>, and /find-advisor are all advisor-area.
+        expect(route).toMatch(/^\/(advisors?|find-advisor)/);
+      }
+    }
+  });
+
+  it("covers the directory, specialty hubs, find-advisor, and a profile", () => {
+    const routes = ADVISOR_PERSONAS.flatMap((p) => p.routes ?? []);
+    expect(routes).toContain("/advisors");
+    expect(routes).toContain("/find-advisor");
+    expect(routes.some((r) => r.startsWith("/advisor/"))).toBe(true);
+    expect(routes).toContain("/advisors/firb-specialists");
+    expect(routes).toContain("/advisors/migration-agents");
+    expect(routes).toContain("/advisors/international-tax-specialists");
+    // A type listing and a type-by-state slice.
+    expect(routes.some((r) => /^\/advisors\/[a-z-]+$/.test(r))).toBe(true);
+    expect(routes.some((r) => /^\/advisors\/[a-z-]+\/[a-z-]+$/.test(r))).toBe(true);
+  });
+});
 
 describe("persona registry integrity", () => {
   it("every persona has a non-empty name and description", () => {
@@ -26,6 +72,14 @@ describe("persona registry integrity", () => {
   it("persona names are unique across all arrays", () => {
     const names = ALL_PERSONAS.map((p) => p.name);
     expect(new Set(names).size).toBe(names.length);
+  });
+
+  it("every persona declares routes or a goal", () => {
+    for (const persona of ALL_PERSONAS) {
+      const hasRoutes = (persona.routes?.length ?? 0) > 0;
+      const hasGoal = Boolean(persona.goal);
+      expect(hasRoutes || hasGoal).toBe(true);
+    }
   });
 
   it("deterministic (anon) personas declare routes", () => {

--- a/bots/README.md
+++ b/bots/README.md
@@ -23,6 +23,31 @@ npm run bots                  # drive a local dev server (auto-started)
 BOTS_BASE_URL=https://my-preview.vercel.app npm run bots
 ```
 
+## Testing the Netlify mirror (/advisors)
+
+The live Netlify **mirror** (`https://lambent-sawine-17c3dd.netlify.app`) is the
+default remote target for ad-hoc QA. It is a `protected` target, so **every
+state-mutating write is auto-mocked** by `safety/money-paths.ts` — nothing real
+happens.
+
+```bash
+npm run bots:mirror      # full fleet (incl. advisor personas) against the mirror
+npm run bots:advisors    # same, scoped to the advisor personas only (-g advisor)
+```
+
+Both scripts set `BOTS_BASE_URL` to the mirror and `BOTS_IGNORE_HTTPS_ERRORS=1`
+(this workspace sits behind a TLS-MITM proxy). The fleet includes the
+`ADVISOR_PERSONAS` (in `personas.ts`) which cover the adviser directory
+(`/advisors`, `/advisors/<type>`, `/advisors/<type>/<state>`), the specialty
+hubs (`/advisors/firb-specialists`, `/advisors/migration-agents`,
+`/advisors/international-tax-specialists`), the `/find-advisor` entry point, and
+a seeded profile (`/advisor/<slug>`).
+
+These personas are **anonymous** (no auth). For logged-in advisor flows
+(advisor-portal, lead management), seed and capture auth as described under
+[AI-driven bots](#ai-driven-bots) / the authenticated-personas roadmap item —
+the mirror's writes remain mocked regardless.
+
 The run writes `bots/.runs/<runId>/report.html` (visual report), `summary.md`
 (plain-English digest), and `findings.json`.
 

--- a/bots/fleet.spec.ts
+++ b/bots/fleet.spec.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import { test } from "@playwright/test";
 import { loadConfig } from "./config";
 import { BotSession } from "./session";
-import { PHASE0_PERSONAS, AI_PERSONAS, AUTHED_PERSONAS } from "./personas";
+import { PHASE0_PERSONAS, ADVISOR_PERSONAS, AI_PERSONAS, AUTHED_PERSONAS } from "./personas";
 import { resolveAiKey } from "./ai/anthropic-client";
 
 /**
@@ -20,7 +20,12 @@ import { resolveAiKey } from "./ai/anthropic-client";
 
 const config = loadConfig();
 
-for (const persona of PHASE0_PERSONAS) {
+// Deterministic anonymous personas (no storage state needed). ADVISOR_PERSONAS
+// adds adviser-directory coverage and runs the same way as PHASE0_PERSONAS — the
+// intended default target is the protected Netlify mirror via `npm run bots:mirror`.
+const DETERMINISTIC_PERSONAS = [...PHASE0_PERSONAS, ...ADVISOR_PERSONAS];
+
+for (const persona of DETERMINISTIC_PERSONAS) {
   test(`bot persona: ${persona.name}`, async ({ browser }) => {
     const session = await BotSession.create(browser, config, {
       persona: persona.name,
@@ -78,7 +83,8 @@ for (const persona of AUTHED_PERSONAS) {
 }
 
 if (aiEnabled) {
-  for (const persona of AI_PERSONAS) {
+  // Advisor personas carry goals too, so let them explore/judge when AI is on.
+  for (const persona of [...AI_PERSONAS, ...ADVISOR_PERSONAS]) {
     test(`AI bot: ${persona.name}`, async ({ browser }) => {
       const session = await BotSession.create(browser, config, {
         persona: persona.name,

--- a/bots/personas.ts
+++ b/bots/personas.ts
@@ -89,3 +89,57 @@ export const AUTHED_PERSONAS: Persona[] = [
     goal: "As a logged-in investor, explore your account dashboard, review your holdings and saved bookmarks, and try to save a plan or send an advisor enquiry. Note anything broken, confusing, or any missing fees/risk disclosures. (Money and external actions are mocked — do not worry about real side effects.)",
   },
 ];
+
+/**
+ * Advisor-area personas — anonymous coverage of the adviser directory, the
+ * specialty hubs, the get-matched entry point, and a seeded profile. Designed to
+ * be run against the protected Netlify mirror (writes are auto-mocked), so every
+ * route here is read-only / public; no `storageStateFile` is attached. Each
+ * carries a deterministic route list AND an AI goal, so the same array drives
+ * both the page-sweep and (when AI is enabled) the explore/judge loop.
+ *
+ * `/advisor/james-wong-sydney` is a known slug from the mock-advisor seed
+ * (`supabase/migrations/20260309_seed_mock_advisors.sql`); if the target isn't
+ * seeded it falls back to a 404-handled profile, still useful as a smoke check.
+ */
+export const ADVISOR_PERSONAS: Persona[] = [
+  {
+    name: "advisor-directory-browser",
+    description:
+      "Browsing the adviser directory: the landing page, a type listing, and a type-by-state slice.",
+    routes: [
+      "/advisors",
+      "/advisors/financial-planners",
+      "/advisors/financial-planners/nsw",
+    ],
+    startPath: "/advisors",
+    goal: "Browse the adviser directory, drill into a profession (financial planners) and then a state, and judge whether listings, filters, and disclosures are clear. Flag dead ends, empty states, or missing AFSL/fee disclosures.",
+  },
+  {
+    name: "advisor-specialty-seeker",
+    description:
+      "Looking for niche adviser specialties (FIRB, migration, international tax).",
+    routes: [
+      "/advisors/firb-specialists",
+      "/advisors/migration-agents",
+      "/advisors/international-tax-specialists",
+    ],
+    startPath: "/advisors/firb-specialists",
+    goal: "As a foreign investor, find a specialist (FIRB, migration, or international tax) who can help, and reach a point where you could make contact. Flag anything confusing, broken, or any missing disclosures.",
+  },
+  {
+    name: "advisor-matchmaker",
+    description: "Using the guided find-an-adviser entry point.",
+    routes: ["/find-advisor", "/advisors"],
+    startPath: "/find-advisor",
+    goal: "Use the find-an-adviser flow to get matched with a suitable adviser, and judge whether the matching is clear and trustworthy. Flag dead ends or missing disclosures.",
+  },
+  {
+    name: "advisor-profile-explorer",
+    description:
+      "Reading a single adviser profile in depth before making contact.",
+    routes: ["/advisor/james-wong-sydney", "/advisors"],
+    startPath: "/advisor/james-wong-sydney",
+    goal: "Read an adviser's profile in detail and decide whether you'd contact them. Judge whether credentials, fees, and disclosures are present and trustworthy; flag anything broken or missing.",
+  },
+];

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "bots:install": "playwright install --with-deps chromium",
     "bots:seed-users": "npx tsx scripts/seed-bot-users.ts",
     "bots:sandbox": "BOTS_TARGET_CLASS=sandbox playwright test --config bots/playwright.config.ts",
+    "bots:mirror": "BOTS_BASE_URL=https://lambent-sawine-17c3dd.netlify.app BOTS_IGNORE_HTTPS_ERRORS=1 BOTS_SKIP_WEBSERVER=1 playwright test --config bots/playwright.config.ts",
+    "bots:advisors": "BOTS_BASE_URL=https://lambent-sawine-17c3dd.netlify.app BOTS_IGNORE_HTTPS_ERRORS=1 BOTS_SKIP_WEBSERVER=1 playwright test --config bots/playwright.config.ts -g \"advisor\"",
     "screenshots": "playwright test --config e2e/visual/playwright.config.ts e2e/visual/screenshots.spec.ts",
     "screenshots:seed": "node scripts/screenshots-seed.mjs",
     "screenshots:auto-seed": "node scripts/screenshots-auto-seed.mjs",


### PR DESCRIPTION
Makes the bots fleet easy to point at the live Netlify **mirror** and adds adviser-area coverage, per founder request ("all the bots testing and using https://lambent-sawine-17c3dd.netlify.app/advisors").

## What
- **`ADVISOR_PERSONAS`** (new export in `bots/personas.ts`) — anonymous personas covering the adviser directory (`/advisors`, `/advisors/<type>`, `/advisors/<type>/<state>`), the specialty hubs (`/advisors/firb-specialists`, `/advisors/migration-agents`, `/advisors/international-tax-specialists`), `/find-advisor`, and a seeded profile (`/advisor/james-wong-sydney`, from the mock-advisor seed). Each carries both a route list and an AI goal.
- **`bots/fleet.spec.ts`** — advisor personas run in the deterministic sweep alongside `PHASE0_PERSONAS` (same anonymous, no-storage-state pattern) and join the AI explore/judge loop when AI is enabled.
- **`package.json`** — `npm run bots:mirror` (full fleet vs the mirror) and `npm run bots:advisors` (advisor-scoped via `-g advisor`). Both set `BOTS_BASE_URL` to the mirror and `BOTS_IGNORE_HTTPS_ERRORS=1` (workspace TLS-MITM proxy).
- **`bots/README.md`** — new "Testing the Netlify mirror (/advisors)" section.
- **`__tests__/bots/personas.test.ts`** — new; asserts persona-registry integrity.

## Safety
The mirror is a **protected** target, so every state-mutating write is auto-mocked by `bots/safety/money-paths.ts` — **0 real writes/postbacks**. Personas here are anonymous. `isProdHost` matches only `invest.com.au`, so the netlify host needs **no** `BOTS_PROD_OVERRIDE`. The hardcoded localhost default in `config.ts` is untouched — the mirror is opt-in via the new scripts.

## Run it
```
npm run bots:mirror      # full fleet (incl. advisor personas) vs the mirror
npm run bots:advisors    # advisor personas only
```

## Verify
- `npm test -- __tests__/bots/personas.test.ts` → 7 passing
- `npx eslint --max-warnings 0` on changed source/test files → clean

Tier B (test-infra; non-money, non-regulated).