### PR TITLE
fix(versus): create missing versus_votes table (every /versus/* vote widget 500s)

### DIFF
--- a/bots/reports/ai-journey-2026-06-05.md
+++ b/bots/reports/ai-journey-2026-06-05.md
@@ -1,0 +1,82 @@
+# AI Journey — expanded run (2026-06-05)
+
+Second AI-driven sweep of the live site (`lambent-sawine-17c3dd.netlify.app`),
+covering the personas/funnels the 2026-06-02 run skipped. In-session on the Max
+plan (Claude is the judgment brain); side-effect firewall on throughout.
+
+## What ran
+
+**6 personas, ~12 steps each (~72 pages walked):**
+
+| Persona | Start | Verdict |
+|---|---|---|
+| intl-investor (SG-based, country mode) | `/foreign-investment` | ✅ healthy |
+| smsf-saver | `/smsf` | ✅ healthy |
+| crypto-buyer | `/crypto` | ✅ healthy |
+| wholesale-hnw | `/wholesale` | ✅ healthy |
+| wealth-stack | `/wealth-stack` | ✅ healthy page; surfaced the versus bug |
+| quiz-taker | `/get-matched` | ✅ healthy (entry + advisor nav) |
+
+Every candidate finding was re-verified with retries before reporting (the
+sandbox TLS-MITM proxy throws transient 403/SSL/`Failed to fetch` noise).
+
+## 🔴 Confirmed bug — every `/versus/*` vote widget is broken (FIX SHIPPED)
+
+`GET /api/versus/vote` returns **500 on every pair** (verified 5/5 retries across
+broker-vs-broker *and* savings-vs-super pairs — not cross-category-specific).
+
+**Root cause (confirmed by direct DB query, proxy-independent):** the
+`versus_votes` table **does not exist** in production —
+`to_regclass('public.versus_votes')` is `NULL`, and no `CREATE TABLE` for it
+exists in `supabase/migrations/`. The feature
+(`app/api/versus/vote/route.ts` + the versus-page Community Vote widget) shipped
+without its schema. Visible symptom: the Community Vote widget renders both
+options but no tallies/percentages.
+
+**Fix:** `supabase/migrations/20260831010000_create_versus_votes.sql` — creates
+the table with the exact columns the route reads/writes, the pair+ip_hash dedup
+unique index, RLS enabled, service-role-only policy (all access is mediated by
+the route's admin client). Additive and safe to auto-apply on merge.
+
+## ✅ Prior finding resolved — `/wholesale` hub now exists
+
+The 2026-06-02 run flagged `/wholesale` as a 404 (links from
+`investing-for/[occupation]` + the dashboard pointed at a missing page). It has
+since been **built** into a polished hub (eligibility cards, wholesale-vs-retail
+table, a "what you give up — read this first" risk-disclosure block, FAQs).
+Confirmed 200 with real content. No action needed.
+
+## Rejected (false positives — proxy artifacts, not prod defects)
+
+- **`/crypto` `TypeError: Failed to fetch`** — accompanied by `403` +
+  "SSL certificate error fetching the script" in `proxyNoise`; the TLS-MITM
+  proxy dropping a script. `/crypto` serves 200 consistently.
+- **Advisor profile pages — React #419** (`/advisor/priya-sharma-mortgage-broker`,
+  `/advisor/sarah-mitchell-…`). Reproduced 2–3/3 in a real browser, but **always
+  co-occurring with proxy SSL/403 noise** (the proxy drops the page's SSR/Suspense
+  data fetch → boundary can't finish → #419 → client fallback). Page still 200s
+  and client-renders. Not confirmable in-sandbox; **re-check on a non-proxied
+  deploy** (Vercel) before treating as real.
+
+## UX / UI observations (no code change — product calls)
+
+- **Content → conversion path is loose on non-affiliate verticals.** Deep SMSF/
+  super/wholesale content pages carry few inline provider CTAs — partly by design
+  (super funds and wholesale have no/limited affiliate program; super CPA = $0),
+  but a content reader has to navigate back to `/compare` to act. Worth a
+  "next step" nudge on these guides.
+- **Cross-category versus pages look thin.** On `…-vs-australiansuper` (savings
+  vs super), the "Head-to-Head Comparison" and "Pros & Cons" sections rendered
+  blank in the capture. Likely proxy-dropped SSR (same confound as #419), but
+  cross-category pairings may also legitimately have sparse comparison data —
+  worth checking whether these pairings should be generated at all.
+- **Positive:** ~72 pages across 6 funnels with **zero real 404s/dead-ends**,
+  fees + risk disclosures present on every content page walked, and strong
+  internal deep-linking. `/wholesale` and `/wealth-stack` are clean, well-
+  structured pages.
+
+## Harness note
+The link-crawler follows links, so multi-step **forms** (the get-matched quiz,
+the wealth-stack builder) aren't completed end-to-end in-sandbox — the proxy
+drops their async fetches. Run `ai-form.cjs` against the Vercel deploy to walk a
+flow all the way to a result.

--- a/supabase/migrations/20260831010000_create_versus_votes.sql
+++ b/supabase/migrations/20260831010000_create_versus_votes.sql
@@ -1,0 +1,49 @@
+-- Create the missing `versus_votes` table.
+--
+-- Found by the AI-journey bot sweep (2026-06-05, wealth-stack persona): every
+-- /versus/* page's community-vote widget calls GET /api/versus/vote, which
+-- queries `versus_votes` — but that table was never created by any migration.
+-- The endpoint 500s on every pair (verified 5/5 retries across broker-vs-broker
+-- and savings-vs-super pairs; to_regclass('public.versus_votes') = NULL in prod).
+-- The feature (app/api/versus/vote/route.ts + the versus-page widget) shipped
+-- without its schema.
+--
+-- Columns mirror exactly what the route reads/writes:
+--   GET  selects chosen_slug filtered by (broker_a_slug, broker_b_slug)
+--   POST inserts { broker_a_slug, broker_b_slug, chosen_slug, ip_hash, created_at }
+--        and dedups on (broker_a_slug, broker_b_slug, ip_hash).
+-- The route normalises each pair so broker_a_slug < broker_b_slug before storage.
+--
+-- Access is fully mediated by the route's service-role client (createAdminClient),
+-- so RLS is enabled with a service_role-only policy: no anon/authenticated client
+-- touches the table directly, and raw per-voter rows (incl. ip_hash) are never
+-- exposed — only the aggregated tallies the GET endpoint returns.
+--
+-- Idempotent. Rollback: drop table public.versus_votes;
+
+create table if not exists public.versus_votes (
+  id           bigint generated always as identity primary key,
+  broker_a_slug text not null,
+  broker_b_slug text not null,
+  chosen_slug   text not null,
+  ip_hash       text not null,
+  created_at    timestamptz not null default now()
+);
+
+-- One vote per normalised pair per hashed IP (the route's dedup check).
+create unique index if not exists versus_votes_pair_voter_uniq
+  on public.versus_votes (broker_a_slug, broker_b_slug, ip_hash);
+
+-- Tally lookups filter by the normalised pair.
+create index if not exists versus_votes_pair_idx
+  on public.versus_votes (broker_a_slug, broker_b_slug);
+
+alter table public.versus_votes enable row level security;
+
+drop policy if exists "service_role manages versus_votes" on public.versus_votes;
+create policy "service_role manages versus_votes"
+  on public.versus_votes
+  for all
+  to public
+  using ((select auth.role()) = 'service_role')
+  with check ((select auth.role()) = 'service_role');


### PR DESCRIPTION
## Found by the AI-journey bot sweep (2026-06-05)

The expanded 6-persona journey (`bots/reports/ai-journey-2026-06-05.md`) found that **`GET /api/versus/vote` returns 500 on every broker pair** — so every `/versus/*` page's Community Vote widget has been silently failing (renders both options, no tallies).

### Root cause (confirmed, proxy-independent)
The `versus_votes` table **does not exist in production**: `to_regclass('public.versus_votes')` is `NULL`, and there is **no `CREATE TABLE` for it anywhere in `supabase/migrations/`**. The feature (`app/api/versus/vote/route.ts` GET/POST + the versus-page widget) shipped without its schema. Verified 5/5 retries across broker-vs-broker *and* savings-vs-super pairs (it's not cross-category-specific — the table is just missing).

### Fix
`supabase/migrations/20260831010000_create_versus_votes.sql` creates the table modelled exactly on the route's reads/writes:
- columns `broker_a_slug, broker_b_slug, chosen_slug, ip_hash, created_at`
- unique index on `(broker_a_slug, broker_b_slug, ip_hash)` — the POST dedup
- index on `(broker_a_slug, broker_b_slug)` — the GET tally lookup
- RLS enabled + **service-role-only** policy (all access is mediated by the route's `createAdminClient`; raw per-voter rows incl. `ip_hash` never exposed)

Additive and idempotent — safe to auto-apply on merge (`supabase-migrate.yml`). No app-code change needed; the route already expects this table.

### CI notes
- Forward types-drift gate: unaffected (it flags types *without* a migration; this is the reverse). 
- `Supabase types drift`: generates from the live schema (where the table doesn't exist yet) and only warns — no diff, no failure.
- RLS-isolation gate: skips — no `user_id`/`owner_id` column.

### Also in this PR
The full journey report. Highlights beyond this bug: the `/wholesale` 404 from the 2026-06-02 run is **resolved** (hub was built); two candidate errors (`/crypto` failed-fetch, advisor-page React #419) were **rejected as proxy artifacts** after retry verification; plus UX/UI notes (loose content→convert path on non-affiliate verticals; thin cross-category versus pages) for product triage.


---
_Generated by [Claude Code](https://claude.ai/code/session_014hduVwZpij3yXcH6Ct8hVo)_