### PR TITLE
fix(marketplace): stop invoice API leaking raw Stripe ids + scope getPlanById by owner

### DIFF
--- a/__tests__/api/marketplace-invoice-id.test.ts
+++ b/__tests__/api/marketplace-invoice-id.test.ts
@@ -84,6 +84,48 @@ describe("GET /api/marketplace/invoice/[id]", () => {
     const res = await GET(req, { params });
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.invoice).toEqual(invoice);
+    expect(body.invoice).toMatchObject(invoice);
+    expect(body.invoice.stripe_payment_reference).toBeNull();
+  });
+
+  it("never exposes raw payment-processor ids; derives a truncated reference", async () => {
+    const longIntent = "pi_" + "x".repeat(40);
+    const invoice = {
+      id: 7,
+      broker_slug: "broker-a",
+      amount_cents: 5000,
+      stripe_payment_intent_id: longIntent,
+      stripe_checkout_session_id: "cs_secret_should_never_appear",
+    };
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+    mockAdminFrom
+      .mockReturnValueOnce(makeAccountBuilder({ broker_slug: "broker-a" }))
+      .mockReturnValueOnce(makeInvoiceBuilder(invoice));
+    const { req, params } = makeRequest("7");
+    const res = await GET(req, { params });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // Raw processor ids must not be present anywhere in the payload.
+    expect(body.invoice.stripe_payment_intent_id).toBeUndefined();
+    expect(body.invoice.stripe_checkout_session_id).toBeUndefined();
+    expect(JSON.stringify(body)).not.toContain(longIntent);
+    expect(JSON.stringify(body)).not.toContain("cs_secret_should_never_appear");
+    // Display-only truncated reference is derived (24 chars + ellipsis).
+    expect(body.invoice.stripe_payment_reference).toBe(
+      `${longIntent.slice(0, 24)}...`,
+    );
+  });
+
+  it("requests an explicit column list (not select *)", async () => {
+    const invoiceBuilder = makeInvoiceBuilder({ id: 5, broker_slug: "broker-a" });
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+    mockAdminFrom
+      .mockReturnValueOnce(makeAccountBuilder({ broker_slug: "broker-a" }))
+      .mockReturnValueOnce(invoiceBuilder);
+    const { req, params } = makeRequest("5");
+    await GET(req, { params });
+    const selectArg = invoiceBuilder.select.mock.calls[0]?.[0] as string;
+    expect(selectArg).not.toBe("*");
+    expect(selectArg).not.toContain("stripe_checkout_session_id");
   });
 });

--- a/__tests__/app/account-plan-detail-page.test.tsx
+++ b/__tests__/app/account-plan-detail-page.test.tsx
@@ -106,6 +106,6 @@ describe("account plans/[id] auth ordering", () => {
 
     await expect(renderPage("42")).rejects.toThrow("NOT_FOUND");
     expect(mockRedirect).not.toHaveBeenCalled();
-    expect(mockGetPlanById).toHaveBeenCalledWith(42);
+    expect(mockGetPlanById).toHaveBeenCalledWith(42, VIEWER_UUID);
   });
 });

--- a/__tests__/lib/getmatched/action-plans-get-by-id.test.ts
+++ b/__tests__/lib/getmatched/action-plans-get-by-id.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// getPlanById uses the admin client (RLS bypass). Ownership is enforced by the
+// caller, so the privileged owner read MUST scope the query by auth_user_id.
+// These tests assert the query carries (or omits) that filter correctly.
+
+const { mockFrom, mockCreateAdminClient } = vi.hoisted(() => {
+  const mockFrom = vi.fn();
+  return {
+    mockFrom,
+    mockCreateAdminClient: vi.fn(() => ({ from: mockFrom })),
+  };
+});
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: mockCreateAdminClient,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+}));
+
+import { getPlanById } from "@/lib/getmatched/action-plans";
+
+interface EqCall {
+  col: string;
+  val: unknown;
+}
+
+function makeBuilder(row: unknown) {
+  const eqCalls: EqCall[] = [];
+  const builder = {
+    eqCalls,
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn((col: string, val: unknown) => {
+      eqCalls.push({ col, val });
+      return builder;
+    }),
+    maybeSingle: vi.fn(() => Promise.resolve({ data: row })),
+  };
+  return builder;
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("getPlanById", () => {
+  it("scopes the query by auth_user_id when authUserId is provided", async () => {
+    const builder = makeBuilder({ id: 5, auth_user_id: "owner-1" });
+    mockFrom.mockReturnValue(builder);
+
+    const plan = await getPlanById(5, "owner-1");
+
+    expect(plan).toEqual({ id: 5, auth_user_id: "owner-1" });
+    expect(builder.eqCalls).toContainEqual({ col: "id", val: 5 });
+    expect(builder.eqCalls).toContainEqual({
+      col: "auth_user_id",
+      val: "owner-1",
+    });
+  });
+
+  it("does not add an auth_user_id filter for anonymous / draft reads", async () => {
+    const builder = makeBuilder({ id: 9, auth_user_id: null });
+    mockFrom.mockReturnValue(builder);
+
+    await getPlanById(9);
+
+    expect(builder.eqCalls).toContainEqual({ col: "id", val: 9 });
+    expect(builder.eqCalls.some((c) => c.col === "auth_user_id")).toBe(false);
+  });
+
+  it("returns null when the scoped read matches no row (other user's plan)", async () => {
+    const builder = makeBuilder(null);
+    mockFrom.mockReturnValue(builder);
+
+    const plan = await getPlanById(5, "not-the-owner");
+
+    expect(plan).toBeNull();
+    expect(builder.eqCalls).toContainEqual({
+      col: "auth_user_id",
+      val: "not-the-owner",
+    });
+  });
+});

--- a/app/account/plans/[id]/page.tsx
+++ b/app/account/plans/[id]/page.tsx
@@ -37,7 +37,7 @@ export default async function MyPlanDetailPage({
   const planId = Number(id);
   if (!Number.isFinite(planId)) notFound();
 
-  const plan = await getPlanById(planId);
+  const plan = await getPlanById(planId, user.id);
   if (!plan || plan.auth_user_id !== user.id) notFound();
 
   const template = plan.route

--- a/app/api/marketplace/invoice/[id]/route.ts
+++ b/app/api/marketplace/invoice/[id]/route.ts
@@ -49,10 +49,15 @@ export async function GET(
     return NextResponse.json({ error: "No broker account" }, { status: 403 });
   }
 
-  // Get invoice (only if belongs to this broker)
+  // Get invoice (only if belongs to this broker).
+  // Explicit column list — never select the raw payment-processor identifiers
+  // (`stripe_payment_intent_id`, `stripe_checkout_session_id`). A truncated,
+  // display-only payment reference is derived server-side below.
   const { data: invoice, error } = await supabase
     .from("marketplace_invoices")
-    .select("*")
+    .select(
+      "id, broker_slug, type, amount_cents, currency, status, invoice_number, description, line_items, subtotal_cents, tax_cents, paid_at, broker_email, broker_company_name, broker_abn, created_at, stripe_payment_intent_id",
+    )
     .eq("id", invoiceId)
     .eq("broker_slug", account.broker_slug)
     .maybeSingle();
@@ -61,5 +66,21 @@ export async function GET(
     return NextResponse.json({ error: "Invoice not found" }, { status: 404 });
   }
 
-  return NextResponse.json({ invoice });
+  // Defensively strip any raw payment-processor identifiers; expose only a
+  // truncated, display-only reference. (The .select() above already omits
+  // stripe_checkout_session_id — this guards against the column list drifting.)
+  const {
+    stripe_payment_intent_id,
+    stripe_checkout_session_id: _omitSession,
+    ...safeInvoice
+  } = invoice as typeof invoice & { stripe_checkout_session_id?: string };
+  const stripe_payment_reference = stripe_payment_intent_id
+    ? stripe_payment_intent_id.length > 24
+      ? `${stripe_payment_intent_id.slice(0, 24)}...`
+      : stripe_payment_intent_id
+    : null;
+
+  return NextResponse.json({
+    invoice: { ...safeInvoice, stripe_payment_reference },
+  });
 }

--- a/app/broker-portal/invoices/[id]/page.tsx
+++ b/app/broker-portal/invoices/[id]/page.tsx
@@ -23,7 +23,9 @@ interface Invoice {
   tax_cents: number;
   amount_cents: number;
   status: "paid" | "pending" | "failed" | "refunded";
-  stripe_payment_intent_id: string | null;
+  // Server-derived, display-only truncated reference. The raw
+  // stripe_payment_intent_id is never sent to the client.
+  stripe_payment_reference: string | null;
 }
 
 export default function InvoiceDetailPage() {
@@ -117,11 +119,7 @@ export default function InvoiceDetailPage() {
     );
   };
 
-  const truncatedStripeId = invoice.stripe_payment_intent_id
-    ? invoice.stripe_payment_intent_id.length > 24
-      ? `${invoice.stripe_payment_intent_id.slice(0, 24)}...`
-      : invoice.stripe_payment_intent_id
-    : null;
+  const truncatedStripeId = invoice.stripe_payment_reference;
 
   return (
     <div className="space-y-6">

--- a/lib/getmatched/action-plans.ts
+++ b/lib/getmatched/action-plans.ts
@@ -57,13 +57,29 @@ export async function createPlan(input: CreatePlanInput): Promise<ActionPlan> {
   return data as ActionPlan;
 }
 
-export async function getPlanById(id: number): Promise<ActionPlan | null> {
+/**
+ * Fetch a plan by id.
+ *
+ * Pass `authUserId` to scope the read to the owning user — the query then only
+ * matches rows whose `auth_user_id` equals the caller, so the admin client
+ * (RLS bypass) cannot return another user's plan even if the id is guessed.
+ * Owner-facing read paths (e.g. `/account/plans/[id]`) MUST pass it. Anonymous
+ * / draft flows that legitimately operate on session-keyed rows with a null
+ * owner omit it and keep their existing behaviour.
+ */
+export async function getPlanById(
+  id: number,
+  authUserId?: string,
+): Promise<ActionPlan | null> {
   const admin = createAdminClient();
-  const { data } = await admin
+  let query = admin
     .from("get_matched_action_plans")
     .select("*")
-    .eq("id", id)
-    .maybeSingle();
+    .eq("id", id);
+  if (authUserId) {
+    query = query.eq("auth_user_id", authUserId);
+  }
+  const { data } = await query.maybeSingle();
   return (data as ActionPlan) ?? null;
 }
 


### PR DESCRIPTION
Two distinct access-control fixes.

**1. `app/api/marketplace/invoice/[id]/route.ts` — data exposure.** The handler selected `*` from `marketplace_invoices`, returning the raw `stripe_payment_intent_id` to the client (and the row also carries `stripe_checkout_session_id`). Replaced with an explicit column literal that omits the checkout-session id, then derive a truncated, display-only `stripe_payment_reference` server-side — matching exactly what the broker-portal page already rendered — and never emit the raw intent id. The raw intent id is still selected only to build the truncated reference, then destructured out. The consumer page (`app/broker-portal/invoices/[id]/page.tsx`) now reads the derived reference field.

**2. `lib/getmatched/action-plans.ts` `getPlanById` — RLS-bypass scoping.** Used the admin client keyed by `id` alone, with ownership enforced only in the caller. Added an optional `authUserId` argument that scopes the query by `auth_user_id`, so a guessed id cannot return another user's plan even though the admin client bypasses RLS. The owner-facing `/account/plans/[id]` page now passes `user.id`. Anonymous/draft flows that legitimately operate on session-keyed rows with a null owner omit the argument and keep their existing behaviour.

Tests: extended `__tests__/api/marketplace-invoice-id.test.ts` (asserts raw processor ids never appear in the payload and the select is not `*`); added `__tests__/lib/getmatched/action-plans-get-by-id.test.ts` (asserts the `auth_user_id` filter is applied when scoped and omitted otherwise). No migrations.