### PR TITLE
fix(getmatched): point fallback fee-calculator links at /fee-impact

### DIFF
--- a/__tests__/lib/getmatched/fallbacks.test.ts
+++ b/__tests__/lib/getmatched/fallbacks.test.ts
@@ -6,7 +6,17 @@ import {
   FALLBACK_INTENTS,
   FALLBACK_QUESTIONS,
 } from "@/lib/getmatched/fallbacks";
-import type { RouteType } from "@/lib/getmatched/types";
+import type { ResultTemplate, RouteType } from "@/lib/getmatched/types";
+
+/** Every href referenced by a result template (checklist + CTAs + cross-sells). */
+function templateHrefs(template: ResultTemplate): string[] {
+  return [
+    ...template.checklist.map((item) => item.href),
+    template.primary_cta.href,
+    ...template.secondary_ctas.map((cta) => cta.href),
+    ...template.cross_sells.map((sell) => sell.href),
+  ].filter((href): href is string => typeof href === "string");
+}
 
 const ROUTES: RouteType[] = [
   "compare",
@@ -40,6 +50,26 @@ describe("FALLBACK_TEMPLATES integrity", () => {
   it("every template carries a defined route", () => {
     for (const template of Object.values(FALLBACK_TEMPLATES)) {
       expect(template.route).toBeDefined();
+    }
+  });
+
+  it("never links to the non-existent /calculators/fee-impact route", () => {
+    for (const template of Object.values(FALLBACK_TEMPLATES)) {
+      for (const href of templateHrefs(template)) {
+        expect(href).not.toContain("/calculators/fee-impact");
+      }
+    }
+  });
+
+  it("points compare's fee-calculator links at the real /fee-impact route", () => {
+    const feeLinks = [
+      ...FALLBACK_TEMPLATES.compare.checklist,
+      ...FALLBACK_TEMPLATES.compare.secondary_ctas,
+    ].filter((item) => /fee calculator/i.test(item.label));
+
+    expect(feeLinks.length).toBeGreaterThan(0);
+    for (const link of feeLinks) {
+      expect(link.href).toBe("/fee-impact");
     }
   });
 });

--- a/lib/getmatched/fallbacks.ts
+++ b/lib/getmatched/fallbacks.ts
@@ -424,13 +424,13 @@ export const FALLBACK_TEMPLATES: Record<RouteType, ResultTemplate> = {
     checklist: [
       { label: "See your top match", href: "/compare" },
       { label: "Compare the full shortlist", href: "/compare" },
-      { label: "Run the fee calculator", href: "/calculators/fee-impact" },
+      { label: "Run the fee calculator", href: "/fee-impact" },
       { label: "Check CHESS sponsorship", href: "/chess-lookup" },
       { label: "Save your shortlist" },
     ],
     primary_cta: { label: "See full comparison", href: "/compare" },
     secondary_ctas: [
-      { label: "Fee calculator", href: "/calculators/fee-impact" },
+      { label: "Fee calculator", href: "/fee-impact" },
       { label: "Get expert help if unsure", href: "/get-matched?goal=help" },
     ],
     cross_sells: [


### PR DESCRIPTION
## What

`FALLBACK_TEMPLATES.compare` in `lib/getmatched/fallbacks.ts` linked its checklist item ("Run the fee calculator") and a secondary CTA ("Fee calculator") at `/calculators/fee-impact`, which 404s. The real route is `/fee-impact` (`app/fee-impact/page.tsx`). Both occurrences are repointed to `/fee-impact`. A repo-wide grep confirmed these were the only two source references.

Extended `__tests__/lib/getmatched/fallbacks.test.ts`:
- new `templateHrefs` helper collecting every href (checklist + CTAs + cross-sells)
- asserts no fallback template links to `/calculators/fee-impact`
- asserts compare's fee-calculator links resolve to `/fee-impact`

## Verify

`npx vitest run __tests__/lib/getmatched/fallbacks.test.ts` — 17 passing. ESLint clean (--max-warnings 0).

Tier A (page UI / content fix + focused test).