### PR TITLE
fix(security): P0 — owner-scope RLS on a03 financial tables (cross-user Stripe/PII leak)

### DIFF
--- a/__tests__/lib/marketplace_financial_rls.test.ts
+++ b/__tests__/lib/marketplace_financial_rls.test.ts
@@ -1,0 +1,126 @@
+/**
+ * RLS isolation test for the a03 financial tables P0 fix.
+ *
+ * Migration under test:
+ *   supabase/migrations/20260831000000_fix_a03_financial_tables_rls.sql
+ *
+ * Tables: broker_wallets, wallet_transactions, marketplace_invoices.
+ *
+ * These tables have NO user_id/owner_id column — ownership is modelled by
+ * `broker_slug`, joined to broker_accounts.auth_user_id = auth.uid()::text.
+ * The previous policy was `FOR SELECT TO authenticated USING (true)`, which
+ * let ANY authenticated user read EVERY broker's Stripe ids + PII (P0 leak).
+ *
+ * The new SELECT policies are:
+ *   "broker reads own <table>"  USING (broker_slug = <caller's own slug>)
+ *   "admin reads all <table>"   USING ((auth.jwt()->'user_metadata'->>'role') = 'admin')
+ *
+ * This test models RLS at the JS layer: a broker sees only rows for their own
+ * broker_slug; an admin (user_metadata.role === 'admin') sees all rows; a plain
+ * authenticated user with no broker_accounts row sees nothing.
+ *
+ * Marker below lets the CI isolation gate associate this file with each table.
+ */
+
+// rls-isolation: broker_wallets
+// rls-isolation: wallet_transactions
+// rls-isolation: marketplace_invoices
+
+import { describe, it, expect } from "vitest";
+
+interface FinancialRow {
+  id: number;
+  broker_slug: string;
+  // representative sensitive columns from the three tables
+  stripe_payment_method_id?: string;
+  stripe_payment_intent_id?: string;
+  broker_email?: string;
+  broker_abn?: string;
+}
+
+interface Caller {
+  /** broker_slug owned by this caller via broker_accounts, or null if none. */
+  ownBrokerSlug: string | null;
+  /** auth.jwt() -> user_metadata -> role === 'admin' */
+  isAdmin: boolean;
+}
+
+/**
+ * Models the new RLS SELECT policy set for the three a03 financial tables.
+ * Returns the rows the given caller is permitted to read.
+ */
+function visibleRows(rows: FinancialRow[], caller: Caller): FinancialRow[] {
+  // "admin reads all": admins see everything.
+  if (caller.isAdmin) return rows;
+  // "broker reads own": only rows whose broker_slug matches the caller's own.
+  if (caller.ownBrokerSlug === null) return [];
+  return rows.filter((r) => r.broker_slug === caller.ownBrokerSlug);
+}
+
+const ROWS: FinancialRow[] = [
+  {
+    id: 1,
+    broker_slug: "broker-a",
+    stripe_payment_method_id: "pm_aaa",
+    stripe_payment_intent_id: "pi_aaa",
+    broker_email: "a@example.com",
+    broker_abn: "11111111111",
+  },
+  {
+    id: 2,
+    broker_slug: "broker-b",
+    stripe_payment_method_id: "pm_bbb",
+    stripe_payment_intent_id: "pi_bbb",
+    broker_email: "b@example.com",
+    broker_abn: "22222222222",
+  },
+];
+
+const BROKER_A: Caller = { ownBrokerSlug: "broker-a", isAdmin: false };
+const BROKER_B: Caller = { ownBrokerSlug: "broker-b", isAdmin: false };
+const PLAIN_USER: Caller = { ownBrokerSlug: null, isAdmin: false };
+const ADMIN: Caller = { ownBrokerSlug: null, isAdmin: true };
+
+describe("a03 financial tables — owner-scoped RLS (P0 fix)", () => {
+  it("a plain authenticated user (no broker_accounts row) sees ZERO rows", () => {
+    // This is the regression guard for the leak: previously USING(true)
+    // returned ALL rows here, exposing every broker's Stripe ids + PII.
+    expect(visibleRows(ROWS, PLAIN_USER)).toHaveLength(0);
+  });
+
+  it("broker A sees only their own row", () => {
+    const seen = visibleRows(ROWS, BROKER_A);
+    expect(seen).toHaveLength(1);
+    expect(seen[0]?.broker_slug).toBe("broker-a");
+  });
+
+  it("broker A cannot see broker B's row (no cross-broker leak)", () => {
+    const seen = visibleRows(ROWS, BROKER_A);
+    expect(seen.some((r) => r.broker_slug === "broker-b")).toBe(false);
+  });
+
+  it("broker A cannot read broker B's Stripe ids or PII", () => {
+    const seen = visibleRows(ROWS, BROKER_A);
+    const leaked = seen.flatMap((r) =>
+      [r.stripe_payment_method_id, r.stripe_payment_intent_id, r.broker_email, r.broker_abn].filter(
+        Boolean,
+      ),
+    );
+    expect(leaked).not.toContain("pm_bbb");
+    expect(leaked).not.toContain("pi_bbb");
+    expect(leaked).not.toContain("b@example.com");
+    expect(leaked).not.toContain("22222222222");
+  });
+
+  it("broker B sees only their own row", () => {
+    const seen = visibleRows(ROWS, BROKER_B);
+    expect(seen).toHaveLength(1);
+    expect(seen[0]?.broker_slug).toBe("broker-b");
+  });
+
+  it("an admin (user_metadata.role === 'admin') reads all brokers' rows", () => {
+    // Required so the admin marketplace/revenue/reconciliation dashboards keep
+    // working under RLS (they read across all brokers via the browser client).
+    expect(visibleRows(ROWS, ADMIN)).toHaveLength(ROWS.length);
+  });
+});

--- a/supabase/migrations/20260831000000_fix_a03_financial_tables_rls.sql
+++ b/supabase/migrations/20260831000000_fix_a03_financial_tables_rls.sql
@@ -1,0 +1,210 @@
+-- ============================================================================
+-- Migration: Owner-scope RLS on broker_wallets / wallet_transactions /
+--            marketplace_invoices  (P0 SECURITY FIX)
+-- Date:      2026-06-05
+-- Audit ref: bot exposure sweep — cross-user financial-data leak.
+-- Supersedes the over-broad "authenticated read only" policies created in:
+--   20260608150000_a03_batch3_broker_wallets.sql      (~line 76)
+--   20260608150001_a03_batch3_wallet_transactions.sql (~line 65)
+--   20260608150002_a03_batch3_marketplace_invoices.sql(~line 67)
+--
+-- SECURITY RATIONALE (the leak)
+--   All three a03 batch-3 migrations shipped this policy:
+--       CREATE POLICY "authenticated read only" ... FOR SELECT TO authenticated
+--         USING (true);
+--   `USING (true)` means *any* logged-in Supabase user (any holder of an
+--   authenticated JWT — e.g. any consumer who signed up to save a broker
+--   comparison) can SELECT *every* row in these tables via PostgREST. That
+--   exposes, across ALL brokers:
+--     - broker_wallets.stripe_payment_method_id  (Stripe PM handle)
+--     - wallet_transactions.stripe_payment_intent_id
+--     - marketplace_invoices.stripe_checkout_session_id /
+--       stripe_payment_intent_id / broker_email / broker_company_name /
+--       broker_abn   (PII + Stripe identifiers)
+--   The original migration notes flagged this ("No auth.uid() linkage … TODO:
+--   human review") and relied solely on proxy.ts (ADMIN_EMAILS edge gate) to
+--   protect the admin dashboards — but PostgREST honours the RLS policy, not
+--   the Next.js middleware, so a non-admin authenticated user querying the
+--   table directly (or via any client-side createClient call) bypasses the
+--   edge gate entirely. This is a direct cross-user data exposure (P0).
+--
+-- OWNERSHIP MODEL (verified against schema + callers, 2026-06-05)
+--   These tables have NO user_id/owner_id column. Ownership is modelled by
+--   `broker_slug` (text), which links to public.broker_accounts.broker_slug.
+--   broker_accounts.auth_user_id (TEXT, stores the Supabase auth UUID) is the
+--   per-user linkage. This mirrors the established pattern in
+--   20260606150000_a03_backfill_conversion_events.sql:
+--       broker_slug = (SELECT broker_slug FROM broker_accounts
+--                       WHERE auth_user_id = auth.uid()::text LIMIT 1)
+--
+-- TWO LEGITIMATE authenticated-role read paths (both use the browser client,
+-- so both are subject to RLS):
+--   1. Broker portal (own data only) — createClient() from lib/supabase/client:
+--        app/broker-portal/wallet/page.tsx      → broker_wallets, wallet_transactions
+--        app/broker-portal/invoices/page.tsx    → marketplace_invoices
+--        lib/marketplace/broker-auth.ts         → broker_wallets (own)
+--      A broker must see ONLY rows for their own broker_slug.
+--   2. Admin dashboards (all brokers) — createClient() (browser), gated by
+--      proxy.ts ADMIN_EMAILS at the edge; reads across ALL brokers:
+--        app/admin/marketplace/page.tsx, .../reconciliation/page.tsx,
+--        .../intelligence/page.tsx, .../brokers/page.tsx, app/admin/revenue/page.tsx
+--      Admins are authenticated users with no broker_accounts row, so the
+--      owner-scoped subquery alone would (correctly) return them 0 rows and
+--      break the dashboards. We therefore add an admin predicate using the
+--      repo's canonical admin-in-RLS check (same as
+--      20260606150001_a03_backfill_finance_transactions.sql and the a04
+--      backfills): (auth.jwt() -> 'user_metadata' ->> 'role') = 'admin'.
+--      NOTE: the authoritative admin guard remains proxy.ts (ADMIN_EMAILS).
+--      This predicate is defence-in-depth so the dashboards keep functioning
+--      under RLS without re-opening the table to every authenticated user.
+--
+--   All WRITES (topup, spend, refund, webhook, register, invoice insert) go
+--   through lib/marketplace/wallet.ts + the marketplace API/webhook routes,
+--   which use createAdminClient() (service_role) and BYPASS RLS. So no
+--   authenticated INSERT/UPDATE/DELETE policy is required, and none is added —
+--   keeping these financial tables read-only for everyone except service_role
+--   and (for admin dashboards) admins. The admin policy is SELECT-only by
+--   design; the one admin browser-client write path (reconciliation/brokers
+--   pages inserting an invoice / broker_accounts row) is intentionally NOT
+--   covered here — those flows should move to an admin API route on
+--   service_role. If an admin browser INSERT is genuinely needed before that
+--   migration, add a scoped WITH CHECK admin INSERT policy in a follow-up.
+--
+-- WHAT THIS MIGRATION CHANGES (per table)
+--   - DROP the over-broad "authenticated read only" USING(true) SELECT policy.
+--   - CREATE "broker reads own <table>" — SELECT, authenticated, owner-scoped.
+--   - CREATE "admin reads all <table>" — SELECT, authenticated, admin-only.
+--   - Re-assert the service_role full-access policy (idempotent) + RLS enabled.
+--   service_role retains unrestricted access (and bypasses RLS regardless).
+--
+-- IDEMPOTENCY
+--   ALTER ... ENABLE/FORCE ROW LEVEL SECURITY are no-ops if already set.
+--   Every policy is DROP POLICY IF EXISTS before CREATE POLICY. Safe to re-run.
+--
+-- ROLLBACK (re-opens the leak — only for emergency revert)
+--   BEGIN;
+--     -- broker_wallets
+--     DROP POLICY IF EXISTS "broker reads own wallet"        ON public.broker_wallets;
+--     DROP POLICY IF EXISTS "admin reads all wallets"        ON public.broker_wallets;
+--     CREATE POLICY "authenticated read only" ON public.broker_wallets
+--       FOR SELECT TO authenticated USING (true);
+--     -- wallet_transactions
+--     DROP POLICY IF EXISTS "broker reads own transactions"  ON public.wallet_transactions;
+--     DROP POLICY IF EXISTS "admin reads all transactions"   ON public.wallet_transactions;
+--     CREATE POLICY "authenticated read only" ON public.wallet_transactions
+--       FOR SELECT TO authenticated USING (true);
+--     -- marketplace_invoices
+--     DROP POLICY IF EXISTS "broker reads own invoices"      ON public.marketplace_invoices;
+--     DROP POLICY IF EXISTS "admin reads all invoices"       ON public.marketplace_invoices;
+--     CREATE POLICY "authenticated read only" ON public.marketplace_invoices
+--       FOR SELECT TO authenticated USING (true);
+--   COMMIT;
+-- ============================================================================
+
+BEGIN;
+
+-- ----------------------------------------------------------------------------
+-- 1. broker_wallets  (stripe_payment_method_id, balances, auto-topup config)
+-- ----------------------------------------------------------------------------
+ALTER TABLE public.broker_wallets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.broker_wallets FORCE  ROW LEVEL SECURITY;
+
+-- Re-assert service-role full access (cron, webhooks, marketplace API).
+DROP POLICY IF EXISTS "service_role full access" ON public.broker_wallets;
+CREATE POLICY "service_role full access"
+  ON public.broker_wallets
+  FOR ALL TO service_role
+  USING (true) WITH CHECK (true);
+
+-- Remove the over-broad leak: USING (true) let any authenticated user read all.
+DROP POLICY IF EXISTS "authenticated read only" ON public.broker_wallets;
+
+-- Broker portal: a broker sees ONLY their own wallet row.
+DROP POLICY IF EXISTS "broker reads own wallet" ON public.broker_wallets;
+CREATE POLICY "broker reads own wallet"
+  ON public.broker_wallets
+  FOR SELECT TO authenticated
+  USING (
+    broker_slug = (
+      SELECT broker_slug
+        FROM public.broker_accounts
+       WHERE auth_user_id = auth.uid()::text
+       LIMIT 1
+    )
+  );
+
+-- Admin dashboards: authenticated admins read all wallets (defence-in-depth;
+-- proxy.ts ADMIN_EMAILS remains the primary edge gate).
+DROP POLICY IF EXISTS "admin reads all wallets" ON public.broker_wallets;
+CREATE POLICY "admin reads all wallets"
+  ON public.broker_wallets
+  FOR SELECT TO authenticated
+  USING ((auth.jwt() -> 'user_metadata' ->> 'role') = 'admin');
+
+-- ----------------------------------------------------------------------------
+-- 2. wallet_transactions  (stripe_payment_intent_id, ledger)
+-- ----------------------------------------------------------------------------
+ALTER TABLE public.wallet_transactions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.wallet_transactions FORCE  ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "service_role full access" ON public.wallet_transactions;
+CREATE POLICY "service_role full access"
+  ON public.wallet_transactions
+  FOR ALL TO service_role
+  USING (true) WITH CHECK (true);
+
+DROP POLICY IF EXISTS "authenticated read only" ON public.wallet_transactions;
+
+DROP POLICY IF EXISTS "broker reads own transactions" ON public.wallet_transactions;
+CREATE POLICY "broker reads own transactions"
+  ON public.wallet_transactions
+  FOR SELECT TO authenticated
+  USING (
+    broker_slug = (
+      SELECT broker_slug
+        FROM public.broker_accounts
+       WHERE auth_user_id = auth.uid()::text
+       LIMIT 1
+    )
+  );
+
+DROP POLICY IF EXISTS "admin reads all transactions" ON public.wallet_transactions;
+CREATE POLICY "admin reads all transactions"
+  ON public.wallet_transactions
+  FOR SELECT TO authenticated
+  USING ((auth.jwt() -> 'user_metadata' ->> 'role') = 'admin');
+
+-- ----------------------------------------------------------------------------
+-- 3. marketplace_invoices  (stripe ids + broker_email + broker_abn + PII)
+-- ----------------------------------------------------------------------------
+ALTER TABLE public.marketplace_invoices ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.marketplace_invoices FORCE  ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "service_role full access" ON public.marketplace_invoices;
+CREATE POLICY "service_role full access"
+  ON public.marketplace_invoices
+  FOR ALL TO service_role
+  USING (true) WITH CHECK (true);
+
+DROP POLICY IF EXISTS "authenticated read only" ON public.marketplace_invoices;
+
+DROP POLICY IF EXISTS "broker reads own invoices" ON public.marketplace_invoices;
+CREATE POLICY "broker reads own invoices"
+  ON public.marketplace_invoices
+  FOR SELECT TO authenticated
+  USING (
+    broker_slug = (
+      SELECT broker_slug
+        FROM public.broker_accounts
+       WHERE auth_user_id = auth.uid()::text
+       LIMIT 1
+    )
+  );
+
+DROP POLICY IF EXISTS "admin reads all invoices" ON public.marketplace_invoices;
+CREATE POLICY "admin reads all invoices"
+  ON public.marketplace_invoices
+  FOR SELECT TO authenticated
+  USING ((auth.jwt() -> 'user_metadata' ->> 'role') = 'admin');
+
+COMMIT;


### PR DESCRIPTION
## P0 — cross-user Stripe/PII leak on a03 financial tables

### The leak
The three a03 batch-3 backfill migrations shipped this RLS policy on each table:

```sql
CREATE POLICY "authenticated read only" ... FOR SELECT TO authenticated USING (true);
```

`USING (true)` means **any** authenticated Supabase user (e.g. a consumer who signed up to save a broker comparison) can `SELECT` **every** row via PostgREST. PostgREST honours the RLS policy, **not** the `proxy.ts` `ADMIN_EMAILS` edge gate the original migrations relied on — so a non-admin authenticated user querying the table directly (or via any client-side `createClient`) bypasses the middleware entirely. Exposed across **all** brokers:

- `broker_wallets.stripe_payment_method_id`
- `wallet_transactions.stripe_payment_intent_id`
- `marketplace_invoices` → `stripe_checkout_session_id`, `stripe_payment_intent_id`, `broker_email`, `broker_company_name`, `broker_abn`

### Ownership model used
These tables have **no** `user_id`/`owner_id` column. Ownership is modelled by `broker_slug` (text), which links to `public.broker_accounts.broker_slug`; `broker_accounts.auth_user_id` (TEXT, the Supabase auth UUID) is the per-user linkage. The owner-scope predicate mirrors the established precedent in `20260606150000_a03_backfill_conversion_events.sql`:

```sql
broker_slug = (SELECT broker_slug FROM public.broker_accounts
               WHERE auth_user_id = auth.uid()::text LIMIT 1)
```

There are **two** legitimate authenticated-role read paths (both browser client, both under RLS):
1. **Broker portal** (own data only) — `app/broker-portal/wallet`, `.../invoices`, `lib/marketplace/broker-auth.ts`.
2. **Admin dashboards** (all brokers, `ADMIN_EMAILS`-gated) — `app/admin/marketplace/{page,reconciliation,intelligence,brokers}`, `app/admin/revenue`. Admins have no `broker_accounts` row, so owner-scope alone would (correctly) give them 0 rows and break the dashboards. The admin predicate uses the repo's canonical admin-in-RLS check (same as `a03_backfill_finance_transactions` + the a04 backfills): `(auth.jwt() -> 'user_metadata' ->> 'role') = 'admin'`. `proxy.ts` `ADMIN_EMAILS` remains the primary edge gate; this is defence-in-depth.

### The fix
New forward-only migration `supabase/migrations/20260831000000_fix_a03_financial_tables_rls.sql`. Original a03 files are untouched (forward-only). Per table (`broker_wallets`, `wallet_transactions`, `marketplace_invoices`):

| Action | Policy |
|---|---|
| DROP | `authenticated read only` (`USING (true)` — the leak) |
| CREATE | `broker reads own <table>` — SELECT, authenticated, `broker_slug = caller's own slug` |
| CREATE | `admin reads all <table>` — SELECT, authenticated, `user_metadata.role = 'admin'` |
| re-assert | `service_role full access` (FOR ALL) + `ENABLE`/`FORCE ROW LEVEL SECURITY` |

Idempotent (`DROP POLICY IF EXISTS` before each `CREATE`). No authenticated **write** policies added — all writes go through `service_role` (`lib/marketplace/wallet.ts` + marketplace API/webhook routes via the admin client, which bypass RLS).

### How a reviewer verifies non-owner sees 0 rows
1. As a non-admin authenticated user **with no `broker_accounts` row**, via the browser client: `supabase.from('broker_wallets').select('*')` → expect `[]`. Repeat for `wallet_transactions`, `marketplace_invoices`. (Pre-fix this returned every broker's rows.)
2. As broker A (own `broker_accounts` row) → only `broker_slug = A` rows, never B's. As broker B → only B's.
3. As an admin (`user_metadata.role = 'admin'`) → all rows (dashboards still work).

JS-modelled regression guard: `__tests__/lib/marketplace_financial_rls.test.ts` (6 tests, green) — asserts plain user sees 0, each broker sees only own, admin sees all, and broker A never reads B's Stripe ids/PII.

### RLS gates
Both `check-rls-migrations.mjs` and `check-rls-isolation.mjs` only trigger on new `CREATE TABLE`; this migration creates no tables, so neither gate flags it. RLS remains enabled+forced on all three.

### Rollback
Full rollback block in the migration header (re-creates the `USING (true)` policies — **re-opens the leak**, emergency only).

### Uncertainty for human check
- **Admin predicate**: I followed the repo's canonical `user_metadata.role = 'admin'` convention. Confirm admin logins actually carry `user_metadata.role = 'admin'` in their JWT (the authoritative gate is `proxy.ts` `ADMIN_EMAILS`; if admin JWTs don't set this claim, the admin dashboards would read 0 rows — though they'd remain edge-protected). If admin identity is email-based only, swap the admin predicate to `(auth.jwt() ->> 'email') IN (...)` or move the admin dashboards to a service-role API route.
- **Out of scope (pre-existing, separate bug)**: `app/broker-portal/settings/page.tsx` `handleSaveAlerts` does a browser-client `UPDATE` on `broker_wallets` (low-balance alert prefs). The original SELECT-only policy already denied this UPDATE, so it was already non-functional — not a regression from this PR. An owner-scoped UPDATE policy is deferred because it would let a broker edit **any** column of their own wallet row (incl. `balance_cents`); the safe fix is a column-scoped RPC or an admin API route. Same pattern applies to the `broker_accounts` UPDATEs on that page (batch4 policy is SELECT-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
