### PR TITLE
feat(invest): Wave 5 — structure-aware after-tax return + FIRB fee + SIV score

### DIFF
--- a/__tests__/lib/invest-decision-tools.test.ts
+++ b/__tests__/lib/invest-decision-tools.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from "vitest";
+import {
+  afterTaxReturn,
+  frankingAdjustedYield,
+  firbFeeForListing,
+  sivComplianceScore,
+  cgtDiscountStatus,
+  defaultReturnSplit,
+  INVESTMENT_STRUCTURES,
+  STRUCTURE_OPTIONS,
+} from "@/lib/invest-decision-tools";
+import type { InvestmentListing } from "@/lib/types";
+
+function listing(overrides: Record<string, unknown>): InvestmentListing {
+  return {
+    id: 1,
+    vertical: "funds",
+    title: "T",
+    slug: "t",
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  } as unknown as InvestmentListing;
+}
+
+describe("afterTaxReturn", () => {
+  it("SMSF pension keeps the full gross return (0% tax)", () => {
+    const r = afterTaxReturn({ grossReturnPct: 8, structure: "smsf_pension", incomeShare: 0.5 });
+    expect(r.afterTaxReturnPct).toBeCloseTo(8, 1);
+    expect(r.taxDragPct).toBeCloseTo(0, 1);
+    expect(r.effectiveTaxRate).toBeCloseTo(0, 2);
+  });
+
+  it("individual top bracket pays more tax than SMSF accumulation", () => {
+    const ind = afterTaxReturn({ grossReturnPct: 10, structure: "individual_top", incomeShare: 0.5, heldOver12Months: true });
+    const smsf = afterTaxReturn({ grossReturnPct: 10, structure: "smsf_accumulation", incomeShare: 0.5, heldOver12Months: true });
+    expect(ind.afterTaxReturnPct).toBeLessThan(smsf.afterTaxReturnPct);
+    expect(ind.taxDragPct).toBeGreaterThan(smsf.taxDragPct);
+  });
+
+  it("growth-heavy returns are taxed less than income-heavy for individuals (CGT discount)", () => {
+    const incomeHeavy = afterTaxReturn({ grossReturnPct: 10, structure: "individual_top", incomeShare: 1, heldOver12Months: true });
+    const growthHeavy = afterTaxReturn({ grossReturnPct: 10, structure: "individual_top", incomeShare: 0, heldOver12Months: true });
+    expect(growthHeavy.afterTaxReturnPct).toBeGreaterThan(incomeHeavy.afterTaxReturnPct);
+  });
+
+  it("companies get no CGT discount — held>12mo and held<12mo are identical on capital", () => {
+    const long = afterTaxReturn({ grossReturnPct: 10, structure: "company", incomeShare: 0, heldOver12Months: true });
+    const short = afterTaxReturn({ grossReturnPct: 10, structure: "company", incomeShare: 0, heldOver12Months: false });
+    expect(long.afterTaxReturnPct).toBeCloseTo(short.afterTaxReturnPct, 2);
+    // 30% flat → 7% kept on a 10% pure-growth return
+    expect(long.afterTaxReturnPct).toBeCloseTo(7, 1);
+  });
+
+  it("undiscounted (held < 12mo) capital is taxed harder than discounted for individuals", () => {
+    const long = afterTaxReturn({ grossReturnPct: 10, structure: "individual_top", incomeShare: 0, heldOver12Months: true });
+    const short = afterTaxReturn({ grossReturnPct: 10, structure: "individual_top", incomeShare: 0, heldOver12Months: false });
+    expect(short.afterTaxReturnPct).toBeLessThan(long.afterTaxReturnPct);
+  });
+
+  it("franked income improves the after-tax outcome vs unfranked", () => {
+    const franked = afterTaxReturn({ grossReturnPct: 6, structure: "individual_37", incomeShare: 1, frankingPct: 100 });
+    const unfranked = afterTaxReturn({ grossReturnPct: 6, structure: "individual_37", incomeShare: 1 });
+    expect(franked.afterTaxReturnPct).toBeGreaterThan(unfranked.afterTaxReturnPct);
+  });
+
+  it("effectiveTaxRate is 0..1 and afterTax never exceeds gross", () => {
+    for (const s of STRUCTURE_OPTIONS) {
+      const r = afterTaxReturn({ grossReturnPct: 12, structure: s.key, incomeShare: 0.5 });
+      expect(r.effectiveTaxRate).toBeGreaterThanOrEqual(0);
+      expect(r.effectiveTaxRate).toBeLessThanOrEqual(1);
+      expect(r.afterTaxReturnPct).toBeLessThanOrEqual(r.grossReturnPct + 0.01);
+    }
+  });
+});
+
+describe("frankingAdjustedYield", () => {
+  it("grossed-up yield exceeds cash yield for franked dividends", () => {
+    const r = frankingAdjustedYield(4.2, 100, 0.45);
+    expect(r.grossedUpYieldPct).toBeGreaterThan(r.cashYieldPct);
+    // 100% franked: 4.2 / (1-0.3) = 6.0 grossed up
+    expect(r.grossedUpYieldPct).toBeCloseTo(6.0, 1);
+  });
+
+  it("0% franking leaves cash == grossed-up", () => {
+    const r = frankingAdjustedYield(5, 0, 0.45);
+    expect(r.grossedUpYieldPct).toBeCloseTo(r.cashYieldPct, 1);
+  });
+
+  it("a low marginal rate keeps more net yield than a high one", () => {
+    const low = frankingAdjustedYield(5, 100, 0.19);
+    const high = frankingAdjustedYield(5, 100, 0.45);
+    expect(low.netYieldPct).toBeGreaterThan(high.netYieldPct);
+  });
+});
+
+describe("firbFeeForListing", () => {
+  it("returns a tiered fee for a priced for-sale asset", () => {
+    const r = firbFeeForListing(listing({
+      vertical: "commercial_property", listing_kind: "for_sale_asset",
+      asking_price_cents: 850_000_00, // $850k
+    }));
+    expect(r.applicable).toBe(true);
+    expect(r.valueAud).toBe(850_000);
+    expect(r.feeAud).toBeGreaterThan(0);
+  });
+
+  it("scales the fee up with value", () => {
+    const small = firbFeeForListing(listing({ vertical: "farmland", listing_kind: "for_sale_asset", asking_price_cents: 900_000_00 }));
+    const big = firbFeeForListing(listing({ vertical: "farmland", listing_kind: "for_sale_asset", asking_price_cents: 4_000_000_00 }));
+    expect(big.feeAud).toBeGreaterThan(small.feeAud);
+  });
+
+  it("listed securities and funds are out of FIRB residential/commercial scope", () => {
+    const sec = firbFeeForListing(listing({ vertical: "uranium", listing_kind: "listed_security", asking_price_cents: null, key_metrics: { asx_ticker: "PDN" } }));
+    const fund = firbFeeForListing(listing({ vertical: "funds", listing_kind: "fund", asking_price_cents: null, key_metrics: { min_investment_aud: 250000 } }));
+    expect(sec.applicable).toBe(false);
+    expect(fund.applicable).toBe(false);
+  });
+
+  it("falls back to min_investment when no asking price", () => {
+    const r = firbFeeForListing(listing({
+      vertical: "commercial_property", listing_kind: "for_sale_asset",
+      asking_price_cents: null, key_metrics: { min_investment_aud: 1_500_000 },
+    }));
+    expect(r.valueAud).toBe(1_500_000);
+    expect(r.applicable).toBe(true);
+  });
+});
+
+describe("sivComplianceScore", () => {
+  it("computes the complying value share by dollar value", () => {
+    const r = sivComplianceScore([
+      listing({ siv_complying: true, asking_price_cents: 5_000_000_00 }),
+      listing({ siv_complying: false, asking_price_cents: 5_000_000_00 }),
+    ]);
+    expect(r.complyingPct).toBe(50);
+    expect(r.complyingCount).toBe(1);
+    expect(r.totalCount).toBe(2);
+  });
+
+  it("returns 0% for an all-non-complying shortlist", () => {
+    const r = sivComplianceScore([listing({ siv_complying: false, asking_price_cents: 100_00 })]);
+    expect(r.complyingPct).toBe(0);
+  });
+
+  it("handles empty input without dividing by zero", () => {
+    const r = sivComplianceScore([]);
+    expect(r.complyingPct).toBe(0);
+    expect(r.totalValueAud).toBe(0);
+  });
+
+  it("uses min_investment when asking price is absent", () => {
+    const r = sivComplianceScore([
+      listing({ siv_complying: true, asking_price_cents: null, key_metrics: { min_investment_aud: 250_000 } }),
+    ]);
+    expect(r.complyingValueAud).toBe(250_000);
+    expect(r.complyingPct).toBe(100);
+  });
+});
+
+describe("cgtDiscountStatus", () => {
+  it("reports eligible once 12 months have passed", () => {
+    const acquired = new Date();
+    acquired.setFullYear(acquired.getFullYear() - 2);
+    const r = cgtDiscountStatus(acquired.toISOString());
+    expect(r.eligible).toBe(true);
+    expect(r.daysRemaining).toBe(0);
+  });
+
+  it("counts down when within the first 12 months", () => {
+    const acquired = new Date();
+    acquired.setMonth(acquired.getMonth() - 6);
+    const r = cgtDiscountStatus(acquired.toISOString());
+    expect(r.eligible).toBe(false);
+    expect(r.daysRemaining).toBeGreaterThan(150);
+    expect(r.daysRemaining).toBeLessThan(200);
+  });
+
+  it("handles a bad date gracefully", () => {
+    const r = cgtDiscountStatus("not-a-date");
+    expect(r.eligible).toBe(false);
+  });
+});
+
+describe("defaultReturnSplit + structures", () => {
+  it("physical assets are pure capital growth", () => {
+    expect(defaultReturnSplit("physical_asset")).toEqual({ income: 0, growth: 1 });
+  });
+  it("royalties are almost all income", () => {
+    expect(defaultReturnSplit("royalty").income).toBeGreaterThan(0.9);
+  });
+  it("every structure has a sensible income rate (0..0.5)", () => {
+    for (const s of STRUCTURE_OPTIONS) {
+      expect(s.incomeRate).toBeGreaterThanOrEqual(0);
+      expect(s.incomeRate).toBeLessThanOrEqual(0.5);
+    }
+  });
+  it("SMSF pension is the only fully-exempt structure", () => {
+    expect(INVESTMENT_STRUCTURES.smsf_pension.incomeRate).toBe(0);
+    expect(INVESTMENT_STRUCTURES.smsf_pension.capitalRateDiscounted).toBe(0);
+  });
+});

--- a/app/invest/alternatives/listings/[slug]/page.tsx
+++ b/app/invest/alternatives/listings/[slug]/page.tsx
@@ -5,6 +5,7 @@ import Icon from "@/components/Icon";
 import ListingImageGallery from "@/components/ListingImageGallery";
 import ListingCard, { type InvestmentListing } from "@/components/ListingCard";
 import ListingEnquiryForm from "@/components/ListingEnquiryForm";
+import ListingDecisionTools from "@/components/invest/ListingDecisionTools";
 import ListingsEmptyState from "@/components/ListingsEmptyState";
 import SubCategoryListingsView from "@/components/SubCategoryListingsView";
 import {
@@ -278,6 +279,9 @@ export default async function AlternativesListingDetailPage({
                   vertical="alternatives"
                 />
               </div>
+              {/* Wave 5 — structure-aware after-tax return + FIRB estimate */}
+              <ListingDecisionTools listing={l} />
+
 
               {/* Stats */}
               <div className="bg-slate-50 border border-slate-200 rounded-xl p-4 flex gap-6">

--- a/app/invest/buy-business/listings/[slug]/page.tsx
+++ b/app/invest/buy-business/listings/[slug]/page.tsx
@@ -5,6 +5,7 @@ import Icon from "@/components/Icon";
 import ListingImageGallery from "@/components/ListingImageGallery";
 import ListingCard, { type InvestmentListing } from "@/components/ListingCard";
 import ListingEnquiryForm from "@/components/ListingEnquiryForm";
+import ListingDecisionTools from "@/components/invest/ListingDecisionTools";
 import ListingsEmptyState from "@/components/ListingsEmptyState";
 import SubCategoryListingsView from "@/components/SubCategoryListingsView";
 import {
@@ -255,6 +256,9 @@ export default async function BusinessListingDetailPage({
                   vertical="business"
                 />
               </div>
+              {/* Wave 5 — structure-aware after-tax return + FIRB estimate */}
+              <ListingDecisionTools listing={l} />
+
 
               {/* Stats */}
               <div className="bg-slate-50 border border-slate-200 rounded-xl p-4 flex gap-6">

--- a/app/invest/commercial-property/listings/[slug]/page.tsx
+++ b/app/invest/commercial-property/listings/[slug]/page.tsx
@@ -5,6 +5,7 @@ import Icon from "@/components/Icon";
 import ListingImageGallery from "@/components/ListingImageGallery";
 import ListingCard, { type InvestmentListing } from "@/components/ListingCard";
 import ListingEnquiryForm from "@/components/ListingEnquiryForm";
+import ListingDecisionTools from "@/components/invest/ListingDecisionTools";
 import ListingsEmptyState from "@/components/ListingsEmptyState";
 import SubCategoryListingsView from "@/components/SubCategoryListingsView";
 import {
@@ -217,6 +218,9 @@ export default async function CommercialListingDetailPage({
                 <p className="text-xs text-slate-500 mb-4">Confidential enquiry to the listing agent.</p>
                 <ListingEnquiryForm listingId={l.id} listingTitle={l.title} vertical="commercial_property" />
               </div>
+              {/* Wave 5 — structure-aware after-tax return + FIRB estimate */}
+              <ListingDecisionTools listing={l} />
+
               <div className="bg-slate-50 border border-slate-200 rounded-xl p-4 flex gap-6">
                 <div className="text-center">
                   <p className="text-lg font-bold text-slate-900">{l.views ?? 0}</p>

--- a/app/invest/farmland/listings/[slug]/page.tsx
+++ b/app/invest/farmland/listings/[slug]/page.tsx
@@ -5,6 +5,7 @@ import Icon from "@/components/Icon";
 import ListingImageGallery from "@/components/ListingImageGallery";
 import ListingCard, { type InvestmentListing } from "@/components/ListingCard";
 import ListingEnquiryForm from "@/components/ListingEnquiryForm";
+import ListingDecisionTools from "@/components/invest/ListingDecisionTools";
 import ListingsEmptyState from "@/components/ListingsEmptyState";
 import SubCategoryListingsView from "@/components/SubCategoryListingsView";
 import {
@@ -226,6 +227,9 @@ export default async function FarmlandListingDetailPage({
                 <p className="text-xs text-slate-500 mb-4">Send a confidential enquiry to the selling agent.</p>
                 <ListingEnquiryForm listingId={l.id} listingTitle={l.title} vertical="farmland" />
               </div>
+              {/* Wave 5 — structure-aware after-tax return + FIRB estimate */}
+              <ListingDecisionTools listing={l} />
+
               <div className="bg-slate-50 border border-slate-200 rounded-xl p-4 flex gap-6">
                 <div className="text-center">
                   <p className="text-lg font-bold text-slate-900">{l.views ?? 0}</p>

--- a/app/invest/franchise/listings/[slug]/page.tsx
+++ b/app/invest/franchise/listings/[slug]/page.tsx
@@ -5,6 +5,7 @@ import Icon from "@/components/Icon";
 import ListingImageGallery from "@/components/ListingImageGallery";
 import ListingCard, { type InvestmentListing } from "@/components/ListingCard";
 import ListingEnquiryForm from "@/components/ListingEnquiryForm";
+import ListingDecisionTools from "@/components/invest/ListingDecisionTools";
 import ListingsEmptyState from "@/components/ListingsEmptyState";
 import SubCategoryListingsView from "@/components/SubCategoryListingsView";
 import {
@@ -226,6 +227,9 @@ export default async function FranchiseListingDetailPage({
                 <p className="text-xs text-slate-500 mb-4">Get a Franchise Disclosure Document and speak with the franchisor.</p>
                 <ListingEnquiryForm listingId={l.id} listingTitle={l.title} vertical="franchise" />
               </div>
+              {/* Wave 5 — structure-aware after-tax return + FIRB estimate */}
+              <ListingDecisionTools listing={l} />
+
               <div className="bg-slate-50 border border-slate-200 rounded-xl p-4 flex gap-6">
                 <div className="text-center">
                   <p className="text-lg font-bold text-slate-900">{l.views ?? 0}</p>

--- a/app/invest/infrastructure/listings/[slug]/page.tsx
+++ b/app/invest/infrastructure/listings/[slug]/page.tsx
@@ -5,6 +5,7 @@ import Icon from "@/components/Icon";
 import ListingImageGallery from "@/components/ListingImageGallery";
 import ListingCard, { type InvestmentListing } from "@/components/ListingCard";
 import ListingEnquiryForm from "@/components/ListingEnquiryForm";
+import ListingDecisionTools from "@/components/invest/ListingDecisionTools";
 import ListingsEmptyState from "@/components/ListingsEmptyState";
 import SubCategoryListingsView from "@/components/SubCategoryListingsView";
 import {
@@ -273,6 +274,9 @@ export default async function InfrastructureListingDetailPage({
                   vertical="infrastructure"
                 />
               </div>
+              {/* Wave 5 — structure-aware after-tax return + FIRB estimate */}
+              <ListingDecisionTools listing={l} />
+
 
               {/* Stats */}
               <div className="bg-slate-50 border border-slate-200 rounded-xl p-4 flex gap-6">

--- a/app/invest/mining/listings/[slug]/page.tsx
+++ b/app/invest/mining/listings/[slug]/page.tsx
@@ -5,6 +5,7 @@ import Icon from "@/components/Icon";
 import ListingImageGallery from "@/components/ListingImageGallery";
 import ListingCard, { type InvestmentListing } from "@/components/ListingCard";
 import ListingEnquiryForm from "@/components/ListingEnquiryForm";
+import ListingDecisionTools from "@/components/invest/ListingDecisionTools";
 import ListingsEmptyState from "@/components/ListingsEmptyState";
 import SubCategoryListingsView from "@/components/SubCategoryListingsView";
 import {
@@ -230,6 +231,9 @@ export default async function MiningOpportunityDetailPage({
                 <p className="text-xs text-slate-500 mb-4">Send a confidential enquiry to the project team.</p>
                 <ListingEnquiryForm listingId={l.id} listingTitle={l.title} vertical="mining" />
               </div>
+              {/* Wave 5 — structure-aware after-tax return + FIRB estimate */}
+              <ListingDecisionTools listing={l} />
+
               <div className="bg-slate-50 border border-slate-200 rounded-xl p-4 flex gap-6">
                 <div className="text-center">
                   <p className="text-lg font-bold text-slate-900">{l.views ?? 0}</p>

--- a/app/invest/pre-ipo/listings/[slug]/page.tsx
+++ b/app/invest/pre-ipo/listings/[slug]/page.tsx
@@ -5,6 +5,7 @@ import Icon from "@/components/Icon";
 import ListingImageGallery from "@/components/ListingImageGallery";
 import ListingCard, { type InvestmentListing } from "@/components/ListingCard";
 import ListingEnquiryForm from "@/components/ListingEnquiryForm";
+import ListingDecisionTools from "@/components/invest/ListingDecisionTools";
 import ListingsEmptyState from "@/components/ListingsEmptyState";
 import {
   fetchListingBySlug,
@@ -242,6 +243,9 @@ export default async function PreIpoOpportunityDetailPage({
                 </p>
                 <ListingEnquiryForm listingId={l.id} listingTitle={l.title} vertical="pre_ipo" />
               </div>
+              {/* Wave 5 — structure-aware after-tax return + FIRB estimate */}
+              <ListingDecisionTools listing={l} />
+
               <div className="bg-slate-50 border border-slate-200 rounded-xl p-4 flex gap-6">
                 <div className="text-center">
                   <p className="text-lg font-bold text-slate-900">{l.views ?? 0}</p>

--- a/app/invest/private-credit/listings/[slug]/page.tsx
+++ b/app/invest/private-credit/listings/[slug]/page.tsx
@@ -5,6 +5,7 @@ import Icon from "@/components/Icon";
 import ListingImageGallery from "@/components/ListingImageGallery";
 import ListingCard, { type InvestmentListing } from "@/components/ListingCard";
 import ListingEnquiryForm from "@/components/ListingEnquiryForm";
+import ListingDecisionTools from "@/components/invest/ListingDecisionTools";
 import ListingsEmptyState from "@/components/ListingsEmptyState";
 import SubCategoryListingsView from "@/components/SubCategoryListingsView";
 import {
@@ -265,6 +266,9 @@ export default async function PrivateCreditListingDetailPage({
                   vertical="private_credit"
                 />
               </div>
+              {/* Wave 5 — structure-aware after-tax return + FIRB estimate */}
+              <ListingDecisionTools listing={l} />
+
 
               {/* Stats */}
               <div className="bg-slate-50 border border-slate-200 rounded-xl p-4 flex gap-6">

--- a/app/invest/renewable-energy/listings/[slug]/page.tsx
+++ b/app/invest/renewable-energy/listings/[slug]/page.tsx
@@ -5,6 +5,7 @@ import Icon from "@/components/Icon";
 import ListingImageGallery from "@/components/ListingImageGallery";
 import ListingCard, { type InvestmentListing } from "@/components/ListingCard";
 import ListingEnquiryForm from "@/components/ListingEnquiryForm";
+import ListingDecisionTools from "@/components/invest/ListingDecisionTools";
 import ListingsEmptyState from "@/components/ListingsEmptyState";
 import SubCategoryListingsView from "@/components/SubCategoryListingsView";
 import {
@@ -227,6 +228,9 @@ export default async function EnergyProjectDetailPage({
                 <p className="text-xs text-slate-500 mb-4">Send a confidential enquiry to the project development team.</p>
                 <ListingEnquiryForm listingId={l.id} listingTitle={l.title} vertical="energy" />
               </div>
+              {/* Wave 5 — structure-aware after-tax return + FIRB estimate */}
+              <ListingDecisionTools listing={l} />
+
               <div className="bg-slate-50 border border-slate-200 rounded-xl p-4 flex gap-6">
                 <div className="text-center">
                   <p className="text-lg font-bold text-slate-900">{l.views ?? 0}</p>

--- a/app/invest/startups/listings/[slug]/page.tsx
+++ b/app/invest/startups/listings/[slug]/page.tsx
@@ -5,6 +5,7 @@ import Icon from "@/components/Icon";
 import ListingImageGallery from "@/components/ListingImageGallery";
 import ListingCard, { type InvestmentListing } from "@/components/ListingCard";
 import ListingEnquiryForm from "@/components/ListingEnquiryForm";
+import ListingDecisionTools from "@/components/invest/ListingDecisionTools";
 import ListingsEmptyState from "@/components/ListingsEmptyState";
 import SubCategoryListingsView from "@/components/SubCategoryListingsView";
 import {
@@ -274,6 +275,9 @@ export default async function StartupOpportunityDetailPage({
                   <ListingEnquiryForm listingId={l.id} listingTitle={l.title} vertical="startup" />
                 )}
               </div>
+              {/* Wave 5 — structure-aware after-tax return + FIRB estimate */}
+              <ListingDecisionTools listing={l} />
+
               <div className="bg-slate-50 border border-slate-200 rounded-xl p-4 flex gap-6">
                 <div className="text-center">
                   <p className="text-lg font-bold text-slate-900">{l.views ?? 0}</p>

--- a/components/invest/AfterTaxReturnPanel.tsx
+++ b/components/invest/AfterTaxReturnPanel.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  afterTaxReturn,
+  defaultReturnSplit,
+  STRUCTURE_OPTIONS,
+  INVESTMENT_STRUCTURES,
+  type InvestmentStructure,
+} from "@/lib/invest-decision-tools";
+import { deriveListingKind } from "@/lib/listing-kind";
+import type { DecisionToolListing } from "@/lib/invest-decision-tools";
+import Icon from "@/components/Icon";
+
+/**
+ * Structure-aware after-tax return estimator. The defensible white-space
+ * tool from the gap audit — no AU marketplace shows how a listing's
+ * headline return survives tax across investment structures.
+ *
+ * Reads a sensible default gross return from the listing's key_metrics
+ * (target IRR / yield / return) and lets the user adjust the return,
+ * structure, hold period, and income/growth split. All maths is in the
+ * unit-tested lib/invest-decision-tools — this component is presentation.
+ */
+export default function AfterTaxReturnPanel({ listing }: { listing: DecisionToolListing }) {
+  const kind = deriveListingKind(listing);
+  const km = useMemo(
+    () => (listing.key_metrics ?? {}) as Record<string, unknown>,
+    [listing.key_metrics],
+  );
+
+  // Seed the gross return from the listing where possible.
+  const seededReturn = useMemo(() => {
+    const candidates = [
+      km["target_irr_pct"], km["target_irr"], km["target_yield_pct"],
+      km["target_yield_pa"], km["distribution_yield"], km["net_yield_pct"],
+      km["gross_yield_pct"], km["dividend_yield"], km["historical_return_pa"],
+      km["target_return_pa"], km["return_5yr_pa"], km["lease_yield_pct_pa"],
+    ];
+    for (const c of candidates) {
+      const n = typeof c === "number" ? c : typeof c === "string" ? Number(c.replace(/[^\d.]/g, "")) : NaN;
+      if (Number.isFinite(n) && n > 0 && n < 60) return Math.round(n * 10) / 10;
+    }
+    return 8; // neutral default
+  }, [km]);
+
+  const seededFranking = useMemo(() => {
+    // Only listed securities / dividend-bearing listings get a franking default.
+    if (kind === "listed_security") return 100;
+    return 0;
+  }, [kind]);
+
+  const split = defaultReturnSplit(kind);
+
+  const [grossReturn, setGrossReturn] = useState<number>(seededReturn);
+  const [structure, setStructure] = useState<InvestmentStructure>("individual_top");
+  const [incomeShare, setIncomeShare] = useState<number>(Math.round(split.income * 100));
+  const [heldOver12, setHeldOver12] = useState(true);
+  const [franking, setFranking] = useState<number>(seededFranking);
+
+  const result = useMemo(
+    () => afterTaxReturn({
+      grossReturnPct: grossReturn,
+      structure,
+      incomeShare: incomeShare / 100,
+      heldOver12Months: heldOver12,
+      frankingPct: franking,
+    }),
+    [grossReturn, structure, incomeShare, heldOver12, franking],
+  );
+
+  // Compare across all structures for the mini-table.
+  const acrossStructures = useMemo(
+    () => STRUCTURE_OPTIONS.map((s) => ({
+      meta: s,
+      r: afterTaxReturn({
+        grossReturnPct: grossReturn,
+        structure: s.key,
+        incomeShare: incomeShare / 100,
+        heldOver12Months: heldOver12,
+        frankingPct: franking,
+      }),
+    })),
+    [grossReturn, incomeShare, heldOver12, franking],
+  );
+
+  const bestStructure = acrossStructures.reduce((a, b) => (b.r.afterTaxReturnPct > a.r.afterTaxReturnPct ? b : a));
+
+  return (
+    <div className="bg-white border border-slate-200 rounded-xl p-5">
+      <div className="flex items-start gap-2 mb-1">
+        <span className="shrink-0 mt-0.5 text-emerald-600"><Icon name="calculator" size={16} /></span>
+        <div>
+          <h2 className="text-base font-bold text-slate-900">After-tax return estimator</h2>
+          <p className="text-xs text-slate-500">See how this listing&apos;s return survives tax across investment structures.</p>
+        </div>
+      </div>
+
+      {/* Headline */}
+      <div className="mt-4 grid grid-cols-2 gap-3">
+        <div className="rounded-lg bg-slate-50 border border-slate-200 p-3 text-center">
+          <p className="text-[0.6rem] uppercase tracking-wide text-slate-400 font-semibold">Gross return</p>
+          <p className="text-2xl font-extrabold text-slate-900">{result.grossReturnPct}%</p>
+        </div>
+        <div className="rounded-lg bg-emerald-50 border border-emerald-200 p-3 text-center">
+          <p className="text-[0.6rem] uppercase tracking-wide text-emerald-600 font-semibold">After-tax</p>
+          <p className="text-2xl font-extrabold text-emerald-700">{result.afterTaxReturnPct}%</p>
+        </div>
+      </div>
+      <p className="mt-1.5 text-[0.65rem] text-slate-500 text-center">
+        {INVESTMENT_STRUCTURES[structure].label} · {result.effectiveTaxRate > 0 ? `${Math.round(result.effectiveTaxRate * 100)}% effective tax drag` : "tax-exempt"}
+      </p>
+
+      {/* Controls */}
+      <div className="mt-4 space-y-3">
+        <label className="block">
+          <span className="text-[0.65rem] font-bold uppercase tracking-wide text-slate-500">Gross return: {grossReturn}% p.a.</span>
+          <input
+            type="range" min={1} max={30} step={0.5} value={grossReturn}
+            onChange={(e) => setGrossReturn(Number(e.target.value))}
+            className="w-full mt-1 accent-emerald-600"
+            aria-label="Gross return percent"
+          />
+        </label>
+
+        <label className="block">
+          <span className="text-[0.65rem] font-bold uppercase tracking-wide text-slate-500">Investment structure</span>
+          <select
+            value={structure}
+            onChange={(e) => setStructure(e.target.value as InvestmentStructure)}
+            className="w-full mt-1 rounded-lg border border-slate-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-400"
+          >
+            {STRUCTURE_OPTIONS.map((s) => <option key={s.key} value={s.key}>{s.label}</option>)}
+          </select>
+        </label>
+
+        <label className="block">
+          <span className="text-[0.65rem] font-bold uppercase tracking-wide text-slate-500">
+            Income / growth split: {incomeShare}% income · {100 - incomeShare}% growth
+          </span>
+          <input
+            type="range" min={0} max={100} step={5} value={incomeShare}
+            onChange={(e) => setIncomeShare(Number(e.target.value))}
+            className="w-full mt-1 accent-emerald-600"
+            aria-label="Income share percent"
+          />
+        </label>
+
+        <div className="flex items-center gap-3 flex-wrap">
+          <label className="inline-flex items-center gap-1.5 text-xs text-slate-700">
+            <input type="checkbox" checked={heldOver12} onChange={(e) => setHeldOver12(e.target.checked)} className="accent-emerald-600" />
+            Held &gt; 12 months (CGT discount)
+          </label>
+          {(kind === "listed_security" || incomeShare > 0) && (
+            <label className="inline-flex items-center gap-1.5 text-xs text-slate-700">
+              Franking
+              <select
+                value={franking}
+                onChange={(e) => setFranking(Number(e.target.value))}
+                className="rounded border border-slate-300 px-1.5 py-0.5 text-xs"
+                aria-label="Franking percent"
+              >
+                <option value={0}>0%</option>
+                <option value={50}>50%</option>
+                <option value={100}>100%</option>
+              </select>
+            </label>
+          )}
+        </div>
+      </div>
+
+      {/* Across-structures mini table */}
+      <div className="mt-4 border-t border-slate-100 pt-3">
+        <p className="text-[0.6rem] uppercase tracking-wide text-slate-400 font-semibold mb-2">After-tax return by structure</p>
+        <div className="space-y-1">
+          {acrossStructures.map(({ meta, r }) => {
+            const isBest = meta.key === bestStructure.meta.key;
+            const pctOfBest = bestStructure.r.afterTaxReturnPct > 0 ? (r.afterTaxReturnPct / bestStructure.r.afterTaxReturnPct) * 100 : 0;
+            return (
+              <div key={meta.key} className="flex items-center gap-2">
+                <span className={`text-[0.65rem] w-40 shrink-0 truncate ${meta.key === structure ? "font-bold text-slate-900" : "text-slate-500"}`}>
+                  {meta.label}
+                </span>
+                <div className="flex-1 h-3.5 rounded bg-slate-100 overflow-hidden">
+                  <div
+                    className={`h-full rounded ${isBest ? "bg-emerald-500" : "bg-slate-300"}`}
+                    style={{ width: `${Math.max(2, pctOfBest)}%` }}
+                  />
+                </div>
+                <span className={`text-[0.7rem] tabular-nums w-12 text-right ${isBest ? "font-bold text-emerald-700" : "text-slate-600"}`}>
+                  {r.afterTaxReturnPct}%
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <p className="mt-3 text-[0.6rem] text-slate-400 leading-snug">
+        {INVESTMENT_STRUCTURES[structure].note} Estimate only — single-year annualised tax drag, not a multi-year IRR with deferred CGT.
+        Not personal advice. Confirm with a registered tax agent.
+      </p>
+    </div>
+  );
+}

--- a/components/invest/FirbFeeEstimate.tsx
+++ b/components/invest/FirbFeeEstimate.tsx
@@ -1,0 +1,36 @@
+import { firbFeeForListing } from "@/lib/invest-decision-tools";
+import type { DecisionToolListing } from "@/lib/invest-decision-tools";
+import Icon from "@/components/Icon";
+import Link from "next/link";
+
+/**
+ * FIRB application-fee estimate for a foreign buyer evaluating a listing.
+ * Server-rendered (no interactivity) — reads the fee from the unit-tested
+ * lib helper. Renders nothing for out-of-scope kinds (listed securities,
+ * fund units) so it doesn't add noise to listings where FIRB doesn't bite.
+ */
+export default function FirbFeeEstimate({ listing }: { listing: DecisionToolListing }) {
+  const est = firbFeeForListing(listing);
+  if (!est.applicable) return null;
+
+  return (
+    <div className="bg-blue-50 border border-blue-200 rounded-xl p-4">
+      <div className="flex items-start gap-2">
+        <span className="shrink-0 mt-0.5 text-blue-600"><Icon name="globe" size={15} /></span>
+        <div className="min-w-0">
+          <h3 className="text-sm font-bold text-blue-900">Foreign buyer? Estimated FIRB fee</h3>
+          <p className="text-xl font-extrabold text-blue-700 mt-0.5">
+            ${est.feeAud.toLocaleString("en-AU")}
+          </p>
+          <p className="text-[0.65rem] text-blue-700/80 mt-0.5 leading-snug">
+            FIRB application fee on a ${est.valueAud.toLocaleString("en-AU")} acquisition (non-refundable, indexed annually).
+            State stamp-duty surcharges may also apply.{" "}
+            <Link href="/property/foreign-investment" className="font-semibold underline underline-offset-2 hover:text-blue-900">
+              FIRB guide
+            </Link>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/invest/ListingDecisionTools.tsx
+++ b/components/invest/ListingDecisionTools.tsx
@@ -1,0 +1,33 @@
+import type { DecisionToolListing } from "@/lib/invest-decision-tools";
+import { deriveListingKind } from "@/lib/listing-kind";
+import AfterTaxReturnPanel from "@/components/invest/AfterTaxReturnPanel";
+import FirbFeeEstimate from "@/components/invest/FirbFeeEstimate";
+
+/**
+ * Bundle of decision tools for a single listing's detail page (Wave 5).
+ * Server component — renders the FIRB estimate (server) and the
+ * after-tax return panel (client island). Drop it into any listing
+ * detail sidebar; it self-selects which tools are relevant for the
+ * listing's kind:
+ *
+ *   - After-tax return panel: every kind except pure listed_security
+ *     (where the broker-side after-tax story lives on /compare). Listed
+ *     securities still get it because franking matters there.
+ *   - FIRB fee estimate: only foreign-investor-relevant kinds (handled
+ *     inside FirbFeeEstimate, which returns null when out of scope).
+ */
+export default function ListingDecisionTools({ listing }: { listing: DecisionToolListing }) {
+  const kind = deriveListingKind(listing);
+
+  // Equity raises and physical collectibles are pure-growth / illiquid
+  // enough that an annualised after-tax-return panel is misleading — skip
+  // it for those, keep the FIRB estimate where relevant.
+  const showAfterTax = kind !== "equity_raise";
+
+  return (
+    <div className="space-y-5">
+      {showAfterTax && <AfterTaxReturnPanel listing={listing} />}
+      <FirbFeeEstimate listing={listing} />
+    </div>
+  );
+}

--- a/lib/invest-decision-tools.ts
+++ b/lib/invest-decision-tools.ts
@@ -1,0 +1,421 @@
+/**
+ * Listing-aware decision tools for /invest (Wave 5).
+ *
+ * Thin, listing-shaped layer over the existing AU-tax engines:
+ *   - lib/tax/brackets.ts            → marginalRate, incomeTax
+ *   - lib/franking-math.ts           → computeFranking
+ *   - lib/calculators/cgt.ts         → CGT discount constants
+ *   - lib/firb-data.ts               → getFirbFee
+ *
+ * This module deliberately does NOT re-implement bracket maths or
+ * franking gross-up — it composes the canonical engines and adds the
+ * structure-aware, per-listing view that the marketplace UI needs:
+ *
+ *   1. afterTaxReturn()        — gross return → after-tax return by
+ *                                investment structure (individual /
+ *                                SMSF accumulation / SMSF pension /
+ *                                company / trust). The "defensible
+ *                                white space" flagged in the gap audit:
+ *                                no AU marketplace shows structure-aware
+ *                                after-tax returns on listings.
+ *   2. frankingAdjustedYield() — cash yield ↔ grossed-up yield toggle.
+ *   3. firbFeeForListing()     — FIRB application fee estimate for a
+ *                                foreign buyer, picking the right $ value
+ *                                from the listing.
+ *   4. sivComplianceScore()    — % of a shortlist's value that is
+ *                                SIV-complying (Significant Investor Visa
+ *                                needs ≥ specified mix of complying assets).
+ *   5. cgtDiscountStatus()     — 12-month CGT-discount countdown for an
+ *                                already-held asset.
+ *
+ * Everything here is a pure function — unit-tested in
+ * __tests__/lib/invest-decision-tools.test.ts — so the components stay
+ * thin and the tax logic stays verifiable.
+ */
+
+import { CGT_DISCOUNT_INDIVIDUAL, CGT_DISCOUNT_SUPER } from "@/lib/calculators/cgt";
+import { computeFranking } from "@/lib/franking-math";
+import { getFirbFee } from "@/lib/firb-data";
+import { deriveListingKind } from "@/lib/listing-kind";
+import type { ListingKind } from "@/lib/types";
+
+/**
+ * Structural listing shape the decision tools read. Looser than the full
+ * `InvestmentListing` so the detail pages (which hold the narrower
+ * ListingCard type) can pass `l` directly without a cast. Every field the
+ * tools touch is optional except the identity trio.
+ */
+export type DecisionToolListing = {
+  id: number;
+  vertical: string;
+  slug: string;
+  title?: string | null;
+  key_metrics?: Record<string, unknown> | null;
+  asking_price_cents?: number | null;
+  price_display?: string | null;
+  listing_kind?: string | null;
+  firb_eligible?: boolean | null;
+  siv_complying?: boolean | null;
+};
+
+const MEDICARE = 0.02;
+
+// ─── Investment structures ────────────────────────────────────────────────
+
+export type InvestmentStructure =
+  | "individual_top"
+  | "individual_37"
+  | "smsf_accumulation"
+  | "smsf_pension"
+  | "company"
+  | "trust";
+
+export interface StructureMeta {
+  key: InvestmentStructure;
+  label: string;
+  /** Marginal rate applied to the income component of a return. */
+  incomeRate: number;
+  /** Effective rate on a capital gain realised AFTER 12 months, i.e.
+   *  the headline rate already reduced by the structure's CGT discount.
+   *  Companies get no discount; SMSF pension is exempt. */
+  capitalRateDiscounted: number;
+  /** Effective rate on a capital gain realised WITHIN 12 months (no
+   *  discount available). */
+  capitalRateUndiscounted: number;
+  /** Short explainer shown in the widget tooltip. */
+  note: string;
+}
+
+const TOP = 0.45 + MEDICARE;       // 47%
+const R37 = 0.37 + MEDICARE;       // 39%
+const SMSF = 0.15;                 // accumulation phase
+const COMPANY = 0.30;              // full company rate (conservative vs 25% base-rate)
+
+export const INVESTMENT_STRUCTURES: Record<InvestmentStructure, StructureMeta> = {
+  individual_top: {
+    key: "individual_top",
+    label: "Individual (top bracket)",
+    incomeRate: TOP,
+    capitalRateDiscounted: TOP * (1 - CGT_DISCOUNT_INDIVIDUAL), // 23.5%
+    capitalRateUndiscounted: TOP,
+    note: "47% marginal (45% + 2% Medicare). 50% CGT discount on assets held > 12 months → 23.5% on gains.",
+  },
+  individual_37: {
+    key: "individual_37",
+    label: "Individual ($135k–$190k)",
+    incomeRate: R37,
+    capitalRateDiscounted: R37 * (1 - CGT_DISCOUNT_INDIVIDUAL), // 19.5%
+    capitalRateUndiscounted: R37,
+    note: "39% marginal (37% + 2% Medicare). 50% CGT discount → 19.5% on gains held > 12 months.",
+  },
+  smsf_accumulation: {
+    key: "smsf_accumulation",
+    label: "SMSF (accumulation)",
+    incomeRate: SMSF,
+    capitalRateDiscounted: SMSF * (1 - CGT_DISCOUNT_SUPER), // 10%
+    capitalRateUndiscounted: SMSF,
+    note: "15% on income. ⅓ CGT discount on assets held > 12 months → 10% on gains.",
+  },
+  smsf_pension: {
+    key: "smsf_pension",
+    label: "SMSF (pension)",
+    incomeRate: 0,
+    capitalRateDiscounted: 0,
+    capitalRateUndiscounted: 0,
+    note: "Retirement-phase pension assets are tax-exempt on both income and capital gains (subject to the transfer-balance cap).",
+  },
+  company: {
+    key: "company",
+    label: "Company",
+    incomeRate: COMPANY,
+    capitalRateDiscounted: COMPANY, // companies get NO CGT discount
+    capitalRateUndiscounted: COMPANY,
+    note: "30% flat (25% for base-rate entities). Companies do NOT receive the 50% CGT discount.",
+  },
+  trust: {
+    key: "trust",
+    label: "Discretionary trust",
+    incomeRate: TOP, // approximated at top-beneficiary rate; trusts flow through
+    capitalRateDiscounted: TOP * (1 - CGT_DISCOUNT_INDIVIDUAL),
+    capitalRateUndiscounted: TOP,
+    note: "Income flows to beneficiaries and is taxed at their rates — shown at the top individual rate as a conservative estimate. The 50% CGT discount flows through to individual beneficiaries.",
+  },
+};
+
+export const STRUCTURE_OPTIONS: StructureMeta[] = Object.values(INVESTMENT_STRUCTURES);
+
+// ─── Income vs growth split by listing kind ───────────────────────────────
+
+/**
+ * Default split of a total return into income vs capital-growth
+ * components, by listing kind. Used when the listing doesn't carry an
+ * explicit yield. These are deliberately conservative archetype splits;
+ * the widget lets the user override.
+ */
+export function defaultReturnSplit(kind: ListingKind): { income: number; growth: number } {
+  switch (kind) {
+    case "fund":             return { income: 0.65, growth: 0.35 };
+    case "for_sale_asset":   return { income: 0.55, growth: 0.45 }; // commercial property / farmland / water
+    case "for_sale_business":return { income: 0.80, growth: 0.20 };
+    case "royalty":          return { income: 0.95, growth: 0.05 };
+    case "project_equity":   return { income: 0.25, growth: 0.75 };
+    case "equity_raise":     return { income: 0.0,  growth: 1.0 };
+    case "listed_security":  return { income: 0.40, growth: 0.60 };
+    case "physical_asset":   return { income: 0.0,  growth: 1.0 }; // bullion, collectibles — pure capital
+    default:                 return { income: 0.5,  growth: 0.5 };
+  }
+}
+
+// ─── 1. After-tax return ──────────────────────────────────────────────────
+
+export interface AfterTaxReturnInput {
+  /** Gross expected total return, percent per annum (e.g. 8 = 8% p.a.). */
+  grossReturnPct: number;
+  structure: InvestmentStructure;
+  /** Fraction of the return that is income (0..1). Defaults from kind. */
+  incomeShare?: number;
+  /** Whether the capital component qualifies for the > 12-month CGT discount. */
+  heldOver12Months?: boolean;
+  /** For listed/dividend income, the franking percentage (0..100). When
+   *  set, the income component is treated as franked and grossed-up. */
+  frankingPct?: number;
+}
+
+export interface AfterTaxReturnResult {
+  grossReturnPct: number;
+  afterTaxReturnPct: number;
+  /** Effective blended tax drag, percentage points (gross − afterTax). */
+  taxDragPct: number;
+  /** Effective blended tax rate on the whole return (0..1). */
+  effectiveTaxRate: number;
+  incomeComponentPct: number;
+  growthComponentPct: number;
+  structure: StructureMeta;
+}
+
+/**
+ * Convert a gross annual return into an after-tax annual return for a
+ * given investment structure. Splits the return into income and capital
+ * components, taxes each appropriately, and (when the income is franked)
+ * applies the franking-credit offset via the canonical franking engine.
+ *
+ * This is a single-year approximation — it models the annualised tax
+ * drag, not a full multi-year IRR with deferred CGT. Clearly labelled as
+ * an estimate in the UI.
+ */
+export function afterTaxReturn(input: AfterTaxReturnInput): AfterTaxReturnResult {
+  const structure = INVESTMENT_STRUCTURES[input.structure];
+  const gross = Math.max(0, input.grossReturnPct);
+  const incomeShare = clamp01(input.incomeShare ?? 0.5);
+  const growthShare = 1 - incomeShare;
+
+  const incomeComponent = gross * incomeShare;
+  const growthComponent = gross * growthShare;
+
+  // Income component — franked or unfranked.
+  let incomeAfterTax: number;
+  if (input.frankingPct != null && input.frankingPct > 0 && structure.incomeRate > 0) {
+    // Use the canonical franking engine on a $-scaled dividend so the
+    // refundable-offset behaviour (e.g. SMSF getting cash back) is exact.
+    // We scale to $10,000 of income then convert back to a percentage.
+    const scaled = computeFranking({
+      dividend: incomeComponent * 1000, // arbitrary $ scale; ratio preserved
+      frankingPct: input.frankingPct,
+      marginalRate: structure.incomeRate - MEDICARE < 0 ? 0 : structure.incomeRate - MEDICARE,
+      includeMedicare: structure.incomeRate > SMSF, // SMSF/company don't pay Medicare
+    });
+    // netAfterTax is dollars kept per dividend; convert back to pct scale.
+    incomeAfterTax = scaled.dividend > 0 ? (scaled.netAfterTax / 1000) : incomeComponent * (1 - structure.incomeRate);
+  } else {
+    incomeAfterTax = incomeComponent * (1 - structure.incomeRate);
+  }
+
+  // Growth component — CGT-discounted if held > 12 months.
+  const capitalRate = (input.heldOver12Months ?? true)
+    ? structure.capitalRateDiscounted
+    : structure.capitalRateUndiscounted;
+  const growthAfterTax = growthComponent * (1 - capitalRate);
+
+  const afterTax = incomeAfterTax + growthAfterTax;
+  const effectiveTaxRate = gross > 0 ? clamp01(1 - afterTax / gross) : 0;
+
+  return {
+    grossReturnPct: round2(gross),
+    afterTaxReturnPct: round2(afterTax),
+    taxDragPct: round2(gross - afterTax),
+    effectiveTaxRate: round4(effectiveTaxRate),
+    incomeComponentPct: round2(incomeComponent),
+    growthComponentPct: round2(growthComponent),
+    structure,
+  };
+}
+
+// ─── 2. Franking-adjusted yield ───────────────────────────────────────────
+
+export interface FrankingYieldResult {
+  cashYieldPct: number;
+  grossedUpYieldPct: number;
+  frankingPct: number;
+  /** Net yield kept after tax + refundable offset, at the given rate. */
+  netYieldPct: number;
+}
+
+/**
+ * Convert a cash dividend yield into its grossed-up equivalent and the
+ * after-tax net yield, for a given marginal rate. Wraps computeFranking.
+ *
+ * @param cashYieldPct  Cash yield, percent (e.g. 4.2).
+ * @param frankingPct   Franking percentage (0..100). Default 100.
+ * @param marginalRate  Investor's marginal rate fraction (default 0.45).
+ */
+export function frankingAdjustedYield(
+  cashYieldPct: number,
+  frankingPct = 100,
+  marginalRate = 0.45,
+): FrankingYieldResult {
+  const cash = Math.max(0, cashYieldPct);
+  // Scale to dollars for the engine, then back to percent.
+  const r = computeFranking({
+    dividend: cash * 1000,
+    frankingPct,
+    marginalRate,
+    includeMedicare: true,
+  });
+  return {
+    cashYieldPct: round2(cash),
+    grossedUpYieldPct: round2(r.grossedUp / 1000),
+    frankingPct: clampPct(frankingPct),
+    netYieldPct: round2(r.netAfterTax / 1000),
+  };
+}
+
+// ─── 3. FIRB fee for a listing ────────────────────────────────────────────
+
+export interface FirbFeeEstimate {
+  /** The $ value the fee is calculated on (asking price or min-investment). */
+  valueAud: number;
+  /** Estimated FIRB application fee in AUD. */
+  feeAud: number;
+  /** Whether this listing is plausibly FIRB-relevant at all. */
+  applicable: boolean;
+}
+
+/**
+ * Estimate the FIRB application fee a foreign buyer would pay for a
+ * listing. Picks the dollar value from asking price, else a
+ * min-investment key_metric. Returns applicable=false for listing kinds
+ * where FIRB residential/commercial fees don't map (e.g. listed
+ * securities bought on-market, managed-fund units — generally outside
+ * FIRB).
+ */
+export function firbFeeForListing(listing: DecisionToolListing): FirbFeeEstimate {
+  const kind = deriveListingKind(listing);
+  const km = (listing.key_metrics ?? {}) as Record<string, unknown>;
+
+  // Listed securities + fund units bought through normal channels are
+  // generally outside FIRB residential/commercial fee schedules.
+  const outOfScope = kind === "listed_security" || kind === "fund";
+  const minInvest = num(km["min_investment_aud"]) ?? num(km["min_commit_aud"]) ?? num(km["min_investment"]);
+  const valueAud = listing.asking_price_cents != null
+    ? listing.asking_price_cents / 100
+    : (minInvest ?? 0);
+
+  if (outOfScope || valueAud <= 0) {
+    return { valueAud, feeAud: 0, applicable: false };
+  }
+
+  return {
+    valueAud,
+    feeAud: getFirbFee(valueAud),
+    applicable: true,
+  };
+}
+
+// ─── 4. SIV compliance score ──────────────────────────────────────────────
+
+export interface SivComplianceResult {
+  /** Total $ value across the listings (asking or min-invest). */
+  totalValueAud: number;
+  /** $ value that is SIV-complying. */
+  complyingValueAud: number;
+  /** Percentage of value that is SIV-complying (0..100). */
+  complyingPct: number;
+  /** Count of complying vs total listings. */
+  complyingCount: number;
+  totalCount: number;
+}
+
+/**
+ * Given a set of listings (e.g. a visitor's shortlist), compute what
+ * share of the combined value is SIV-complying. The Significant Investor
+ * Visa requires a $5M complying-investment portfolio with a prescribed
+ * minimum mix — surfacing the mix helps prospective applicants see how
+ * close their shortlist gets.
+ */
+export function sivComplianceScore(
+  listings: Array<Pick<DecisionToolListing, "siv_complying" | "asking_price_cents" | "key_metrics">>,
+): SivComplianceResult {
+  let total = 0;
+  let complying = 0;
+  let complyingCount = 0;
+  for (const l of listings) {
+    const km = (l.key_metrics ?? {}) as Record<string, unknown>;
+    const minInvest = num(km["min_investment_aud"]) ?? num(km["min_commit_aud"]) ?? num(km["min_investment"]);
+    const value = l.asking_price_cents != null ? l.asking_price_cents / 100 : (minInvest ?? 0);
+    total += value;
+    if (l.siv_complying) {
+      complying += value;
+      complyingCount++;
+    }
+  }
+  return {
+    totalValueAud: Math.round(total),
+    complyingValueAud: Math.round(complying),
+    complyingPct: total > 0 ? Math.round((complying / total) * 100) : 0,
+    complyingCount,
+    totalCount: listings.length,
+  };
+}
+
+// ─── 5. CGT discount countdown ────────────────────────────────────────────
+
+export interface CgtDiscountStatus {
+  eligible: boolean;
+  /** Days until the 12-month CGT-discount threshold (0 if already past). */
+  daysRemaining: number;
+  /** Human-readable summary. */
+  summary: string;
+}
+
+/**
+ * For an asset already acquired on `acquiredISO`, report whether it has
+ * crossed the 12-month CGT-discount threshold and, if not, how long
+ * remains. Used on holdings the user already owns (cross-linked from the
+ * portfolio tracker).
+ */
+export function cgtDiscountStatus(acquiredISO: string, now: Date = new Date()): CgtDiscountStatus {
+  const acquired = new Date(acquiredISO);
+  if (Number.isNaN(acquired.getTime())) {
+    return { eligible: false, daysRemaining: 0, summary: "Unknown acquisition date." };
+  }
+  const threshold = new Date(acquired);
+  threshold.setFullYear(threshold.getFullYear() + 1);
+  const msRemaining = threshold.getTime() - now.getTime();
+  if (msRemaining <= 0) {
+    return { eligible: true, daysRemaining: 0, summary: "Held > 12 months — eligible for the 50% CGT discount on disposal." };
+  }
+  const days = Math.ceil(msRemaining / 86_400_000);
+  return {
+    eligible: false,
+    daysRemaining: days,
+    summary: `Hold ${days} more day${days !== 1 ? "s" : ""} (until ${threshold.toLocaleDateString("en-AU", { day: "numeric", month: "short", year: "numeric" })}) to qualify for the 50% CGT discount.`,
+  };
+}
+
+// ─── helpers ──────────────────────────────────────────────────────────────
+
+function clamp01(n: number): number { return Math.max(0, Math.min(1, n)); }
+function clampPct(n: number): number { return Math.max(0, Math.min(100, n)); }
+function round2(n: number): number { return Math.round(n * 100) / 100; }
+function round4(n: number): number { return Math.round(n * 10000) / 10000; }
+function num(v: unknown): number | undefined { return typeof v === "number" && Number.isFinite(v) ? v : undefined; }

--- a/lib/listing-kind.ts
+++ b/lib/listing-kind.ts
@@ -16,8 +16,22 @@ import type { InvestmentListing, ListingKind } from "@/lib/types";
 
 /** Mirror of the SQL backfill in 20260725200000_add_listing_kind.sql.
  *  Keep in sync if either side changes. */
-export function deriveListingKind(row: Pick<InvestmentListing, "vertical" | "key_metrics" | "asking_price_cents" | "listing_kind">): ListingKind {
-  if (row.listing_kind) return row.listing_kind;
+/**
+ * Structural input for `deriveListingKind` — looser than the full
+ * `InvestmentListing` so callers holding a narrower row shape (e.g. the
+ * ListingCard type used on detail pages, which omits `updated_at` and
+ * types `vertical` as a plain string) can derive a kind without a cast.
+ * The function only reads these four fields.
+ */
+export type DerivableListing = {
+  vertical: string;
+  key_metrics?: Record<string, unknown> | null;
+  asking_price_cents?: number | null;
+  listing_kind?: string | null;
+};
+
+export function deriveListingKind(row: DerivableListing): ListingKind {
+  if (row.listing_kind) return row.listing_kind as ListingKind;
 
   const km = (row.key_metrics ?? {}) as Record<string, unknown>;
   const v = row.vertical as string;


### PR DESCRIPTION
## Summary

Tier 2 of the post-Wave-3 roadmap — the **decision tools**. The gap audit flagged the "after-tax, structure-aware return calculator" as defensible white space: no AU marketplace shows how a listing's headline return survives tax across investment structures. This wave ships that, as a thin listing-aware layer over the **existing** tax engines (no re-implementation).

## Library — `lib/invest-decision-tools.ts` (pure, 25 unit tests)

| Function | What it does | Reuses |
|---|---|---|
| `afterTaxReturn()` | Gross → after-tax return by structure (individual top / 37% / SMSF accumulation / SMSF pension / company / trust). Splits income vs growth, applies CGT discount (50% individual, ⅓ super, none company), routes franked income through the canonical engine for exact refundable-offset behaviour. | `computeFranking`, `CGT_DISCOUNT_*` |
| `frankingAdjustedYield()` | Cash ↔ grossed-up ↔ net yield | `computeFranking` |
| `firbFeeForListing()` | FIRB fee estimate, right $ value, null for out-of-scope kinds | `getFirbFee` |
| `sivComplianceScore()` | % of a shortlist's value that's SIV-complying | — |
| `cgtDiscountStatus()` | 12-month CGT-discount countdown | — |

Widened `deriveListingKind()` to a structural `DerivableListing` input so detail pages (holding the narrower ListingCard type) derive a kind without a cast.

## Components

- **`AfterTaxReturnPanel`** (client) — gross-return slider, structure selector, income/growth split, >12mo toggle, franking selector, plus an across-all-structures bar chart highlighting the most tax-efficient structure. Seeds the gross return from the listing's `key_metrics`.
- **`FirbFeeEstimate`** (server) — "Foreign buyer? Estimated FIRB fee $X". Renders null for out-of-scope kinds.
- **`ListingDecisionTools`** (server wrapper) — self-selects relevant tools per kind; skips after-tax panel for `equity_raise`.

## Wiring

Mounted `<ListingDecisionTools listing={l} />` into all **11** `/invest/*/listings/[slug]` detail-page sidebars (deterministic insertion as a sibling after the enquiry-form card).

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean (fixed a useMemo dep warning)
- [x] `vitest` — 45/45 relevant tests pass (25 new decision-tools + 20 categories)
- [x] `next build` succeeds
- [ ] Visual smoke on preview — open any `/invest/*/listings/[slug]`, confirm the after-tax panel renders, sliders update the headline + bar chart, FIRB block appears on foreign-relevant priced listings.

## Roadmap position

Wave 4 (categories, merged #1385) = Tier 1. This = Tier 2. Still to come: Tier 3 (cross-product wiring — calculators/hubs/concierge → /invest deep-links) and Tier 4 (programmatic SEO landing pages).

https://claude.ai/code/session_019Rvnw5P7FXjNMRxiKkPFPh

---
_Generated by [Claude Code](https://claude.ai/code/session_019Rvnw5P7FXjNMRxiKkPFPh)_