### PR TITLE
chore(db): lock quiz_weights SELECT to admins (deny anon read) — merge after #1411 deploys

### DIFF
--- a/supabase/migrations/20260831000000_lock_quiz_weights_anon_read.sql
+++ b/supabase/migrations/20260831000000_lock_quiz_weights_anon_read.sql
@@ -1,0 +1,40 @@
+-- Lock quiz_weights SELECT to admins only (deny anonymous read).
+--
+-- quiz_weights holds the tuned per-broker ranking weights that drive the Get
+-- Matched quiz. The "Public read quiz weights" policy (SELECT to public USING
+-- (true)) made the whole matrix world-readable: the Supabase anon key is
+-- embedded in the client bundle, so anyone could call PostgREST directly —
+--   GET /rest/v1/quiz_weights?select=*
+-- — and extract the full weight matrix, a commercially-sensitive ranking asset.
+--
+-- After PR #1411 (+ the top-match service-role switch) every legitimate reader
+-- reaches the table WITHOUT the anon role:
+--   * app/api/quiz/score            — service-role (public quiz scoring)
+--   * lib/getmatched/top-match.ts   — service-role (get-matched hero card)
+--   * app/admin/quiz-weights        — browser client, authenticated, is_admin()
+-- Service-role bypasses RLS; the admin editor's browser session carries an
+-- @invest.com.au JWT, so is_admin() is true for it. The existing admin
+-- INSERT/UPDATE policies ("Admin can insert/update quiz weights", both
+-- is_admin()-scoped) are unchanged. We only re-scope SELECT.
+--
+-- ⚠️ ORDER OF OPERATIONS — DO NOT MERGE THIS PR UNTIL #1411 IS DEPLOYED.
+-- supabase-migrate.yml auto-applies on push to main, and the app deploy lags
+-- the migration by ~15-20 min. Applying this before the service-role readers
+-- are live degrades the quiz GRACEFULLY (public scoring falls back to the coarse
+-- client weights; the get-matched hero card is skipped) until the new code ships
+-- — never a hard break, but a real regression window. Merge only after #1411's
+-- deploy is confirmed live.
+--
+-- Idempotent (drop-if-exists + create). Rollback: recreate the dropped policy
+--   create policy "Public read quiz weights" on public.quiz_weights
+--     for select to public using (true);
+-- — NOT recommended (re-opens anonymous extraction of the weight matrix).
+
+drop policy if exists "Public read quiz weights" on public.quiz_weights;
+drop policy if exists "Admins read quiz weights" on public.quiz_weights;
+
+create policy "Admins read quiz weights"
+  on public.quiz_weights
+  for select
+  to public
+  using (public.is_admin());


### PR DESCRIPTION
## ⚠️ Do NOT merge until #1411 is deployed
`supabase-migrate.yml` auto-applies migrations on push to `main`, and the app deploy lags the migration by ~15–20 min. Merging this before #1411's service-role readers are live would degrade the live quiz (public scoring falls back to coarse client weights; the get-matched hero card is skipped) for that window — graceful, but a real regression. **Merge only after #1411's deploy is confirmed live.**

## Why
`quiz_weights` holds the tuned per-broker ranking weights behind the Get Matched quiz. The live policy is `Public read quiz weights` → `SELECT to public USING (true)`. Because the Supabase anon key is embedded in the client bundle, anyone can call PostgREST directly — `GET /rest/v1/quiz_weights?select=*` — and extract the **entire weight matrix**. #1411 stopped *our app* shipping it, but the table itself is still world-readable. This closes that.

## What
Re-scopes the SELECT policy from `USING (true)` to `USING (public.is_admin())` — same pattern as #1410's anon-read fix. Denies anon; keeps the admin weights editor working (its browser session carries an `@invest.com.au` JWT, so `is_admin()` is true). The existing `is_admin()`-scoped INSERT/UPDATE policies are untouched.

## Why this is safe to apply *after* #1411 deploys
Every legitimate reader then reaches the table without the anon role:
| Reader | Path | Client |
|---|---|---|
| `app/api/quiz/score` | public quiz scoring | service-role (bypasses RLS) |
| `lib/getmatched/top-match.ts` | get-matched hero card | service-role (switched in #1411) |
| `app/admin/quiz-weights` | weights editor | browser, authenticated, `is_admin()` |

Idempotent (drop-if-exists + create). Rollback documented in the migration header (recreate the `USING (true)` policy — not recommended).

## Verification
- SQL validated against the live policy set (`Public read quiz weights` exists; `public.is_admin()` exists and is `auth.jwt()->>'email' LIKE '%@invest.com.au'`).
- **Not applied to prod** — this PR is the apply mechanism, gated on the merge precondition above.


---
_Generated by [Claude Code](https://claude.ai/code/session_014hduVwZpij3yXcH6Ct8hVo)_