### PR TITLE
fix(rate-alerts): anon subscribe 500s — insert + treat 23505 as success

### DIFF
--- a/__tests__/api/rate-alerts.test.ts
+++ b/__tests__/api/rate-alerts.test.ts
@@ -2,9 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
 
 const mockServerFrom = vi.fn();
+const mockGetUser = vi.fn();
 
 vi.mock("@/lib/supabase/server", () => ({
-  createClient: vi.fn().mockResolvedValue({ from: (...args: unknown[]) => mockServerFrom(...args) }),
+  createClient: vi.fn().mockResolvedValue({
+    from: (...args: unknown[]) => mockServerFrom(...args),
+    auth: { getUser: (...args: unknown[]) => mockGetUser(...args) },
+  }),
 }));
 
 vi.mock("@/lib/logger", () => ({
@@ -48,6 +52,10 @@ function makeUpsertBuilder(error: unknown = null) {
   return { upsert: vi.fn(() => Promise.resolve({ error })) };
 }
 
+function makeInsertBuilder(error: unknown = null) {
+  return { insert: vi.fn(() => Promise.resolve({ error })) };
+}
+
 function makeUpdateDeleteBuilder() {
   const b: Record<string, unknown> = {};
   b.update = vi.fn(() => b);
@@ -60,6 +68,8 @@ beforeEach(() => {
   mockIsRateLimited.mockResolvedValue(false);
   mockIsSuppressed.mockResolvedValue(false);
   mockFetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+  // Default to an anonymous visitor — the common subscribe path.
+  mockGetUser.mockResolvedValue({ data: { user: null } });
   process.env.RESEND_API_KEY = "test-resend-key";
 });
 
@@ -122,8 +132,10 @@ describe("POST /api/rate-alerts", () => {
     expect(mockServerFrom).not.toHaveBeenCalled();
   });
 
-  it("upserts the subscription on a clean POST and sends a verification email", async () => {
-    const builder = makeUpsertBuilder(null);
+  it("inserts (not upserts) for an anonymous subscriber and sends a verification email", async () => {
+    // Anon RLS grants INSERT only — an upsert would 500. The route must
+    // .insert() for unauthenticated visitors.
+    const builder = makeInsertBuilder(null);
     mockServerFrom.mockReturnValueOnce(builder);
 
     const res = await POST(
@@ -132,28 +144,69 @@ describe("POST /api/rate-alerts", () => {
 
     expect(res.status).toBe(200);
     expect(mockServerFrom).toHaveBeenCalledWith("rate_alert_subscriptions");
-    expect(builder.upsert).toHaveBeenCalledTimes(1);
-    const call = builder.upsert.mock.calls[0] as unknown as [Record<string, unknown>, Record<string, unknown>];
-    const [payload, opts] = call;
+    expect(builder.insert).toHaveBeenCalledTimes(1);
+    const call = builder.insert.mock.calls[0] as unknown as [Record<string, unknown>];
+    const [payload] = call;
     expect(payload.threshold_bps).toBe(525);
     expect(payload.email).toBe("u@example.com");
     expect(payload.product_kind).toBe("savings_account");
     expect(payload.verified).toBe(false);
-    expect(opts).toEqual({ onConflict: "email,product_kind" });
     expect(mockFetch).toHaveBeenCalledWith("https://api.resend.com/emails", expect.any(Object));
   });
 
-  it("returns 500 when the upsert fails", async () => {
-    mockServerFrom.mockReturnValueOnce(makeUpsertBuilder({ message: "boom" }));
+  it("treats a duplicate (23505) anon insert as success (200, not 500)", async () => {
+    // Re-subscribing the same (email, product_kind) hits the unique index.
+    // A unique-violation means "already subscribed" — report 200, not 500.
+    const builder = makeInsertBuilder({ code: "23505", message: "duplicate key value" });
+    mockServerFrom.mockReturnValueOnce(builder);
+
+    const res = await POST(
+      makePost({ email: "dupe@example.com", product_kind: "savings_account", threshold_pct: 5 }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(builder.insert).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 500 when an anon insert fails with a non-23505 error", async () => {
+    mockServerFrom.mockReturnValueOnce(
+      makeInsertBuilder({ code: "42501", message: "permission denied" }),
+    );
     const res = await POST(
       makePost({ email: "u@example.com", product_kind: "term_deposit", threshold_pct: 4.0 }),
     );
     expect(res.status).toBe(500);
   });
 
+  it("upserts for an authenticated subscriber (FOR ALL policy permits it)", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: { id: "user-1" } } });
+    const builder = makeUpsertBuilder(null);
+    mockServerFrom.mockReturnValueOnce(builder);
+
+    const res = await POST(
+      makePost({ email: "auth@example.com", product_kind: "term_deposit", threshold_pct: 4.5 }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(builder.upsert).toHaveBeenCalledTimes(1);
+    const call = builder.upsert.mock.calls[0] as unknown as [Record<string, unknown>, Record<string, unknown>];
+    const [payload, opts] = call;
+    expect(payload.threshold_bps).toBe(450);
+    expect(opts).toEqual({ onConflict: "email,product_kind" });
+  });
+
+  it("returns 500 when an authenticated upsert fails", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: { id: "user-1" } } });
+    mockServerFrom.mockReturnValueOnce(makeUpsertBuilder({ message: "boom" }));
+    const res = await POST(
+      makePost({ email: "auth@example.com", product_kind: "term_deposit", threshold_pct: 4.0 }),
+    );
+    expect(res.status).toBe(500);
+  });
+
   it("succeeds even when RESEND_API_KEY is unset", async () => {
     delete process.env.RESEND_API_KEY;
-    mockServerFrom.mockReturnValueOnce(makeUpsertBuilder(null));
+    mockServerFrom.mockReturnValueOnce(makeInsertBuilder(null));
     const res = await POST(
       makePost({ email: "u@example.com", product_kind: "term_deposit", threshold_pct: 4.5 }),
     );

--- a/app/api/rate-alerts/route.ts
+++ b/app/api/rate-alerts/route.ts
@@ -81,31 +81,57 @@ export async function POST(request: NextRequest) {
   const unsubscribeToken = randomBytes(24).toString("hex");
   const thresholdBps = Math.round(threshold_pct * 100);
 
-  // Upsert on (lower(email), product_kind). Re-subscribing with the same
-  // pair refreshes the threshold + tokens; old verified state is reset
-  // because the threshold change is a meaningful intent shift.
-  const { error: insertErr } = await supabase
-    .from("rate_alert_subscriptions")
-    .upsert(
-      {
-        email: email.toLowerCase(),
-        product_kind,
-        threshold_bps: thresholdBps,
-        product_filters: product_filters ?? {},
-        frequency,
-        verified: false,
-        verify_token: verifyToken,
-        unsubscribe_token: unsubscribeToken,
-        last_notified_at: null,
-        notification_count: 0,
-        updated_at: new Date().toISOString(),
-      },
-      { onConflict: "email,product_kind" },
-    );
+  // Anon RLS on rate_alert_subscriptions grants INSERT ONLY (see
+  // supabase/migrations/20260518010000_rate_alert_subscriptions.sql) — an
+  // .upsert() (INSERT ... ON CONFLICT DO UPDATE) needs UPDATE + SELECT and
+  // so 500s for every anonymous subscriber. Branch on session: authenticated
+  // users fall under the service_role/FOR ALL path where an upsert is fine;
+  // anonymous users do a plain .insert() and treat a unique-violation
+  // (Postgres 23505 on the (lower(email), product_kind) index) as success —
+  // they're already subscribed. Mirrors graceful-duplicate handling
+  // elsewhere (e.g. app/api/account/watchlist/route.ts).
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
 
-  if (insertErr) {
-    log.error("rate-alert subscribe upsert failed", { err: insertErr.message });
-    return NextResponse.json({ error: "Failed to subscribe." }, { status: 500 });
+  const row = {
+    email: email.toLowerCase(),
+    product_kind,
+    threshold_bps: thresholdBps,
+    product_filters: product_filters ?? {},
+    frequency,
+    verified: false,
+    verify_token: verifyToken,
+    unsubscribe_token: unsubscribeToken,
+    last_notified_at: null,
+    notification_count: 0,
+    updated_at: new Date().toISOString(),
+  };
+
+  if (user) {
+    // Authenticated path: upsert on (lower(email), product_kind). Re-subscribing
+    // with the same pair refreshes the threshold + tokens; old verified state is
+    // reset because the threshold change is a meaningful intent shift.
+    const { error: upsertErr } = await supabase
+      .from("rate_alert_subscriptions")
+      .upsert(row, { onConflict: "email,product_kind" });
+
+    if (upsertErr) {
+      log.error("rate-alert subscribe upsert failed", { err: upsertErr.message });
+      return NextResponse.json({ error: "Failed to subscribe." }, { status: 500 });
+    }
+  } else {
+    // Anonymous path: INSERT only. A 23505 means the (email, product_kind)
+    // pair already exists — already subscribed, so report success rather than
+    // 500. The verification email below still re-fires so the user can confirm.
+    const { error: insertErr } = await supabase
+      .from("rate_alert_subscriptions")
+      .insert(row);
+
+    if (insertErr && insertErr.code !== "23505") {
+      log.error("rate-alert subscribe insert failed", { err: insertErr.message });
+      return NextResponse.json({ error: "Failed to subscribe." }, { status: 500 });
+    }
   }
 
   // Fire-and-forget verification email; the subscriber row already


### PR DESCRIPTION
## What

`POST /api/rate-alerts` `.upsert()`d the subscription row for every subscriber. But anon RLS on `rate_alert_subscriptions` grants **INSERT ONLY** (see `supabase/migrations/20260518010000_rate_alert_subscriptions.sql`). `INSERT ... ON CONFLICT DO UPDATE` needs UPDATE + SELECT, so **every anonymous subscribe 500'd** — P1.

Code-only fix (no migration):
- Branch on session via `supabase.auth.getUser()`.
- **Authenticated** users keep `.upsert()` (they fall under the service_role / FOR ALL path).
- **Anonymous** users do a plain `.insert()`; a unique-violation (Postgres `23505` on the `(lower(email), product_kind)` index) is treated as success — already subscribed -> 200. Mirrors graceful-duplicate handling in `app/api/account/watchlist/route.ts`.

Tests added/updated in `__tests__/api/rate-alerts.test.ts`: anon insert -> 200; duplicate 23505 -> 200 (not 500); non-23505 anon error -> 500; authenticated upsert path + its 500. 15 tests pass.

Tier C (touches an API route writing a user-data table). No migration; RLS unchanged.