### PR TITLE
fix(seo): noindex soft-404 metadata on dynamic content routes

### DIFF
--- a/__tests__/app/find/find-advisor.test.ts
+++ b/__tests__/app/find/find-advisor.test.ts
@@ -128,6 +128,6 @@ describe("generateMetadata", () => {
       params: Promise.resolve({ "advisor-type": "unknown-type", city: "sydney" }),
     });
 
-    expect(result).toEqual({});
+    expect(result).toEqual({ robots: { index: false } });
   });
 });

--- a/__tests__/lib/soft-404-noindex.test.ts
+++ b/__tests__/lib/soft-404-noindex.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Soft-404 noindex enforcement.
+ *
+ * Dynamic content routes whose `generateMetadata` short-circuits on a
+ * missing entity (the same branch where the page component calls
+ * `notFound()`) must return a `noindex` directive — otherwise Google
+ * indexes the soft-404 "not found" shell with `index,follow` (the
+ * Next.js default), causing SEO harm.
+ *
+ * The canonical pattern is in app/best-for/[slug]/page.tsx:
+ *   if (!scenario) return { title: "Not found", robots: "noindex" };
+ *
+ * This is a static-analysis guard: a not-found metadata branch must not
+ * be a bare `return {};` (which inherits the default indexable robots).
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = process.cwd();
+
+// The three routes flagged in the audit, plus a representative set of the
+// other dynamic content routes whose generateMetadata previously returned
+// bare `{}` on the not-found branch.
+const ROUTES = [
+  "app/best/[slug]/page.tsx",
+  "app/etfs/[ticker]/page.tsx",
+  "app/etfs/vs/[slugs]/page.tsx",
+  "app/academy/[slug]/page.tsx",
+  "app/advisor/[slug]/page.tsx",
+  "app/articles/[category]/page.tsx",
+  "app/firm/[slug]/page.tsx",
+  "app/glossary/[term]/page.tsx",
+  "app/help/[category]/page.tsx",
+  "app/just/[event]/page.tsx",
+  "app/learn/[path]/page.tsx",
+  "app/questions/[slug]/page.tsx",
+  "app/teams/[slug]/page.tsx",
+  "app/versus/[slugs]/page.tsx",
+];
+
+describe("soft-404 metadata returns noindex", () => {
+  for (const rel of ROUTES) {
+    const src = readFileSync(join(ROOT, rel), "utf8");
+
+    it(`${rel} never returns a bare {} from a generateMetadata guard`, () => {
+      // `return {};` from a not-found guard inherits the default
+      // index,follow robots — the regression we are guarding against.
+      expect(
+        /return\s*\{\s*\}\s*;/.test(src),
+        `${rel} has a bare \`return {};\` metadata branch — add robots noindex (e.g. \`return { robots: { index: false } };\`).`,
+      ).toBe(false);
+    });
+
+    it(`${rel} declares a noindex robots directive`, () => {
+      expect(
+        /robots:\s*("noindex"|'noindex'|\{\s*index:\s*false)/.test(src),
+        `${rel} should set a noindex robots directive on its not-found metadata branch.`,
+      ).toBe(true);
+    });
+  }
+});

--- a/app/academy/[slug]/page.tsx
+++ b/app/academy/[slug]/page.tsx
@@ -35,7 +35,7 @@ export async function generateStaticParams() {
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { slug } = await params;
   const course = await getAcademyCourse(slug);
-  if (!course || course.status !== "published") return {};
+  if (!course || course.status !== "published") return { robots: { index: false } };
 
   return {
     title: `${course.title} | Invest.com.au Academy`,

--- a/app/advisor-guides/[slug]/page.tsx
+++ b/app/advisor-guides/[slug]/page.tsx
@@ -16,7 +16,7 @@ export function generateStaticParams() {
 export async function generateMetadata({ params }: { params: Promise<{ slug: string }> }): Promise<Metadata> {
   const { slug } = await params;
   const guide = getAdvisorGuide(slug);
-  if (!guide) return {};
+  if (!guide) return { robots: { index: false } };
 
   return {
     title: `${guide.title} (${CURRENT_YEAR})`,

--- a/app/advisor/[slug]/insights/[id]/page.tsx
+++ b/app/advisor/[slug]/insights/[id]/page.tsx
@@ -30,7 +30,7 @@ const TYPE_COLORS: Record<PostType, { bg: string; color: string }> = {
 export async function generateMetadata({ params }: { params: Promise<{ slug: string; id: string }> }): Promise<Metadata> {
   const { slug, id } = await params;
   const postId = parseInt(id, 10);
-  if (!Number.isFinite(postId)) return {};
+  if (!Number.isFinite(postId)) return { robots: { index: false } };
 
   const supabase = await createClient();
 
@@ -42,7 +42,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
     .eq("professionals.slug", slug)
     .maybeSingle();
 
-  if (!post) return {};
+  if (!post) return { robots: { index: false } };
 
   const pro = post.professional as unknown as { name: string; slug: string } | null;
   const title = pro?.name

--- a/app/advisor/[slug]/insights/page.tsx
+++ b/app/advisor/[slug]/insights/page.tsx
@@ -46,7 +46,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
     .eq("slug", slug)
     .eq("status", "active")
     .single();
-  if (!pro) return {};
+  if (!pro) return { robots: { index: false } };
 
   const typeLabel = PROFESSIONAL_TYPE_LABELS[pro.type as keyof typeof PROFESSIONAL_TYPE_LABELS] ?? "Advisor";
   const title = `${pro.name} — Insights & Updates | Invest.com.au`;

--- a/app/advisor/[slug]/page.tsx
+++ b/app/advisor/[slug]/page.tsx
@@ -41,7 +41,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
   const { slug } = await params;
   const supabase = await createClient();
   const { data: pro } = await supabase.from("professionals").select("name, firm_name, type, location_display, meta_title, meta_description").eq("slug", slug).eq("status", "active").single();
-  if (!pro) return {};
+  if (!pro) return { robots: { index: false } };
 
   const typeLabel = PROFESSIONAL_TYPE_LABELS[pro.type as keyof typeof PROFESSIONAL_TYPE_LABELS] || "Financial Professional";
   const title = pro.meta_title || `${pro.name}${pro.firm_name ? ` — ${pro.firm_name}` : ""} — ${typeLabel}`;

--- a/app/advisors/[type]/[state]/page.tsx
+++ b/app/advisors/[type]/[state]/page.tsx
@@ -78,7 +78,7 @@ export async function generateMetadata({ params }: { params: Promise<{ type: str
   const { type: typeSlug, state: locSlug } = await params;
   const professionalType = SLUG_TO_TYPE[typeSlug];
   const loc = resolveLocation(locSlug);
-  if (!professionalType || !loc) return {};
+  if (!professionalType || !loc) return { robots: { index: false } };
 
   const label = PROFESSIONAL_TYPE_LABELS[professionalType];
   const title = `${label}s in ${loc.name} (${CURRENT_YEAR})`;

--- a/app/advisors/[type]/page.tsx
+++ b/app/advisors/[type]/page.tsx
@@ -557,7 +557,7 @@ export function generateStaticParams() {
 export async function generateMetadata({ params }: { params: Promise<{ type: string }> }): Promise<Metadata> {
   const { type: typeSlug } = await params;
   const professionalType = SLUG_TO_TYPE[typeSlug];
-  if (!professionalType) return {};
+  if (!professionalType) return { robots: { index: false } };
 
   const label = PROFESSIONAL_TYPE_LABELS[professionalType];
   const title = `Best ${label}s in Australia (${CURRENT_YEAR}) — Find & Compare`;

--- a/app/articles/[category]/page.tsx
+++ b/app/articles/[category]/page.tsx
@@ -36,7 +36,7 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { category } = await params;
   const label = CATEGORIES[category];
-  if (!label) return {};
+  if (!label) return { robots: { index: false } };
   const title = `${label} Articles & Guides (${CURRENT_YEAR}) — Invest.com.au`;
   return {
     title,

--- a/app/best/[slug]/page.tsx
+++ b/app/best/[slug]/page.tsx
@@ -82,7 +82,7 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { slug } = await params;
   const cat = getCategoryBySlug(slug);
-  if (!cat) return {};
+  if (!cat) return { title: "Not found", robots: "noindex" };
   const ogImageUrl = `/api/og?title=${encodeURIComponent(cat.h1)}&subtitle=${encodeURIComponent(cat.metaDescription.slice(0, 80))}&type=best`;
   return {
     title: cat.title,

--- a/app/broker/[slug]/changelog/page.tsx
+++ b/app/broker/[slug]/changelog/page.tsx
@@ -25,7 +25,7 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { slug } = await params;
   const broker = await getBrokerBySlug(slug);
-  if (!broker) return {};
+  if (!broker) return { robots: { index: false } };
   return {
     title: `${broker.name} Fee & Data Changelog (${CURRENT_YEAR})`,
     description: `Full history of fee changes, rating updates, and data corrections for ${broker.name} on Invest.com.au.`,

--- a/app/consultations/[slug]/page.tsx
+++ b/app/consultations/[slug]/page.tsx
@@ -42,7 +42,7 @@ async function getConsultation(slug: string) {
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { slug } = await params;
   const consultation = await getConsultation(slug);
-  if (!consultation) return {};
+  if (!consultation) return { robots: { index: false } };
 
   const title = `${consultation.title} — Expert Consultation`;
   const description =

--- a/app/courses/[slug]/[lessonSlug]/page.tsx
+++ b/app/courses/[slug]/[lessonSlug]/page.tsx
@@ -23,7 +23,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const { slug, lessonSlug } = await params;
   const lessons = await getCourseLessons(slug);
   const info = findLessonBySlug(lessons, lessonSlug);
-  if (!info) return {};
+  if (!info) return { robots: { index: false } };
 
   const course = await getCourse(slug);
   const courseTitle = course?.title || slug;

--- a/app/courses/[slug]/page.tsx
+++ b/app/courses/[slug]/page.tsx
@@ -24,7 +24,7 @@ interface PageProps {
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { slug } = await params;
   const course = await getCourse(slug);
-  if (!course || course.status !== "published") return {};
+  if (!course || course.status !== "published") return { robots: { index: false } };
 
   return {
     title: course.title,

--- a/app/etfs/[ticker]/page.tsx
+++ b/app/etfs/[ticker]/page.tsx
@@ -20,7 +20,7 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { ticker } = await params;
   const etf = getETFByTicker(ticker);
-  if (!etf) return { title: "ETF Not Found" };
+  if (!etf) return { title: "ETF Not Found", robots: "noindex" };
 
   const title = `${etf.ticker} ETF (${CURRENT_YEAR}) — ${etf.name}`;
   const description = `${etf.ticker} ETF review: ${etf.provider}, ${etf.benchmark}, MER ${etf.mer}%, AUM $${etf.aumMillions >= 1000 ? `${(etf.aumMillions / 1000).toFixed(1)}B` : `${etf.aumMillions}M`}. Compare with similar ETFs on invest.com.au.`;

--- a/app/etfs/vs/[slugs]/page.tsx
+++ b/app/etfs/vs/[slugs]/page.tsx
@@ -297,10 +297,10 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { slugs } = await params;
   const parts = slugs.split("-vs-");
-  if (parts.length !== 2) return {};
+  if (parts.length !== 2) return { title: "Not found", robots: "noindex" };
   const a = ETF_DATABASE[parts[0]];
   const b = ETF_DATABASE[parts[1]];
-  if (!a || !b) return {};
+  if (!a || !b) return { title: "Not found", robots: "noindex" };
   const title = `${a.ticker} vs ${b.ticker} (${CURRENT_YEAR}) — Which ETF is Better?`;
   const description = `${a.ticker} vs ${b.ticker}: compare MER, AUM, yield, franking credits, and performance. Which is the better ETF for Australian investors in ${CURRENT_YEAR}?`;
   return {

--- a/app/events/[id]/page.tsx
+++ b/app/events/[id]/page.tsx
@@ -126,7 +126,7 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { id } = await params;
   const idNum = parseInt(id, 10);
-  if (isNaN(idNum)) return {};
+  if (isNaN(idNum)) return { robots: { index: false } };
 
   const supabase = await createClient();
   const { data } = await supabase
@@ -136,7 +136,7 @@ export async function generateMetadata({
     .eq("status", "published")
     .single();
 
-  if (!data) return {};
+  if (!data) return { robots: { index: false } };
 
   const dateStr = formatShortDate(data.starts_at as string);
   const title = `${data.title as string} — ${data.event_type as string} | ${SITE_NAME}`;

--- a/app/find/[advisor-type]/[city]/page.tsx
+++ b/app/find/[advisor-type]/[city]/page.tsx
@@ -84,7 +84,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { "advisor-type": typeSlug, city: citySlug } = await params;
   const dbType = slugToType(typeSlug);
   const typeInfo = ADVISOR_TYPE_MAP[dbType];
-  if (!typeInfo) return {};
+  if (!typeInfo) return { robots: { index: false } };
 
   const city = citySlugToDisplay(citySlug);
   const title = `Find ${typeInfo.plural} in ${city} (${CURRENT_YEAR})`;

--- a/app/firm/[slug]/page.tsx
+++ b/app/firm/[slug]/page.tsx
@@ -22,7 +22,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
     .eq("status", "active")
     .single();
 
-  if (!firm) return {};
+  if (!firm) return { robots: { index: false } };
 
   const title = `${firm.name} — Advisory Firm Profile`;
   const description = firm.tagline || (firm.bio

--- a/app/foreign-investment/compare/[pair]/page.tsx
+++ b/app/foreign-investment/compare/[pair]/page.tsx
@@ -50,7 +50,7 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { pair } = await params;
   const parsed = parsePairSlug(pair);
-  if (!parsed) return {};
+  if (!parsed) return { robots: { index: false } };
 
   const { cfgA, cfgB } = parsed;
   const title = `${cfgA.countryName} vs ${cfgB.countryName} Investing in Australia — Tax, FIRB & Rules (${CURRENT_YEAR})`;

--- a/app/glossary/[term]/page.tsx
+++ b/app/glossary/[term]/page.tsx
@@ -21,7 +21,7 @@ export async function generateStaticParams() {
 export async function generateMetadata({ params }: { params: Promise<{ term: string }> }): Promise<Metadata> {
   const { term: slug } = await params;
   const entry = await getGlossaryBySlug(slug);
-  if (!entry) return {};
+  if (!entry) return { robots: { index: false } };
 
   const title = `What Is ${entry.term}? — Definition & Explanation`;
   const description = entry.definition.length > 155 ? entry.definition.slice(0, 152) + "..." : entry.definition;

--- a/app/help/[category]/[article]/page.tsx
+++ b/app/help/[category]/[article]/page.tsx
@@ -18,7 +18,7 @@ export async function generateMetadata(
 ): Promise<Metadata> {
   const { category, article } = await params;
   const found = getArticleBySlug(category, article);
-  if (!found) return {};
+  if (!found) return { robots: { index: false } };
   const { category: cat, article: art } = found;
   return {
     title: `${art.title} | Help Centre | Invest.com.au`,

--- a/app/help/[category]/page.tsx
+++ b/app/help/[category]/page.tsx
@@ -15,7 +15,7 @@ export async function generateMetadata(
 ): Promise<Metadata> {
   const { category: categorySlug } = await params;
   const cat = getCategoryBySlug(categorySlug);
-  if (!cat) return {};
+  if (!cat) return { robots: { index: false } };
   return {
     title: `${cat.title} | Help Centre | Invest.com.au`,
     description: cat.description,

--- a/app/how-to/[slug]/page.tsx
+++ b/app/how-to/[slug]/page.tsx
@@ -36,7 +36,7 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { slug } = await params;
   const guide = getGuide(slug);
-  if (!guide) return {};
+  if (!guide) return { robots: { index: false } };
 
   return {
     title: buildTitle(guide.title),

--- a/app/invest/[slug]/listings/[subcategory]/page.tsx
+++ b/app/invest/[slug]/listings/[subcategory]/page.tsx
@@ -37,9 +37,9 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { slug: category, subcategory } = await params;
   const cat = getInvestCategoryBySlug(category);
-  if (!cat) return {};
+  if (!cat) return { robots: { index: false } };
   const sub = getSubcategoryBySlug(category, subcategory);
-  if (!sub) return {};
+  if (!sub) return { robots: { index: false } };
 
   const ogImageUrl = `/api/og?title=${encodeURIComponent(sub.h1)}&subtitle=${encodeURIComponent(sub.metaDescription.slice(0, 80))}&type=invest`;
 

--- a/app/investing/[city]/page.tsx
+++ b/app/investing/[city]/page.tsx
@@ -41,7 +41,7 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { city: slug } = await params;
   const city = getCityBySlug(slug);
-  if (!city) return {};
+  if (!city) return { robots: { index: false } };
 
   return {
     title: city.metaTitle,

--- a/app/just/[event]/page.tsx
+++ b/app/just/[event]/page.tsx
@@ -594,7 +594,7 @@ type Props = { params: Promise<{ event: string }> };
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { event } = await params;
   const e = EVENT_MAP.get(event);
-  if (!e) return {};
+  if (!e) return { robots: { index: false } };
 
   const title = `${e.headline}: Your financial checklist (${CURRENT_YEAR}) — ${SITE_NAME}`;
   const description = e.subhead;

--- a/app/lead-magnets/[slug]/page.tsx
+++ b/app/lead-magnets/[slug]/page.tsx
@@ -18,7 +18,7 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { slug } = await params;
   const magnet = LEAD_MAGNETS.find((m) => m.slug === slug);
-  if (!magnet) return {};
+  if (!magnet) return { robots: { index: false } };
   return {
     title: `${magnet.title} — Free Download | invest.com.au`,
     description: magnet.description,

--- a/app/learn/[path]/page.tsx
+++ b/app/learn/[path]/page.tsx
@@ -23,7 +23,7 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { path: pathSlug } = await params;
   const learningPath = getLearningPath(pathSlug);
-  if (!learningPath) return {};
+  if (!learningPath) return { robots: { index: false } };
 
   const totalMins = sumEstimatedMinutes(learningPath);
   const hours = (totalMins / 60).toFixed(1);

--- a/app/persona/[type]/page.tsx
+++ b/app/persona/[type]/page.tsx
@@ -58,7 +58,7 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { type } = await params;
   const personaType = SLUG_TO_TYPE[type];
-  if (!personaType) return {};
+  if (!personaType) return { robots: { index: false } };
   const result = personaFromType(personaType);
   const ogUrl = absoluteUrl(
     `/api/og?type=persona&persona=${encodeURIComponent(personaType)}&title=${encodeURIComponent(personaType)}&subtitle=${encodeURIComponent(result.tagline)}`,

--- a/app/questions/[slug]/page.tsx
+++ b/app/questions/[slug]/page.tsx
@@ -24,7 +24,7 @@ interface Props {
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { slug } = await params;
   const question = QUESTIONS_BY_SLUG.get(slug);
-  if (!question) return {};
+  if (!question) return { robots: { index: false } };
   return {
     title: question.metaTitle,
     description: question.metaDescription,

--- a/app/quotes/by/[type]/[state]/page.tsx
+++ b/app/quotes/by/[type]/[state]/page.tsx
@@ -50,7 +50,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const { type, state } = await params;
   const typeKey = type.toLowerCase();
   const stateKey = state.toUpperCase();
-  if (!isValidType(typeKey) || !isValidState(stateKey)) return {};
+  if (!isValidType(typeKey) || !isValidState(stateKey)) return { robots: { index: false } };
 
   const label = TYPE_LABELS[typeKey] ?? typeKey;
   return {

--- a/app/scenarios/compare/[preset]/page.tsx
+++ b/app/scenarios/compare/[preset]/page.tsx
@@ -30,7 +30,7 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { preset: slug } = await params;
   const p = getPreset(slug);
-  if (!p) return {};
+  if (!p) return { robots: { index: false } };
 
   const description = `${p.summary.slice(0, 150)}… General information only — not personal advice.`;
 

--- a/app/share/shortlist/[code]/page.tsx
+++ b/app/share/shortlist/[code]/page.tsx
@@ -69,7 +69,7 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { code } = await params;
   const loaded = await loadShortlist(code);
-  if (!loaded) return {};
+  if (!loaded) return { robots: { index: false } };
   const names = loaded.brokers.map((b) => b.name).join(", ");
   const title = loaded.brokers.length
     ? `${loaded.brokers.length} brokers I'm comparing (${names.slice(0, 80)}${names.length > 80 ? "…" : ""})`

--- a/app/switch-scripts/[broker-slug]/page.tsx
+++ b/app/switch-scripts/[broker-slug]/page.tsx
@@ -21,7 +21,7 @@ export async function generateMetadata({
 }: PageProps): Promise<Metadata> {
   const { "broker-slug": slug } = await params;
   const script = getSwitchScript(slug);
-  if (!script) return {};
+  if (!script) return { robots: { index: false } };
   const title = `Switch from ${script.brokerName} — negotiation script + transfer steps | ${SITE_NAME}`;
   const description = `How to ask ${script.brokerName} to match a competitor's pricing, and step-by-step what to do if you decide to leave. CHESS / custodian transfer process, AU tax notes (CGT, in-specie, DRP).`;
   return {

--- a/app/switch/[type]/page.tsx
+++ b/app/switch/[type]/page.tsx
@@ -49,7 +49,7 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { type } = await params;
   const meta = META[type];
-  if (!meta) return {};
+  if (!meta) return { robots: { index: false } };
   return {
     title: meta.title,
     description: meta.description,

--- a/app/teams/[slug]/page.tsx
+++ b/app/teams/[slug]/page.tsx
@@ -38,7 +38,7 @@ export async function generateMetadata({
     .eq("public", true)
     .eq("verification_status", "verified")
     .maybeSingle();
-  if (!team) return {};
+  if (!team) return { robots: { index: false } };
   return {
     title: `${team.name} — Verified Expert Team (${CURRENT_YEAR})`,
     description: (team.description as string)?.slice(0, 155) ?? `${team.name} is a verified expert team on Invest.com.au.`,

--- a/app/versus/[slugs]/page.tsx
+++ b/app/versus/[slugs]/page.tsx
@@ -175,7 +175,7 @@ export async function generateMetadata({
   const { slugs } = await params;
   const brokerSlugs = parseSlugs(slugs);
 
-  if (brokerSlugs.length < 2 || brokerSlugs.length > 4) return {};
+  if (brokerSlugs.length < 2 || brokerSlugs.length > 4) return { robots: { index: false } };
 
   const supabase = await createClient();
   const { data: brokers } = await supabase
@@ -184,7 +184,7 @@ export async function generateMetadata({
     .in("slug", brokerSlugs)
     .eq("status", "active");
 
-  if (!brokers || brokers.length < 2) return {};
+  if (!brokers || brokers.length < 2) return { robots: { index: false } };
 
   // Preserve the order from the URL
   const ordered = brokerSlugs


### PR DESCRIPTION
## What

Dynamic content routes whose `generateMetadata` short-circuits on a missing entity (the same branch where the page calls `notFound()`) returned a bare `return {}`. Next.js then applies the default `index,follow` robots, so Google indexes the soft-404 "not found" shell — direct SEO harm.

Applied the canonical pattern already used in `app/best-for/[slug]/page.tsx` (`robots: 'noindex'` / `robots: { index: false }`) to:

- The three flagged routes: `best/[slug]`, `etfs/[ticker]`, `etfs/vs/[slugs]`
- ~30 other dynamic content routes with the same bare-`{}` not-found guard (advisor, glossary, academy, courses, help, questions, teams, versus, etc.)

Added `__tests__/lib/soft-404-noindex.test.ts` — a static-analysis guard asserting the flagged routes never return a bare `{}` from a metadata guard and always declare a noindex directive, so the regression can't reappear.

Data-fetching helpers that legitimately return `{}` (e.g. `fetchBrokers` in `how-to/transfer-from`, `ShortlistClient`) were left untouched — they are not metadata guards.

## Verification

- `npx vitest run __tests__/lib/soft-404-noindex.test.ts` — 28 passing
- `npx tsc --noEmit` — 0 errors
- `eslint --fix` on changed files clean (2 pre-existing warnings on untouched lines, present on base main)

Finding ref: P2 soft-404 indexable not-found pages. Tier B.