### PR TITLE
fix(smsf): remove dead SMSF Insurance topic card (404)

### DIFF
--- a/__tests__/app/smsf-hub-page.test.tsx
+++ b/__tests__/app/smsf-hub-page.test.tsx
@@ -8,6 +8,8 @@
  * tests assert the current page's real content; the HubPage template itself is
  * still validated via the dividends hub test.
  */
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 import { describe, it, expect } from "vitest";
 import { render, screen } from "../components/setup";
 import SmsfPage from "@/app/smsf/page";
@@ -56,6 +58,23 @@ describe("SmsfPage", () => {
   it("renders the general-advice compliance warning", () => {
     render(<SmsfPage />);
     expect(screen.getByText(/general in nature/i)).toBeInTheDocument();
+  });
+
+  it("links every topic card to a real /smsf/* route (no dead links)", () => {
+    render(<SmsfPage />);
+    const cardLinks = screen
+      .getAllByRole("link", { name: /read guide/i })
+      .map((a) => a.getAttribute("href"))
+      .filter((href): href is string => Boolean(href));
+
+    expect(cardLinks.length).toBeGreaterThan(0);
+
+    for (const href of cardLinks) {
+      expect(href.startsWith("/smsf/")).toBe(true);
+      const slug = href.replace(/^\/smsf\//, "");
+      const routeFile = join(process.cwd(), "app", "smsf", slug, "page.tsx");
+      expect(existsSync(routeFile), `${href} should resolve to ${routeFile}`).toBe(true);
+    }
   });
 
   it("emits BreadcrumbList + FAQPage JSON-LD", () => {

--- a/app/smsf/page.tsx
+++ b/app/smsf/page.tsx
@@ -81,11 +81,6 @@ const TOPIC_CARDS = [
     href: "/smsf/investment-strategy",
   },
   {
-    title: "SMSF Insurance",
-    description: "Trustee obligations to consider life, TPD and income protection inside the fund.",
-    href: "/smsf/insurance",
-  },
-  {
     title: "SMSF Audits",
     description: "Annual audit requirements, what auditors check, and how to find a registered SMSF auditor.",
     href: "/smsf/auditors",


### PR DESCRIPTION
## What

The SMSF hub page (`app/smsf/page.tsx`) rendered a topic card titled "SMSF Insurance" linking `/smsf/insurance`, but no `app/smsf/insurance/page.tsx` route exists — the card hard-404'd on click.

Safe minimal fix: remove the dead card. The route is not referenced anywhere else (not in `app/sitemap.ts`), and every sibling topic card (`setup`, `property`, `borrowing`, `crypto`, `wind-up`, `investment-strategy`, `auditors`) resolves to an existing route. No page was fabricated.

Added a focused test that renders the hub and asserts every topic-card href resolves to a real `app/smsf/<slug>/page.tsx`, guarding against this dead-link class going forward.

## Verify

- `npm test -- __tests__/app/smsf-hub-page.test.tsx` (8 passed, incl. new guard)
- `npx eslint --max-warnings 0` on changed files — clean

Finding ref: P2 dead-link / SMSF Insurance topic card. Tier B.