### PR TITLE
fix(account): preserve /account/holdings deep-link on logged-out redirect

### DIFF
--- a/__tests__/lib/portal-gate.test.ts
+++ b/__tests__/lib/portal-gate.test.ts
@@ -66,6 +66,19 @@ describe("enforcePortalKind", () => {
     expect(mockGetActiveKind).not.toHaveBeenCalled();
   });
 
+  it("preserves the actual requested deep-link path in next= when given (Campaign 3 P3)", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    await expect(
+      enforcePortalKind("investor", "/account/holdings"),
+    ).rejects.toThrow(/REDIRECT/);
+    // Without the requestedPath arg the gate would default to /account and drop
+    // the /account/holdings deep-link before the page's own redirect can run.
+    expect(mockRedirect).toHaveBeenCalledWith(
+      `/auth/login?next=${encodeURIComponent("/account/holdings")}`,
+    );
+    expect(mockGetActiveKind).not.toHaveBeenCalled();
+  });
+
   it("allows the happy path (active matches + holds the kind)", async () => {
     mockGetActiveKind.mockResolvedValue("investor");
     mockGetKindsForUser.mockResolvedValue([{ kind: "investor" }]);

--- a/app/account/holdings/page.tsx
+++ b/app/account/holdings/page.tsx
@@ -19,7 +19,10 @@ export default async function HoldingsPage() {
   // advisor in advisor workspace navigating here gets redirected back to
   // /account/select-workspace. RLS already isolates by auth.uid(); the
   // gate just makes the workspace promise visible at the UX layer.
-  await enforcePortalKind("investor");
+  // Pass the actual route so a logged-out deep-link to /account/holdings is
+  // preserved in next= (the gate would otherwise default to /account, dropping
+  // the deep-link before this page's own getUser/redirect below ever runs).
+  await enforcePortalKind("investor", "/account/holdings");
 
   const supabase = await createClient();
   const {

--- a/lib/portal-gate.ts
+++ b/lib/portal-gate.ts
@@ -58,11 +58,25 @@ async function bestEffortSetActiveKind(kind: WorkspaceKind): Promise<void> {
   }
 }
 
-export async function enforcePortalKind(expected: WorkspaceKind): Promise<void> {
+/**
+ * @param expected      the workspace kind this portal/page belongs to.
+ * @param requestedPath the ACTUAL path the visitor asked for. Used only to
+ *   build the `next=` deep-link on the unauthenticated → /auth/login redirect,
+ *   so a logged-out visitor to e.g. `/account/holdings` lands back on holdings
+ *   after sign-in instead of the workspace root. When omitted, falls back to
+ *   the portal root (`currentPortalPath(expected)`) — the prior behaviour, so
+ *   every existing caller is unchanged. Pass the page's own route here on
+ *   deep-linkable sub-pages (Campaign 3 P3).
+ */
+export async function enforcePortalKind(
+  expected: WorkspaceKind,
+  requestedPath?: string,
+): Promise<void> {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) {
-    redirect(`/auth/login?next=${encodeURIComponent(currentPortalPath(expected))}`);
+    const next = requestedPath ?? currentPortalPath(expected);
+    redirect(`/auth/login?next=${encodeURIComponent(next)}`);
   }
 
   const [active, memberships] = await Promise.all([


### PR DESCRIPTION
## What

A logged-out visitor to `/account/holdings` was redirected to `/auth/login?next=/account` (workspace root), losing the deep-link — after sign-in they landed on `/account` instead of `/account/holdings`.

## Why

`enforcePortalKind("investor")` runs at the top of the holdings page, before the page's own `getUser()`/`redirect("/auth/login?next=/account/holdings")`. For an unauthenticated user the gate redirected first, building `next=` from `currentPortalPath("investor")` = `/account`, so the page's correct deep-link redirect never ran.

## Fix

`enforcePortalKind` gains an optional `requestedPath` arg used only for the unauthenticated → `/auth/login` `next=` target. It defaults to the portal root (`currentPortalPath(expected)`), so every existing caller and every other portal is unchanged. The holdings page passes its own route.

## Test

Added a focused case to `__tests__/lib/portal-gate.test.ts` asserting the deep-link path is preserved in `next=`. Full file: 9/9 passing. ESLint clean (`--max-warnings 0`).