### PR TITLE
fix(routing): exclude /brokers/full-service from the plural-alias redirect

### DIFF
--- a/__tests__/config/brokers-redirect.test.ts
+++ b/__tests__/config/brokers-redirect.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { pathToRegexp } from "next/dist/compiled/path-to-regexp";
+import config from "../../next.config";
+
+/**
+ * /brokers/:slug → /broker/:slug plural-alias redirect must NOT shadow the
+ * real curated /brokers/full-service hub (and its /brokers/full-service/:slug
+ * firm profiles), which are first-class app routes (app/brokers/full-service/**).
+ *
+ * Regression: the original catch-all `/brokers/:slug*` 308ed /brokers/full-service
+ * to a non-existent /broker/full-service → "Broker Not Found". The fix adds a
+ * negative-lookahead to the redirect source. This test pins that behaviour to
+ * the real next.config redirect rule so it can't silently regress.
+ */
+describe("/brokers plural-alias redirect", () => {
+  type Redirect = {
+    source: string;
+    destination: string;
+    permanent?: boolean;
+  };
+
+  let brokerSlugRule: Redirect;
+  let matchSource: (path: string) => string | null;
+
+  beforeAll(async () => {
+    const redirects: Redirect[] = await config.redirects!();
+
+    const rule = redirects.find(
+      (r) =>
+        r.source.startsWith("/brokers/") &&
+        r.destination.startsWith("/broker/"),
+    );
+    if (!rule) {
+      throw new Error("could not find the /brokers/:slug → /broker/:slug rule");
+    }
+    brokerSlugRule = rule;
+
+    const keys: Array<{ name: string | number }> = [];
+    const re = pathToRegexp(brokerSlugRule.source, keys);
+
+    matchSource = (path: string) => {
+      const m = re.exec(path);
+      if (!m) return null;
+      let out = brokerSlugRule.destination;
+      keys.forEach((k, i) => {
+        out = out.replace(`:${k.name}`, m[i + 1] ?? "");
+      });
+      return out;
+    };
+  });
+
+  it("does NOT redirect /brokers/full-service (real curated hub)", () => {
+    expect(matchSource("/brokers/full-service")).toBeNull();
+  });
+
+  it("does NOT redirect /brokers/full-service/:slug (firm profiles)", () => {
+    expect(matchSource("/brokers/full-service/morgans")).toBeNull();
+  });
+
+  it("still redirects an ordinary broker slug to the singular profile", () => {
+    expect(matchSource("/brokers/commsec")).toBe("/broker/commsec");
+  });
+
+  it("still redirects a slug that merely starts with 'full-service-'", () => {
+    // The exclusion is segment-anchored, so a real broker whose slug happens
+    // to begin with "full-service-" must still redirect.
+    expect(matchSource("/brokers/full-service-broker-xyz")).toBe(
+      "/broker/full-service-broker-xyz",
+    );
+  });
+
+  it("preserves multi-segment redirect behaviour", () => {
+    expect(matchSource("/brokers/foo/bar")).toBe("/broker/foo/bar");
+  });
+
+  it("is a permanent (308) redirect for link-equity transfer", () => {
+    expect(brokerSlugRule.permanent).toBe(true);
+  });
+});

--- a/__tests__/config/brokers-redirect.test.ts
+++ b/__tests__/config/brokers-redirect.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeAll } from "vitest";
+// @ts-expect-error - next bundles path-to-regexp without type declarations
 import { pathToRegexp } from "next/dist/compiled/path-to-regexp";
 import config from "../../next.config";
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -273,9 +273,16 @@ const nextConfig: NextConfig = {
         destination: "/savings/:slug*",
         permanent: true,
       },
+      // /brokers/<broker-slug> 301s to the canonical singular profile at
+      // /broker/<broker-slug>. The negative-lookahead excludes the real
+      // curated /brokers/full-service hub (and its /brokers/full-service/:slug
+      // firm profiles) — those are first-class app routes
+      // (app/brokers/full-service/**), not plural aliases. Without the
+      // exclusion this redirect shadowed them, 308ing /brokers/full-service to
+      // a non-existent /broker/full-service → "Broker Not Found".
       {
-        source: "/brokers/:slug*",
-        destination: "/broker/:slug*",
+        source: "/brokers/:slug((?!full-service(?:/|$)).+)",
+        destination: "/broker/:slug",
         permanent: true,
       },
       // /advisors/search retired 2026-05 — the inline filter panel on


### PR DESCRIPTION
## What

`/brokers/full-service` is a real curated page (`app/brokers/full-service/page.tsx`, plus `[slug]` firm profiles), but the catch-all redirect `/brokers/:slug* -> /broker/:slug*` in `next.config.ts` shadowed it — 308ing the hub to a non-existent `/broker/full-service` -> "Broker Not Found".

Replace the catch-all source with a segment-anchored negative-lookahead:

```
source: "/brokers/:slug((?!full-service(?:/|$)).+)"
destination: "/broker/:slug"
```

- `/brokers/full-service` and `/brokers/full-service/<firm>` now pass through to their first-class app routes.
- Ordinary broker slugs (`/brokers/commsec`) still 308 to `/broker/commsec`.
- Slugs that merely begin with `full-service-` (e.g. a real broker named `full-service-broker-xyz`) still redirect — the exclusion is segment-anchored.
- Multi-segment and 308-permanence preserved.

Adds `__tests__/config/brokers-redirect.test.ts` which pins the behaviour to the live `next.config` redirect rule via path-to-regexp so it can't silently regress.

Finding ref: P1 — /brokers/full-service redirect shadow. Tier C (routing config).