### PR TITLE
feat(invest): Wave 8 — state landing pages, curated best-for combos, vertical-drift fix

### DIFF
--- a/__tests__/lib/invest-best-for.test.ts
+++ b/__tests__/lib/invest-best-for.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import { BEST_FOR_COMBOS, getBestForCombo } from "@/lib/invest-best-for";
+import { listingMatchesCombo } from "@/lib/invest-best-for-data";
+import { getInvestCategoryBySlug } from "@/lib/invest-categories";
+import type { InvestmentListing, InvestListingVertical } from "@/lib/types";
+
+function listing(
+  vertical: string,
+  sub_category?: string,
+): Pick<InvestmentListing, "vertical" | "sub_category"> {
+  return { vertical: vertical as InvestListingVertical, sub_category };
+}
+
+describe("BEST_FOR_COMBOS integrity", () => {
+  it("has unique slugs", () => {
+    const slugs = BEST_FOR_COMBOS.map((c) => c.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it("every combo carries the required authored fields", () => {
+    for (const c of BEST_FOR_COMBOS) {
+      expect(c.title.length).toBeGreaterThan(0);
+      expect(c.intro.length).toBeGreaterThan(40);
+      expect(c.why.length).toBeGreaterThanOrEqual(3);
+      expect(c.filterQuery.length).toBeGreaterThan(0);
+      expect(c.verticalLabel.length).toBeGreaterThan(0);
+      expect(c.profileLabel.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("every combo's display category resolves to a real /invest category", () => {
+    for (const c of BEST_FOR_COMBOS) {
+      expect(getInvestCategoryBySlug(c.categorySlug), c.slug).toBeDefined();
+    }
+  });
+
+  it("deep-link filterQuery never points at a non-existent category=sda-housing dead-end", () => {
+    // SDA listings resolve to the commercial-property bucket on the client,
+    // so the deep-link must use the sub filter, not category=sda-housing.
+    const sda = getBestForCombo("sda-housing-for-smsf");
+    expect(sda?.filterQuery).toContain("sub=sda_housing");
+    expect(sda?.filterQuery).not.toContain("category=sda-housing");
+  });
+
+  it("getBestForCombo returns the combo or undefined", () => {
+    expect(getBestForCombo("bullion-for-smsf")?.slug).toBe("bullion-for-smsf");
+    expect(getBestForCombo("does-not-exist")).toBeUndefined();
+  });
+});
+
+describe("listingMatchesCombo", () => {
+  const commercialSmsf = getBestForCombo("commercial-property-for-smsf")!;
+  const sdaSmsf = getBestForCombo("sda-housing-for-smsf")!;
+  const fundsRetirees = getBestForCombo("funds-for-retirees")!;
+  const renewables = getBestForCombo("renewable-energy-for-impact-investors")!;
+
+  it("matches a plain commercial-property listing to the commercial combo", () => {
+    expect(listingMatchesCombo(listing("commercial_property", "office"), commercialSmsf)).toBe(true);
+  });
+
+  it("matches drifted vertical strings (renewable-energy → energy)", () => {
+    expect(listingMatchesCombo(listing("renewable-energy", "solar"), renewables)).toBe(true);
+  });
+
+  it("matches SDA listings to the SDA combo via matchCategory + subCategory", () => {
+    expect(listingMatchesCombo(listing("commercial_property", "sda_housing"), sdaSmsf)).toBe(true);
+  });
+
+  it("does not match non-SDA commercial property to the SDA combo", () => {
+    expect(listingMatchesCombo(listing("commercial_property", "office"), sdaSmsf)).toBe(false);
+  });
+
+  it("includes SDA listings under the broader commercial combo (no sub filter)", () => {
+    expect(listingMatchesCombo(listing("commercial_property", "sda_housing"), commercialSmsf)).toBe(true);
+  });
+
+  it("excludes guide-vertical sector-hub listings from the funds combo", () => {
+    // oil-gas / uranium listings fall back to the 'funds' bucket via
+    // categoryForListing, but are not canonical verticals and must not
+    // pollute the income-funds combo.
+    expect(listingMatchesCombo(listing("oil-gas", "Refining & Retail"), fundsRetirees)).toBe(false);
+    expect(listingMatchesCombo(listing("uranium", "Uranium Producer"), fundsRetirees)).toBe(false);
+  });
+
+  it("matches genuine fund listings to the funds combo", () => {
+    expect(listingMatchesCombo(listing("fund", "managed_fund"), fundsRetirees)).toBe(true);
+    // drifted 'funds' vertical also resolves to the funds bucket
+    expect(listingMatchesCombo(listing("funds", "managed_fund"), fundsRetirees)).toBe(true);
+  });
+});

--- a/__tests__/lib/investment-listings-query.test.ts
+++ b/__tests__/lib/investment-listings-query.test.ts
@@ -104,8 +104,17 @@ describe("fetchListingsByVertical", () => {
 
   it("filters by vertical + status=active", async () => {
     await fetchListingsByVertical("mining");
-    expect(eqCalls).toContainEqual({ col: "vertical", val: "mining" });
+    expect(inCalls).toContainEqual({ col: "vertical", val: ["mining"] });
     expect(eqCalls).toContainEqual({ col: "status", val: "active" });
+  });
+
+  it("matches drifted vertical variants via .in()", async () => {
+    await fetchListingsByVertical("energy");
+    // "renewable-energy" drift listings must be picked up alongside "energy".
+    expect(inCalls).toContainEqual({
+      col: "vertical",
+      val: ["energy", "renewable-energy"],
+    });
   });
 
   it("passes subCategories to .in() when provided", async () => {
@@ -164,6 +173,8 @@ describe("fetchListingsBySubCategory", () => {
     listingsData = [];
     queryError = null;
     throwOnCreate = false;
+    eqCalls.length = 0;
+    inCalls.length = 0;
   });
 
   it("returns [] for empty subCategory", async () => {
@@ -174,7 +185,7 @@ describe("fetchListingsBySubCategory", () => {
     listingsData = [{ id: 1 }];
     const res = await fetchListingsBySubCategory("fund", "art");
     expect(res).toEqual([{ id: 1 }]);
-    expect(eqCalls).toContainEqual({ col: "vertical", val: "fund" });
+    expect(inCalls).toContainEqual({ col: "vertical", val: ["fund", "funds"] });
     expect(eqCalls).toContainEqual({ col: "sub_category", val: "art" });
     expect(eqCalls).toContainEqual({ col: "status", val: "active" });
   });

--- a/__tests__/lib/listing-url.test.ts
+++ b/__tests__/lib/listing-url.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { categoryForListing, listingUrl } from "@/lib/listing-url";
+import {
+  categoryForListing,
+  listingUrl,
+  normaliseVertical,
+  rawVerticalVariants,
+  isCanonicalVertical,
+} from "@/lib/listing-url";
 import type { InvestmentListing, InvestListingVertical } from "@/lib/types";
 
 function listing(
@@ -60,6 +66,65 @@ describe("categoryForListing", () => {
     expect(
       categoryForListing({ vertical: "mining", sub_category: "art" }),
     ).toBe("mining");
+  });
+
+  it("normalises drifted vertical strings to the right category", () => {
+    // These non-canonical vertical values exist in the DB from earlier
+    // seed waves and must not silently fall through to "funds".
+    const cases: [string, string][] = [
+      ["commercial-property", "commercial-property"],
+      ["startups", "startups"],
+      ["renewable-energy", "renewable-energy"],
+      ["funds", "funds"],
+    ];
+    for (const [vertical, slug] of cases) {
+      expect(
+        categoryForListing({
+          vertical: vertical as InvestListingVertical,
+          sub_category: undefined,
+        }),
+      ).toBe(slug);
+    }
+  });
+
+  it("applies fund sub-category overrides to the drifted 'funds' vertical", () => {
+    // A 'funds' (drift) listing with a private_credit sub still routes to
+    // private-credit, the same as the canonical 'fund' vertical.
+    expect(
+      categoryForListing({
+        vertical: "funds" as InvestListingVertical,
+        sub_category: "private_credit",
+      }),
+    ).toBe("private-credit");
+  });
+});
+
+describe("vertical normalisation helpers", () => {
+  it("normaliseVertical maps drift → canonical and leaves canonical/guide untouched", () => {
+    expect(normaliseVertical("commercial-property")).toBe("commercial_property");
+    expect(normaliseVertical("funds")).toBe("fund");
+    expect(normaliseVertical("startups")).toBe("startup");
+    expect(normaliseVertical("renewable-energy")).toBe("energy");
+    expect(normaliseVertical("mining")).toBe("mining");
+    expect(normaliseVertical("oil-gas")).toBe("oil-gas");
+  });
+
+  it("rawVerticalVariants returns canonical + drift variants for querying", () => {
+    expect(rawVerticalVariants("commercial_property")).toEqual([
+      "commercial_property",
+      "commercial-property",
+    ]);
+    expect(rawVerticalVariants("fund")).toEqual(["fund", "funds"]);
+    expect(rawVerticalVariants("mining")).toEqual(["mining"]);
+  });
+
+  it("isCanonicalVertical accepts canonical + drift, rejects guide/unknown", () => {
+    expect(isCanonicalVertical("commercial_property")).toBe(true);
+    expect(isCanonicalVertical("renewable-energy")).toBe(true); // drift → energy
+    expect(isCanonicalVertical("fund")).toBe(true);
+    expect(isCanonicalVertical("oil-gas")).toBe(false);
+    expect(isCanonicalVertical("uranium")).toBe(false);
+    expect(isCanonicalVertical("nonsense")).toBe(false);
   });
 });
 

--- a/app/invest-in/[state]/page.tsx
+++ b/app/invest-in/[state]/page.tsx
@@ -1,0 +1,210 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { STATE_SURCHARGES } from "@/lib/firb-data";
+import { getInvestStateData } from "@/lib/invest-state-data";
+import { getInvestCategoryBySlug } from "@/lib/invest-categories";
+import { absoluteUrl, breadcrumbJsonLd, CURRENT_YEAR, UPDATED_LABEL, SITE_NAME } from "@/lib/seo";
+import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
+import InvestListingCard from "@/components/InvestListingCard";
+import Icon from "@/components/Icon";
+
+export const revalidate = 3600;
+
+/**
+ * Programmatic /invest-in/[state] landing pages (Wave 8 SEO).
+ *
+ * One page per Australian state/territory — geo-qualified deal-flow that
+ * serves "investment opportunities NSW", "commercial property to buy
+ * Victoria"-style intent. Clean dedicated namespace (no collision with
+ * the static /invest/<vertical>/ dirs). Combines live per-state listing
+ * data with state-specific foreign-buyer surcharge context (reused from
+ * lib/firb-data).
+ */
+
+const STATES = STATE_SURCHARGES.map((s) => ({
+  code: s.stateCode,
+  name: s.state,
+  surchargePercent: s.surchargePercent,
+  landTaxSurchargePercent: s.landTaxSurchargePercent ?? 0,
+  notes: s.notes,
+}));
+
+function stateByCode(code: string) {
+  return STATES.find((s) => s.code.toLowerCase() === code.toLowerCase());
+}
+
+export async function generateStaticParams() {
+  return STATES.map((s) => ({ state: s.code.toLowerCase() }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ state: string }>;
+}): Promise<Metadata> {
+  const { state } = await params;
+  const st = stateByCode(state);
+  if (!st) return { title: "Invest by state", robots: { index: false } };
+  const title = `Investment Opportunities in ${st.name} (${CURRENT_YEAR})`;
+  const description = `Browse investment opportunities across ${st.name} (${st.code}) — businesses, commercial property, farmland, projects and funds. Plus ${st.name} foreign-buyer stamp-duty surcharge and FIRB context.`;
+  return {
+    title: `${title} | ${SITE_NAME}`,
+    description,
+    alternates: { canonical: absoluteUrl(`/invest-in/${st.code.toLowerCase()}`) },
+    openGraph: { title, description, url: absoluteUrl(`/invest-in/${st.code.toLowerCase()}`), type: "website" },
+    twitter: { card: "summary_large_image" },
+  };
+}
+
+export default async function InvestInStatePage({
+  params,
+}: {
+  params: Promise<{ state: string }>;
+}) {
+  const { state } = await params;
+  const st = stateByCode(state);
+  if (!st) notFound();
+
+  const data = await getInvestStateData(st.code);
+  const browseHref = `/invest?state=${st.code}`;
+
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: absoluteUrl("/") },
+    { name: "Invest", url: absoluteUrl("/invest") },
+    { name: st.name },
+  ]);
+
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
+
+      <div className="container-custom max-w-5xl py-8 md:py-12">
+        <nav aria-label="Breadcrumb" className="text-xs md:text-sm text-slate-500 mb-5">
+          <Link href="/" className="hover:text-slate-900">Home</Link>
+          <span className="mx-1.5">/</span>
+          <Link href="/invest" className="hover:text-slate-900">Invest</Link>
+          <span className="mx-1.5">/</span>
+          <span className="text-slate-700">{st.name}</span>
+        </nav>
+
+        <header className="mb-8">
+          <p className="text-xs font-semibold uppercase tracking-wider text-emerald-700 mb-2">
+            {st.name} · {UPDATED_LABEL}
+          </p>
+          <h1 className="text-3xl md:text-4xl font-extrabold tracking-tight mb-3">
+            Investment opportunities in {st.name}
+          </h1>
+          <p className="text-base md:text-lg text-slate-600 leading-relaxed">
+            Browse live investment opportunities across {st.name} — businesses for sale, commercial
+            property, farmland, projects, funds and more. Filter by ticket size, sector and FIRB
+            eligibility on the marketplace.
+          </p>
+          {data.total > 0 && (
+            <div className="mt-4">
+              <Link
+                href={browseHref}
+                className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white font-bold text-sm px-4 py-2 transition-colors"
+              >
+                See {data.total} {st.code} {data.total === 1 ? "opportunity" : "opportunities"}
+                <Icon name="arrow-right" size={14} />
+              </Link>
+            </div>
+          )}
+        </header>
+
+        {/* Category breakdown */}
+        {data.byCategory.length > 0 && (
+          <section className="mb-10">
+            <h2 className="text-xl md:text-2xl font-extrabold mb-4">{st.name} opportunities by sector</h2>
+            <div className="flex flex-wrap gap-2">
+              {data.byCategory.map(({ slug, count }) => {
+                const cat = getInvestCategoryBySlug(slug);
+                const label = cat?.label ?? slug.replace(/-/g, " ");
+                return (
+                  <Link
+                    key={slug}
+                    href={`/invest?category=${slug}&state=${st.code}`}
+                    className="inline-flex items-center gap-1.5 rounded-full bg-slate-50 hover:bg-emerald-50 border border-slate-200 hover:border-emerald-200 px-3 py-1.5 text-xs font-semibold text-slate-700 transition-colors capitalize"
+                  >
+                    {label}
+                    <span className="text-emerald-700 tabular-nums">{count}</span>
+                  </Link>
+                );
+              })}
+            </div>
+          </section>
+        )}
+
+        {/* Foreign-buyer context (state-specific) */}
+        <section className="mb-10">
+          <h2 className="text-xl md:text-2xl font-extrabold mb-3">
+            Foreign buyers: {st.name} surcharges
+          </h2>
+          <div className="rounded-xl border border-blue-200 bg-blue-50 p-4 md:p-5">
+            <div className="flex items-start gap-3">
+              <span className="shrink-0 text-blue-600 mt-0.5"><Icon name="globe" size={18} /></span>
+              <div>
+                <div className="flex flex-wrap gap-4 mb-2">
+                  <div>
+                    <p className="text-2xl font-extrabold text-blue-700">{st.surchargePercent}%</p>
+                    <p className="text-[0.65rem] uppercase tracking-wide text-blue-700/70 font-semibold">Stamp-duty surcharge</p>
+                  </div>
+                  {st.landTaxSurchargePercent > 0 && (
+                    <div>
+                      <p className="text-2xl font-extrabold text-blue-700">{st.landTaxSurchargePercent}%</p>
+                      <p className="text-[0.65rem] uppercase tracking-wide text-blue-700/70 font-semibold">Annual land-tax surcharge</p>
+                    </div>
+                  )}
+                </div>
+                <p className="text-sm text-blue-900/80 leading-relaxed">{st.notes}</p>
+                <p className="text-xs text-blue-700/70 mt-2">
+                  Foreign purchasers also need FIRB approval and pay a federal application fee on top of these state surcharges.{" "}
+                  <Link href="/property/foreign-investment" className="font-semibold underline underline-offset-2 hover:text-blue-900">FIRB guide</Link>
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Sample listings */}
+        {data.listings.length > 0 && (
+          <section className="mb-10">
+            <div className="flex items-center justify-between gap-2 mb-4">
+              <h2 className="text-xl md:text-2xl font-extrabold">Latest {st.code} opportunities</h2>
+              <Link href={browseHref} className="text-sm font-semibold text-emerald-700 hover:text-emerald-900 inline-flex items-center gap-1">
+                View all {data.total}
+                <Icon name="arrow-right" size={13} />
+              </Link>
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+              {data.listings.map((l) => (
+                <InvestListingCard key={l.id} listing={l} />
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* Other states */}
+        <section className="mb-10">
+          <h2 className="text-lg font-bold mb-3">Browse other states</h2>
+          <div className="flex flex-wrap gap-2">
+            {STATES.filter((s) => s.code !== st.code).map((s) => (
+              <Link
+                key={s.code}
+                href={`/invest-in/${s.code.toLowerCase()}`}
+                className="inline-flex items-center rounded-full border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-600 hover:bg-slate-50"
+              >
+                {s.name}
+              </Link>
+            ))}
+          </div>
+        </section>
+
+        <div className="border border-amber-200 bg-amber-50 rounded-lg px-4 py-3 text-xs text-slate-600 leading-relaxed">
+          <strong className="text-slate-700">General Advice Warning:</strong> {GENERAL_ADVICE_WARNING}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/invest/best-for/[combo]/page.tsx
+++ b/app/invest/best-for/[combo]/page.tsx
@@ -1,0 +1,188 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { BEST_FOR_COMBOS, getBestForCombo } from "@/lib/invest-best-for";
+import { getBestForListings } from "@/lib/invest-best-for-data";
+import { getInvestCategoryBySlug } from "@/lib/invest-categories";
+import { absoluteUrl, breadcrumbJsonLd, CURRENT_YEAR, UPDATED_LABEL, SITE_NAME } from "@/lib/seo";
+import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
+import InvestListingCard from "@/components/InvestListingCard";
+import InvestOpportunitiesCallout from "@/components/invest/InvestOpportunitiesCallout";
+import Icon from "@/components/Icon";
+
+export const revalidate = 3600;
+
+/**
+ * Programmatic /invest/best-for/[combo] landing pages (Wave 8 SEO).
+ *
+ * High-intent pages that intersect an opportunity vertical with an
+ * investor archetype ("best commercial property for SMSF", "best funds
+ * for SIV applicants"). Dedicated static `best-for` segment — no
+ * collision with the /invest/<vertical>/ dirs. Each page pairs authored
+ * rationale with a live sample of matching listings and a deep-link into
+ * the pre-filtered marketplace.
+ */
+
+export function generateStaticParams() {
+  return BEST_FOR_COMBOS.map((c) => ({ combo: c.slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ combo: string }>;
+}): Promise<Metadata> {
+  const { combo: slug } = await params;
+  const combo = getBestForCombo(slug);
+  if (!combo) return { title: "Best investments by profile", robots: { index: false } };
+  const title = `${combo.title} (${CURRENT_YEAR})`;
+  const description = combo.intro.slice(0, 155);
+  const url = absoluteUrl(`/invest/best-for/${combo.slug}`);
+  return {
+    title: `${title} | ${SITE_NAME}`,
+    description,
+    alternates: { canonical: url },
+    openGraph: { title, description, url, type: "website" },
+    twitter: { card: "summary_large_image" },
+  };
+}
+
+export default async function BestForComboPage({
+  params,
+}: {
+  params: Promise<{ combo: string }>;
+}) {
+  const { combo: slug } = await params;
+  const combo = getBestForCombo(slug);
+  if (!combo) notFound();
+
+  const { listings, total } = await getBestForListings(combo);
+  const cat = getInvestCategoryBySlug(combo.categorySlug);
+  const browseHref = `/invest?${combo.filterQuery}`;
+
+  // Related combos: prefer ones sharing this investor profile, then fill
+  // with others. Cap at 4.
+  const related = [
+    ...BEST_FOR_COMBOS.filter((c) => c.slug !== combo.slug && c.profileLabel === combo.profileLabel),
+    ...BEST_FOR_COMBOS.filter((c) => c.slug !== combo.slug && c.profileLabel !== combo.profileLabel),
+  ].slice(0, 4);
+
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: absoluteUrl("/") },
+    { name: "Invest", url: absoluteUrl("/invest") },
+    { name: combo.title },
+  ]);
+
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
+
+      <div className="container-custom max-w-5xl py-8 md:py-12">
+        <nav aria-label="Breadcrumb" className="text-xs md:text-sm text-slate-500 mb-5">
+          <Link href="/" className="hover:text-slate-900">Home</Link>
+          <span className="mx-1.5">/</span>
+          <Link href="/invest" className="hover:text-slate-900">Invest</Link>
+          <span className="mx-1.5">/</span>
+          <span className="text-slate-700">{combo.verticalLabel} for {combo.profileLabel}</span>
+        </nav>
+
+        <header className="mb-8">
+          <p className="text-xs font-semibold uppercase tracking-wider text-emerald-700 mb-2">
+            Best for {combo.profileLabel} · {UPDATED_LABEL}
+          </p>
+          <h1 className="text-3xl md:text-4xl font-extrabold tracking-tight mb-3">
+            {combo.title}
+          </h1>
+          <p className="text-base md:text-lg text-slate-600 leading-relaxed">{combo.intro}</p>
+          <div className="mt-4 flex flex-wrap items-center gap-3">
+            <Link
+              href={browseHref}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white font-bold text-sm px-4 py-2 transition-colors"
+            >
+              {total > 0
+                ? `Browse ${total} matching ${total === 1 ? "opportunity" : "opportunities"}`
+                : "Browse the marketplace"}
+              <Icon name="arrow-right" size={14} />
+            </Link>
+            {cat && (
+              <Link
+                href={`/invest/${cat.slug}`}
+                className="text-sm font-semibold text-slate-600 hover:text-slate-900 inline-flex items-center gap-1"
+              >
+                {cat.label} overview
+                <Icon name="arrow-right" size={13} />
+              </Link>
+            )}
+          </div>
+        </header>
+
+        {/* Why this fits */}
+        <section className="mb-10">
+          <h2 className="text-xl md:text-2xl font-extrabold mb-4">
+            Why {combo.verticalLabel} suits {combo.profileLabel}
+          </h2>
+          <ul className="space-y-3">
+            {combo.why.map((reason, i) => (
+              <li key={i} className="flex items-start gap-3">
+                <span className="shrink-0 mt-0.5 text-emerald-600"><Icon name="check-circle" size={18} /></span>
+                <span className="text-sm md:text-base text-slate-700 leading-relaxed">{reason}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        {/* Live matching listings */}
+        {listings.length > 0 && (
+          <section className="mb-10">
+            <div className="flex items-center justify-between gap-2 mb-4">
+              <h2 className="text-xl md:text-2xl font-extrabold">Matching opportunities</h2>
+              <Link href={browseHref} className="text-sm font-semibold text-emerald-700 hover:text-emerald-900 inline-flex items-center gap-1">
+                View all {total}
+                <Icon name="arrow-right" size={13} />
+              </Link>
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+              {listings.map((l) => (
+                <InvestListingCard key={l.id} listing={l} />
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* Related combos */}
+        {related.length > 0 && (
+          <section className="mb-10">
+            <h2 className="text-lg font-bold mb-3">More curated picks</h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              {related.map((c) => (
+                <Link
+                  key={c.slug}
+                  href={`/invest/best-for/${c.slug}`}
+                  className="group rounded-xl border border-slate-200 bg-white hover:border-emerald-300 hover:bg-emerald-50/40 p-4 transition-colors"
+                >
+                  <p className="text-sm font-bold text-slate-900 group-hover:text-emerald-800">{c.title}</p>
+                  <p className="text-xs text-slate-500 mt-1 line-clamp-2">{c.intro}</p>
+                </Link>
+              ))}
+            </div>
+          </section>
+        )}
+
+        <div className="mb-8">
+          <InvestOpportunitiesCallout
+            icon="target"
+            heading="Not sure which structure fits?"
+            blurb="Compare every opportunity type side by side, filter by ticket size, FIRB eligibility and SMSF-suitability, and shortlist what fits your mandate."
+            href={browseHref}
+            ctaLabel="Open the marketplace"
+            secondary={{ label: "All curated picks", href: "/invest" }}
+          />
+        </div>
+
+        <div className="border border-amber-200 bg-amber-50 rounded-lg px-4 py-3 text-xs text-slate-600 leading-relaxed">
+          <strong className="text-slate-700">General Advice Warning:</strong> {GENERAL_ADVICE_WARNING}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/invest/page.tsx
+++ b/app/invest/page.tsx
@@ -17,7 +17,7 @@ import {
 } from "@/lib/compliance";
 import type { InvestmentListing } from "@/lib/types";
 import { logger } from "@/lib/logger";
-import { listingUrl } from "@/lib/listing-url";
+import { listingUrl, categoryForListing } from "@/lib/listing-url";
 import InvestListingsClient from "@/components/InvestListingsClient";
 import GetMatchedEmbed from "@/components/get-matched/GetMatchedEmbed";
 import { loadInvestPageContext } from "@/lib/listing-page-context";
@@ -172,8 +172,20 @@ export default async function InvestMarketplacePage() {
   const categories = getOpportunityCategories();
   const categoryTabs = categories.map((c) => ({ slug: c.slug, label: c.label }));
 
+  // Discovery-card counts must match what the client filter actually shows
+  // when a card is clicked, so we bucket each listing the same way the
+  // client does — via categoryForListing — rather than summing raw
+  // dbVerticals (which misses drifted vertical strings like
+  // "renewable-energy"/"startups" and double-counts fund sub-categories
+  // that belong to other categories).
+  const categoryCounts: Record<string, number> = {};
+  for (const l of listings) {
+    const slug = categoryForListing(l);
+    categoryCounts[slug] = (categoryCounts[slug] || 0) + 1;
+  }
+
   function getCategoryCount(cat: InvestCategory): number {
-    return cat.dbVerticals.reduce((sum, v) => sum + (verticalCounts[v] || 0), 0);
+    return categoryCounts[cat.slug] || 0;
   }
 
   // ── JSON-LD ──

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -9,6 +9,8 @@ import {
   getOpportunityCategories,
   getAllSubcategorySlugs,
 } from "@/lib/invest-categories";
+import { BEST_FOR_COMBOS } from "@/lib/invest-best-for";
+import { STATE_SURCHARGES } from "@/lib/firb-data";
 import { listingUrl } from "@/lib/listing-url";
 import type { InvestListingVertical, PlatformType } from "@/lib/types";
 import { generateVersusPairs } from "@/lib/versus-pairs";
@@ -683,6 +685,22 @@ async function buildShard2(): Promise<MetadataRoute.Sitemap> {
     priority: 0.7,
   }));
 
+  // Curated "best {vertical} for {profile}" landing pages.
+  const investBestForPages = BEST_FOR_COMBOS.map((c) => ({
+    url: `${base}/invest/best-for/${c.slug}`,
+    lastModified: new Date(),
+    changeFrequency: "weekly" as const,
+    priority: 0.7,
+  }));
+
+  // Per-state investment landing pages (/invest-in/{state}).
+  const investStatePages = STATE_SURCHARGES.map((s) => ({
+    url: `${base}/invest-in/${s.stateCode.toLowerCase()}`,
+    lastModified: new Date(),
+    changeFrequency: "weekly" as const,
+    priority: 0.7,
+  }));
+
   // Individual investment listing detail pages
   const { data: investListings } = supabase
     ? await supabase.from("investment_listings").select("slug, vertical, sub_category, updated_at").eq("status", "active")
@@ -707,6 +725,8 @@ async function buildShard2(): Promise<MetadataRoute.Sitemap> {
     ...stockbrokerFirmPages,
     ...investCategoryPages,
     ...investSubcategoryPages,
+    ...investBestForPages,
+    ...investStatePages,
     ...investListingPages,
   ];
 }

--- a/lib/invest-best-for-data.ts
+++ b/lib/invest-best-for-data.ts
@@ -1,0 +1,83 @@
+/**
+ * DB helper for /invest/best-for/[combo] landing pages (Wave 8 SEO).
+ *
+ * Returns the live listings that match a curated "best {vertical} for
+ * {profile}" combo, plus a total count, so each page shows a real,
+ * self-updating sample of the marketplace rather than static copy.
+ *
+ * Matching mirrors the /invest client: a listing belongs to a combo when
+ * its canonical category (via categoryForListing) equals the combo's
+ * match category, optionally narrowed by sub_category. Guide-vertical
+ * sector-hub listings are excluded so they don't leak into, e.g., the
+ * income-funds combos.
+ *
+ * Server-only; failure-tolerant (empty result on error).
+ */
+
+import { createClient } from "@/lib/supabase/server";
+import { logger } from "@/lib/logger";
+import type { InvestmentListing } from "@/lib/types";
+import { categoryForListing, isCanonicalVertical } from "@/lib/listing-url";
+import type { BestForCombo } from "@/lib/invest-best-for";
+
+const log = logger("invest-best-for-data");
+
+/** Upper bound on rows scanned — plenty of headroom for the marketplace. */
+const SCAN_LIMIT = 500;
+
+export interface BestForListings {
+  /** Listings matching the combo, newest first, capped at `limit`. */
+  listings: InvestmentListing[];
+  /** Total matching listings (may exceed `listings.length`). */
+  total: number;
+}
+
+/** Predicate: does this listing belong to the given combo? */
+export function listingMatchesCombo(
+  listing: Pick<InvestmentListing, "vertical" | "sub_category">,
+  combo: Pick<BestForCombo, "categorySlug" | "matchCategory" | "subCategory">,
+): boolean {
+  if (!isCanonicalVertical(listing.vertical as string)) return false;
+  const target = combo.matchCategory ?? combo.categorySlug;
+  if (categoryForListing(listing) !== target) return false;
+  if (combo.subCategory && listing.sub_category !== combo.subCategory) return false;
+  return true;
+}
+
+export async function getBestForListings(
+  combo: BestForCombo,
+  limit = 6,
+): Promise<BestForListings> {
+  const empty: BestForListings = { listings: [], total: 0 };
+
+  try {
+    const supabase = await createClient();
+    const { data, error } = await supabase
+      .from("investment_listings")
+      .select("*")
+      .eq("status", "active")
+      .order("listing_type", { ascending: false })
+      .order("created_at", { ascending: false })
+      .limit(SCAN_LIMIT);
+
+    if (error) {
+      log.warn("best-for listings query failed", {
+        combo: combo.slug,
+        error: error.message,
+        code: error.code,
+      });
+      return empty;
+    }
+
+    const matched = ((data ?? []) as InvestmentListing[]).filter((l) =>
+      listingMatchesCombo(l, combo),
+    );
+    return { listings: matched.slice(0, limit), total: matched.length };
+  } catch (err) {
+    log.error("getBestForListings threw", {
+      combo: combo.slug,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return empty;
+  }
+}

--- a/lib/invest-best-for.ts
+++ b/lib/invest-best-for.ts
@@ -1,0 +1,233 @@
+/**
+ * Curated "Best {vertical} for {investor profile}" combos (Wave 8 SEO).
+ *
+ * Powers /invest/best-for/[combo] — high-intent landing pages that
+ * intersect an opportunity vertical with an investor archetype
+ * ("best commercial property for SMSF", "best funds for SIV applicants").
+ * Each combo carries an authored rationale and a deep-link into the
+ * pre-filtered marketplace, reusing the real filter params.
+ *
+ * Curated (not a full cartesian product) so every page has genuine,
+ * differentiated editorial — not thin programmatic spam.
+ */
+
+export interface BestForCombo {
+  /** URL slug, e.g. "commercial-property-for-smsf". */
+  slug: string;
+  /** /invest category slug the combo points at. */
+  categorySlug: string;
+  /** Human label for the vertical, e.g. "commercial property". */
+  verticalLabel: string;
+  /** Investor-profile label, e.g. "SMSF trustees". */
+  profileLabel: string;
+  /** Short page title fragment. */
+  title: string;
+  /** One-paragraph intro. */
+  intro: string;
+  /** 3–4 reasons this vertical suits this profile. */
+  why: string[];
+  /** Querystring (without leading ?) for the /invest deep-link. */
+  filterQuery: string;
+  /**
+   * The category slug that `categoryForListing` returns for this combo's
+   * listings, when it differs from `categorySlug`. SDA-housing listings,
+   * for example, share the commercial-property bucket but are surfaced
+   * under their own combo. Defaults to `categorySlug`.
+   */
+  matchCategory?: string;
+  /** Optional sub_category to narrow the live-listing match (e.g. "sda_housing"). */
+  subCategory?: string;
+}
+
+export const BEST_FOR_COMBOS: BestForCombo[] = [
+  {
+    slug: "commercial-property-for-smsf",
+    categorySlug: "commercial-property",
+    verticalLabel: "commercial property",
+    profileLabel: "SMSF trustees",
+    title: "Best commercial property for SMSF investors",
+    intro: "Commercial property is one of the most popular and tax-efficient assets to hold inside a self-managed super fund — particularly business real property a member's own business can lease back at market rent.",
+    why: [
+      "Business real property can be acquired from a related party and leased to a related business at market rent — unique to commercial (not residential) property in super.",
+      "Rental income is taxed at 15% in accumulation phase and 0% in pension phase; the CGT discount is one-third (effective 10%) after 12 months.",
+      "LRBA bare-trust structures let an SMSF borrow to acquire property — many marketplace listings are flagged LRBA-compatible.",
+      "Long WALE, single-tenant assets provide predictable cash flow suited to a fund's retirement objective.",
+    ],
+    filterQuery: "category=commercial-property",
+  },
+  {
+    slug: "sda-housing-for-smsf",
+    categorySlug: "sda-housing",
+    verticalLabel: "SDA (NDIS) housing",
+    profileLabel: "SMSF trustees",
+    title: "Best SDA / NDIS housing for SMSF investors",
+    intro: "Specialist Disability Accommodation pairs government-backed NDIS rent with the 15%/0% super tax environment — a combination that produces high, stable after-tax yields inside an SMSF.",
+    why: [
+      "NDIA pays Reasonable Rent Contribution directly, underpinning 10–13% gross yields.",
+      "Net rent taxed at 15% (accumulation) or 0% (pension) inside super.",
+      "New SDA builds carry substantial Division 43 capital-works and Division 40 plant depreciation.",
+      "LRBA-compatible structures available for funds that want to gear the purchase.",
+    ],
+    // SDA listings live in the commercial_property vertical, distinguished
+    // by sub_category — so they match the commercial-property bucket and
+    // deep-link via the sub filter rather than a (non-existent) category.
+    matchCategory: "commercial-property",
+    subCategory: "sda_housing",
+    filterQuery: "category=commercial-property&sub=sda_housing",
+  },
+  {
+    slug: "bullion-for-smsf",
+    categorySlug: "bullion",
+    verticalLabel: "wholesale gold & bullion",
+    profileLabel: "SMSF trustees",
+    title: "Best gold & bullion for SMSF investors",
+    intro: "Allocated bullion is a recognised SMSF asset class — a non-correlated store of value that satisfies the sole-purpose test when stored correctly.",
+    why: [
+      "Allocated metal vaulted at an APRA-approved depository satisfies the sole-purpose test.",
+      "Investment-grade gold (≥99.5%), silver (≥99.9%) and platinum (≥99%) are GST-free.",
+      "Non-correlated hedge against equity and property drawdowns in a concentrated fund.",
+      "ASX gold ETFs (PMGOLD, GOLD) offer the same exposure with one-unit minimums and full liquidity.",
+    ],
+    filterQuery: "category=bullion",
+  },
+  {
+    slug: "water-rights-for-smsf",
+    categorySlug: "water-rights",
+    verticalLabel: "water entitlements",
+    profileLabel: "SMSF trustees",
+    title: "Best water entitlements for SMSF investors",
+    intro: "Water access entitlements are a long-duration, income-plus-growth real asset that SMSFs can hold subject to the sole-purpose test — uncorrelated with shares and property.",
+    why: [
+      "High-security entitlements deliver reliable lease income (3–5%) plus capital growth as scarcity tightens.",
+      "Held subject to the sole-purpose test; income taxed at 15%/0% in super.",
+      "Uncorrelated with equities — driven by rainfall cycles and agricultural demand.",
+      "The 50% (⅓ in super) CGT discount applies on disposal after 12 months.",
+    ],
+    filterQuery: "category=water-rights",
+  },
+  {
+    slug: "funds-for-siv-applicants",
+    categorySlug: "funds",
+    verticalLabel: "managed funds",
+    profileLabel: "Significant Investor Visa (SIV) applicants",
+    title: "Best SIV-complying funds for visa applicants",
+    intro: "The Significant Investor Visa requires a $5M complying-investment portfolio with a prescribed minimum mix. SIV-complying managed funds are the core building block.",
+    why: [
+      "SIV-complying funds satisfy the complying-investment framework set by the Department of Home Affairs.",
+      "Professional management meets the compliance and reporting demands of the visa.",
+      "Filter the marketplace to SIV-complying listings to assemble a qualifying mix.",
+      "Pair with the shortlist's SIV compliance score to track how close your portfolio gets to the threshold.",
+    ],
+    subCategory: "siv_complying",
+    filterQuery: "category=funds&siv=complying",
+  },
+  {
+    slug: "commercial-property-for-foreign-investors",
+    categorySlug: "commercial-property",
+    verticalLabel: "commercial property",
+    profileLabel: "foreign investors",
+    title: "Best commercial property for foreign investors",
+    intro: "Commercial property is generally more accessible to foreign buyers than residential — but FIRB approval and state surcharges still apply. Filter to FIRB-eligible listings to start.",
+    why: [
+      "Commercial property faces fewer foreign-ownership restrictions than established residential dwellings.",
+      "FIRB approval is still required — budget the federal application fee plus state surcharges.",
+      "MIT-structured commercial assets can offer eligible foreign investors a 15% withholding rate.",
+      "Each listing's after-tax estimator and the FIRB fee estimate model your true net cost.",
+    ],
+    filterQuery: "category=commercial-property&firb=eligible",
+  },
+  {
+    slug: "startups-for-sophisticated-investors",
+    categorySlug: "startups",
+    verticalLabel: "startups",
+    profileLabel: "sophisticated (wholesale) investors",
+    title: "Best startup investments for sophisticated investors",
+    intro: "Wholesale investors get access to priced angel rounds and ESVCLP funds — and the ESIC and ESVCLP tax concessions that make early-stage investing uniquely attractive in Australia.",
+    why: [
+      "ESIC-qualifying companies give a 20% non-refundable carry-forward tax offset plus a 10-year CGT exemption.",
+      "ESVCLP funds pass through a flat 10% offset and a 100% CGT exemption at the fund level.",
+      "Wholesale (s708) status unlocks priced rounds beyond retail equity-crowdfunding caps.",
+      "Diversify across a fund rather than single deals — most startups fail.",
+    ],
+    filterQuery: "category=startups&esic=true",
+  },
+  {
+    slug: "private-credit-for-retirees",
+    categorySlug: "private-credit",
+    verticalLabel: "private credit",
+    profileLabel: "retirees & income investors",
+    title: "Best private credit for retirees seeking income",
+    intro: "Private credit funds target equity-like yields from senior-secured lending — attractive for income-focused investors, provided you understand the liquidity and default trade-offs.",
+    why: [
+      "Target yields well above term deposits, paid as regular income distributions.",
+      "Senior-secured structures sit above equity in the capital stack.",
+      "Inside an SMSF in pension phase, income distributions can be tax-free.",
+      "Mind the liquidity: most funds have lock-ups and gated redemptions — size accordingly.",
+    ],
+    filterQuery: "category=private-credit&min_yield=6",
+  },
+  {
+    slug: "funds-for-retirees",
+    categorySlug: "funds",
+    verticalLabel: "managed funds",
+    profileLabel: "retirees & income investors",
+    title: "Best income funds for retirees",
+    intro: "Income-oriented managed funds — from listed REITs to private-credit and infrastructure funds — can underpin a retiree's cash flow. Filter to higher-distribution options and weigh fees.",
+    why: [
+      "Distribution-focused funds provide regular income to fund retirement spending.",
+      "Franked-income funds add franking credits — grossed-up yield can materially exceed the cash yield.",
+      "0% tax on distributions inside an SMSF pension account.",
+      "Compare MER against the distribution yield — fees compound against you.",
+    ],
+    filterQuery: "category=funds&min_yield=5",
+  },
+  {
+    slug: "buy-business-for-owner-operators",
+    categorySlug: "buy-business",
+    verticalLabel: "businesses for sale",
+    profileLabel: "owner-operators",
+    title: "Best businesses to buy for owner-operators",
+    intro: "If you want to buy yourself a job-plus-asset, owner-operated businesses trade at lower multiples than manager-run ones — your sweat equity is the upside.",
+    why: [
+      "Owner-operated businesses price at lower SDE multiples than passive, manager-run ones.",
+      "Going-concern transfers are GST-free, and small-business CGT concessions can apply on exit.",
+      "You control operations, pricing and growth — unlike a passive financial asset.",
+      "Verify the SDE add-backs survive a change of ownership before you commit.",
+    ],
+    filterQuery: "category=buy-business",
+  },
+  {
+    slug: "carbon-credits-for-corporates",
+    categorySlug: "carbon-credits",
+    verticalLabel: "carbon & biodiversity credits",
+    profileLabel: "corporates & Safeguard entities",
+    title: "Best carbon credits for corporate buyers",
+    intro: "Facilities covered by the reformed Safeguard Mechanism are structural buyers of ACCUs; corporates with voluntary net-zero targets buy ACCUs and certified offsets to retire.",
+    why: [
+      "ACCUs are tradeable into Safeguard Mechanism compliance for covered facilities.",
+      "Voluntary units (Verra, Gold Standard) suit corporate net-zero retirement programs.",
+      "Method matters — savanna-burning and HIR ACCUs carry different price premiums and co-benefits.",
+      "Hold ACCUs via an ANREU registry account; trade via Xpansiv / CORE Markets.",
+    ],
+    filterQuery: "category=carbon-credits",
+  },
+  {
+    slug: "renewable-energy-for-impact-investors",
+    categorySlug: "renewable-energy",
+    verticalLabel: "renewable energy",
+    profileLabel: "impact & ESG investors",
+    title: "Best renewable energy investments for impact investors",
+    intro: "Renewable-energy project equity and clean-energy funds let impact-minded investors back the transition while targeting infrastructure-style returns.",
+    why: [
+      "Direct project equity in solar, wind and battery storage with contracted PPA cash flows.",
+      "Listed clean-energy ETFs (FUEL, CLNE, ERTH) for diversified, liquid exposure.",
+      "Measurable emissions-avoidance impact alongside financial return.",
+      "Mind policy and grid-connection risk on pre-FID development equity.",
+    ],
+    filterQuery: "category=renewable-energy",
+  },
+];
+
+export function getBestForCombo(slug: string): BestForCombo | undefined {
+  return BEST_FOR_COMBOS.find((c) => c.slug === slug);
+}

--- a/lib/invest-categories.ts
+++ b/lib/invest-categories.ts
@@ -2175,6 +2175,11 @@ const categoriesRaw: Omit<InvestCategory, "intent">[] = [
     slug: "sda-housing",
     label: "SDA Housing (NDIS)",
     dbVerticals: ["commercial_property"],
+    // SDA listings share the commercial_property vertical with generic
+    // commercial real estate; the sub_category is what distinguishes them.
+    // Without this, /invest/sda-housing/listings would show all commercial
+    // property rather than only the NDIS-accommodation listings.
+    dbFundSubCategories: ["sda_housing"],
     color: {
       bg: "bg-fuchsia-50",
       border: "border-fuchsia-200",

--- a/lib/invest-state-data.ts
+++ b/lib/invest-state-data.ts
@@ -1,0 +1,80 @@
+/**
+ * DB helper for /invest-in/[state] state landing pages (Wave 8 SEO).
+ *
+ * Returns a state's live marketplace footprint — total active listings,
+ * a per-category breakdown, and a few sample listings — so each state
+ * page shows real, self-updating geo deal-flow rather than static copy.
+ *
+ * Server-only; failure-tolerant (empty stats on error).
+ */
+
+import { createClient } from "@/lib/supabase/server";
+import { logger } from "@/lib/logger";
+import type { InvestmentListing } from "@/lib/types";
+import { categoryForListing, isCanonicalVertical } from "@/lib/listing-url";
+
+const log = logger("invest-state-data");
+const SAMPLE_LIMIT = 6;
+
+export interface InvestStateData {
+  total: number;
+  /** Per /invest category slug → count, descending. */
+  byCategory: Array<{ slug: string; count: number }>;
+  listings: InvestmentListing[];
+}
+
+export async function getInvestStateData(stateCode: string): Promise<InvestStateData> {
+  const empty: InvestStateData = { total: 0, byCategory: [], listings: [] };
+  if (!stateCode) return empty;
+
+  try {
+    const supabase = await createClient();
+
+    // All active listings in the state — narrow column select for the
+    // category rollup, plus a separate sample fetch for cards. We roll up
+    // via categoryForListing (the same function the /invest client uses to
+    // bucket listings) so each chip links to a filter that actually
+    // returns rows. Guide-vertical sector-hub listings (oil-gas, uranium,
+    // …) are excluded so they don't pollute the breakdown.
+    const { data: rollupRows, error: rollupErr } = await supabase
+      .from("investment_listings")
+      .select("vertical, sub_category")
+      .eq("status", "active")
+      .eq("location_state", stateCode);
+    if (rollupErr) {
+      log.warn("state rollup failed", { error: rollupErr.message, stateCode });
+      return empty;
+    }
+
+    const rows = (rollupRows ?? []) as Array<{ vertical: string; sub_category: string | null }>;
+    const canonicalRows = rows.filter((r) => isCanonicalVertical(r.vertical));
+    const catCounts = new Map<string, number>();
+    for (const r of canonicalRows) {
+      const slug = categoryForListing({
+        vertical: r.vertical as InvestmentListing["vertical"],
+        sub_category: r.sub_category ?? undefined,
+      });
+      catCounts.set(slug, (catCounts.get(slug) ?? 0) + 1);
+    }
+    const byCategory = Array.from(catCounts.entries())
+      .map(([slug, count]) => ({ slug, count }))
+      .sort((a, b) => b.count - a.count);
+
+    const { data: sampleRows } = await supabase
+      .from("investment_listings")
+      .select("*")
+      .eq("status", "active")
+      .eq("location_state", stateCode)
+      .order("created_at", { ascending: false })
+      .limit(SAMPLE_LIMIT);
+
+    return {
+      total: rows.length,
+      byCategory,
+      listings: (sampleRows ?? []) as InvestmentListing[],
+    };
+  } catch (err) {
+    log.error("getInvestStateData threw", { err: err instanceof Error ? err.message : String(err) });
+    return empty;
+  }
+}

--- a/lib/investment-listings-query.ts
+++ b/lib/investment-listings-query.ts
@@ -1,6 +1,7 @@
 import { createClient } from "@/lib/supabase/server";
 import type { InvestmentListing, InvestListingVertical } from "@/lib/types";
 import { logger } from "@/lib/logger";
+import { rawVerticalVariants } from "@/lib/listing-url";
 
 const log = logger("invest-listings-query");
 
@@ -47,7 +48,7 @@ export async function fetchListingsByVertical(
     let query = supabase
       .from("investment_listings")
       .select("*")
-      .eq("vertical", vertical)
+      .in("vertical", rawVerticalVariants(vertical))
       .eq("status", "active")
       .order("listing_type", { ascending: false })
       .order("created_at", { ascending: false })
@@ -101,7 +102,7 @@ export async function countListingsByVertical(
     let query = supabase
       .from("investment_listings")
       .select("id", { count: "exact", head: true })
-      .eq("vertical", vertical)
+      .in("vertical", rawVerticalVariants(vertical))
       .eq("status", "active");
 
     if (subCategories && subCategories.length > 0) {
@@ -168,7 +169,7 @@ export async function fetchListingsBySubCategory(
     const { data, error } = await supabase
       .from("investment_listings")
       .select("*")
-      .eq("vertical", vertical)
+      .in("vertical", rawVerticalVariants(vertical))
       .eq("sub_category", subCategory)
       .eq("status", "active")
       .order("listing_type", { ascending: false })
@@ -251,7 +252,7 @@ export async function fetchRelatedListings(
     let query = supabase
       .from("investment_listings")
       .select("*")
-      .eq("vertical", vertical)
+      .in("vertical", rawVerticalVariants(vertical))
       .eq("status", "active")
       .neq("slug", excludeSlug)
       .limit(limit);

--- a/lib/listing-url.ts
+++ b/lib/listing-url.ts
@@ -30,6 +30,71 @@ export const VERTICAL_TO_CATEGORY: Record<InvestListingVertical, string> = {
 };
 
 /**
+ * Non-canonical `vertical` strings that have drifted into the database
+ * via various seed waves, mapped back to their canonical
+ * `InvestListingVertical`. Several seeds stored the hyphenated/plural
+ * *category* slug (e.g. "renewable-energy", "startups") in the
+ * `vertical` column instead of the canonical union value ("energy",
+ * "startup"). Left unnormalised, `categoryForListing` falls these
+ * through to the "funds" bucket, so commercial-property / startups /
+ * renewable-energy filters and deep-links silently show nothing.
+ *
+ * Normalising in code (rather than mutating prod data) keeps the fix
+ * reversible and avoids an autonomous data migration. The root-cause
+ * data cleanup is tracked separately.
+ */
+export const VERTICAL_ALIASES: Record<string, string> = {
+  "commercial-property": "commercial_property",
+  funds: "fund",
+  startups: "startup",
+  "renewable-energy": "energy",
+};
+
+/** Canonical vertical for a (possibly drifted) raw vertical string. */
+export function normaliseVertical(raw: string): string {
+  return VERTICAL_ALIASES[raw] ?? raw;
+}
+
+/**
+ * The reverse of {@link VERTICAL_ALIASES}: every canonical vertical mapped
+ * to the full set of raw strings (canonical + drift variants) that should
+ * be matched when querying the DB for that vertical. Built once at module
+ * load.
+ */
+const RAW_VERTICAL_VARIANTS: Record<string, string[]> = (() => {
+  const map: Record<string, string[]> = {};
+  for (const [raw, canonical] of Object.entries(VERTICAL_ALIASES)) {
+    (map[canonical] ??= [canonical]).push(raw);
+  }
+  return map;
+})();
+
+/**
+ * All raw `vertical` strings to match for a canonical vertical — the
+ * canonical value plus any drifted variants. Use in `.in("vertical", …)`
+ * queries so listings seeded with a drifted vertical aren't missed.
+ */
+export function rawVerticalVariants(canonical: string): string[] {
+  return RAW_VERTICAL_VARIANTS[canonical] ?? [canonical];
+}
+
+/** The set of canonical vertical values (keys of VERTICAL_TO_CATEGORY). */
+export const CANONICAL_VERTICALS: ReadonlySet<string> = new Set(
+  Object.keys(VERTICAL_TO_CATEGORY),
+);
+
+/**
+ * Whether a raw vertical normalises to a known canonical vertical. Guide
+ * sector-hub verticals (e.g. "oil-gas", "uranium", "hydrogen") and any
+ * other unrecognised string return false — callers building the
+ * Opportunities IA use this to exclude such listings from category counts
+ * and curated samples rather than letting them pollute the "funds" bucket.
+ */
+export function isCanonicalVertical(raw: string): boolean {
+  return CANONICAL_VERTICALS.has(normaliseVertical(raw));
+}
+
+/**
  * Some `fund` listings actually belong to a different category based on
  * their `sub_category` value. For example, a fund with sub_category "art"
  * is an "alternatives" category listing.
@@ -51,11 +116,12 @@ export const FUND_SUB_TO_CATEGORY: Record<string, string> = {
  * Used to construct correct URLs for listing detail pages.
  */
 export function categoryForListing(listing: Pick<InvestmentListing, "vertical" | "sub_category">): string {
-  if (listing.vertical === "fund" && listing.sub_category) {
+  const vertical = normaliseVertical(listing.vertical as string);
+  if (vertical === "fund" && listing.sub_category) {
     const override = FUND_SUB_TO_CATEGORY[listing.sub_category];
     if (override) return override;
   }
-  return VERTICAL_TO_CATEGORY[listing.vertical] ?? "funds";
+  return VERTICAL_TO_CATEGORY[vertical as InvestListingVertical] ?? "funds";
 }
 
 /**


### PR DESCRIPTION
Closes the final tier-4 items from the `/invest` gap-analysis report — two programmatic SEO surfaces, plus the root-cause fix for vertical-string drift in the listings table.

## New SEO surfaces

- **`/invest-in/[state]`** (8 pages — one per AU state/territory) — per-state geo landing pages combining live deal-flow (category breakdown + sample listings) with the state-specific foreign-buyer stamp-duty / land-tax surcharge data already in `lib/firb-data`. Dedicated `/invest-in/` namespace avoids the static/dynamic shadowing under `/invest/`.
- **`/invest/best-for/[combo]`** (12 curated combos) — high-intent landing pages that intersect an opportunity vertical with an investor archetype (e.g. `commercial-property-for-smsf`, `funds-for-siv-applicants`, `sda-housing-for-smsf`, `bullion-for-smsf`, `private-credit-for-retirees`, `carbon-credits-for-corporates`, …). Each combo has hand-authored "why this fits" rationale, a live sample of matching listings via the new data helper, related-combo cross-links, and a deep-link into the pre-filtered marketplace using real filter params.
- Both families wired into `app/sitemap.ts` shard 2 alongside the existing `/invest/{slug}/listings` and `/invest/{slug}/listings/{sub}` entries.

## Vertical-drift fix (silent dead-link killer)

Several prior seed waves stored *category* slugs in the `vertical` column (`commercial-property`, `funds`, `startups`, `renewable-energy`) rather than the canonical `InvestListingVertical` union value (`commercial_property`, `fund`, `startup`, `energy`). Left as-is, `categoryForListing` silently dumped all of them into the `funds` bucket — making the commercial-property / startups / renewable-energy tabs and any matching deep-link near-empty.

Fixed in code, not via a data migration:

- New `VERTICAL_ALIASES` + `normaliseVertical` / `rawVerticalVariants` / `isCanonicalVertical` in `lib/listing-url.ts`.
- `categoryForListing` normalises its input.
- `lib/investment-listings-query.ts` switched to `.in("vertical", rawVerticalVariants(...))` in fetch / count / sub / related queries so drift variants are picked up.
- The `/invest` discovery-card counts now bucket via `categoryForListing` so a card-count == what clicking the card returns.
- `sda-housing` carries `dbFundSubCategories=["sda_housing"]` so its category-listings route narrows correctly inside the `commercial_property` vertical it shares with generic commercial RE.

## Helpers

- `lib/invest-state-data.getInvestStateData(stateCode)` — fail-tolerant per-state rollup + sample, gated to canonical verticals so guide-vertical sector-hub listings don't pollute the breakdown.
- `lib/invest-best-for` + `lib/invest-best-for-data` — combo registry, the pure `listingMatchesCombo` predicate, and the live-listing fetch. The SDA combo uses `matchCategory`/`subCategory` so its listings — which live in the `commercial_property` bucket — still surface under the combo page and the deep-link routes through the `sub` filter rather than a dead `category=sda-housing`.

## Test plan

- [x] `__tests__/lib/listing-url.test.ts` — drift normalisation, `rawVerticalVariants`, `isCanonicalVertical` (22 tests).
- [x] `__tests__/lib/investment-listings-query.test.ts` — drift variants matched via `.in()` (23 tests).
- [x] `__tests__/lib/invest-best-for.test.ts` — combo integrity (unique slugs, real `categorySlug`, authored fields), no dead `category=sda-housing` deep-link, `listingMatchesCombo` edge cases (drift, SDA narrowing, guide-vertical exclusion) (12 tests).
- [x] Existing adjacent suites verified green: `invest-categories` (20), `sitemap` (44), `robots` (4), `InvestListingsClient` (6).
- [x] `npm run type-check` — clean.
- [x] `npm run lint` (via lint-staged on commit) — clean, `--max-warnings 0`.
- [ ] Smoke-check `/invest-in/nsw`, `/invest-in/vic`, `/invest/best-for/commercial-property-for-smsf`, `/invest/best-for/sda-housing-for-smsf` on the Netlify preview once it's ready.
- [ ] Verify the Wave-4 categories (`commercial-property` tab, `renewable-energy` tab, `startups` tab) now show non-zero counts that match what clicking returns.


---
_Generated by [Claude Code](https://claude.ai/code/session_019Rvnw5P7FXjNMRxiKkPFPh)_