### PR TITLE
fix(office-hours): don't forward anonymous asker display_name to client

### DIFF
--- a/__tests__/app/office-hours-detail-page.test.tsx
+++ b/__tests__/app/office-hours-detail-page.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Privacy regression test for app/office-hours/[id]/page.tsx.
+ *
+ * The office-hours session page must NOT serialize an anonymous asker's
+ * display_name into the props handed to the OfficeHoursLiveStream client
+ * component. Client-component props ship to the browser in the RSC/HTML
+ * payload, so forwarding the raw display_name for is_anonymous questions
+ * deanonymises the asker even though the UI renders "Anonymous".
+ *
+ * Finding: "Office-hours detail page forwards anonymous asker display_name to
+ * the client" (Tier A).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "../components/setup";
+
+const { mockFrom, capturedProps } = vi.hoisted(() => ({
+  mockFrom: vi.fn(),
+  capturedProps: { current: null as Record<string, unknown> | null },
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn().mockResolvedValue({ from: mockFrom }),
+}));
+
+vi.mock("@/lib/seo", () => ({
+  absoluteUrl: (p: string) => `https://invest.com.au${p}`,
+  breadcrumbJsonLd: () => ({}),
+  SITE_URL: "https://invest.com.au",
+}));
+
+vi.mock("@/lib/compliance", () => ({
+  GENERAL_ADVICE_WARNING: "advice warning",
+}));
+
+vi.mock("@/components/RsvpButton", () => ({
+  default: () => null,
+}));
+
+// Capture the props the page hands across the client boundary.
+vi.mock("@/components/OfficeHoursLiveStream", () => ({
+  default: (props: Record<string, unknown>) => {
+    capturedProps.current = props;
+    return null;
+  },
+}));
+
+const SESSION_ROW = {
+  id: 1,
+  title: "Live Q&A",
+  description: "Ask anything",
+  scheduled_at: "2026-06-10T03:00:00.000Z",
+  ends_at: null,
+  status: "transcript",
+  max_questions: 50,
+  rsvp_count: 0,
+  is_published: true,
+  advisor_id: 9,
+  professionals: {
+    id: 9,
+    name: "Jane Advisor",
+    slug: "jane-advisor",
+    type: "financial-adviser",
+    firm_name: "Acme",
+    headshot_url: null,
+  },
+};
+
+const NAMED_QUESTION = {
+  id: 100,
+  session_id: 1,
+  display_name: "Public Asker",
+  question: "What is an ETF?",
+  is_anonymous: false,
+  answer: "A fund.",
+  answered_at: "2026-06-10T03:05:00.000Z",
+  upvote_count: 2,
+  created_at: "2026-06-10T03:01:00.000Z",
+};
+
+const SECRET_NAME = "Secret Real Name";
+const ANON_QUESTION = {
+  id: 101,
+  session_id: 1,
+  display_name: SECRET_NAME,
+  question: "How do I avoid tax?",
+  is_anonymous: true,
+  answer: null,
+  answered_at: null,
+  upvote_count: 5,
+  created_at: "2026-06-10T03:02:00.000Z",
+};
+
+function makeFrom() {
+  return (table: string) => {
+    if (table === "advisor_office_hours") {
+      const single = vi.fn().mockResolvedValue({ data: SESSION_ROW });
+      const eq2 = vi.fn().mockReturnValue({ single });
+      const eq1 = vi.fn().mockReturnValue({ eq: eq2 });
+      const select = vi.fn().mockReturnValue({ eq: eq1 });
+      return { select };
+    }
+    if (table === "office_hour_questions") {
+      const limit = vi
+        .fn()
+        .mockResolvedValue({ data: [NAMED_QUESTION, ANON_QUESTION] });
+      const order2 = vi.fn().mockReturnValue({ limit });
+      const order1 = vi.fn().mockReturnValue({ order: order2 });
+      const eq2 = vi.fn().mockReturnValue({ order: order1 });
+      const eq1 = vi.fn().mockReturnValue({ eq: eq2 });
+      const select = vi.fn().mockReturnValue({ eq: eq1 });
+      return { select };
+    }
+    throw new Error(`unexpected table ${table}`);
+  };
+}
+
+import OfficeHoursSessionPage from "@/app/office-hours/[id]/page";
+
+async function renderPage() {
+  render(await OfficeHoursSessionPage({ params: Promise.resolve({ id: "1" }) }));
+}
+
+describe("OfficeHoursSessionPage anonymous display_name serialization", () => {
+  beforeEach(() => {
+    capturedProps.current = null;
+    mockFrom.mockImplementation(makeFrom());
+  });
+
+  it("does NOT forward an anonymous asker's display_name to the client", async () => {
+    await renderPage();
+
+    const props = capturedProps.current;
+    expect(props).not.toBeNull();
+
+    // The secret real name must never appear in the serialized payload.
+    expect(JSON.stringify(props)).not.toContain(SECRET_NAME);
+
+    const questions = props!.initialQuestions as Record<string, unknown>[];
+    const anon = questions.find((q) => q.id === 101)!;
+    expect(anon.display_name).toBe("");
+    // The anonymity flag itself is still forwarded so the UI can label it.
+    expect(anon.is_anonymous).toBe(true);
+  });
+
+  it("still forwards the display_name for non-anonymous questions", async () => {
+    await renderPage();
+
+    const props = capturedProps.current!;
+    const questions = props.initialQuestions as Record<string, unknown>[];
+    const named = questions.find((q) => q.id === 100)!;
+    expect(named.display_name).toBe("Public Asker");
+    expect(named.is_anonymous).toBe(false);
+  });
+});

--- a/app/office-hours/[id]/page.tsx
+++ b/app/office-hours/[id]/page.tsx
@@ -123,7 +123,13 @@ export default async function OfficeHoursSessionPage({
   if (!sessionResult.data) notFound();
 
   const session = sessionResult.data as unknown as Session;
-  const questions = (questionsResult.data ?? []) as Question[];
+  // Respect anonymity: never forward an anonymous asker's display_name into
+  // client RSC props. The stream UI renders "Anonymous" for these, but the raw
+  // value would otherwise be serialised into the page payload and readable in
+  // the HTML source. Blank it server-side before it crosses the boundary.
+  const questions = ((questionsResult.data ?? []) as Question[]).map((q) =>
+    q.is_anonymous ? { ...q, display_name: "" } : q,
+  );
   const isTranscript = session.status === "transcript";
   const advisor = session.professionals;
 


### PR DESCRIPTION
The session detail page (`app/office-hours/[id]/page.tsx`) selected `display_name` for every question and forwarded the rows into the `OfficeHoursLiveStream` client component as `initialQuestions`. Client-component props are serialised into the RSC/HTML payload, so an anonymous asker's real `display_name` was readable in the page source even though the UI renders "Anonymous" for those rows — defeating the anonymity toggle.

Fix: blank `display_name` server-side for `is_anonymous` questions before it crosses the client boundary, keeping the field intact for non-anonymous askers. Mirrors the merged forum `author_id` privacy fix.

Adds `__tests__/app/office-hours-detail-page.test.tsx` asserting the anonymous asker's name never appears in the captured client props while named questions keep their display name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)