### PR TITLE
fix(seo): grammatical + double-brand fix on investing-for/[occupation] titles

### DIFF
--- a/__tests__/lib/seo.test.ts
+++ b/__tests__/lib/seo.test.ts
@@ -5,6 +5,7 @@ import {
   SITE_DESCRIPTION,
   CURRENT_YEAR,
   absoluteUrl,
+  buildTitle,
   breadcrumbJsonLd,
   websiteJsonLd,
   ORGANIZATION_JSONLD,
@@ -39,6 +40,20 @@ describe("constants", () => {
 
   it("CURRENT_YEAR is a valid year", () => {
     expect(CURRENT_YEAR).toBeGreaterThanOrEqual(2025);
+  });
+});
+
+describe("buildTitle", () => {
+  it("returns a plain string for brand-free titles so the layout template fires", () => {
+    expect(buildTitle("How to Buy Shares")).toBe("How to Buy Shares");
+  });
+
+  it("returns an absolute title when the brand is already present, preventing a doubled suffix", () => {
+    // Without this, the root template "%s — Invest.com.au" would produce
+    // "Careers | Invest.com.au — Invest.com.au".
+    expect(buildTitle(`Careers | ${SITE_NAME}`)).toEqual({
+      absolute: `Careers | ${SITE_NAME}`,
+    });
   });
 });
 

--- a/app/investing-for/[occupation]/page.tsx
+++ b/app/investing-for/[occupation]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Link from "next/link";
-import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR, absoluteUrl } from "@/lib/seo";
+import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR, absoluteUrl, buildTitle } from "@/lib/seo";
 import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
 
 export const revalidate = 3600;
@@ -985,11 +985,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const cfg = OCCUPATIONS[occupation];
   if (!cfg) return { title: "Not found" };
   return {
-    title: `Investing as a ${cfg.label.split(" ")[0]} in Australia (${CURRENT_YEAR}) | Invest.com.au`,
+    title: buildTitle(`Investing for ${cfg.label} in Australia (${CURRENT_YEAR})`),
     description: cfg.metaDescription,
     alternates: { canonical: `${SITE_URL}/investing-for/${occupation}` },
     openGraph: {
-      title: `Investing as a ${cfg.label.split(" ")[0]} — ${CURRENT_YEAR} Guide`,
+      title: `Investing for ${cfg.label} — ${CURRENT_YEAR} Guide`,
       description: cfg.metaDescription,
       url: `${SITE_URL}/investing-for/${occupation}`,
       type: "website",
@@ -1054,7 +1054,7 @@ export default async function InvestingForOccupationPage({ params }: Props) {
             </span>
           </div>
           <h1 className="text-3xl md:text-4xl font-extrabold text-slate-900 mb-3">
-            Investing as a {cfg.label.includes("&") ? cfg.label : cfg.label} — {CURRENT_YEAR} Guide
+            Investing for {cfg.label} — {CURRENT_YEAR} Guide
           </h1>
           <p className="text-lg text-slate-600 leading-relaxed">{cfg.intro}</p>
         </header>


### PR DESCRIPTION
## What

The `/investing-for/[occupation]` page had three cosmetic SEO/meta bugs:

1. **"a Doctors" grammar** — title and h1 read `Investing as a ${cfg.label.split(" ")[0]}`. Every occupation `label` is plural ("Doctors & Medical Practitioners", "Nurses & Midwives", "Pilots & Aircrew", …), so this rendered "Investing as a Doctors" — a singular article on a plural noun, on all 26 occupations.
2. **Doubled brand suffix** — the metadata `title` hardcoded ` | Invest.com.au`. The root layout template is `%s — Invest.com.au`, so Next.js produced `Investing … | Invest.com.au — Invest.com.au`.
3. **No-op ternary** in the h1: `cfg.label.includes("&") ? cfg.label : cfg.label` (both branches identical).

## Fix

- Reword to **"Investing for {label}"** — grammatical for plural labels and consistent with the existing `metaDescription` / route convention ("Investing guide for …").
- Route the metadata title through the existing **`buildTitle()`** helper (`lib/seo.ts`), which returns `{ absolute }` when the brand is already present so it is never appended twice.
- Drop the no-op ternary.
- Add focused `buildTitle` unit tests (brand-free passes through; brand-present returns `{ absolute }`).

## Verification

- `npx vitest run __tests__/lib/seo.test.ts` → 75 passed
- `npx eslint --fix --max-warnings 0` on changed files → clean
- `tsc --noEmit` → no errors on the changed files

## Notes

Patterns (1) and (3) live only on this page. The double-brand class (pattern 2) also exists on other pages that set a plain-string `title` containing the brand without `buildTitle`; those are left out of this focused cosmetic PR. No doubled-year occurrence was found in current code (the only `{CURRENT_YEAR}`-twice usage is an intentional FY range on the account calendar).

Tier A (cosmetic, non-money, non-compliance).