### PR TITLE
🚨 docs: cron fleet dark ~13 days (Vercel account blocked) — cron-health sweep

### DIFF
--- a/bots/reports/site-audit-2026-06-05.md
+++ b/bots/reports/site-audit-2026-06-05.md
@@ -1,0 +1,48 @@
+# Full-site page-sweep — 2026-06-05
+
+Deterministic launch-readiness crawl (`bots/journey/site-audit.cjs`) against the
+live Netlify mirror, firewall on. **65 routes audited · 886 internal links
+discovered · 80 re-probed with retries.**
+
+## Result: structurally healthy — zero current-code bugs
+
+- **0 broken links** of 80 probed (with retry verification).
+- **All 11 flagged routes resolve to false positives** once verified:
+
+| Flag | Routes | Verdict |
+|---|---|---|
+| HTTP 403/503/502, "Failed to fetch" | `/`, `/compare`, `/robo-advisors`, `/property-platforms`, `/advisors/tax-agents`, `/grants` | **Proxy noise** — every one returns **200 on 5/5** retry probes. The sandbox TLS-MITM proxy throws transient 4xx/5xx + SSL errors. |
+| `gated-not-redirected` | `/admin`, `/org-portal` | **By design** — client-gated (AdminAuthGuard / portal login), 200 + client redirect, not a server 3xx. The 401 console on `/org-portal` is its data fetch correctly refusing an unauthenticated caller. |
+| `no-h1` | `/quiz`, `/get-matched`, `/start` | **Stale deploy, not a code bug** (see below). |
+
+## Meta-finding: the live mirror is stale (deploy-side of the Vercel block)
+
+The `no-h1` flags are real *on the live site* but **current code already has the
+headings**:
+- `/quiz` — sr-only `<h1>` at `app/quiz/page.tsx:987`, added **2026-06-04**
+  (commit `81c49d6`) — not present on the live build.
+- `/get-matched` — visible `<h1>` in `GetMatchedClient.tsx:638`.
+- `/start` — a server `redirect("/quiz")`, so it inherits `/quiz`.
+
+The live mirror is missing code merged as recently as **yesterday (2026-06-04)**.
+This is the **deploy-side twin of the cron outage** (`CRON-HEALTH-2026-06-05.md`):
+the blocked Vercel account has frozen both scheduled jobs *and* deploys, so the
+live site no longer reflects `main`. Any live-site audit currently measures a
+stale build, not current code.
+
+## Conclusion
+
+The site is healthy at the code level — clean link graph, no broken pages, no
+real 5xx. The single systemic problem remains the **blocked Vercel account**,
+which is now confirmed to affect three things at once:
+1. CI deploy status (red on every PR),
+2. the cron fleet (dark ~13 days),
+3. production deploys (live build behind `main`).
+
+**No code PR from this sweep.** Re-run it once Vercel is unblocked and `main` is
+deployed, to audit current code against a fresh build.
+
+## Method
+`bots/journey/site-audit.cjs` (route list + site-wide link crawl, proxy-noise
+filtered, retry-verified) · per-flag HTTP retry probes (5×) · browser h1 checks ·
+`git log -S` to date the heading code vs the live build.

--- a/docs/audits/CRON-HEALTH-2026-06-05.md
+++ b/docs/audits/CRON-HEALTH-2026-06-05.md
@@ -1,0 +1,90 @@
+# Cron-health sweep — 2026-06-05
+
+## 🚨 HEADLINE: the entire cron fleet has been dark for ~13 days
+
+**No scheduled job has run since 2026-05-23 23:05 UTC** (now: 2026-06-05 21:24).
+Ground truth from the live `cron_run_log`:
+
+| Metric | Value |
+|---|---|
+| Last cron run (any job) | **2026-05-23 23:05:47 UTC** |
+| Runs in the last 7 days | **0** |
+| Runs after 2026-05-23 23:10 | **0** |
+| Vercel crons defined in `vercel.json` | **40** |
+
+All 40 scheduled jobs stopped firing on the same day. This is a fleet-wide
+outage, not a per-job failure.
+
+## Root cause (near-certain): the Vercel account is blocked
+
+Crons are **Vercel Cron** jobs (`vercel.json` → `/api/cron/dispatch/*` fan-out;
+CLAUDE.md: "Vercel cron routes live under `app/api/cron/*`"). There is **no
+Supabase pg_cron fallback**. Vercel executes the schedules — and the Vercel
+account is **blocked** (the `Vercel — Account is blocked` commit status that has
+shown red on every recent PR, linking to
+`vercel.com/knowledge/why-is-my-account-deployment-blocked`). A blocked account
+runs no crons, which exactly matches the fleet-wide stop.
+
+**This is an infra/billing action, not a code fix:** the account must be
+unblocked (founder/billing) before any scheduled job runs again.
+
+## Impact of ~13 days with no crons
+
+Everything time-driven has been silently off. A non-exhaustive read of the 40
+schedules:
+
+- **Revenue / finance:** `revenue-reconciliation`, `affiliate-payout-recon`,
+  `monthly-affiliate-report`, `month-end-close`, `referral-payouts`,
+  `subscription-dunning`, `advisor-dunning`.
+- **Lead / SLA:** `enforce-lead-sla`, `lead-sla-check`, `lead-followup-reminders`,
+  `confirm-lead-notify`, `auction-close`, `marketplace-stale-briefs`.
+- **Lifecycle email (engagement/revenue):** every `*-drip`, `welcome-drip`,
+  `winback-drip`, `abandoned-*-drip`, `investor-drip`, all digests/newsletters.
+- **Data freshness:** `broker-snapshot`, `check-fees`, `fee-index`,
+  `refresh-savings-rates`, `refresh-loan-rates`, `invest-score`,
+  `property-suburb-refresh`.
+- **Compliance / safety:** `gdpr-retention-purge`, `hard-delete-expired`,
+  `redact-deleted-users`, `account-deletion-reminder`, `afsl-expiry-monitor`,
+  `complaints-sla`.
+- **Monitoring:** `heartbeat`, `slo-monitor`, `synthetic-checks`,
+  `cron-health-alert`, `web-vitals-rollup`.
+
+## Why nothing alerted (watchdog blind spot)
+
+The freshness watchdogs — `heartbeat`, `cron-health-alert`, `cron-freshness`,
+`slo-monitor`, `synthetic-checks` — are **themselves Vercel crons**. When Vercel
+stopped, they stopped too, so the system that would page on a stale fleet went
+dark in the same instant. **A watchdog that runs on the thing it watches cannot
+report that thing being down.**
+
+## Compounding: 5 crons will still fail once Vercel is restored
+
+Even after unblocking, these query relations that don't exist in prod (see
+`docs/audits/SCHEMA-DRIFT-2026-06-05.md`) and will error on first run:
+
+| Cron | Phantom table(s) | Severity |
+|---|---|---|
+| `ipo-alerts` | `ipo_offers`, `ipo_watchlist`, `ipo_alert_sends` | fully broken (all its tables) |
+| `refresh-loan-rates` | `investment_loan_rates` | fully broken (its only table) |
+| `rate-alerts` | `investment_loan_rates` | partial |
+| `personalized-digest` | `digest_sends` | partial |
+| `revenue-reconciliation` | `stripe_payouts` | partial |
+
+## Recommendations
+
+1. **Unblock the Vercel account** (founder/billing) — restores all 40 schedules.
+   Until then the background fleet is fully offline.
+2. **Add a Vercel-independent watchdog.** A Supabase **pg_cron** job (runs in the
+   DB, not on Vercel) that checks `max(started_at)` in `cron_run_log` and alerts
+   if it's older than ~2h would have caught this on day one. This is the single
+   highest-value prevention — it removes the watchdog blind spot. (Build is
+   founder-gated: needs pg_cron enabled + an alert sink.)
+3. **Create the 5 phantom tables / gate those crons** before re-enabling, so the
+   first post-restore run doesn't error.
+4. Consider a `cron_run_log` retention note: it still holds the pre-outage
+   history, which is what made this diagnosable.
+
+## Method
+Live `cron_run_log` aggregates (counts/timestamps only) + `vercel.json` schedule
+parse + cross-ref of each `app/api/cron/*` route's `.from()` targets against the
+live schema. No code changed — this is a diagnosis + escalation.


### PR DESCRIPTION
## 🚨 The entire cron fleet has been dark for ~13 days

The cron-health sweep (you said run it next) found something urgent. Ground truth from the live `cron_run_log`:

| Metric | Value |
|---|---|
| Last cron run (any of 40 jobs) | **2026-05-23 23:05 UTC** |
| Runs in the last 7 days | **0** |
| Now | 2026-06-05 21:24 UTC |

**All 40 Vercel-scheduled jobs stopped on the same day** — a fleet-wide outage, not a per-job bug.

### Root cause (near-certain): the blocked Vercel account
Crons are Vercel Cron (`vercel.json` → `/api/cron/dispatch/*`), no Supabase pg_cron fallback. Vercel runs the schedules — and the Vercel **account is blocked** (the `Vercel — Account is blocked` status that's been red on every PR). Blocked account = no crons, exactly matching the fleet-wide stop. **This is a billing/infra action (unblock Vercel), not a code fix.**

### ~13 days of impact
Revenue reconciliation + affiliate payouts, lead SLAs, all lifecycle/drip email, data freshness (broker/fee/rate snapshots), GDPR retention purges, and **all monitoring** — silently off.

### Why nothing alerted
`heartbeat`, `cron-health-alert`, `slo-monitor`, `synthetic-checks` are **themselves Vercel crons** — they died with the fleet. A watchdog running on the thing it watches can't report that thing down.

### Compounding (from the schema-drift probe)
Even once Vercel is restored, 5 crons will error on phantom tables: `ipo-alerts` + `refresh-loan-rates` (fully), `rate-alerts`, `personalized-digest`, `revenue-reconciliation` (partial).

### This PR
Docs-only — `docs/audits/CRON-HEALTH-2026-06-05.md` (the diagnosis + impact + recommendations). No code change; the fix is unblocking Vercel.

### Recommendations
1. **Unblock the Vercel account** (founder/billing) — restores all 40 schedules.
2. **Add a Vercel-independent pg_cron watchdog** that alerts when `cron_run_log` goes stale (>~2h) — removes the blind spot that hid this for two weeks. (Founder-gated: pg_cron + alert sink.)
3. Create the 5 phantom tables / gate those crons before re-enabling.


---
_Generated by [Claude Code](https://claude.ai/code/session_014hduVwZpij3yXcH6Ct8hVo)_