### PR TITLE
fix(advisor): distinct 503 enquiry message during gated windows

### DIFF
--- a/__tests__/components/AdvisorProfileClient.test.tsx
+++ b/__tests__/components/AdvisorProfileClient.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import AdvisorProfileClient from "@/app/advisor/[slug]/AdvisorProfileClient";
@@ -56,7 +56,7 @@ async function submitValidEnquiry() {
 }
 
 describe("AdvisorProfileClient enquiry submit", () => {
-  let fetchSpy: ReturnType<typeof vi.spyOn<typeof globalThis, "fetch">>;
+  let fetchSpy: MockInstance<typeof fetch>;
 
   beforeEach(() => {
     fetchSpy = vi.spyOn(globalThis, "fetch");

--- a/__tests__/components/AdvisorProfileClient.test.tsx
+++ b/__tests__/components/AdvisorProfileClient.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import AdvisorProfileClient from "@/app/advisor/[slug]/AdvisorProfileClient";
+import type { Professional } from "@/lib/types";
+
+// Heavy children / browser-only helpers irrelevant to the enquiry-submit branch.
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn(), prefetch: vi.fn() }),
+  usePathname: () => "/advisor/jane-smith",
+  useSearchParams: () => new URLSearchParams(),
+}));
+vi.mock("@/components/BookingWidget", () => ({ default: () => null }));
+vi.mock("@/components/AdvisorAppointmentsWidget", () => ({ default: () => null }));
+vi.mock("@/components/AdvisorReviewForm", () => ({ default: () => null }));
+vi.mock("@/components/AdvisorFeeOpinionButton", () => ({ default: () => null }));
+vi.mock("@/components/SocialShareButtons", () => ({ default: () => null }));
+vi.mock("@/lib/tracking", async (importOriginal) => ({
+  ...(await importOriginal() as Record<string, unknown>),
+  trackEvent: vi.fn(),
+}));
+vi.mock("@/lib/posthog/events", () => ({ trackEvent: vi.fn() }));
+vi.mock("@/lib/qualification-store", () => ({ getQualificationData: () => ({}) }));
+vi.mock("@/components/UtmCapture", () => ({ getStoredUtm: () => ({}) }));
+vi.mock("@/lib/hooks/useAdvisorShortlist", () => ({
+  useAdvisorShortlist: () => ({ toggle: vi.fn(), has: () => false, count: 0, max: 3 }),
+}));
+
+function pro(overrides: Partial<Professional> = {}): Professional {
+  return {
+    id: 1,
+    slug: "jane-smith",
+    name: "Jane Smith",
+    type: "financial_planner",
+    specialties: ["Retirement Planning"],
+    rating: 4.8,
+    review_count: 20,
+    verified: true,
+    status: "active",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  } as Professional;
+}
+
+function renderProfile() {
+  return render(
+    <AdvisorProfileClient professional={pro()} similar={[]} reviews={[]} />,
+  );
+}
+
+async function submitValidEnquiry() {
+  fireEvent.change(screen.getByLabelText(/Your name/i), { target: { value: "Test User" } });
+  fireEvent.change(screen.getByLabelText(/^Email/i), { target: { value: "test@example.com" } });
+  fireEvent.click(screen.getByRole("button", { name: /Send Enquiry to Jane/i }));
+}
+
+describe("AdvisorProfileClient enquiry submit", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it("shows a temporarily-unavailable message when the API returns 503 (kill switch)", async () => {
+    fetchSpy.mockResolvedValue(new Response(null, { status: 503 }));
+
+    renderProfile();
+    await submitValidEnquiry();
+
+    await waitFor(() => {
+      expect(screen.getByText(/temporarily unavailable/i)).toBeInTheDocument();
+    });
+    // The generic error copy must not appear for the gated-window case.
+    expect(screen.queryByText(/Something went wrong/i)).not.toBeInTheDocument();
+  });
+
+  it("shows the generic error message for other non-2xx failures", async () => {
+    fetchSpy.mockResolvedValue(new Response(null, { status: 500 }));
+
+    renderProfile();
+    await submitValidEnquiry();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Something went wrong/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/temporarily unavailable/i)).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/components/AdvisorProfileClient.test.tsx
+++ b/__tests__/components/AdvisorProfileClient.test.tsx
@@ -56,7 +56,7 @@ async function submitValidEnquiry() {
 }
 
 describe("AdvisorProfileClient enquiry submit", () => {
-  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  let fetchSpy: ReturnType<typeof vi.spyOn<typeof globalThis, "fetch">>;
 
   beforeEach(() => {
     fetchSpy = vi.spyOn(globalThis, "fetch");

--- a/app/advisor/[slug]/AdvisorProfileClient.tsx
+++ b/app/advisor/[slug]/AdvisorProfileClient.tsx
@@ -130,7 +130,7 @@ export default function AdvisorProfileClient({
   firm?: AdvisorFirm | null;
   expertArticles?: ExpertArticle[];
 }) {
-  const [formState, setFormState] = useState<"idle" | "submitting" | "success" | "error">("idle");
+  const [formState, setFormState] = useState<"idle" | "submitting" | "success" | "error" | "unavailable">("idle");
   const [formError, setFormError] = useState("");
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
@@ -219,6 +219,9 @@ export default function AdvisorProfileClient({
           source_section: `/advisor/${pro.slug}`,
         });
         setName(""); setEmail(""); setPhone(""); setMessage(""); setTouched({});
+      } else if (res.status === 503) {
+        // Intentional kill-switch / gated window — give users an accurate signal.
+        setFormState("unavailable");
       } else {
         setFormState("error");
       }
@@ -1284,6 +1287,14 @@ export default function AdvisorProfileClient({
                     {formState === "error" && (
                       <p className="text-xs text-center text-red-500">
                         Something went wrong.{" "}
+                        <button onClick={() => setFormState("idle")} className="underline font-semibold">
+                          Try again
+                        </button>
+                      </p>
+                    )}
+                    {formState === "unavailable" && (
+                      <p className="text-xs text-center text-amber-600">
+                        Enquiries are temporarily unavailable. Please try again later.{" "}
                         <button onClick={() => setFormState("idle")} className="underline font-semibold">
                           Try again
                         </button>


### PR DESCRIPTION
**Tier A** (page UI polish).

## What
`AdvisorProfileClient.handleSubmit` treated every non-2xx response — including the intentional **503 kill-switch** — as the generic `Something went wrong. Try again.` error. During a gated enquiry window that gives users a misleading "broken" signal instead of "come back later".

This adds an `"unavailable"` form state, branched on `res.status === 503`, that renders a *"Enquiries are temporarily unavailable. Please try again later."* message. The generic error is kept for all other failures (incl. network throws). No behaviour change on the 2xx success path.

## Tests
New `__tests__/components/AdvisorProfileClient.test.tsx` covers both branches:
- 503 -> temporarily-unavailable copy (and asserts the generic copy is absent)
- 500 -> generic error copy (and asserts the unavailable copy is absent)

Verified locally: focused vitest green, `eslint --fix --max-warnings 0` clean, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)