### PR TITLE
fix(admin): revenue-summary resilient to missing broker_campaigns + schema-drift audit (31 phantom tables)

### DIFF
--- a/__tests__/api/admin-revenue-summary.test.ts
+++ b/__tests__/api/admin-revenue-summary.test.ts
@@ -74,4 +74,16 @@ describe("/api/admin/revenue-summary", () => {
     const res = await GET();
     expect(res.status).toBe(500);
   });
+
+  it("survives a missing broker_campaigns relation (schema drift) with 0 campaigns", async () => {
+    // broker_campaigns does not exist in prod — must not 500 the whole dashboard.
+    tableResults = {
+      brokers: { data: [], error: null },
+      broker_campaigns: { data: null, error: { message: 'relation "broker_campaigns" does not exist' } },
+    };
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.marketplaceRev.activeCampaigns).toBe(0);
+  });
 });

--- a/app/api/admin/revenue-summary/route.ts
+++ b/app/api/admin/revenue-summary/route.ts
@@ -68,19 +68,29 @@ export async function GET() {
     supabase.from("lead_disputes").select("id"),
   ]);
 
+  // Fatal-error check EXCLUDES campaignsRes: the `broker_campaigns` relation
+  // does not exist in production (schema drift — see
+  // docs/audits/SCHEMA-DRIFT-2026-06-05.md). The pre-#1410 browser dashboard
+  // read each table independently and simply showed 0 active campaigns when that
+  // query failed; this server route must not let one missing optional table
+  // 500 the entire revenue dashboard. activeCampaigns falls back to 0 below.
   const firstError =
     clicksRes.error ||
     brokersRes.error ||
     leadsRes.error ||
     billingRes.error ||
     walletsRes.error ||
-    campaignsRes.error ||
     articlesRes.error ||
     prosRes.error ||
     disputesRes.error;
   if (firstError) {
     log.error("Revenue summary read failed", { err: firstError.message });
     return NextResponse.json({ error: "Failed to load revenue data" }, { status: 500 });
+  }
+  if (campaignsRes.error) {
+    log.warn("Revenue summary: broker_campaigns read failed (treating as 0)", {
+      err: campaignsRes.error.message,
+    });
   }
 
   // Broker platform-type map (drives the client-side CPA estimate).

--- a/docs/audits/SCHEMA-DRIFT-2026-06-05.md
+++ b/docs/audits/SCHEMA-DRIFT-2026-06-05.md
@@ -1,0 +1,64 @@
+# Schema-drift probe — code references vs live DB (2026-06-05)
+
+Bot-driven API & schema-drift sweep. Method: extract every `.from("<table>")`
+literal in `app/` + `lib/` (406 distinct), diff against the live project's
+`information_schema.tables` (the actual relations). **31 relations are referenced
+in code but do not exist in production.** This is the systemic version of the
+`versus_votes` bug (found by the AI-journey run) — code shipped against tables
+that were never created or never applied.
+
+> NB: the repo's `npm run audit:unapplied-migrations` compares migration files
+> against the `schema_migrations` *ledger*, so it lists migrations whose tables
+> already exist (ledger drift). This probe compares against the **actual tables**,
+> so it catches the relations that genuinely 500 at runtime.
+
+## Class B — migration EXISTS but table is ABSENT in prod (unapplied)
+
+These two migration files are committed but their tables aren't in the live DB —
+the auto-apply (`supabase-migrate.yml`) never landed them (likely errored on
+apply or pre-dated the workflow). The features are dead in prod.
+
+| Migration file | Tables missing in prod | Feature broken |
+|---|---|---|
+| `20260729_sp02_startup_portal_schema.sql` | `startup_profiles`, `startup_rounds`, `startup_sessions`, `startup_data_room_files`, `startup_data_room_access`, `startup_investor_inquiries`, `esic_verifications`, `wholesale_investor_certifications` | Startup portal (`/admin/startups`, `/invest/startups/*`), wholesale-cert (`/account/wholesale-cert`, `/api/wholesale-investor-cert/*`) |
+| `20260520_dd03_session_booking_payments.sql` | `booking_payments` | Session-booking Stripe handler (`lib/stripe-webhook/handlers/checkout-session-completed.ts`) |
+
+**Fix:** re-apply these migrations to prod (manual `workflow_dispatch` of
+Supabase migrate, or diagnose why they error). **Needs founder awareness** — it's
+a multi-table prod schema change; confirm the migrations apply cleanly against
+current prod before triggering. NOT auto-applied here.
+
+## Class A — NO migration anywhere (code references a table that was never defined)
+
+The `versus_votes` class. ~21 relations. Highest-impact confirmed first:
+
+| Table | Referenced by | Reachable | Impact |
+|---|---|---|---|
+| `weights` | `app/api/wealth-stack/route.ts` | anon POST | **wealth-stack ("Revenue #1") POST 500s on every build** — the route reads `from("weights").select("broker_slug, weights")`; prod has `quiz_weights` (flat cols), not `weights` (jsonb). Needs product call: create+seed `weights`, or repoint to `quiz_weights`. |
+| `broker_campaigns` | `app/api/admin/revenue-summary/route.ts`, `app/admin/revenue` | admin | revenue dashboard — **regression fixed in this PR** (route no longer 500s on it; shows 0 campaigns). Still needs the table created or repointed to `campaigns`. |
+| `investment_loan_rates` | `/api/admin/loan-rates`, `/api/cron/refresh-loan-rates`, `/api/cron/rate-alerts`, `/pro/insights` | admin + cron | loan-rate refresh + alerts cron likely erroring |
+| `ipo_offers`, `ipo_watchlist`, `ipo_alert_sends` | `/api/ipo-offers`, `/api/cron/ipo-alerts`, `/invest/ipo-calendar` | anon + cron | IPO calendar + alerts |
+| `course_enrollments` | `/api/courses/enroll`, `/api/courses/[slug]/complete`, `/my-learning`, `/academy/[slug]` | user | course enrolment flow |
+| `referrals` | `/api/referrals` | user | referral feature |
+| `user_profiles` | `app/account/dashboard/page.tsx` | user | dashboard (prod table is `profiles` — likely wrong name) |
+| `pro_subscribers` | `app/admin/analytics/AdminAnalyticsClient.tsx` | admin | analytics widget |
+| `professional_views` | `/api/advisor-auth/firm/analytics` | advisor | firm analytics |
+| `sponsorship_orders` | (grep) | — | triage |
+| `stripe_payouts` | (grep) | — | triage |
+| `digest_sends`, `push_send_log` | (grep) | cron | triage |
+| `incentive_reviews` | (grep) | — | triage |
+| `advisor_cohort_metrics`, `advisor_search_alerts` | (grep) | — | triage |
+| `api_consumer_webhooks`, `api_key_subscriptions`, `consumer_webhook_deliveries` | (grep) | — | API/webhook feature — triage |
+
+(`public` from the diff is a false positive — `.from("public")`-style parse, not a table.)
+
+## Fixed in this PR
+- `/api/admin/revenue-summary` made resilient to the missing `broker_campaigns`
+  relation (was a #1410 regression: one missing optional table 500'd the whole
+  admin revenue dashboard). Now logs + shows 0 active campaigns.
+
+## Recommended sequencing
+1. **Class B re-apply** (founder-gated) — unblocks 9 tables / 3 features at once via 2 existing migrations.
+2. **`weights` / wealth-stack** — product call (create+seed vs repoint to `quiz_weights`); it's the named revenue feature and 500s today.
+3. **Cron-backed Class A** (`investment_loan_rates`, `ipo_*`, `*_sends`) — these silently fail on schedule; create tables or gate the crons.
+4. **Prevention:** add a CI gate that diffs `.from()` literals against committed migrations' `CREATE TABLE`s (extends the existing types-drift gate to cover *all* `.from()` targets, not just typed tables), so code can't reference an undefined relation again.


### PR DESCRIPTION
## API & schema-drift probe (the mega-session you picked)

Cross-referenced **every `.from("<table>")` literal in `app/` + `lib/` (406 distinct)** against the live project's `information_schema.tables`. **31 relations are referenced in code but don't exist in production** — the systemic version of the `versus_votes` bug (#1414). Full classified map: `docs/audits/SCHEMA-DRIFT-2026-06-05.md`.

> The repo's `audit:unapplied-migrations` checks the migration *ledger* (lists migrations whose tables already exist). This probe checks **actual tables**, so it catches relations that genuinely 500 at runtime.

### Two root-cause classes
- **Class B — migration exists, never applied to prod (9 tables):** the whole `20260729_sp02_startup_portal_schema.sql` (startup portal + wholesale-cert + esic) and `20260520_dd03_session_booking_payments.sql`. Auto-apply never landed them → those features are dead in prod. **Founder-gated re-apply** recommended (multi-table prod schema change — confirm they apply cleanly first), not done here.
- **Class A — no migration anywhere (~21 tables):** the `versus_votes` class. Highest impact: **`weights`** (the wealth-stack "Revenue #1" POST 500s on every build — reads `from("weights")`, prod only has `quiz_weights`), plus `broker_campaigns`, `investment_loan_rates` (+crons), `ipo_*` (+cron), `course_enrollments`, `referrals`, `user_profiles`, etc.

### Fixed here (the one regression traced to merged code)
`/api/admin/revenue-summary` (#1410) listed `broker_campaigns` in its fatal-error check, but that relation doesn't exist in prod — so the **entire admin revenue dashboard 500s**. The pre-#1410 browser version read each table independently and just showed 0 campaigns. Restored: exclude `campaignsRes` from the fatal check, warn, fall back to 0. Test added.

### Verification
`tsc` ✓ · `admin-revenue-summary` tests 4/4 (incl. new missing-`broker_campaigns` case) ✓ · lint ✓ · pre-push ✓.

### Recommended next (in the doc)
1. Re-apply Class B (unblocks 9 tables/3 features via 2 existing migrations) — needs your go.
2. `weights`/wealth-stack product call: create+seed vs repoint to `quiz_weights`.
3. Cron-backed Class A tables (loan-rates, IPO) — silently failing on schedule.
4. **Prevention:** a CI gate diffing every `.from()` target against committed `CREATE TABLE`s so code can't reference an undefined relation again.


---
_Generated by [Claude Code](https://claude.ai/code/session_014hduVwZpij3yXcH6Ct8hVo)_