### PR TITLE
fix(brokers): stop leaking internal commercial fields to client

### DIFF
--- a/__tests__/lib/request-cache.test.ts
+++ b/__tests__/lib/request-cache.test.ts
@@ -62,7 +62,9 @@ import {
   getArticleBySlug,
   getProfessionalBySlug,
   getCurrentUser,
+  stripInternalBrokerFields,
 } from "@/lib/request-cache";
+import type { Broker } from "@/lib/types";
 
 describe("request-cache helpers", () => {
   beforeEach(() => {
@@ -96,6 +98,69 @@ describe("request-cache helpers", () => {
       expect(call?.table).toBe("brokers");
       expect(call?.filters).toContainEqual({ col: "slug", val: "stake-unique-2" });
       expect(call?.filters).toContainEqual({ col: "status", val: "active" });
+    });
+
+    it("strips internal commercial/affiliate-economics fields from the returned row", async () => {
+      brokerData = {
+        id: 1,
+        slug: "stake",
+        name: "Stake",
+        rating: 4.5,
+        // internal commercial fields that must NOT reach the client
+        cpa_value: 400,
+        monthly_sponsorship_fee: 1500,
+        affiliate_priority: "high",
+        commission_type: "cpa",
+        commission_value: 400,
+        estimated_epc: 12.5,
+        promoted_placement: true,
+      };
+      const res = (await getBrokerBySlug("stake-strip-1")) as unknown as Record<string, unknown>;
+      expect(res).not.toBeNull();
+      // public fields survive
+      expect(res.id).toBe(1);
+      expect(res.name).toBe("Stake");
+      expect(res.rating).toBe(4.5);
+      // commercial fields are gone
+      for (const field of [
+        "cpa_value",
+        "monthly_sponsorship_fee",
+        "affiliate_priority",
+        "commission_type",
+        "commission_value",
+        "estimated_epc",
+        "promoted_placement",
+      ]) {
+        expect(res).not.toHaveProperty(field);
+      }
+      // and they are absent from the JSON that gets serialised to the client
+      const serialised = JSON.stringify(res);
+      expect(serialised).not.toContain("cpa_value");
+      expect(serialised).not.toContain("sponsorship_fee");
+      expect(serialised).not.toContain("affiliate_priority");
+    });
+  });
+
+  describe("stripInternalBrokerFields", () => {
+    it("removes commercial fields without mutating the original", () => {
+      const original = {
+        id: 2,
+        slug: "ig",
+        name: "IG",
+        cpa_value: 250,
+        affiliate_priority: "medium",
+        monthly_sponsorship_fee: 0,
+      } as unknown as Broker;
+      const cleaned = stripInternalBrokerFields(original);
+      // original retained for server-side ranking/sponsorship use
+      expect(original.cpa_value).toBe(250);
+      expect(original.affiliate_priority).toBe("medium");
+      // cleaned shape is client-safe
+      expect(cleaned).not.toHaveProperty("cpa_value");
+      expect(cleaned).not.toHaveProperty("affiliate_priority");
+      expect(cleaned).not.toHaveProperty("monthly_sponsorship_fee");
+      expect(cleaned.id).toBe(2);
+      expect(cleaned.name).toBe("IG");
     });
   });
 

--- a/lib/request-cache.ts
+++ b/lib/request-cache.ts
@@ -26,10 +26,53 @@ import { createClient } from "@/lib/supabase/server";
 import type { Broker, Article } from "@/lib/types";
 
 /**
+ * Internal commercial / affiliate-economics columns that must never
+ * reach the browser. These are paid-placement and revenue figures
+ * (CPA, sponsorship fees, EPC, affiliate ranking weight) — useful only
+ * for server-side ranking/sponsorship logic, which fetches them via
+ * its own dedicated queries (lib/cached-data.ts, lib/compare-engine.ts,
+ * the admin pages, exit-match, submit-lead). The broker-detail consumers
+ * of `getBrokerBySlug` (page header, similar brokers, compare/versus,
+ * changelog) never read them, so we strip them here before the row is
+ * serialised into the RSC payload / passed to client components.
+ *
+ * Bot exposure sweep: a `select("*")` was leaking these to the client.
+ */
+const INTERNAL_BROKER_COMMERCIAL_FIELDS = [
+  "cpa_value",
+  "affiliate_priority",
+  "monthly_sponsorship_fee",
+  "commission_type",
+  "commission_value",
+  "estimated_epc",
+  "promoted_placement",
+] as const satisfies readonly (keyof Broker)[];
+
+/**
+ * Removes internal commercial/affiliate-economics fields from a broker
+ * row so it is safe to serialise to the client. Server-side ranking and
+ * sponsorship logic must read those columns from their own queries, not
+ * from this client-facing shape.
+ */
+export function stripInternalBrokerFields(broker: Broker): Broker {
+  const cleaned = { ...broker };
+  for (const field of INTERNAL_BROKER_COMMERCIAL_FIELDS) {
+    delete cleaned[field];
+  }
+  return cleaned;
+}
+
+/**
  * Memoised broker fetch by slug (with reviewer join).
  * Use on /broker/[slug] routes where the metadata, page header,
  * similar-brokers section, and nested components all want the
  * same broker row.
+ *
+ * Internal commercial fields (CPA, sponsorship fee, affiliate priority,
+ * commission, EPC, promoted-placement) are stripped before returning —
+ * this row is passed straight into client components, and those fields
+ * must not reach the browser. Ranking/sponsorship logic reads them via
+ * its own server-only queries.
  */
 export const getBrokerBySlug = cache(async (slug: string): Promise<Broker | null> => {
   const supabase = await createClient();
@@ -39,7 +82,8 @@ export const getBrokerBySlug = cache(async (slug: string): Promise<Broker | null
     .eq("slug", slug)
     .eq("status", "active")
     .maybeSingle();
-  return (data as Broker | null) || null;
+  if (!data) return null;
+  return stripInternalBrokerFields(data as Broker);
 });
 
 /**


### PR DESCRIPTION
## What

The broker-detail page (`app/broker/[slug]/page.tsx`) passes the full broker row returned by `getBrokerBySlug` (`lib/request-cache.ts`) straight into the `BrokerReviewClient` client component, which serialises every column into the RSC payload. The query used `select("*")`, so internal commercial / affiliate-economics fields were exposed to the browser:

- `cpa_value`
- `monthly_sponsorship_fee` (the "sponsorship_fee" in the finding)
- `affiliate_priority`
- `commission_type`, `commission_value`, `estimated_epc`, `promoted_placement` (sibling internal fields spotted in `lib/types.ts`)

Flagged by the bot exposure sweep.

## Fix

`getBrokerBySlug` now strips these fields server-side (via a new `stripInternalBrokerFields` helper) before the row is forwarded to client components.

Server-side ranking/sponsorship logic is **unaffected** — it reads these columns from its own dedicated queries (`lib/cached-data.ts`, `lib/compare-engine.ts`, the admin pages, `exit-match`, `submit-lead`, the revenue-refresh cron), none of which route through this React-`cache()` helper. The only consumers of `getBrokerBySlug` (broker detail page, its changelog, and compare/versus) never read the commercial fields.

## Verify

- `npx vitest run __tests__/lib/request-cache.test.ts` → 11 passed (added a focused test asserting the commercial fields are absent from the returned shape and its serialised JSON, plus a unit test for `stripInternalBrokerFields`).
- `npx eslint --fix` on changed files → clean (`--max-warnings 0`).
- `tsc --noEmit` full project → 0 errors.

Tier B (data-exposure fix, non-money/non-compliance; additive test + narrow lib change).