### PR TITLE
fix(advisor): stop leaking internal professional fields to anon profile page

### DIFF
--- a/__tests__/app/advisor/public-columns.test.ts
+++ b/__tests__/app/advisor/public-columns.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import {
+  ADVISOR_PUBLIC_COLUMN_LIST,
+  ADVISOR_PUBLIC_COLUMNS,
+} from "@/app/advisor/[slug]/public-columns";
+
+// Regression guard for the advisor-profile data-exposure fix.
+//
+// `app/advisor/[slug]/page.tsx` used to `select('*')` and hand the whole
+// professionals row to the anonymous client component, leaking internal
+// CRM/billing/scoring columns into the serialized browser payload. The page now
+// projects an explicit allow-list; these tests pin that allow-list so the leak
+// can never silently come back.
+
+// Columns that must NEVER reach an anonymous visitor. Internal CRM, Stripe /
+// billing, lead economics, admin notes, scoring, and operational SLA internals.
+const FORBIDDEN_INTERNAL_COLUMNS = [
+  // Stripe / billing
+  "stripe_customer_id",
+  "stripe_connect_account_id",
+  "credit_balance_cents",
+  "lifetime_credit_cents",
+  "lifetime_lead_spend_cents",
+  "free_leads_used",
+  "lead_price_cents",
+  // Lead economics / CRM
+  "total_leads",
+  "total_leads_received",
+  "leads_this_month",
+  "last_lead_at",
+  "unresponded_leads",
+  // Admin / moderation
+  "admin_notes",
+  "admin_tags",
+  "health_status",
+  "health_score",
+  "tier_change_reason",
+  "alert_preferences",
+  // Scoring internals
+  "profile_score",
+  "profile_quality_gate",
+  "profile_gate_checked_at",
+  "profile_missing_fields",
+  // Auth / session internals
+  "last_login_at",
+  "login_count",
+  // Verification internals (the public method label is allowed; the rest is not)
+  "verified_by",
+  "verification_failures",
+  "verification_notes",
+  "last_verified_at",
+  // Operational pause internals
+  "auto_paused_at",
+  "auto_pause_reason",
+  "pause_warning_sent_at",
+];
+
+describe("advisor profile public column projection", () => {
+  it("is an explicit allow-list, never a wildcard select", () => {
+    expect(ADVISOR_PUBLIC_COLUMNS).not.toContain("*");
+    expect(ADVISOR_PUBLIC_COLUMN_LIST.length).toBeGreaterThan(0);
+  });
+
+  it("excludes every internal / stripe / scoring column", () => {
+    const projected = new Set<string>(ADVISOR_PUBLIC_COLUMN_LIST);
+    const leaked = FORBIDDEN_INTERNAL_COLUMNS.filter((col) => projected.has(col));
+    expect(leaked).toEqual([]);
+  });
+
+  it("does not name any internal column inside the joined select string", () => {
+    // Defends against a forbidden column sneaking in via a comma-joined alias.
+    const columns = ADVISOR_PUBLIC_COLUMNS.split(",").map((c) => c.trim());
+    for (const forbidden of FORBIDDEN_INTERNAL_COLUMNS) {
+      expect(columns).not.toContain(forbidden);
+    }
+  });
+
+  it("still includes the public fields the profile UI renders", () => {
+    const projected = new Set<string>(ADVISOR_PUBLIC_COLUMN_LIST);
+    const requiredPublic = [
+      "id",
+      "slug",
+      "name",
+      "firm_name",
+      "type",
+      "bio",
+      "photo_url",
+      "specialties",
+      "rating",
+      "review_count",
+      "verified",
+      "afsl_number",
+      "qualifications",
+      "languages",
+      "fee_description",
+      "verification_method",
+      "account_type",
+    ];
+    const missing = requiredPublic.filter((col) => !projected.has(col));
+    expect(missing).toEqual([]);
+  });
+});

--- a/app/advisor/[slug]/page.tsx
+++ b/app/advisor/[slug]/page.tsx
@@ -72,12 +72,14 @@ export default async function AdvisorProfilePage({ params }: { params: Promise<{
   const { slug } = await params;
   const supabase = await createClient();
 
-  const { data: pro } = await supabase
+  const { data: proRow } = await supabase
     .from("professionals")
     .select(ADVISOR_PUBLIC_COLUMNS)
     .eq("slug", slug)
     .eq("status", "active")
     .single();
+  // Explicit column projection makes Supabase return GenericStringError typing; cast back to the row shape.
+  const pro = proRow as unknown as Professional | null;
 
   if (!pro) notFound();
 

--- a/app/advisor/[slug]/page.tsx
+++ b/app/advisor/[slug]/page.tsx
@@ -388,11 +388,11 @@ export default async function AdvisorProfilePage({ params }: { params: Promise<{
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(personLd) }} />
       {localBusinessLd && <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(localBusinessLd) }} />}
-      {pro.faqs?.length > 0 && (
+      {(pro.faqs?.length ?? 0) > 0 && (
         <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify({
           "@context": "https://schema.org",
           "@type": "FAQPage",
-          mainEntity: pro.faqs.map((f: { q: string; a: string }) => ({
+          mainEntity: (pro.faqs ?? []).map((f: { q: string; a: string }) => ({
             "@type": "Question",
             name: f.q,
             acceptedAnswer: { "@type": "Answer", text: f.a },

--- a/app/advisor/[slug]/page.tsx
+++ b/app/advisor/[slug]/page.tsx
@@ -25,6 +25,7 @@ import FollowAdvisorButton from "@/components/FollowAdvisorButton";
 import { computeIdealClientBoost, type UserMatchProfile, type IdealClientCriteria } from "@/lib/advisor-profile-match";
 import { getRelatedForAdvisor } from "@/lib/related-content";
 import RelatedRail from "@/components/RelatedRail";
+import { ADVISOR_PUBLIC_COLUMNS } from "./public-columns";
 
 export const revalidate = 1800;
 
@@ -73,7 +74,7 @@ export default async function AdvisorProfilePage({ params }: { params: Promise<{
 
   const { data: pro } = await supabase
     .from("professionals")
-    .select("*")
+    .select(ADVISOR_PUBLIC_COLUMNS)
     .eq("slug", slug)
     .eq("status", "active")
     .single();

--- a/app/advisor/[slug]/public-columns.ts
+++ b/app/advisor/[slug]/public-columns.ts
@@ -1,0 +1,78 @@
+// Explicit PUBLIC column projection for the advisor profile page.
+//
+// The advisor profile page (`app/advisor/[slug]/page.tsx`) renders for ANONYMOUS
+// visitors and passes the professionals row straight to the client component, so
+// it must never `select('*')`. The professionals row also carries internal
+// CRM/billing/scoring columns (stripe_customer_id, credit/lead balances,
+// health_status, admin_notes/tags, profile_score, login_count,
+// verification_failures, auto-pause reason, lead counts, etc.) that would
+// otherwise leak into the serialized browser payload.
+//
+// Only the columns the profile UI actually renders are listed here. If the UI
+// starts rendering a new field, add it here explicitly — do NOT switch back to
+// `*`. Lives in its own module so the security invariant can be unit-tested
+// without importing the full RSC render chain.
+export const ADVISOR_PUBLIC_COLUMN_LIST = [
+  "id",
+  "slug",
+  "name",
+  "firm_name",
+  "firm_id",
+  "type",
+  "account_type",
+  "is_firm_admin",
+  "specialties",
+  "service_areas",
+  "meeting_types",
+  "ideal_client",
+  "location_state",
+  "location_suburb",
+  "location_display",
+  "afsl_number",
+  "abn",
+  "registration_number",
+  "bio",
+  "photo_url",
+  "intro_video_url",
+  "website",
+  "phone",
+  "linkedin_url",
+  "twitter_url",
+  "fee_structure",
+  "fee_description",
+  "hourly_rate_cents",
+  "flat_fee_cents",
+  "aum_percentage",
+  "initial_consultation_free",
+  "rating",
+  "review_count",
+  "verified",
+  "verified_at",
+  "verification_method",
+  "qualifications",
+  "education",
+  "memberships",
+  "languages",
+  "years_experience",
+  "faqs",
+  "testimonials",
+  "accepting_new_clients",
+  "accepts_new_clients",
+  "availability_status",
+  "response_time_hours",
+  "avg_response_minutes",
+  "accepts_international_clients",
+  "international_tax_specialist",
+  "firb_specialist",
+  "follower_count",
+  "booking_link",
+  "offer_text",
+  "offer_terms",
+  "offer_active",
+  "meta_title",
+  "meta_description",
+  "created_at",
+] as const;
+
+/** Comma-joined column projection passed to Supabase `.select(...)`. */
+export const ADVISOR_PUBLIC_COLUMNS = ADVISOR_PUBLIC_COLUMN_LIST.join(", ");


### PR DESCRIPTION
## What

`app/advisor/[slug]/page.tsx` (~line 74) loaded the advisor profile with `select('*')` and passed the whole `professionals` row to the **anonymous** client component (`AdvisorProfileClient`). The serialized RSC payload therefore carried internal CRM/billing/scoring columns that anyone could read from the page source: `stripe_customer_id`, credit/lead balances, `health_status`/`health_score`, `admin_notes`/`admin_tags`, `profile_score`, `login_count`, verification internals, auto-pause reason, lead counts, `tier_change_reason`, `alert_preferences`, etc.

This replaces the wildcard with an explicit **public column projection** (`ADVISOR_PUBLIC_COLUMNS`) that includes only the fields the profile UI actually renders (derived by auditing every `pro.*` access across `app/advisor/[slug]/`). The list lives in its own module (`public-columns.ts`) so the security invariant is unit-testable without importing the heavy RSC render chain.

Same approach as the merged forum `author_id` exposure fix: narrow the projection, keep everything the consumer legitimately needs (response-time signal, verification method, account_type, etc.), drop the internal columns.

## Test

`__tests__/app/advisor/public-columns.test.ts` asserts the projection is an allow-list (never `*`), excludes every internal/stripe/scoring column, and still includes the rendered public fields.

## Notes

- No DB migration — RLS hardening for `professionals` is tracked separately and held.
- The separate `advisor_firms` `select('*')` (firm row) is out of scope for this professionals-row exposure item and left untouched.

Finding: advisor-profile-exposure (P0, data exposure). Tier B.