### PR TITLE
fix(security+a11y): close anon-read RLS leaks; login link a11y; harden bot auto-login

### DIFF
--- a/__tests__/api/admin-email-performance.test.ts
+++ b/__tests__/api/admin-email-performance.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+const mockRequireAdmin = vi.fn();
+vi.mock("@/lib/require-admin", () => ({ requireAdmin: () => mockRequireAdmin() }));
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+function makeBuilder(result: unknown) {
+  const b: Record<string, unknown> = {};
+  for (const m of ["select", "eq", "gte", "order", "limit"]) b[m] = vi.fn(() => b);
+  b.then = (cb: (v: unknown) => unknown) => Promise.resolve(cb(result));
+  return b;
+}
+
+// email_captures is queried 3 times (full list, bounced count, bounce list) with
+// different shapes; resolve those by call order. Everything else is by table name.
+let tableResults: Record<string, unknown> = {};
+let emailCapturesQueue: unknown[] = [];
+const mockFrom = vi.fn((table: string) => {
+  if (table === "email_captures" && emailCapturesQueue.length) {
+    return makeBuilder(emailCapturesQueue.shift());
+  }
+  return makeBuilder(tableResults[table] ?? { data: [], error: null });
+});
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+import { GET } from "@/app/api/admin/email-performance/route";
+
+function makeReq(period?: string): NextRequest {
+  const url = period
+    ? `http://localhost/api/admin/email-performance?period=${period}`
+    : "http://localhost/api/admin/email-performance";
+  return new Request(url) as unknown as NextRequest;
+}
+
+describe("/api/admin/email-performance", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdmin.mockResolvedValue({ ok: true, email: "admin@invest.com.au", userId: "u1" });
+    tableResults = {};
+    emailCapturesQueue = [];
+  });
+
+  it("denies non-admin", async () => {
+    mockRequireAdmin.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    });
+    const res = await GET(makeReq());
+    expect(res.status).toBe(401);
+  });
+
+  it("aggregates metrics including quiz_leads (service-role-only)", async () => {
+    emailCapturesQueue = [
+      // 1: full capture list
+      { data: [
+        { id: 1, source: "popup", created_at: "2026-06-01T00:00:00Z", utm_source: "google", status: "active" },
+        { id: 2, source: "popup", created_at: "2026-06-02T00:00:00Z", utm_source: null, status: "active" },
+      ], error: null },
+      // 2: bounced count
+      { data: null, count: 1, error: null },
+      // 3: bounce list
+      { data: [{ email: "bounce@x.com", status: "bounced" }], error: null },
+    ];
+    tableResults = {
+      quiz_leads: { data: [{ email: "q@x.com", unsubscribed: false, created_at: "2026-06-01T00:00:00Z" }], count: 0, error: null },
+      fee_alert_subscriptions: { data: [{ email: "f@x.com", verified: true }, { email: "g@x.com", verified: false }], error: null },
+      investor_drip_log: { data: [{ email: "d@x.com", template_id: "welcome", sent_at: "2026-06-01T00:00:00Z" }], error: null },
+    };
+    const res = await GET(makeReq("30d"));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+
+    expect(json.totalCaptures).toBe(2);
+    expect(json.totalQuiz).toBe(1); // would be 0 reading via the browser anon client
+    expect(json.totalFeeAlerts).toBe(1); // only verified
+    expect(json.dripsSent).toBe(1);
+    expect(json.capturesBySource).toEqual([["popup", 2]]);
+    expect(json.capturesByUtm).toEqual([["google", 1]]);
+    expect(json.recentBounces).toEqual(["bounce@x.com"]);
+  });
+
+  it("returns 500 when a read errors", async () => {
+    tableResults = { quiz_leads: { data: null, error: { message: "denied" } } };
+    const res = await GET(makeReq());
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/admin-finance.test.ts
+++ b/__tests__/api/admin-finance.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+const mockRequireAdmin = vi.fn();
+vi.mock("@/lib/require-admin", () => ({ requireAdmin: () => mockRequireAdmin() }));
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+function makeBuilder(result: unknown) {
+  const b: Record<string, unknown> = {};
+  for (const m of ["select", "insert", "update", "delete", "eq", "not", "order", "limit", "single"]) {
+    b[m] = vi.fn(() => b);
+  }
+  b.then = (cb: (v: unknown) => unknown) => Promise.resolve(cb(result));
+  return b;
+}
+
+let tableResults: Record<string, unknown> = {};
+const mockFrom = vi.fn((table: string) => makeBuilder(tableResults[table] ?? { data: [], error: null }));
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+import { GET, POST, PATCH, DELETE } from "@/app/api/admin/finance/route";
+import { POST as SYNC } from "@/app/api/admin/finance/sync/route";
+
+function makeReq(method: string, body?: unknown): NextRequest {
+  return new Request("http://localhost/api/admin/finance", {
+    method,
+    ...(body !== undefined
+      ? { body: JSON.stringify(body), headers: { "content-type": "application/json" } }
+      : {}),
+  }) as unknown as NextRequest;
+}
+
+const validTxn = {
+  date: "2026-06-01",
+  type: "expense" as const,
+  category: "hosting",
+  description: "Vercel Pro",
+  amount_cents: 4900,
+};
+
+describe("/api/admin/finance", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdmin.mockResolvedValue({ ok: true, email: "admin@invest.com.au", userId: "u1" });
+    tableResults = {};
+  });
+
+  it("GET denies non-admin", async () => {
+    mockRequireAdmin.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    });
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it("GET returns transactions + monthly (service-role read)", async () => {
+    tableResults = {
+      finance_transactions: { data: [{ id: 1, amount_cents: 100 }], error: null },
+      finance_monthly_summary: { data: [{ month: "2026-06" }], error: null },
+    };
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.transactions).toHaveLength(1);
+    expect(json.monthly).toHaveLength(1);
+  });
+
+  it("POST rejects invalid body", async () => {
+    const res = await POST(makeReq("POST", { type: "expense" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("POST creates a transaction", async () => {
+    tableResults = { finance_transactions: { data: { id: 7, ...validTxn }, error: null } };
+    const res = await POST(makeReq("POST", validTxn));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.transaction.id).toBe(7);
+  });
+
+  it("PATCH rejects body without id", async () => {
+    const res = await PATCH(makeReq("PATCH", { description: "edit" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("PATCH updates a transaction", async () => {
+    tableResults = { finance_transactions: { data: { id: 3, description: "edit" }, error: null } };
+    const res = await PATCH(makeReq("PATCH", { id: 3, description: "edit" }));
+    expect(res.status).toBe(200);
+  });
+
+  it("DELETE rejects missing id", async () => {
+    const res = await DELETE(makeReq("DELETE", {}));
+    expect(res.status).toBe(400);
+  });
+
+  it("DELETE removes a transaction", async () => {
+    tableResults = { finance_transactions: { data: null, error: null } };
+    const res = await DELETE(makeReq("DELETE", { id: 5 }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+  });
+});
+
+describe("/api/admin/finance/sync", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdmin.mockResolvedValue({ ok: true, email: "admin@invest.com.au", userId: "u1" });
+    tableResults = {};
+  });
+
+  it("denies non-admin", async () => {
+    mockRequireAdmin.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    });
+    const res = await SYNC();
+    expect(res.status).toBe(401);
+  });
+
+  it("returns added:0 when no paid billing", async () => {
+    tableResults = { advisor_billing: { data: [], error: null } };
+    const res = await SYNC();
+    const json = await res.json();
+    expect(json.added).toBe(0);
+  });
+
+  it("imports only un-synced paid billing rows", async () => {
+    tableResults = {
+      advisor_billing: {
+        data: [
+          { id: 10, amount_cents: 5000, professional_id: 1, description: "lead", status: "paid", created_at: "2026-06-01T00:00:00Z" },
+          { id: 11, amount_cents: 3000, professional_id: 2, description: "lead", status: "paid", created_at: "2026-06-02T00:00:00Z" },
+        ],
+        error: null,
+      },
+      // id 10 already imported → only id 11 is new.
+      finance_transactions: { data: [{ reference: "advisor_billing_10" }], error: null },
+    };
+    const res = await SYNC();
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.added).toBe(1);
+  });
+});

--- a/__tests__/api/admin-revenue-summary.test.ts
+++ b/__tests__/api/admin-revenue-summary.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextResponse } from "next/server";
+
+const mockRequireAdmin = vi.fn();
+vi.mock("@/lib/require-admin", () => ({ requireAdmin: () => mockRequireAdmin() }));
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+function makeBuilder(result: unknown) {
+  const b: Record<string, unknown> = {};
+  for (const m of ["select", "eq", "not", "order", "limit"]) b[m] = vi.fn(() => b);
+  b.then = (cb: (v: unknown) => unknown) => Promise.resolve(cb(result));
+  return b;
+}
+
+let tableResults: Record<string, unknown> = {};
+const mockFrom = vi.fn((table: string) => makeBuilder(tableResults[table] ?? { data: [], error: null }));
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+import { GET } from "@/app/api/admin/revenue-summary/route";
+
+describe("/api/admin/revenue-summary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdmin.mockResolvedValue({ ok: true, email: "admin@invest.com.au", userId: "u1" });
+    tableResults = {};
+  });
+
+  it("denies non-admin", async () => {
+    mockRequireAdmin.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    });
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it("aggregates advisor + marketplace + article revenue from service-role reads", async () => {
+    tableResults = {
+      affiliate_clicks: { data: [{ id: 1, broker_slug: "x", source: "s", page: "/p", created_at: "2026-06-01" }], error: null },
+      brokers: { data: [{ slug: "x", platform_type: "cfd_forex" }], error: null },
+      professional_leads: { data: [{ id: 1, billed: true, status: "converted" }, { id: 2, billed: false, status: "new" }], error: null },
+      advisor_billing: { data: [{ id: 1, amount_cents: 5000, status: "paid" }, { id: 2, amount_cents: 3000, status: "pending" }], error: null },
+      broker_wallets: { data: [{ balance_cents: 10000, lifetime_deposited_cents: 50000, lifetime_spent_cents: 40000 }], error: null },
+      broker_campaigns: { data: [{ id: 1, status: "active" }], error: null },
+      advisor_articles: { data: [{ id: 1, status: "published", price_cents: 9900, payment_status: "paid" }], error: null },
+      professionals: { data: [{ id: 1, lead_price_cents: 4900, free_leads_used: 2, stripe_customer_id: "cus_1" }], error: null },
+      lead_disputes: { data: [{ id: 1 }], error: null },
+    };
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const json = await res.json();
+
+    expect(json.brokerTypes).toEqual({ x: "cfd_forex" });
+    expect(json.advisorRev.totalLeads).toBe(2);
+    expect(json.advisorRev.billedLeads).toBe(1);
+    expect(json.advisorRev.paidBillingCents).toBe(5000);
+    expect(json.advisorRev.pendingBillingCents).toBe(3000);
+    expect(json.advisorRev.convertedLeads).toBe(1);
+    expect(json.advisorRev.stripeConnected).toBe(1);
+    // broker_wallets is service-role-only — this is the figure that read 0 via the browser.
+    expect(json.marketplaceRev.totalBalanceCents).toBe(10000);
+    expect(json.marketplaceRev.totalSpentCents).toBe(40000);
+    expect(json.marketplaceRev.activeCampaigns).toBe(1);
+    expect(json.articleRev.paidCents).toBe(9900);
+    expect(json.clicks).toHaveLength(1);
+  });
+
+  it("returns 500 when a read errors", async () => {
+    tableResults = { broker_wallets: { data: null, error: { message: "denied" } } };
+    const res = await GET();
+    expect(res.status).toBe(500);
+  });
+});

--- a/app/admin/email-performance/page.tsx
+++ b/app/admin/email-performance/page.tsx
@@ -1,34 +1,7 @@
 "use client";
 
-import { useEffect, useState, useMemo } from "react";
-import { createClient } from "@/lib/supabase/client";
+import { useCallback, useEffect, useState, useMemo } from "react";
 import AdminShell from "@/components/AdminShell";
-
-interface DripLog {
-  email: string;
-  template_id: string;
-  sent_at: string;
-}
-
-interface EmailCapture {
-  id: number;
-  email: string;
-  source: string;
-  status?: string;
-  created_at: string;
-  utm_source?: string;
-}
-
-interface QuizLead {
-  email: string;
-  unsubscribed?: boolean;
-  created_at: string;
-}
-
-interface FeeAlert {
-  email: string;
-  verified: boolean;
-}
 
 type Period = "7d" | "30d" | "90d" | "all";
 
@@ -49,63 +22,29 @@ export default function EmailPerformancePage() {
   const [dripByTemplate, setDripByTemplate] = useState<[string, number][]>([]);
   const [recentBounces, setRecentBounces] = useState<string[]>([]);
 
-  useEffect(() => { fetchData(); }, [period]);
-
-  async function fetchData() {
+  const fetchData = useCallback(async () => {
     setLoading(true);
-    const supabase = createClient();
-    const days = period === "7d" ? 7 : period === "30d" ? 30 : period === "90d" ? 90 : 9999;
-    const since = days < 9999 ? new Date(Date.now() - days * 86400000).toISOString() : "2020-01-01T00:00:00Z";
-
-    const [capturesRes, quizRes, feeAlertsRes, bouncedRes, unsubRes, dripsRes, capturesFullRes] = await Promise.all([
-      supabase.from("email_captures").select("id, source, created_at, utm_source, status").gte("created_at", since).order("created_at", { ascending: false }).limit(5000),
-      supabase.from("quiz_leads").select("email, unsubscribed, created_at").gte("created_at", since),
-      supabase.from("fee_alert_subscriptions").select("email, verified"),
-      supabase.from("email_captures").select("id", { count: "exact", head: true }).eq("status", "bounced"),
-      supabase.from("quiz_leads").select("id", { count: "exact", head: true }).eq("unsubscribed", true),
-      supabase.from("investor_drip_log").select("email, template_id, sent_at").gte("sent_at", since).order("sent_at", { ascending: false }).limit(2000),
-      supabase.from("email_captures").select("email, status").eq("status", "bounced").limit(10),
-    ]);
-
-    const captures = (capturesRes.data || []) as EmailCapture[];
-    const quiz = (quizRes.data || []) as QuizLead[];
-    const drips = (dripsRes.data || []) as DripLog[];
-
-    setTotalCaptures(captures.length);
-    setTotalQuiz(quiz.length);
-    setTotalFeeAlerts((feeAlertsRes.data || []).filter((a: FeeAlert) => a.verified).length);
-    setBounced(bouncedRes.count || 0);
-    setUnsubscribed(unsubRes.count || 0);
-    setDripsSent(drips.length);
-    setRecentBounces((capturesFullRes.data || []).map((c: { email: string }) => c.email));
-
-    // By source
-    const srcMap = new Map<string, number>();
-    for (const c of captures) srcMap.set(c.source || "unknown", (srcMap.get(c.source || "unknown") || 0) + 1);
-    setCapturesBySource([...srcMap.entries()].sort((a, b) => b[1] - a[1]));
-
-    // By UTM
-    const utmMap = new Map<string, number>();
-    for (const c of captures) {
-      if (c.utm_source) utmMap.set(c.utm_source, (utmMap.get(c.utm_source) || 0) + 1);
+    try {
+      const res = await fetch(`/api/admin/email-performance?period=${period}`);
+      if (!res.ok) throw new Error(`email-performance ${res.status}`);
+      const data = await res.json();
+      setTotalCaptures(data.totalCaptures || 0);
+      setTotalQuiz(data.totalQuiz || 0);
+      setTotalFeeAlerts(data.totalFeeAlerts || 0);
+      setBounced(data.bounced || 0);
+      setUnsubscribed(data.unsubscribed || 0);
+      setDripsSent(data.dripsSent || 0);
+      setCapturesBySource(data.capturesBySource || []);
+      setCapturesByUtm(data.capturesByUtm || []);
+      setDailyCaptures(data.dailyCaptures || []);
+      setDripByTemplate(data.dripByTemplate || []);
+      setRecentBounces(data.recentBounces || []);
+    } finally {
+      setLoading(false);
     }
-    setCapturesByUtm([...utmMap.entries()].sort((a, b) => b[1] - a[1]));
+  }, [period]);
 
-    // Daily
-    const dayMap = new Map<string, number>();
-    for (const c of captures) {
-      const day = new Date(c.created_at).toISOString().slice(0, 10);
-      dayMap.set(day, (dayMap.get(day) || 0) + 1);
-    }
-    setDailyCaptures([...dayMap.entries()].sort((a, b) => a[0].localeCompare(b[0])).slice(-30));
-
-    // Drip by template
-    const tplMap = new Map<string, number>();
-    for (const d of drips) tplMap.set(d.template_id || "unknown", (tplMap.get(d.template_id || "unknown") || 0) + 1);
-    setDripByTemplate([...tplMap.entries()].sort((a, b) => b[1] - a[1]));
-
-    setLoading(false);
-  }
+  useEffect(() => { fetchData(); }, [fetchData]);
 
   const listHealth = useMemo(() => {
     const total = totalCaptures + totalQuiz;

--- a/app/admin/finance/page.tsx
+++ b/app/admin/finance/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useEffect, useMemo, useCallback } from "react";
-import { createClient } from "@/lib/supabase/client";
 import AdminShell from "@/components/AdminShell";
 import Icon from "@/components/Icon";
 import ConfirmDialog from "@/components/ConfirmDialog";
@@ -60,66 +59,47 @@ export default function FinanceDashboardPage() {
   const [amountInput, setAmountInput] = useState("");
   const [deleteId, setDeleteId] = useState<number | null>(null);
 
-  const supabase = createClient();
-
   const loadData = useCallback(async () => {
     setLoading(true);
-    const [txnRes, monthRes] = await Promise.all([
-      supabase.from("finance_transactions").select("*").order("date", { ascending: false }).limit(500),
-      supabase.from("finance_monthly_summary").select("*").limit(24),
-    ]);
-    setTxns((txnRes.data || []) as Transaction[]);
-    setMonthly((monthRes.data || []) as MonthlySummary[]);
-    setLoading(false);
-  }, [supabase]);
+    try {
+      const res = await fetch("/api/admin/finance");
+      if (!res.ok) throw new Error(`finance ${res.status}`);
+      const data = await res.json();
+      setTxns((data.transactions || []) as Transaction[]);
+      setMonthly((data.monthly || []) as MonthlySummary[]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
 
   useEffect(() => { loadData(); }, [loadData]);
 
-  // Auto-pull Stripe revenue into transactions
+  // Auto-pull Stripe revenue into transactions (server-side: advisor_billing
+  // and finance_transactions are both service-role-only post-RLS-hardening).
   const syncStripeRevenue = useCallback(async () => {
-    const { data: billing } = await supabase
-      .from("advisor_billing")
-      .select("id, amount_cents, professional_id, description, status, created_at")
-      .eq("status", "paid")
-      .order("created_at", { ascending: false })
-      .limit(100);
-
-    if (!billing || billing.length === 0) return;
-
-    const { data: existingRefs } = await supabase
-      .from("finance_transactions")
-      .select("reference")
-      .eq("category", "advisor_credits")
-      .not("reference", "is", null);
-
-    const existingSet = new Set((existingRefs || []).map(r => r.reference));
-    let added = 0;
-
-    for (const b of billing) {
-      const ref = `advisor_billing_${b.id}`;
-      if (existingSet.has(ref)) continue;
-      await supabase.from("finance_transactions").insert({
-        date: new Date(b.created_at).toISOString().slice(0, 10),
-        type: "income", category: "advisor_credits",
-        description: b.description || `Advisor lead payment`,
-        amount_cents: b.amount_cents,
-        counterparty: `Advisor #${b.professional_id}`,
-        reference: ref,
-      });
-      added++;
-    }
+    const res = await fetch("/api/admin/finance/sync", { method: "POST" });
+    if (!res.ok) return 0;
+    const { added } = await res.json();
     if (added > 0) loadData();
-    return added;
-  }, [supabase, loadData]);
+    return added as number;
+  }, [loadData]);
 
   const handleSave = async () => {
     if (!editing?.description || !editing.amount_cents) return;
     setSaving(true);
     const { id, created_at: _created_at, ...payload } = editing as Transaction;
     if (id) {
-      await supabase.from("finance_transactions").update(payload).eq("id", id);
+      await fetch("/api/admin/finance", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id, ...payload }),
+      });
     } else {
-      await supabase.from("finance_transactions").insert(payload);
+      await fetch("/api/admin/finance", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
     }
     setSaving(false);
     setEditing(null);
@@ -133,7 +113,11 @@ export default function FinanceDashboardPage() {
 
   const confirmDelete = async () => {
     if (deleteId == null) return;
-    await supabase.from("finance_transactions").delete().eq("id", deleteId);
+    await fetch("/api/admin/finance", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id: deleteId }),
+    });
     setDeleteId(null);
     loadData();
   };

--- a/app/admin/revenue/page.tsx
+++ b/app/admin/revenue/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState, useMemo } from "react";
-import { createClient } from "@/lib/supabase/client";
 import AdminShell from "@/components/AdminShell";
 
 interface Click {
@@ -85,64 +84,18 @@ export default function RevenuePage() {
 
   async function fetchData() {
     setLoading(true);
-    const supabase = createClient();
-    const [clicksRes, brokersRes, leadsRes, billingRes, walletsRes, campaignsRes, articlesRes, prosRes, disputesRes] = await Promise.all([
-      supabase.from("affiliate_clicks").select("id, broker_slug, broker_name, source, page, created_at, placement_type").order("created_at", { ascending: false }).limit(5000),
-      supabase.from("brokers").select("slug, platform_type").eq("status", "active"),
-      supabase.from("professional_leads").select("id, billed, bill_amount_cents, status"),
-      supabase.from("advisor_billing").select("id, amount_cents, status"),
-      supabase.from("broker_wallets").select("balance_cents, lifetime_deposited_cents, lifetime_spent_cents"),
-      supabase.from("broker_campaigns").select("id, status").eq("status", "active"),
-      supabase.from("advisor_articles").select("id, status, price_cents, payment_status").not("status", "eq", "draft"),
-      supabase.from("professionals").select("id, lead_price_cents, free_leads_used, stripe_customer_id").eq("status", "active"),
-      supabase.from("lead_disputes").select("id"),
-    ]);
-
-    setClicks(clicksRes.data || []);
-    const typeMap: Record<string, string> = {};
-    for (const b of brokersRes.data || []) typeMap[b.slug] = b.platform_type || "share_broker";
-    setBrokerTypes(typeMap);
-
-    // Advisor revenue
-    const leads = leadsRes.data || [];
-    const billing = billingRes.data || [];
-    const pros = prosRes.data || [];
-    setAdvisorRev({
-      totalLeads: leads.length,
-      billedLeads: leads.filter(l => l.billed).length,
-      freeLeads: leads.filter(l => !l.billed).length,
-      pendingBillingCents: billing.filter(b => b.status === "pending").reduce((s, b) => s + (b.amount_cents || 0), 0),
-      paidBillingCents: billing.filter(b => b.status === "paid").reduce((s, b) => s + (b.amount_cents || 0), 0),
-      totalBillingCents: billing.reduce((s, b) => s + (b.amount_cents || 0), 0),
-      disputedLeads: (disputesRes.data || []).length,
-      convertedLeads: leads.filter(l => l.status === "converted").length,
-      activeAdvisors: pros.length,
-      stripeConnected: pros.filter(p => p.stripe_customer_id).length,
-      freeLeadsUsed: pros.reduce((s, p) => s + (p.free_leads_used || 0), 0),
-      avgLeadPrice: pros.length > 0 ? pros.reduce((s, p) => s + (p.lead_price_cents || 4900), 0) / pros.length : 4900,
-    });
-
-    // Marketplace revenue
-    const wallets = walletsRes.data || [];
-    setMarketplaceRev({
-      totalWallets: wallets.length,
-      totalBalanceCents: wallets.reduce((s, w) => s + (w.balance_cents || 0), 0),
-      totalDepositedCents: wallets.reduce((s, w) => s + (w.lifetime_deposited_cents || 0), 0),
-      totalSpentCents: wallets.reduce((s, w) => s + (w.lifetime_spent_cents || 0), 0),
-      activeCampaigns: (campaignsRes.data || []).length,
-    });
-
-    // Article revenue
-    const articles = articlesRes.data || [];
-    setArticleRev({
-      totalSubmitted: articles.length,
-      totalPublished: articles.filter(a => a.status === "published").length,
-      paidCents: articles.filter(a => a.payment_status === "paid").reduce((s, a) => s + (a.price_cents || 0), 0),
-      waivedCents: articles.filter(a => a.payment_status === "waived").reduce((s, a) => s + (a.price_cents || 0), 0),
-      unpaidCents: articles.filter(a => a.payment_status === "unpaid" && a.status === "approved").reduce((s, a) => s + (a.price_cents || 0), 0),
-    });
-
-    setLoading(false);
+    try {
+      const res = await fetch("/api/admin/revenue-summary");
+      if (!res.ok) throw new Error(`revenue-summary ${res.status}`);
+      const data = await res.json();
+      setClicks(data.clicks || []);
+      setBrokerTypes(data.brokerTypes || {});
+      setAdvisorRev(data.advisorRev || null);
+      setMarketplaceRev(data.marketplaceRev || null);
+      setArticleRev(data.articleRev || null);
+    } finally {
+      setLoading(false);
+    }
   }
 
   const periodClicks = useMemo(() => {

--- a/app/api/admin/email-performance/route.ts
+++ b/app/api/admin/email-performance/route.ts
@@ -1,0 +1,118 @@
+/**
+ * /api/admin/email-performance — admin-only email-list health data.
+ *
+ *   GET ?period=7d|30d|90d|all — returns pre-aggregated capture / quiz / drip
+ *   metrics plus the recent-bounce list.
+ *
+ * Why this exists: the admin Email Performance dashboard previously read
+ * email_captures, quiz_leads, fee_alert_subscriptions and investor_drip_log
+ * through the browser anon client. Post-RLS-hardening, quiz_leads is
+ * service-role-only (browser read returned 0, so the Total-List and
+ * list-health figures were wrong) and fee_alert_subscriptions / email_captures
+ * carry subscriber PII. This route does every read with the service-role
+ * client behind the ADMIN_EMAILS guard and aggregates server-side so only
+ * counts (plus the bounce addresses the admin is here to action) cross the
+ * wire — never the full subscriber list.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/require-admin";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+const log = logger("api:admin:email-performance");
+
+export const runtime = "nodejs";
+
+type Period = "7d" | "30d" | "90d" | "all";
+
+function resolvePeriod(raw: string | null): Period {
+  return raw === "7d" || raw === "90d" || raw === "all" ? raw : "30d";
+}
+
+export async function GET(request: NextRequest) {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+
+  const period = resolvePeriod(new URL(request.url).searchParams.get("period"));
+  const days = period === "7d" ? 7 : period === "30d" ? 30 : period === "90d" ? 90 : 9999;
+  const since =
+    days < 9999
+      ? new Date(Date.now() - days * 86400000).toISOString()
+      : "2020-01-01T00:00:00Z";
+
+  const supabase = createAdminClient();
+
+  const [capturesRes, quizRes, feeAlertsRes, bouncedRes, unsubRes, dripsRes, bounceListRes] =
+    await Promise.all([
+      supabase
+        .from("email_captures")
+        .select("id, source, created_at, utm_source, status")
+        .gte("created_at", since)
+        .order("created_at", { ascending: false })
+        .limit(5000),
+      supabase.from("quiz_leads").select("email, unsubscribed, created_at").gte("created_at", since),
+      supabase.from("fee_alert_subscriptions").select("email, verified"),
+      supabase.from("email_captures").select("id", { count: "exact", head: true }).eq("status", "bounced"),
+      supabase.from("quiz_leads").select("id", { count: "exact", head: true }).eq("unsubscribed", true),
+      supabase
+        .from("investor_drip_log")
+        .select("email, template_id, sent_at")
+        .gte("sent_at", since)
+        .order("sent_at", { ascending: false })
+        .limit(2000),
+      supabase.from("email_captures").select("email, status").eq("status", "bounced").limit(10),
+    ]);
+
+  const firstError =
+    capturesRes.error ||
+    quizRes.error ||
+    feeAlertsRes.error ||
+    bouncedRes.error ||
+    unsubRes.error ||
+    dripsRes.error ||
+    bounceListRes.error;
+  if (firstError) {
+    log.error("Email performance read failed", { err: firstError.message });
+    return NextResponse.json({ error: "Failed to load email data" }, { status: 500 });
+  }
+
+  const captures = capturesRes.data || [];
+  const quiz = quizRes.data || [];
+  const drips = dripsRes.data || [];
+
+  // Captures by source.
+  const srcMap = new Map<string, number>();
+  for (const c of captures) srcMap.set(c.source || "unknown", (srcMap.get(c.source || "unknown") || 0) + 1);
+
+  // Captures by UTM source.
+  const utmMap = new Map<string, number>();
+  for (const c of captures) {
+    if (c.utm_source) utmMap.set(c.utm_source, (utmMap.get(c.utm_source) || 0) + 1);
+  }
+
+  // Daily captures.
+  const dayMap = new Map<string, number>();
+  for (const c of captures) {
+    const day = new Date(c.created_at).toISOString().slice(0, 10);
+    dayMap.set(day, (dayMap.get(day) || 0) + 1);
+  }
+
+  // Drips by template.
+  const tplMap = new Map<string, number>();
+  for (const d of drips) tplMap.set(d.template_id || "unknown", (tplMap.get(d.template_id || "unknown") || 0) + 1);
+
+  return NextResponse.json({
+    totalCaptures: captures.length,
+    totalQuiz: quiz.length,
+    totalFeeAlerts: (feeAlertsRes.data || []).filter((a) => a.verified).length,
+    bounced: bouncedRes.count || 0,
+    unsubscribed: unsubRes.count || 0,
+    dripsSent: drips.length,
+    capturesBySource: [...srcMap.entries()].sort((a, b) => b[1] - a[1]),
+    capturesByUtm: [...utmMap.entries()].sort((a, b) => b[1] - a[1]),
+    dailyCaptures: [...dayMap.entries()].sort((a, b) => a[0].localeCompare(b[0])).slice(-30),
+    dripByTemplate: [...tplMap.entries()].sort((a, b) => b[1] - a[1]),
+    recentBounces: (bounceListRes.data || []).map((c) => c.email),
+  });
+}

--- a/app/api/admin/finance/route.ts
+++ b/app/api/admin/finance/route.ts
@@ -1,0 +1,123 @@
+/**
+ * /api/admin/finance — admin-only finance-ledger CRUD.
+ *
+ *   GET    — { transactions, monthly }  (latest 500 txns + monthly P&L summary)
+ *   POST   — create a transaction
+ *   PATCH  — update a transaction by id
+ *   DELETE — remove a transaction by id
+ *
+ * Why this exists: finance_transactions carries a single RLS policy —
+ * service_role ALL — so the admin Finance dashboard (app/admin/finance), which
+ * used the browser anon client, could neither read (0 rows) nor write (denied)
+ * the ledger. This route moves every operation to the service-role client
+ * behind the standard ADMIN_EMAILS guard. The Stripe-revenue sync lives at
+ * /api/admin/finance/sync.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { requireAdmin } from "@/lib/require-admin";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+const log = logger("api:admin:finance");
+
+export const runtime = "nodejs";
+
+const TxnFields = z.object({
+  date: z.string().min(1),
+  type: z.enum(["income", "expense"]),
+  category: z.string().min(1).max(64),
+  description: z.string().min(1).max(500),
+  amount_cents: z.number().int(),
+  counterparty: z.string().max(200).nullish(),
+  reference: z.string().max(200).nullish(),
+  recurring: z.boolean().optional(),
+  recurring_interval: z.string().max(32).nullish(),
+  notes: z.string().max(2000).nullish(),
+});
+
+const CreateBody = TxnFields;
+const UpdateBody = TxnFields.partial().extend({ id: z.number().int().positive() });
+const DeleteBody = z.object({ id: z.number().int().positive() });
+
+export async function GET() {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+
+  const supabase = createAdminClient();
+  const [txnRes, monthRes] = await Promise.all([
+    supabase.from("finance_transactions").select("*").order("date", { ascending: false }).limit(500),
+    supabase.from("finance_monthly_summary").select("*").limit(24),
+  ]);
+
+  if (txnRes.error || monthRes.error) {
+    log.error("Finance read failed", { err: (txnRes.error || monthRes.error)?.message });
+    return NextResponse.json({ error: "Failed to load finance data" }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    transactions: txnRes.data || [],
+    monthly: monthRes.data || [],
+  });
+}
+
+export async function POST(request: NextRequest) {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+
+  const parsed = CreateBody.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid transaction", details: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const supabase = createAdminClient();
+  const { data, error } = await supabase.from("finance_transactions").insert(parsed.data).select().single();
+  if (error) {
+    log.error("Finance insert failed", { err: error.message });
+    return NextResponse.json({ error: "Failed to create transaction" }, { status: 500 });
+  }
+  return NextResponse.json({ transaction: data });
+}
+
+export async function PATCH(request: NextRequest) {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+
+  const parsed = UpdateBody.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid transaction", details: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const { id, ...fields } = parsed.data;
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("finance_transactions")
+    .update(fields)
+    .eq("id", id)
+    .select()
+    .single();
+  if (error) {
+    log.error("Finance update failed", { err: error.message });
+    return NextResponse.json({ error: "Failed to update transaction" }, { status: 500 });
+  }
+  return NextResponse.json({ transaction: data });
+}
+
+export async function DELETE(request: NextRequest) {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+
+  const parsed = DeleteBody.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json({ error: "id is required" }, { status: 400 });
+  }
+
+  const supabase = createAdminClient();
+  const { error } = await supabase.from("finance_transactions").delete().eq("id", parsed.data.id);
+  if (error) {
+    log.error("Finance delete failed", { err: error.message });
+    return NextResponse.json({ error: "Failed to delete transaction" }, { status: 500 });
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/admin/finance/sync/route.ts
+++ b/app/api/admin/finance/sync/route.ts
@@ -1,0 +1,79 @@
+/**
+ * /api/admin/finance/sync — pull paid advisor_billing rows into the finance
+ * ledger as income transactions, skipping any already imported.
+ *
+ *   POST — { added: number }
+ *
+ * Split out from /api/admin/finance because it reads advisor_billing (a
+ * privileged, is_admin()-only table) and writes finance_transactions
+ * (service-role-only) — both require the service-role client. Previously the
+ * Finance dashboard ran this loop from the browser anon client, which the RLS
+ * hardening now denies on both tables.
+ */
+
+import { NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/require-admin";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+const log = logger("api:admin:finance:sync");
+
+export const runtime = "nodejs";
+
+export async function POST() {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+
+  const supabase = createAdminClient();
+
+  const { data: billing, error: billingError } = await supabase
+    .from("advisor_billing")
+    .select("id, amount_cents, professional_id, description, status, created_at")
+    .eq("status", "paid")
+    .order("created_at", { ascending: false })
+    .limit(100);
+
+  if (billingError) {
+    log.error("Finance sync billing read failed", { err: billingError.message });
+    return NextResponse.json({ error: "Failed to read billing" }, { status: 500 });
+  }
+  if (!billing || billing.length === 0) {
+    return NextResponse.json({ added: 0 });
+  }
+
+  const { data: existingRefs, error: refsError } = await supabase
+    .from("finance_transactions")
+    .select("reference")
+    .eq("category", "advisor_credits")
+    .not("reference", "is", null);
+
+  if (refsError) {
+    log.error("Finance sync refs read failed", { err: refsError.message });
+    return NextResponse.json({ error: "Failed to read existing transactions" }, { status: 500 });
+  }
+
+  const existingSet = new Set((existingRefs || []).map((r) => r.reference));
+  const rows = billing
+    .filter((b) => !existingSet.has(`advisor_billing_${b.id}`))
+    .map((b) => ({
+      date: new Date(b.created_at).toISOString().slice(0, 10),
+      type: "income" as const,
+      category: "advisor_credits",
+      description: b.description || "Advisor lead payment",
+      amount_cents: b.amount_cents,
+      counterparty: `Advisor #${b.professional_id}`,
+      reference: `advisor_billing_${b.id}`,
+    }));
+
+  if (rows.length === 0) {
+    return NextResponse.json({ added: 0 });
+  }
+
+  const { error: insertError } = await supabase.from("finance_transactions").insert(rows);
+  if (insertError) {
+    log.error("Finance sync insert failed", { err: insertError.message });
+    return NextResponse.json({ error: "Failed to import billing" }, { status: 500 });
+  }
+
+  return NextResponse.json({ added: rows.length });
+}

--- a/app/api/admin/revenue-summary/route.ts
+++ b/app/api/admin/revenue-summary/route.ts
@@ -1,0 +1,151 @@
+/**
+ * /api/admin/revenue-summary — admin-only revenue dashboard data.
+ *
+ *   GET — returns the anonymised affiliate-click stream plus pre-aggregated
+ *         advisor / marketplace / article revenue summaries.
+ *
+ * Why this exists: the admin Revenue dashboard (app/admin/revenue) previously
+ * read advisor_billing, broker_wallets, professional_leads and professionals
+ * directly through the browser anon client. After the RLS hardening in
+ * #1407–#1410, those tables deny the browser client (broker_wallets is
+ * broker_slug-scoped, advisor_billing is is_admin()-only, etc.), so the
+ * Cash-Position figures silently read 0. This route moves every privileged
+ * read to the service-role client behind the standard ADMIN_EMAILS guard and
+ * returns only the aggregates — raw Stripe ids, advisor PII and per-row
+ * billing never cross the wire.
+ *
+ * Affiliate clicks are returned as rows (broker_slug / source / page /
+ * created_at only — no PII) because the page does its own period filtering
+ * client-side; that table is anon-readable by design.
+ */
+
+import { NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/require-admin";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+const log = logger("api:admin:revenue-summary");
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  const guard = await requireAdmin();
+  if (!guard.ok) return guard.response;
+
+  const supabase = createAdminClient();
+
+  const [
+    clicksRes,
+    brokersRes,
+    leadsRes,
+    billingRes,
+    walletsRes,
+    campaignsRes,
+    articlesRes,
+    prosRes,
+    disputesRes,
+  ] = await Promise.all([
+    supabase
+      .from("affiliate_clicks")
+      .select("id, broker_slug, broker_name, source, page, created_at, placement_type")
+      .order("created_at", { ascending: false })
+      .limit(5000),
+    supabase.from("brokers").select("slug, platform_type").eq("status", "active"),
+    supabase.from("professional_leads").select("id, billed, bill_amount_cents, status"),
+    supabase.from("advisor_billing").select("id, amount_cents, status"),
+    supabase
+      .from("broker_wallets")
+      .select("balance_cents, lifetime_deposited_cents, lifetime_spent_cents"),
+    supabase.from("broker_campaigns").select("id, status").eq("status", "active"),
+    supabase
+      .from("advisor_articles")
+      .select("id, status, price_cents, payment_status")
+      .not("status", "eq", "draft"),
+    supabase
+      .from("professionals")
+      .select("id, lead_price_cents, free_leads_used, stripe_customer_id")
+      .eq("status", "active"),
+    supabase.from("lead_disputes").select("id"),
+  ]);
+
+  const firstError =
+    clicksRes.error ||
+    brokersRes.error ||
+    leadsRes.error ||
+    billingRes.error ||
+    walletsRes.error ||
+    campaignsRes.error ||
+    articlesRes.error ||
+    prosRes.error ||
+    disputesRes.error;
+  if (firstError) {
+    log.error("Revenue summary read failed", { err: firstError.message });
+    return NextResponse.json({ error: "Failed to load revenue data" }, { status: 500 });
+  }
+
+  // Broker platform-type map (drives the client-side CPA estimate).
+  const brokerTypes: Record<string, string> = {};
+  for (const b of brokersRes.data || []) {
+    brokerTypes[b.slug] = b.platform_type || "share_broker";
+  }
+
+  // Advisor revenue — aggregate server-side; nothing per-row leaves.
+  const leads = leadsRes.data || [];
+  const billing = billingRes.data || [];
+  const pros = prosRes.data || [];
+  const advisorRev = {
+    totalLeads: leads.length,
+    billedLeads: leads.filter((l) => l.billed).length,
+    freeLeads: leads.filter((l) => !l.billed).length,
+    pendingBillingCents: billing
+      .filter((b) => b.status === "pending")
+      .reduce((s, b) => s + (b.amount_cents || 0), 0),
+    paidBillingCents: billing
+      .filter((b) => b.status === "paid")
+      .reduce((s, b) => s + (b.amount_cents || 0), 0),
+    totalBillingCents: billing.reduce((s, b) => s + (b.amount_cents || 0), 0),
+    disputedLeads: (disputesRes.data || []).length,
+    convertedLeads: leads.filter((l) => l.status === "converted").length,
+    activeAdvisors: pros.length,
+    stripeConnected: pros.filter((p) => p.stripe_customer_id).length,
+    freeLeadsUsed: pros.reduce((s, p) => s + (p.free_leads_used || 0), 0),
+    avgLeadPrice:
+      pros.length > 0
+        ? pros.reduce((s, p) => s + (p.lead_price_cents || 4900), 0) / pros.length
+        : 4900,
+  };
+
+  // Marketplace revenue — broker_wallets is service-role-only, hence this route.
+  const wallets = walletsRes.data || [];
+  const marketplaceRev = {
+    totalWallets: wallets.length,
+    totalBalanceCents: wallets.reduce((s, w) => s + (w.balance_cents || 0), 0),
+    totalDepositedCents: wallets.reduce((s, w) => s + (w.lifetime_deposited_cents || 0), 0),
+    totalSpentCents: wallets.reduce((s, w) => s + (w.lifetime_spent_cents || 0), 0),
+    activeCampaigns: (campaignsRes.data || []).length,
+  };
+
+  // Article revenue.
+  const articles = articlesRes.data || [];
+  const articleRev = {
+    totalSubmitted: articles.length,
+    totalPublished: articles.filter((a) => a.status === "published").length,
+    paidCents: articles
+      .filter((a) => a.payment_status === "paid")
+      .reduce((s, a) => s + (a.price_cents || 0), 0),
+    waivedCents: articles
+      .filter((a) => a.payment_status === "waived")
+      .reduce((s, a) => s + (a.price_cents || 0), 0),
+    unpaidCents: articles
+      .filter((a) => a.payment_status === "unpaid" && a.status === "approved")
+      .reduce((s, a) => s + (a.price_cents || 0), 0),
+  };
+
+  return NextResponse.json({
+    clicks: clicksRes.data || [],
+    brokerTypes,
+    advisorRev,
+    marketplaceRev,
+    articleRev,
+  });
+}

--- a/app/auth/login/LoginClient.tsx
+++ b/app/auth/login/LoginClient.tsx
@@ -380,9 +380,9 @@ export default function LoginClient() {
             </p>
             <p className="text-xs text-slate-500">
               By signing in, you agree to our{" "}
-              <Link href="/terms" className="text-slate-700 hover:underline">Terms</Link>
+              <Link href="/terms" className="text-slate-700 underline hover:no-underline">Terms</Link>
               {" "}and{" "}
-              <Link href="/privacy" className="text-slate-700 hover:underline">Privacy Policy</Link>.
+              <Link href="/privacy" className="text-slate-700 underline hover:no-underline">Privacy Policy</Link>.
             </p>
           </div>
         </div>

--- a/docs/audits/IDOR-SWEEP-2026-06-05.md
+++ b/docs/audits/IDOR-SWEEP-2026-06-05.md
@@ -1,0 +1,63 @@
+# Multi-role authorization / IDOR sweep — 2026-06-05
+
+Defensive security pass against the live Supabase project (`guggzyqceattncjwvgyc`),
+driven by 6 captured authenticated role sessions plus direct PostgREST probing with
+the public anon key. Method: static RLS-policy analysis (catches empty-table leaks) +
+live `HEAD count=exact` probes (counts only — no PII pulled). Two correctly-scoped
+tables that hold data (`professional_leads` 9 rows, `broker_notifications` 45 rows)
+returned 0 to anon/individual, validating the probe.
+
+## 🔴 Confirmed live leaks (exploitable now via the public anon key)
+
+| Table | Policy | Exposure | Rows | Verified |
+|---|---|---|---:|---|
+| `advisor_billing` | `"Anyone can read billing"` SELECT public `USING(true)` | `amount_cents, invoice_number, **stripe_invoice_id, stripe_payment_intent_id**, status, paid_at` | 12 | anon HEAD → `200`, count 12 |
+| `fee_alert_subscriptions` | `"Anyone can read fee alerts"` SELECT public `USING(true)` | `email, broker_slugs, verify_token, unsubscribe_token` (PII + action tokens) | 3 | anon HEAD → `200`, count 3 |
+
+`advisor_billing` is the headline: **unauthenticated** read of advisor financial
+records incl. Stripe IDs — same class as the original P0, on a table the code-audit missed.
+
+## 🟠 Latent (empty today, dangerous policy)
+
+| Table | Policy | Risk |
+|---|---|---|
+| `price_drop_notifications` | `"Service manage price drops"` **ALL** public `USING(true)` | public read **and update/delete** of all rows |
+
+## 🟡 By design / needs your call
+
+- `quiz_weights` — public-readable (53 rows). **Intentional and documented**
+  (`lib/getmatched/top-match.ts:16` notes `anon SELECT USING(TRUE)`; the quiz reads it).
+  Exposes per-broker ranking weights. Left as-is — flag only if you consider the
+  weighting methodology commercially sensitive.
+
+## ✅ Confirmed FIXED (prior P0s — no longer leaking)
+
+`broker_wallets`, `wallet_transactions`, `marketplace_invoices` now use
+`broker_slug IN (SELECT … WHERE auth_user_id = auth.uid())` scoping (not `USING(true)`).
+anon/individual probes returned 0. The earlier wallet/invoice leak is closed.
+
+## Root cause (systemic, worth noting)
+
+Three admin dashboards read privileged tables via the **browser** Supabase client:
+- `app/admin/finance/page.tsx` → `advisor_billing`
+- `app/admin/revenue/page.tsx` → `advisor_billing`, `broker_wallets`, `professionals.stripe_customer_id`
+- `app/admin/email-performance/page.tsx` → `fee_alert_subscriptions`, `quiz_leads`
+
+Because admin identity is the `ADMIN_EMAILS` allow-list (not a JWT role), the quick way
+to make browser-client admin reads "work" was permissive `USING(true)` RLS — which also
+exposes the data to the whole internet. Note `app/admin/revenue` reads `broker_wallets`
+via the browser client, so the #1409 broker-scope fix likely **already returns 0 there** —
+the admin revenue page's wallet figures may be silently empty. The durable fix is to move
+these admin reads server-side (service-role API routes); the migration below is the
+minimal, non-breaking stopgap.
+
+## Remediation
+
+`supabase/migrations/20260831000000_fix_public_read_rls_leaks.sql` — replaces the two
+`USING(true)` public SELECT policies with `USING(public.is_admin())` (closes anon access,
+keeps admin dashboards working, advisors keep their own-row policy), and re-scopes
+`price_drop_notifications` to `service_role`. Reversible; passes the RLS-isolation intent.
+
+**Follow-up (not in this migration):** move the three admin dashboard reads to server-side
+service-role routes, then audit `app/admin/*` for any other browser-client reads of
+privileged tables.

--- a/e2e/visual/auto-login.spec.ts
+++ b/e2e/visual/auto-login.spec.ts
@@ -19,6 +19,13 @@ const TEST_USERS = [
 
 const baseURL = process.env.E2E_BASE_URL ?? "http://localhost:3000";
 
+// Remote/sandbox egress proxies can MITM TLS with a CA chromium doesn't trust.
+// Manually-created contexts (browser.newContext()) don't inherit the config's
+// `use.ignoreHTTPSErrors`, so opt in explicitly via the same env the bots use.
+const ignoreHTTPSErrors =
+  process.env.E2E_IGNORE_HTTPS_ERRORS === "1" ||
+  process.env.BOTS_IGNORE_HTTPS_ERRORS === "1";
+
 test("auto-login: create authenticated sessions for all test users", async ({
   browser,
 }) => {
@@ -31,25 +38,35 @@ test("auto-login: create authenticated sessions for all test users", async ({
 
     console.log(`\n🔑 Logging in: ${testUser.state} (${testUser.email})`);
 
-    const context = await browser.newContext();
+    const context = await browser.newContext({ ignoreHTTPSErrors });
     const page = await context.newPage();
 
     try {
-      // Navigate to login
+      // `networkidle` never settles on auth pages (the Supabase client holds a
+      // connection open), so wait for the DOM instead.
       await page.goto(`${baseURL}${state.loginUrl}`, {
-        waitUntil: "networkidle",
-        timeout: 20000,
+        waitUntil: "domcontentloaded",
+        timeout: 30000,
       });
 
-      // Fill email
+      // Wait for the form to hydrate before touching it — otherwise the tab
+      // probe below races client hydration and the password field never mounts.
       const emailInput = page.locator('input[type="email"]').first();
-      await emailInput.fill(testUser.email);
+      await emailInput.waitFor({ state: "visible", timeout: 15000 });
 
-      // Fill password
+      // The public /login form defaults to a magic-link tab; the password
+      // fields only mount once the "Password" tab is selected. Best-effort —
+      // portal login forms don't have this tab.
+      const passwordTab = page.getByRole("button", { name: "Password", exact: true });
+      if (await passwordTab.count()) {
+        await passwordTab.first().click().catch(() => {});
+      }
+
       const passwordInput = page.locator('input[type="password"]').first();
+      await passwordInput.waitFor({ state: "visible", timeout: 10000 });
+      await emailInput.fill(testUser.email);
       await passwordInput.fill(testUser.password);
 
-      // Click login button (try multiple selectors)
       let loginButton = page.locator(
         'button:has-text("Sign in"), button:has-text("Login"), button[type="submit"]'
       );
@@ -58,11 +75,17 @@ test("auto-login: create authenticated sessions for all test users", async ({
       }
       await loginButton.click();
 
-      // Wait for post-login redirect
-      await page.waitForURL(state.postLoginPattern, { timeout: 15000 });
+      // Success = matches the state's post-login pattern AND is no longer a
+      // login page. Without the second clause, patterns like /broker-portal(\/|$)/
+      // match /broker-portal/login and produce a junk "authenticated" session.
+      await page.waitForURL(
+        (url) =>
+          state.postLoginPattern.test(url.pathname) &&
+          !/\/login(\/|$)/i.test(url.pathname),
+        { timeout: 15000 }
+      );
       console.log(`  ✓ Logged in, redirected to: ${page.url()}`);
 
-      // Save authenticated session
       const stateFile = state.storageStateFile;
       await page.context().storageState({ path: stateFile });
       console.log(`  ✓ Session saved to: ${stateFile}`);

--- a/e2e/visual/playwright.config.ts
+++ b/e2e/visual/playwright.config.ts
@@ -21,6 +21,12 @@ export default defineConfig({
     baseURL: process.env.E2E_BASE_URL ?? "http://localhost:3000",
     actionTimeout: 10_000,
     navigationTimeout: 20_000,
+    // Opt-in for remote/sandbox environments whose egress proxy does TLS
+    // interception with a CA chromium doesn't trust (mirrors the bots config's
+    // BOTS_IGNORE_HTTPS_ERRORS). Off by default so local/CI stays strict.
+    ignoreHTTPSErrors:
+      process.env.E2E_IGNORE_HTTPS_ERRORS === "1" ||
+      process.env.BOTS_IGNORE_HTTPS_ERRORS === "1",
   },
   webServer: {
     command: "npm run dev",

--- a/supabase/migrations/20260605071811_fix_public_read_rls_leaks.sql
+++ b/supabase/migrations/20260605071811_fix_public_read_rls_leaks.sql
@@ -1,0 +1,47 @@
+-- Fix public-read RLS leaks on advisor_billing, fee_alert_subscriptions, price_drop_notifications
+--
+-- Found by the multi-role IDOR/authorization bot sweep (2026-06-05; see
+-- docs/audits/IDOR-SWEEP-2026-06-05.md). Three tables carried permissive policies that
+-- exposed privileged data to the *public* role (anyone with the embedded anon key,
+-- including unauthenticated visitors):
+--
+--   * advisor_billing          — "Anyone can read billing"  SELECT public USING (true)
+--                                → anon read of amount_cents, invoice_number,
+--                                  stripe_invoice_id, stripe_payment_intent_id (12 rows).
+--   * fee_alert_subscriptions  — "Anyone can read fee alerts" SELECT public USING (true)
+--                                → anon read of email + verify_token + unsubscribe_token.
+--   * price_drop_notifications — "Service manage price drops" ALL public USING (true)
+--                                → public read/update/delete (latent; empty today).
+--
+-- Root cause: admin dashboards (app/admin/finance, /revenue, /email-performance) read
+-- these tables via the *browser* Supabase client; the permissive policies were the
+-- over-broad enabler. Admin identity is the ADMIN_EMAILS allow-list, surfaced in the DB
+-- by public.is_admin() (auth.jwt()->>'email' LIKE '%@invest.com.au' OR founder). Re-scoping
+-- the reads to is_admin() keeps the dashboards working while denying anon/regular users.
+-- Verified post-apply: anon=0, non-admin authenticated=0, admin authenticated=12.
+--
+-- Idempotent (drops both legacy and new policy names before create). Rollback: re-create
+-- the dropped policies with USING (true) — NOT recommended (re-opens the leak).
+
+-- advisor_billing: admin reads all; advisors keep their existing own-row policy.
+drop policy if exists "Anyone can read billing" on public.advisor_billing;
+drop policy if exists "Admins read all billing" on public.advisor_billing;
+create policy "Admins read all billing"
+  on public.advisor_billing for select to public
+  using (public.is_admin());
+
+-- fee_alert_subscriptions: admin reads all; cron/server paths use the service-role
+-- client (RLS-exempt). The anon INSERT policy is unchanged.
+drop policy if exists "Anyone can read fee alerts" on public.fee_alert_subscriptions;
+drop policy if exists "Admins read all fee alerts" on public.fee_alert_subscriptions;
+create policy "Admins read all fee alerts"
+  on public.fee_alert_subscriptions for select to public
+  using (public.is_admin());
+
+-- price_drop_notifications: was public/USING(true); scope to service_role
+-- (matches broker_notifications).
+drop policy if exists "Service manage price drops" on public.price_drop_notifications;
+create policy "Service manage price drops"
+  on public.price_drop_notifications for all to public
+  using ((select auth.role()) = 'service_role')
+  with check ((select auth.role()) = 'service_role');


### PR DESCRIPTION
> ⚠️ **Scope note:** this branch started as a11y + bot-infra, then a multi-role IDOR bot sweep found a **live anon-read breach**. The RLS fix in `20260605071811_fix_public_read_rls_leaks.sql` has **already been applied to the live project** (with founder authorization) to stop active exposure — the migration file is committed for parity. Verified post-apply: anon=0, non-admin=0, admin=12.

## `fix(security)` — anon-read RLS leaks (applied to prod)
A multi-role IDOR/authorization sweep (`docs/audits/IDOR-SWEEP-2026-06-05.md`) found three tables exposing privileged data to the **public** role (anyone with the embedded anon key, incl. unauthenticated):
- **`advisor_billing`** — `SELECT public USING(true)` → anon read of `amount_cents, invoice_number, stripe_invoice_id, stripe_payment_intent_id` (verified anon count **12**). **P0.**
- **`fee_alert_subscriptions`** — `SELECT public USING(true)` → anon read of `email, verify_token, unsubscribe_token` (count 3). PII.
- **`price_drop_notifications`** — `ALL public USING(true)` → public read/update/delete (latent).

Root cause: three admin dashboards (`finance`, `revenue`, `email-performance`) read these via the **browser** client, and admin identity is the `ADMIN_EMAILS` allow-list, not a JWT role — so permissive RLS was the over-broad enabler. Fix re-scopes reads to `public.is_admin()` (keeps dashboards working, denies anon); `price_drop_notifications` → `service_role`. The prior `broker_wallets`/`wallet_transactions`/`marketplace_invoices` P0s are **already fixed** (broker_slug-scoped) and confirmed 0 in this sweep.

## `fix(admin)` — move dashboards to server-side service-role reads (root-cause fix)
The RLS hardening closed the leaks but left the three dashboards reading privileged tables through the **browser anon client** against policies that now deny them — so they were **silently broken**, not just weakly guarded:
- **finance** — `finance_transactions` is `service_role`-ALL only → browser read 0 rows **and every write denied** (add/edit/delete/sync). Dashboard fully non-functional.
- **revenue** — `broker_wallets` is `broker_slug`-scoped → Cash Position figures read 0 for admins.
- **email-performance** — `quiz_leads` is `service_role`-SELECT only → Total List / list-health counts read 0.

Moved every privileged read/write to the service-role client behind `requireAdmin()` (ADMIN_EMAILS + MFA), matching the `ab-tests` precedent:
- `GET /api/admin/revenue-summary` — aggregates advisor/marketplace/article revenue server-side; only totals cross the wire (no Stripe ids / advisor PII).
- `GET /api/admin/email-performance` — aggregates capture/quiz/drip metrics; returns counts + bounce list only.
- `/api/admin/finance` — GET list + POST/PATCH/DELETE CRUD.
- `POST /api/admin/finance/sync` — imports paid `advisor_billing` into the ledger.

The pages now `fetch()` these routes instead of `@/lib/supabase/client`, so the browser never touches `advisor_billing`, `broker_wallets`, `quiz_leads`, `fee_alert_subscriptions` or professional/lead PII — defense-in-depth even if a future policy regresses. Restores all three dashboards. Route tests cover admin-deny, aggregation correctness, validation, and the sync de-dup path.

## `fix(a11y)` — login Terms/Privacy links
Were `hover:underline` only (distinguishable by colour alone — axe `link-in-text-block`, WCAG 1.4.1). Now persistent underline. Verified live in the deploy preview.

## `test(bots)` — harden `auto-login.spec.ts`
Capturing logged-in sessions against the mirror exposed four real bugs: `networkidle` never settles on auth pages → `domcontentloaded`; password fields only mount after the "Password" tab is clicked → click it + wait for hydration; success asserted on URL pattern alone matched `/portal/login` → also require non-login URL; `browser.newContext()` doesn't inherit `ignoreHTTPSErrors` → explicit env opt-in (proxy MITM). Reliable capture 1/10 → 6/10.

## Verification
- `npm run type-check` ✓ · `npm run lint` (changed files) ✓ · new route tests ✓ (17)
- RLS fix re-probed post-apply: anon/non-admin = 0, admin = 12 (`is_admin()` true).
- a11y fix confirmed in deploy preview.
