### PR TITLE
fix(listings): stop anon GET /api/listings/[id] leaking owner contact + moderation fields

### DIFF
--- a/__tests__/api/listings-id.test.ts
+++ b/__tests__/api/listings-id.test.ts
@@ -136,6 +136,102 @@ describe("GET /api/listings/[id]", () => {
     const res = await GET(req, params);
     expect(res.status).toBe(500);
   });
+
+  it("requests an explicit public column projection (never select('*'))", async () => {
+    const selectSpy = vi.fn().mockReturnThis();
+    let fromCalls = 0;
+    mockFrom.mockImplementation(() => {
+      fromCalls++;
+      if (fromCalls === 1) {
+        return {
+          select: selectSpy,
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: LISTING, error: null }),
+        };
+      }
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        then: vi.fn((cb: (v: unknown) => void) => {
+          cb({ count: 0, data: null, error: null });
+          return Promise.resolve();
+        }),
+      };
+    });
+
+    const [req, params] = makeGet("1");
+    await GET(req, params);
+
+    expect(selectSpy).toHaveBeenCalledTimes(1);
+    const projection = selectSpy.mock.calls[0]?.[0] as string;
+    expect(projection).not.toBe("*");
+    // Sensitive owner/moderation columns must NOT be in the projection.
+    expect(projection).not.toMatch(/contact_email/);
+    expect(projection).not.toMatch(/contact_phone/);
+    expect(projection).not.toMatch(/auto_classified/);
+    expect(projection).not.toMatch(/admin_overridden/);
+    // Legitimate public columns must still be requested.
+    expect(projection).toMatch(/\btitle\b/);
+    expect(projection).toMatch(/\bprice_display\b/);
+  });
+
+  it("does not expose contact details or moderation fields to anon callers", async () => {
+    // Even if the DB row were to carry these (e.g. a stale select), the public
+    // payload must never surface them. We simulate the admin client returning a
+    // full row and assert the response body excludes the sensitive keys.
+    const FULL_ROW = {
+      id: 1,
+      title: "SAAS Business",
+      price_display: "$1.2M",
+      status: "active",
+      contact_email: "owner@example.com",
+      contact_phone: "+61 400 000 000",
+      auto_classified_verdict: "auto_approve",
+      auto_classified_reasons: { foo: "bar" },
+      admin_overridden_by: "finn@invest.com.au",
+    };
+    let fromCalls = 0;
+    mockFrom.mockImplementation(() => {
+      fromCalls++;
+      if (fromCalls === 1) {
+        // The route's projection would normally strip these columns at the DB
+        // layer; here we model the projection by returning only public keys.
+        return {
+          select: vi.fn((cols: string) => {
+            const requested = cols.split(",").map((c) => c.trim());
+            const projected = Object.fromEntries(
+              Object.entries(FULL_ROW).filter(([k]) => requested.includes(k)),
+            );
+            return {
+              eq: vi.fn().mockReturnThis(),
+              single: vi.fn().mockResolvedValue({ data: projected, error: null }),
+            };
+          }),
+        };
+      }
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        then: vi.fn((cb: (v: unknown) => void) => {
+          cb({ count: 0, data: null, error: null });
+          return Promise.resolve();
+        }),
+      };
+    });
+
+    const [req, params] = makeGet("1");
+    const res = await GET(req, params);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).not.toHaveProperty("contact_email");
+    expect(body).not.toHaveProperty("contact_phone");
+    expect(body).not.toHaveProperty("auto_classified_verdict");
+    expect(body).not.toHaveProperty("auto_classified_reasons");
+    expect(body).not.toHaveProperty("admin_overridden_by");
+    // Public fields still present.
+    expect(body.title).toBe("SAAS Business");
+    expect(body.price_display).toBe("$1.2M");
+  });
 });
 
 // ── PUT tests ─────────────────────────────────────────────────────────────────

--- a/app/api/listings/[id]/route.ts
+++ b/app/api/listings/[id]/route.ts
@@ -121,7 +121,7 @@ export async function GET(
       .eq("listing_id", listingId);
 
     return NextResponse.json({
-      ...(listing as Record<string, unknown>),
+      ...(listing as unknown as Record<string, unknown>),
       enquiries_count: count ?? 0,
     });
   } catch (err) {

--- a/app/api/listings/[id]/route.ts
+++ b/app/api/listings/[id]/route.ts
@@ -28,6 +28,43 @@ function emailsMatch(a: string | null | undefined, b: string): boolean {
   return timingSafeEqual(aBuf, bBuf);
 }
 
+// Explicit public projection for the anonymous GET. The previous `select("*")`
+// leaked owner contact details (contact_email, contact_phone) and the internal
+// moderation trail (auto_classified_*, admin_overridden_*) to any unauthenticated
+// caller. This route has no authenticated/owner consumer — owner edit/read flows
+// go through /api/listings/my-listings* — so every column safe to expose to an
+// anonymous visitor is enumerated here. Add new public columns deliberately;
+// do NOT re-introduce `*`.
+const PUBLIC_GET_COLUMNS = [
+  "id",
+  "vertical",
+  "title",
+  "slug",
+  "description",
+  "location_state",
+  "location_city",
+  "asking_price_cents",
+  "price_display",
+  "annual_revenue_cents",
+  "annual_profit_cents",
+  "industry",
+  "sub_category",
+  "key_metrics",
+  "images",
+  "listing_type",
+  "listing_kind",
+  "firb_eligible",
+  "siv_complying",
+  "listed_by_professional_id",
+  "external_url",
+  "status",
+  "expires_at",
+  "views",
+  "enquiries",
+  "created_at",
+  "updated_at",
+].join(", ");
+
 const UPDATABLE_FIELDS = [
   "title",
   "description",
@@ -66,7 +103,7 @@ export async function GET(
 
     const { data: listing, error } = await admin
       .from("investment_listings")
-      .select("*")
+      .select(PUBLIC_GET_COLUMNS)
       .eq("id", listingId)
       .single();
 

--- a/app/api/listings/[id]/route.ts
+++ b/app/api/listings/[id]/route.ts
@@ -121,7 +121,7 @@ export async function GET(
       .eq("listing_id", listingId);
 
     return NextResponse.json({
-      ...listing,
+      ...(listing as Record<string, unknown>),
       enquiries_count: count ?? 0,
     });
   } catch (err) {


### PR DESCRIPTION
## What

`GET /api/listings/[id]` used `select("*")` with a service-role (RLS-bypassing) admin client and returned the **entire row** to any unauthenticated caller — including:

- `contact_email`, `contact_phone` (owner PII)
- the internal moderation trail: `auto_classified_at/verdict/reasons`, `admin_overridden_at/by`

No frontend consumer fetches this dynamic-id route directly (owner read/edit flows go through `/api/listings/my-listings*`), so the endpoint is effectively a public surface.

## Fix

- Replace the wildcard with an explicit `PUBLIC_GET_COLUMNS` projection enumerating only columns safe to expose to an anonymous visitor.
- PUT/DELETE ownership flows are unchanged.
- Added tests asserting the GET projection never requests the sensitive columns, and the response body omits `contact_email`/`contact_phone`/`auto_classified_*`/`admin_overridden_*` while keeping public fields.

## Finding ref

P1 cross-user data exposure — `app/api/listings/[id]/route.ts` GET. No migration (RLS items held).

Tier A.