### PR TITLE
fix(community): stop leaking forum author_id to the client in the threads API

### DIFF
--- a/__tests__/api/community-threads-id.test.ts
+++ b/__tests__/api/community-threads-id.test.ts
@@ -91,7 +91,12 @@ function makeListBuilder(data: unknown[] = [], error: unknown = null) {
 // ── GET tests ──────────────────────────────────────────────────────────────────
 
 describe("GET /api/community/threads/[id]", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // GET now resolves the viewer server-side to derive ownership flags
+    // without serializing author_id. Default: anonymous viewer.
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+  });
 
   it("returns 404 when thread not found", async () => {
     mockAdminFrom.mockReturnValue(makeSingleBuilder(null, { message: "not found" }));
@@ -106,6 +111,7 @@ describe("GET /api/community/threads/[id]", () => {
       author_id: "author-2",
       thread_id: THREAD_ID,
       body: "A reply",
+      is_anonymous: false,
       is_removed: false,
       created_at: new Date().toISOString(),
     };
@@ -135,6 +141,113 @@ describe("GET /api/community/threads/[id]", () => {
     const data = await res.json();
     expect(data.thread.id).toBe(THREAD_ID);
     expect(data.posts).toHaveLength(1);
+  });
+
+  it("does NOT serialize author_id on thread or posts (P1/P3 cross-user leak)", async () => {
+    const thread = makeThread({ author_id: USER_ID, is_anonymous: false });
+    const post = {
+      id: "post-1",
+      author_id: "author-2",
+      thread_id: THREAD_ID,
+      body: "A reply",
+      is_anonymous: false,
+      is_removed: false,
+      created_at: new Date().toISOString(),
+    };
+    const profile = { user_id: USER_ID, display_name: "Alice", reputation: 10, badge: null, is_moderator: false };
+
+    let callCount = 0;
+    mockAdminFrom.mockImplementation((table: string) => {
+      callCount++;
+      if (table === "forum_threads" && callCount === 1) return makeSingleBuilder(thread, null);
+      if (table === "forum_threads" && callCount === 2) {
+        return { update: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis() };
+      }
+      if (table === "forum_posts") return makeListBuilder([post]);
+      if (table === "forum_user_profiles") return makeListBuilder([profile]);
+      return makeSingleBuilder(null, null);
+    });
+
+    const res = await GET(makeRequest("GET"), makeParams());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    // No raw auth UUIDs anywhere in the serialized payload.
+    const serialized = JSON.stringify(data);
+    expect(serialized).not.toContain("author_id");
+    expect(serialized).not.toContain(USER_ID);
+    expect(serialized).not.toContain("author-2");
+
+    expect(data.thread).not.toHaveProperty("author_id");
+    expect(data.posts[0]).not.toHaveProperty("author_id");
+
+    // For an anonymous viewer, ownership is always false.
+    expect(data.thread.is_own).toBe(false);
+    expect(data.posts[0].is_own).toBe(false);
+  });
+
+  it("derives is_own server-side for the viewer's own thread without leaking author_id", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: USER_ID } }, error: null });
+    const thread = makeThread({ author_id: USER_ID, is_anonymous: false });
+    const post = {
+      id: "post-1",
+      author_id: "author-2",
+      thread_id: THREAD_ID,
+      body: "A reply",
+      is_anonymous: false,
+      is_removed: false,
+      created_at: new Date().toISOString(),
+    };
+
+    let callCount = 0;
+    mockAdminFrom.mockImplementation((table: string) => {
+      callCount++;
+      if (table === "forum_threads" && callCount === 1) return makeSingleBuilder(thread, null);
+      if (table === "forum_threads" && callCount === 2) {
+        return { update: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis() };
+      }
+      if (table === "forum_posts") return makeListBuilder([post]);
+      if (table === "forum_user_profiles") return makeListBuilder([]);
+      return makeSingleBuilder(null, null);
+    });
+
+    const res = await GET(makeRequest("GET"), makeParams());
+    const data = await res.json();
+    expect(data.thread.is_own).toBe(true);
+    expect(data.posts[0].is_own).toBe(false);
+    expect(JSON.stringify(data)).not.toContain("author_id");
+  });
+
+  it("withholds author_profile for anonymous threads/posts so they can't be re-identified", async () => {
+    const thread = makeThread({ author_id: USER_ID, is_anonymous: true });
+    const post = {
+      id: "post-1",
+      author_id: USER_ID,
+      thread_id: THREAD_ID,
+      body: "A reply",
+      is_anonymous: true,
+      is_removed: false,
+      created_at: new Date().toISOString(),
+    };
+    const profile = { user_id: USER_ID, display_name: "Alice", reputation: 10, badge: null, is_moderator: false };
+
+    let callCount = 0;
+    mockAdminFrom.mockImplementation((table: string) => {
+      callCount++;
+      if (table === "forum_threads" && callCount === 1) return makeSingleBuilder(thread, null);
+      if (table === "forum_threads" && callCount === 2) {
+        return { update: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis() };
+      }
+      if (table === "forum_posts") return makeListBuilder([post]);
+      if (table === "forum_user_profiles") return makeListBuilder([profile]);
+      return makeSingleBuilder(null, null);
+    });
+
+    const res = await GET(makeRequest("GET"), makeParams());
+    const data = await res.json();
+    expect(data.thread.author_profile).toBeNull();
+    expect(data.posts[0].author_profile).toBeNull();
+    expect(JSON.stringify(data)).not.toContain("author_id");
   });
 
   it("returns 500 on unexpected error", async () => {

--- a/__tests__/api/community-threads.test.ts
+++ b/__tests__/api/community-threads.test.ts
@@ -119,6 +119,28 @@ describe("GET /api/community/threads", () => {
     expect(json.page).toBe(1);
   });
 
+  it("does NOT select or serialize author_id on the thread list (P1/P3 cross-user leak)", async () => {
+    const chain = makeGetChain({
+      // Simulate a row that still carries author_id in the fixture to prove the
+      // route never echoes it back even if present.
+      data: [{ ...SAMPLE_THREADS[0], author_id: "leaked-auth-uid" }],
+      error: null,
+      count: 1,
+    });
+    mockAdminFrom.mockReset();
+    mockAdminFrom.mockReturnValue(chain);
+
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+
+    // The select() column list must not request author_id.
+    const selectArg = (chain.select as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string;
+    expect(typeof selectArg).toBe("string");
+    expect(selectArg).not.toContain("author_id");
+    // Display label is still selected.
+    expect(selectArg).toContain("author_name");
+  });
+
   it("returns 404 when category slug is not found", async () => {
     // First call = category lookup → not found
     mockAdminFrom.mockReset();

--- a/app/api/community/threads/[id]/route.ts
+++ b/app/api/community/threads/[id]/route.ts
@@ -30,6 +30,46 @@ async function isModerator(userId: string, userEmail: string | undefined): Promi
   return data?.is_moderator === true;
 }
 
+// Author identity (author_id, a Supabase auth.uid) is fetched server-side to
+// build the profile lookup and ownership flags, but is NEVER serialized to the
+// client — shipping it deanonymises Investment Confessions authors on a
+// publicly readable endpoint. Mirrors the page-level fix in
+// app/community/[category]/[threadId]/page.tsx (commit 40e67487).
+type ThreadRow = {
+  id: string;
+  category_id: string;
+  author_id: string;
+  author_name: string | null;
+  title: string;
+  slug: string;
+  body: string;
+  thread_type: string;
+  is_anonymous: boolean;
+  is_pinned: boolean;
+  is_locked: boolean;
+  reply_count: number;
+  view_count: number;
+  vote_score: number;
+  last_reply_at: string | null;
+  created_at: string;
+  updated_at: string | null;
+};
+
+type PostRow = {
+  id: string;
+  thread_id: string;
+  parent_id: string | null;
+  author_id: string;
+  author_name: string | null;
+  body: string;
+  is_anonymous: boolean;
+  vote_score: number;
+  is_answer: boolean;
+  is_removed: boolean;
+  created_at: string;
+  updated_at: string | null;
+};
+
 export async function GET(
   _req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
@@ -38,17 +78,30 @@ export async function GET(
     const { id } = await params;
     const admin = createAdminClient();
 
-    // Fetch thread
-    const { data: thread, error: threadError } = await admin
+    // Resolve the viewer once (carries the user's cookie) so ownership can be
+    // computed server-side without ever sending author_id to the browser.
+    const supabase = await createClient();
+    const {
+      data: { user: viewer },
+    } = await supabase.auth.getUser();
+    const viewerId = viewer?.id ?? null;
+
+    // Fetch thread — explicit columns (no select("*")). author_id stays
+    // server-side only.
+    const { data: threadData, error: threadError } = await admin
       .from("forum_threads")
-      .select("*")
+      .select(
+        "id, category_id, author_id, author_name, title, slug, body, thread_type, is_anonymous, is_pinned, is_locked, reply_count, view_count, vote_score, last_reply_at, created_at, updated_at",
+      )
       .eq("id", id)
       .eq("is_removed", false)
       .single();
 
-    if (threadError || !thread) {
+    if (threadError || !threadData) {
       return NextResponse.json({ error: "Thread not found" }, { status: 404 });
     }
+
+    const thread = threadData as unknown as ThreadRow;
 
     // Increment view_count (fire-and-forget)
     void admin
@@ -56,10 +109,12 @@ export async function GET(
       .update({ view_count: (thread.view_count ?? 0) + 1 })
       .eq("id", id);
 
-    // Fetch posts for the thread
-    const { data: posts, error: postsError } = await admin
+    // Fetch posts for the thread — explicit columns, author_id server-side only.
+    const { data: postsData, error: postsError } = await admin
       .from("forum_posts")
-      .select("*")
+      .select(
+        "id, thread_id, parent_id, author_id, author_name, body, is_anonymous, vote_score, is_answer, is_removed, created_at, updated_at",
+      )
       .eq("thread_id", id)
       .eq("is_removed", false)
       .order("created_at", { ascending: true });
@@ -68,13 +123,13 @@ export async function GET(
       log.error("Failed to fetch posts", { error: postsError.message });
     }
 
+    const posts = (postsData as unknown as PostRow[] | null) ?? [];
+
     // Gather unique author IDs from thread + posts
     const authorIds = new Set<string>();
     authorIds.add(thread.author_id);
-    if (posts) {
-      for (const post of posts) {
-        authorIds.add(post.author_id);
-      }
+    for (const post of posts) {
+      authorIds.add(post.author_id);
     }
 
     // Fetch author profiles for reputation badges
@@ -90,12 +145,32 @@ export async function GET(
       }
     }
 
+    // Strip author_id before responding — the client receives only a
+    // per-row ownership boolean. For anonymous threads/posts, the author
+    // profile is withheld too so it can't be used to re-identify the author.
+    const { author_id: threadAuthorId, ...threadRest } = thread;
+    const threadPayload = {
+      ...threadRest,
+      author_profile: thread.is_anonymous
+        ? null
+        : profileMap[threadAuthorId] ?? null,
+      is_own: viewerId != null && threadAuthorId === viewerId,
+    };
+
+    const postsPayload = posts.map((post) => {
+      const { author_id: postAuthorId, ...postRest } = post;
+      return {
+        ...postRest,
+        author_profile: post.is_anonymous
+          ? null
+          : profileMap[postAuthorId] ?? null,
+        is_own: viewerId != null && postAuthorId === viewerId,
+      };
+    });
+
     return NextResponse.json({
-      thread: { ...thread, author_profile: profileMap[thread.author_id] || null },
-      posts: (posts || []).map((post) => ({
-        ...post,
-        author_profile: profileMap[post.author_id] || null,
-      })),
+      thread: threadPayload,
+      posts: postsPayload,
     });
   } catch {
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });

--- a/app/api/community/threads/[id]/route.ts
+++ b/app/api/community/threads/[id]/route.ts
@@ -145,6 +145,18 @@ export async function GET(
       }
     }
 
+    // Public author profile excludes the raw user_id (used only as the map key).
+    type ForumProfile = NonNullable<typeof profiles>[number];
+    const publicProfile = (p: ForumProfile | undefined) =>
+      p
+        ? {
+            display_name: p.display_name,
+            reputation: p.reputation,
+            badge: p.badge,
+            is_moderator: p.is_moderator,
+          }
+        : null;
+
     // Strip author_id before responding — the client receives only a
     // per-row ownership boolean. For anonymous threads/posts, the author
     // profile is withheld too so it can't be used to re-identify the author.
@@ -153,7 +165,7 @@ export async function GET(
       ...threadRest,
       author_profile: thread.is_anonymous
         ? null
-        : profileMap[threadAuthorId] ?? null,
+        : publicProfile(profileMap[threadAuthorId]),
       is_own: viewerId != null && threadAuthorId === viewerId,
     };
 
@@ -163,7 +175,7 @@ export async function GET(
         ...postRest,
         author_profile: post.is_anonymous
           ? null
-          : profileMap[postAuthorId] ?? null,
+          : publicProfile(profileMap[postAuthorId]),
         is_own: viewerId != null && postAuthorId === viewerId,
       };
     });

--- a/app/api/community/threads/route.ts
+++ b/app/api/community/threads/route.ts
@@ -57,10 +57,13 @@ export async function GET(req: NextRequest) {
       categoryId = cat.id;
     }
 
-    // Build the query
+    // Build the query — author_id (a Supabase auth.uid) is intentionally NOT
+    // selected: it must never reach the client on this publicly readable list,
+    // or it deanonymises Investment Confessions authors. author_name carries
+    // the display label ("Anonymous Investor" for anonymous threads).
     let query = supabase
       .from("forum_threads")
-      .select("id, category_id, author_id, author_name, title, slug, is_pinned, is_locked, reply_count, view_count, vote_score, last_reply_at, created_at", { count: "exact" })
+      .select("id, category_id, author_name, title, slug, is_pinned, is_locked, reply_count, view_count, vote_score, last_reply_at, created_at", { count: "exact" })
       .eq("is_removed", false);
 
     if (categoryId) {


### PR DESCRIPTION
GET `/api/community/threads/[id]` selected `forum_threads.*` and `forum_posts.*` and spread whole rows into the JSON response, shipping each author's Supabase `auth.uid` (plus raw `is_anonymous`) to anonymous callers on a publicly readable endpoint. GET `/api/community/threads` (list) explicitly selected `author_id` too. Both deanonymised Investment Confessions authors, contradicting the on-page anonymity guarantee.

Mirrors the merged page-level fix (40e67487):
- Detail GET: select explicit columns (author_id kept server-side only), resolve the viewer once via `supabase.auth.getUser()`, strip `author_id` before responding, derive a per-row `is_own` boolean server-side, and withhold the author profile for anonymous threads/posts so it can't be used to re-identify the author.
- List GET: drop `author_id` from the explicit column list; `author_name` still carries the display label.

Rows are cast to explicit row types before the `author_id` rest-spread to keep field access type-checking with a literal select string.

Tests: extended `__tests__/api/community-threads-id.test.ts` and `__tests__/api/community-threads.test.ts` to assert `author_id` (and raw auth UUIDs) are absent from both responses, that `is_own` is derived server-side, and that anonymous-author profiles are withheld.

Finding: P1/P3 cross-user — forum threads API serializes author_id (Tier A).