### PR TITLE
fix(seo): resolve sitemap shard id Promise — Next 16 served empty shards

### DIFF
--- a/__tests__/lib/sitemap.test.ts
+++ b/__tests__/lib/sitemap.test.ts
@@ -113,6 +113,64 @@ describe("sitemap shard id coercion (Netlify passes string ids)", () => {
       expect(byFilename.length).toBe(byNumber.length);
     }
   });
+
+  // Regression for the all-empty-shards prod failure: Next 16's generated
+  // dynamic-sitemap route (next-metadata-route-loader) invokes the handler as
+  // `handler({ id: targetIdPromise })` — `id` arrives as a PROMISE, not a
+  // string/number. `String(promise)` === "[object Promise]" → the old
+  // parseInt-based parse returned NaN → default:[] → empty <urlset> for EVERY
+  // shard. CI was green because every prior test passed a synchronous "0"/0.
+  it("resolves a PROMISE id (the real Next 16 runtime shape), not just a string", async () => {
+    const asPromise = await sitemap({
+      id: Promise.resolve("0") as unknown as number,
+    });
+    const asNumber = await sitemap({ id: 0 });
+    expect(asPromise.length).toBeGreaterThan(0);
+    expect(asPromise.length).toBe(asNumber.length);
+  });
+
+  it("resolves a Promise of the FILENAME id (Promise<'1.xml'>) for static shard 1", async () => {
+    // Shard 1 (LOCALE_GROUPS) is fully static — must never be empty.
+    const asPromise = await sitemap({
+      id: Promise.resolve("1.xml") as unknown as number,
+    });
+    const asNumber = await sitemap({ id: 1 });
+    expect(asPromise.length).toBeGreaterThan(0);
+    expect(asPromise.length).toBe(asNumber.length);
+  });
+
+  it("tolerates path-style and undefined ids", async () => {
+    // "sitemap/0" / "/sitemap/0.xml" — first digit run wins.
+    const pathStyle = await sitemap({ id: "/sitemap/0.xml" as unknown as number });
+    const asNumber = await sitemap({ id: 0 });
+    expect(pathStyle.length).toBe(asNumber.length);
+    // No digits anywhere → empty (the safe unrecognised-id branch), not a throw.
+    const garbage = await sitemap({ id: undefined as unknown as number });
+    expect(garbage).toEqual([]);
+  });
+
+  it("static shards 0 & 1 are non-empty for every id form the runtime can pass", async () => {
+    for (const id of [
+      0,
+      "0",
+      "0.xml",
+      Promise.resolve("0"),
+      Promise.resolve("0.xml"),
+    ] as unknown as number[]) {
+      const urls = await sitemap({ id });
+      expect(urls.length, `shard 0 empty for id form ${String(id)}`).toBeGreaterThan(0);
+    }
+    for (const id of [
+      1,
+      "1",
+      "1.xml",
+      Promise.resolve("1"),
+      Promise.resolve("1.xml"),
+    ] as unknown as number[]) {
+      const urls = await sitemap({ id });
+      expect(urls.length, `shard 1 empty for id form ${String(id)}`).toBeGreaterThan(0);
+    }
+  });
 });
 
 /** Build a single shard and return its URLs. */

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1265,15 +1265,30 @@ async function buildShard8(): Promise<MetadataRoute.Sitemap> {
 // each shard at `/sitemap/0.xml`, `/sitemap/1.xml`, … `/sitemap/7.xml`.
 // robots.ts already points to `/sitemap.xml` so no change is needed there.
 
-export default async function sitemap({ id }: { id: number }): Promise<MetadataRoute.Sitemap> {
-  // The @netlify/plugin-nextjs runtime passes the shard `id` as the request
-  // FILENAME — "0.xml", not "0" — so `Number("0.xml")` is NaN and the switch
-  // fell through to `default: []`, serving an empty <urlset> for EVERY shard
-  // (Google got empty sitemaps). `parseInt` reads the leading integer from any
-  // form ("0", "0.xml", or a real number) → correct shard on both Netlify and
-  // Vercel. (#1316 used `Number(id)`, which does NOT handle the ".xml" suffix —
-  // its test only exercised "0", so CI was green while prod served empties.)
-  const shard = parseInt(String(id), 10);
+export default async function sitemap({
+  id,
+}: {
+  // Next 16's generated dynamic-sitemap route (next-metadata-route-loader)
+  // calls `handler({ id: targetIdPromise })` — `id` arrives as a PROMISE that
+  // resolves to the base filename string ("0"), NOT a bare number/string.
+  // Older docs/tests assumed a plain number, so the param type is widened to
+  // reflect every form the runtime can actually pass.
+  id: number | string | Promise<number | string | undefined> | undefined;
+}): Promise<MetadataRoute.Sitemap> {
+  // Root cause of the all-empty-shards prod failure: in Next 16 the runtime
+  // passes `id` as a *Promise* (`targetIdPromise`), so `String(id)` was
+  // "[object Promise]" → `parseInt(...)` === NaN → switch fell through to
+  // `default: []`, serving an empty <urlset> for EVERY shard (including the
+  // fully-static 0 & 1 that have no DB dependency). #1316 (`Number(id)`) and
+  // #1326 (`parseInt(id)`) both still assumed a synchronous string and only
+  // tested "0"/"0.xml", so CI stayed green while Google got empty sitemaps.
+  //
+  // Robust parse: await the value (a no-op for non-Promises), then pull the
+  // first digit run and map it to a shard. Tolerant of "0", "0.xml",
+  // "sitemap/0", "/sitemap/0.xml", a bare number, or a Promise of any of these.
+  const resolved = await id;
+  const digits = /(\d+)/.exec(String(resolved ?? ""))?.[1];
+  const shard = digits ? parseInt(digits, 10) : NaN;
   switch (shard) {
     case 0: return buildShard0();
     case 1: return buildShard1();
@@ -1286,7 +1301,10 @@ export default async function sitemap({ id }: { id: number }): Promise<MetadataR
     case 8: return buildShard8();
     default:
       // Never fail silently again: an unrecognised id means empty sitemaps.
-      log.warn("sitemap: unrecognised shard id — serving empty urlset", { id, shard });
+      log.warn("sitemap: unrecognised shard id — serving empty urlset", {
+        resolved: String(resolved ?? ""),
+        shard,
+      });
       return [];
   }
 }


### PR DESCRIPTION
## Finding (P1, Tier A) — GEO-critical

Every `/sitemap/N.xml` shard on the Netlify mirror returned an empty `<urlset>`, **including the fully-static shards 0 (buildShard0, ~300 hardcoded paths) and 1 (buildShard1, LOCALE_GROUPS)** which have no DB dependency.

## Root cause

Next 16's generated dynamic-sitemap route (`next-metadata-route-loader`) invokes the handler as:

```js
const data = await handler({ id: targetIdPromise })
```

`id` arrives as a **Promise** that resolves to the base filename string (`"0"`), not a number/string. The handler did `parseInt(String(id), 10)` — `String(promise)` is `"[object Promise]"` → `parseInt` is `NaN` → the switch fell through to `default: []`, serving an empty sitemap for **every** shard.

`#1316` (`Number(id)`) and `#1326` (`parseInt(id)`) both assumed a synchronous string and only tested `"0"`/`"0.xml"`, so CI stayed green while Google got empty sitemaps.

## Fix

`await` the id (no-op for non-Promises), then extract the first digit run via `/(\d+)/` and map to a shard. Tolerant of `"0"`, `"0.xml"`, `"sitemap/0"`, `"/sitemap/0.xml"`, a bare number, or a Promise of any of these. The param type is widened to reflect every form the runtime can pass.

## Tests

Added regression tests pinning the **Promise form** (the real Next 16 runtime shape) and asserting static shards 0 & 1 stay non-empty for every id form. 48/48 pass; `tsc` and `eslint --max-warnings 0` clean.