### PR TITLE
feat(invest): Wave 6 — cross-product wiring (calculators / hubs / concierge → /invest)

### DIFF
--- a/__tests__/lib/concierge-retrieval.test.ts
+++ b/__tests__/lib/concierge-retrieval.test.ts
@@ -57,6 +57,13 @@ describe("CONCIERGE_BASE_SYSTEM_PROMPT", () => {
       - For users searching for a financial advisor, point to /find-advisor
         (the structured wizard) and /advisors (faceted directory with
         individual, firm, and expert-team filters).
+      - For users browsing investment opportunities, point to the /invest
+        marketplace with the right filter, e.g. [managed funds](/invest?kind=fund),
+        [SIV-complying funds](/invest?siv=complying), [SMSF-eligible property](/invest?category=commercial-property),
+        [wholesale gold & bullion](/invest?category=bullion),
+        [water entitlements](/invest?category=water-rights) or
+        [carbon credits](/invest?category=carbon-credits). Each listing has an
+        after-tax return estimator by investment structure.
       - Decline questions about specific stocks or crypto trades — say we
         cover platforms and educational context only.
 

--- a/app/fire-calculator/page.tsx
+++ b/app/fire-calculator/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { CURRENT_YEAR, SITE_NAME } from "@/lib/seo";
 import FireCalculatorClient from "./FireCalculatorClient";
 import ComplianceFooter from "@/components/ComplianceFooter";
+import InvestOpportunitiesCallout from "@/components/invest/InvestOpportunitiesCallout";
 
 export const revalidate = 86400;
 
@@ -98,7 +99,17 @@ export default function FireCalculatorPage() {
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }} />
       <FireCalculatorClient />
-      <div className="container-custom pb-8"><ComplianceFooter variant="calculator" /></div>
+      <div className="container-custom pb-8 space-y-6">
+        <InvestOpportunitiesCallout
+          icon="coins"
+          heading="Hitting your FIRE number means owning income-producing assets."
+          blurb="Browse income-focused opportunities — managed funds, dividend-paying listed securities and yield-bearing assets — to build the passive cash flow your FIRE plan depends on."
+          href="/invest?kind=fund,listed_security&min_yield=5"
+          ctaLabel="Browse income opportunities"
+          secondary={{ label: "Compare share-trading platforms", href: "/share-trading" }}
+        />
+        <ComplianceFooter variant="calculator" />
+      </div>
 
     </>
   );

--- a/app/halal-investing/page.tsx
+++ b/app/halal-investing/page.tsx
@@ -16,6 +16,7 @@ import Link from "next/link";
 import { SITE_URL, CURRENT_YEAR, UPDATED_LABEL, breadcrumbJsonLd, absoluteUrl } from "@/lib/seo";
 import { faqJsonLd } from "@/lib/schema-markup";
 import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
+import InvestOpportunitiesCallout from "@/components/invest/InvestOpportunitiesCallout";
 
 export const revalidate = 86400;
 
@@ -692,6 +693,18 @@ export default function HalalInvestingPage() {
               </Link>
             </div>
           </section>
+
+          {/* Cross-link into the marketplace (Wave 6) */}
+          <div className="mb-8">
+            <InvestOpportunitiesCallout
+              icon="trending-up"
+              heading="Browse Shariah-aware investment opportunities"
+              blurb="Explore managed funds and listed securities on the marketplace, then verify each provider's Shariah supervisory-board screening before investing. Filter for retail-accessible funds and income-light, asset-backed structures."
+              href="/invest?kind=fund"
+              ctaLabel="Browse funds & opportunities"
+              secondary={{ label: "Compare halal-friendly platforms", href: "/compare" }}
+            />
+          </div>
 
           {/* General advice warning */}
           <div className="border border-amber-200 bg-amber-50 rounded-lg px-5 py-4 text-sm text-slate-700 mb-8">

--- a/app/smsf/property/page.tsx
+++ b/app/smsf/property/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR, UPDATED_LABEL, absoluteUrl } from "@/lib/seo";
 import { faqJsonLd } from "@/lib/schema-markup";
 import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
+import InvestOpportunitiesCallout from "@/components/invest/InvestOpportunitiesCallout";
 
 export const revalidate = 86400;
 
@@ -816,6 +817,19 @@ export default function SmsfPropertyPage() {
               </Link>
             </div>
           </div>
+        </section>
+
+        {/* Cross-link into the marketplace (Wave 6) */}
+        <section className="container-custom max-w-5xl pb-12">
+          <InvestOpportunitiesCallout
+            tone="amber"
+            icon="building"
+            heading="SMSF-eligible property & income opportunities"
+            blurb="Browse commercial property, SDA (NDIS) housing and other LRBA-compatible assets suited to SMSF acquisition — many flagged SMSF-eligible with bare-trust-ready structures. Use the after-tax return estimator on each listing to model the 15% accumulation vs 0% pension outcome."
+            href="/invest?category=commercial-property"
+            ctaLabel="Browse SMSF-eligible listings"
+            secondary={{ label: "SDA / NDIS housing", href: "/invest?category=sda-housing" }}
+          />
         </section>
 
       </div>

--- a/app/tools/withholding-tax-calculator/page.tsx
+++ b/app/tools/withholding-tax-calculator/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Suspense } from "react";
 import { absoluteUrl, breadcrumbJsonLd, CURRENT_YEAR, SITE_NAME } from "@/lib/seo";
 import ComplianceFooter from "@/components/ComplianceFooter";
+import InvestOpportunitiesCallout from "@/components/invest/InvestOpportunitiesCallout";
 import WithholdingTaxClient from "./WithholdingTaxClient";
 
 export const revalidate = 3600;
@@ -66,7 +67,16 @@ export default function WithholdingTaxCalculatorPage() {
       <Suspense fallback={<Loading />}>
         <WithholdingTaxClient />
       </Suspense>
-      <div className="container-custom pb-8">
+      <div className="container-custom pb-8 space-y-6">
+        <InvestOpportunitiesCallout
+          tone="blue"
+          icon="globe"
+          heading="Worked out your withholding rate? Now find the investments."
+          blurb="Browse ASX-listed securities and FIRB-eligible opportunities suited to foreign and non-resident investors — or compare brokers that accept non-residents."
+          href="/invest?kind=listed_security&firb=eligible"
+          ctaLabel="Browse listed opportunities"
+          secondary={{ label: "Compare non-resident brokers", href: "/compare" }}
+        />
         <ComplianceFooter variant="calculator" />
       </div>
     </>

--- a/components/invest/InvestOpportunitiesCallout.tsx
+++ b/components/invest/InvestOpportunitiesCallout.tsx
@@ -1,0 +1,69 @@
+import Link from "next/link";
+import Icon from "@/components/Icon";
+
+/**
+ * Reusable cross-product callout that links a calculator / hub / guide
+ * INTO a filtered /invest marketplace view (Wave 6 cross-product wiring).
+ *
+ * The gap audit found /invest was orphaned from ~70% of upstream
+ * discovery flows — calculators, hubs and the concierge never surfaced a
+ * single listing. This callout is the connective tissue: drop it at the
+ * bottom of a tool or hub with a context-appropriate deep-link.
+ *
+ * Server component — pure presentation, no client state.
+ */
+export default function InvestOpportunitiesCallout({
+  heading,
+  blurb,
+  href,
+  ctaLabel = "Browse opportunities",
+  icon = "trending-up",
+  secondary,
+  tone = "emerald",
+}: {
+  heading: string;
+  blurb: string;
+  href: string;
+  ctaLabel?: string;
+  icon?: string;
+  secondary?: { label: string; href: string };
+  tone?: "emerald" | "amber" | "blue";
+}) {
+  const tones = {
+    emerald: { card: "from-emerald-50 to-white border-emerald-200", chip: "bg-emerald-100 text-emerald-700", cta: "bg-emerald-600 hover:bg-emerald-700" },
+    amber: { card: "from-amber-50 to-white border-amber-200", chip: "bg-amber-100 text-amber-700", cta: "bg-amber-600 hover:bg-amber-700" },
+    blue: { card: "from-blue-50 to-white border-blue-200", chip: "bg-blue-100 text-blue-700", cta: "bg-blue-600 hover:bg-blue-700" },
+  }[tone];
+
+  return (
+    <aside className={`bg-gradient-to-br ${tones.card} border rounded-2xl p-5 md:p-6`}>
+      <div className="flex items-start gap-3">
+        <span className={`shrink-0 rounded-lg p-2 ${tones.chip}`}>
+          <Icon name={icon} size={20} />
+        </span>
+        <div className="min-w-0 flex-1">
+          <h3 className="text-base md:text-lg font-bold text-slate-900">{heading}</h3>
+          <p className="text-sm text-slate-600 mt-1 leading-relaxed">{blurb}</p>
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <Link
+              href={href}
+              className={`inline-flex items-center gap-1.5 rounded-lg ${tones.cta} text-white font-bold text-sm px-4 py-2 transition-colors`}
+            >
+              {ctaLabel}
+              <Icon name="arrow-right" size={14} />
+            </Link>
+            {secondary && (
+              <Link
+                href={secondary.href}
+                className="inline-flex items-center gap-1 text-sm font-semibold text-slate-600 hover:text-slate-900 px-2 py-2"
+              >
+                {secondary.label}
+                <Icon name="arrow-right" size={13} />
+              </Link>
+            )}
+          </div>
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/lib/concierge-retrieval.ts
+++ b/lib/concierge-retrieval.ts
@@ -51,6 +51,13 @@ Guidelines:
 - For users searching for a financial advisor, point to /find-advisor
   (the structured wizard) and /advisors (faceted directory with
   individual, firm, and expert-team filters).
+- For users browsing investment opportunities, point to the /invest
+  marketplace with the right filter, e.g. [managed funds](/invest?kind=fund),
+  [SIV-complying funds](/invest?siv=complying), [SMSF-eligible property](/invest?category=commercial-property),
+  [wholesale gold & bullion](/invest?category=bullion),
+  [water entitlements](/invest?category=water-rights) or
+  [carbon credits](/invest?category=carbon-credits). Each listing has an
+  after-tax return estimator by investment structure.
 - Decline questions about specific stocks or crypto trades — say we
   cover platforms and educational context only.
 


### PR DESCRIPTION
## Summary

Tier 3 of the post-Wave-3 roadmap. The gap audit found `/invest` was orphaned from ~70% of upstream discovery flows — calculators, hubs, and the concierge never surfaced a single listing. This wave is the connective tissue.

## New

**`components/invest/InvestOpportunitiesCallout.tsx`** — reusable server component: a contextual CTA card that deep-links a tool/hub INTO a filtered `/invest` view. Three tones (emerald/amber/blue), primary + optional secondary link.

## Wired in

| Surface | Callout → deep-link |
|---|---|
| Withholding-tax calculator | "Now find the investments" → `/invest?kind=listed_security&firb=eligible` + compare brokers |
| FIRE calculator | "Owning income-producing assets" → `/invest?kind=fund,listed_security&min_yield=5` |
| Halal investing hub | "Browse Shariah-aware opportunities" → `/invest?kind=fund` (with screening caveat) |
| SMSF property guide | "SMSF-eligible property & income" → `/invest?category=commercial-property` + SDA housing |
| Concierge AI | System-prompt routing guideline → `/invest` with the right filter (funds, SIV-complying, SMSF-eligible property, bullion, water rights, carbon credits) + mentions the per-listing after-tax estimator |

All deep-links use the **real** filter params the `InvestListingsClient` already reads (`kind` / `category` / `siv` / `firb` / `min_yield`), so they land on populated, pre-filtered views — no dead ends. The bullion/water/carbon/sda categories come from Wave 4 (merged).

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] `vitest` — concierge-retrieval 15/15 (inline snapshot refreshed for the new prompt line)
- [x] `next build` succeeds
- [ ] Visual smoke — open each tool/hub, confirm the callout renders at the foot and the deep-link lands on a filtered `/invest`.

## Roadmap position

Tier 1 (Wave 4, merged #1385) · Tier 2 (Wave 5, #1386) · **Tier 3 = this**. Remaining: Tier 4 (programmatic SEO landing pages: `/invest/[vertical]/how-to`, `/minimum-investment`, `/tax`, `/best/[vertical]-for-[profile]`, `/invest/[vertical]/[state]/listings`).

https://claude.ai/code/session_019Rvnw5P7FXjNMRxiKkPFPh

---
_Generated by [Claude Code](https://claude.ai/code/session_019Rvnw5P7FXjNMRxiKkPFPh)_