### PR TITLE
feat(nf): record sms_consent on leads — Spam Act 2003 s.16 (audit §5 #20 part 1)

### DIFF
--- a/__tests__/api/cron-snapshot-health-scores.test.ts
+++ b/__tests__/api/cron-snapshot-health-scores.test.ts
@@ -41,6 +41,10 @@ vi.mock("@/lib/cron-run-log", () => ({
   wrapCronHandler: mockWrapCronHandler,
 }));
 
+vi.mock("@/lib/consumer-webhook-dispatch", () => ({
+  fireConsumerWebhook: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock("@/lib/logger", () => ({
   logger: () => ({
     info: vi.fn(),

--- a/__tests__/api/submit-lead.test.ts
+++ b/__tests__/api/submit-lead.test.ts
@@ -226,6 +226,57 @@ describe("POST /api/submit-lead", () => {
       expect(args.user_email).toBe("platform@test.com");
     });
 
+    it("stores sms_consent=true when caller opts in (Spam Act s.16)", async () => {
+      mockFrom.mockImplementation((table: string) => {
+        const b = createChainableBuilder(table, supabaseCalls);
+        if (table === "leads") {
+          b.single = vi.fn(() =>
+            Promise.resolve({ data: { id: 55 }, error: null }),
+          );
+        }
+        return b;
+      });
+
+      const req = buildRequest({
+        lead_type: "platform",
+        user_email: "sms@test.com",
+        user_phone: "+61400000000",
+        sms_consent: true,
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+
+      const leadCalls = supabaseCalls.leads || [];
+      const insertCall = leadCalls.find((c) => c.method === "insert");
+      const args = insertCall?.args[0] as Record<string, unknown>;
+      expect(args.sms_consent).toBe(true);
+    });
+
+    it("defaults sms_consent=false when not provided", async () => {
+      mockFrom.mockImplementation((table: string) => {
+        const b = createChainableBuilder(table, supabaseCalls);
+        if (table === "leads") {
+          b.single = vi.fn(() =>
+            Promise.resolve({ data: { id: 56 }, error: null }),
+          );
+        }
+        return b;
+      });
+
+      const req = buildRequest({
+        lead_type: "platform",
+        user_email: "nosms@test.com",
+        user_phone: "+61400000000",
+      });
+      const res = await POST(req);
+      expect(res.status).toBe(200);
+
+      const leadCalls = supabaseCalls.leads || [];
+      const insertCall = leadCalls.find((c) => c.method === "insert");
+      const args = insertCall?.args[0] as Record<string, unknown>;
+      expect(args.sms_consent).toBe(false);
+    });
+
     it("returns 500 when platform lead insert fails", async () => {
       mockFrom.mockImplementation((table: string) => {
         const b = createChainableBuilder(table, supabaseCalls);

--- a/app/api/submit-lead/route.ts
+++ b/app/api/submit-lead/route.ts
@@ -111,6 +111,7 @@ export async function POST(request: NextRequest) {
     prev_lead_ids,
     dry_run,
     confirm_advisor_id,
+    sms_consent,
     preferred_specialty,
   } = body as {
     lead_type?: string;
@@ -129,6 +130,12 @@ export async function POST(request: NextRequest) {
     dry_run?: boolean;
     /** If set: skip matching, create lead directly for this advisor ID */
     confirm_advisor_id?: number;
+    /**
+     * Spam Act 2003 s.16: user explicitly opted in to SMS/WhatsApp contact.
+     * Stored on the lead so advisors have a legal signal before using
+     * user_phone for outbound SMS or WhatsApp messages.
+     */
+    sms_consent?: boolean;
     /**
      * Cross-border Phase A: when the user arrives from a country page
      * (/foreign-investment/uk → ?specialty=UK+Pension+Transfer), prefer
@@ -189,6 +196,7 @@ export async function POST(request: NextRequest) {
         user_email: normalizedEmail,
         user_name: typeof user_name === "string" ? user_name.trim() : null,
         user_phone: typeof user_phone === "string" ? user_phone.trim() : null,
+        sms_consent: sms_consent === true,
         source_page: typeof source_page === "string" ? source_page : null,
         utm_source: (utm as UtmParams).utm_source ?? null,
         utm_medium: (utm as UtmParams).utm_medium ?? null,
@@ -320,6 +328,7 @@ export async function POST(request: NextRequest) {
         user_email: normalizedEmail,
         user_name: typeof user_name === "string" ? user_name.trim() : null,
         user_phone: typeof user_phone === "string" ? user_phone.trim() : null,
+        sms_consent: sms_consent === true,
         user_location_state: userState,
         user_intent: user_intent ?? null,
         revenue_value_cents: revenue_value_cents_confirmed,
@@ -672,6 +681,7 @@ export async function POST(request: NextRequest) {
       user_email: normalizedEmail,
       user_name: typeof user_name === "string" ? user_name.trim() : null,
       user_phone: typeof user_phone === "string" ? user_phone.trim() : null,
+      sms_consent: sms_consent === true,
       user_location_state: userState,
       user_intent: user_intent ?? null,
       revenue_value_cents,

--- a/lib/submit-lead-client.ts
+++ b/lib/submit-lead-client.ts
@@ -38,6 +38,12 @@ export interface SubmitLeadPayload {
   /** Skip matching, create lead directly for this advisor. */
   confirm_advisor_id?: number;
   /**
+   * Spam Act 2003 s.16: true when the user explicitly opted in to SMS/WhatsApp
+   * contact at the point of submitting their phone number. Only set this when
+   * the form presented a visible, unchecked consent checkbox.
+   */
+  sms_consent?: boolean;
+  /**
    * Cross-border Phase A (FIN_NOTEBOOK 2026-05-01 #24): user arrived from
    * a country page with a specific cross-border specialty hint (e.g.
    * "UK Pension Transfer"). The matcher uses this to bias toward

--- a/supabase/migrations/20260801_nf20_sms_consent.sql
+++ b/supabase/migrations/20260801_nf20_sms_consent.sql
@@ -1,0 +1,25 @@
+-- ============================================================================
+-- Migration: 20260801_nf20_sms_consent.sql
+-- Date: 2026-08-01
+-- Audit ref: docs/audits/2026-05-20-new-features-audit.md §5 #20
+-- Queue item: NF-20 (Consent fixes — SMS/WhatsApp consent record)
+-- Why: Australian Spam Act 2003 s.16 prohibits sending commercial electronic
+--      messages (including SMS and WhatsApp) without prior, explicit consent.
+--      The `leads` and `professional_leads` tables store user_phone but had no
+--      consent field, so advisors had no legal signal before contacting leads
+--      via SMS/WhatsApp.
+-- Idempotent: ADD COLUMN IF NOT EXISTS — safe to re-run
+-- Rollback:
+--   ALTER TABLE leads DROP COLUMN IF EXISTS sms_consent;
+--   ALTER TABLE professional_leads DROP COLUMN IF EXISTS sms_consent;
+-- ============================================================================
+
+BEGIN;
+
+ALTER TABLE leads
+  ADD COLUMN IF NOT EXISTS sms_consent BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE professional_leads
+  ADD COLUMN IF NOT EXISTS sms_consent BOOLEAN NOT NULL DEFAULT FALSE;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Supersedes #1180 (conflicting after main diverged; rebased cleanly onto current main).

Closes NF-20 part 1 from `docs/audits/NEW-FEATURES-GREEN-QUEUE.md`.

The `leads` and `professional_leads` tables stored `user_phone` but had no consent column. Australian Spam Act 2003 s.16 prohibits sending commercial electronic messages (SMS, WhatsApp) without prior explicit consent — advisors had no legal signal before using the phone field for outbound messaging.

**Changes:**

- **Migration** `supabase/migrations/20260801_nf20_sms_consent.sql` — adds `sms_consent BOOLEAN NOT NULL DEFAULT FALSE` to both tables. Idempotent (`ADD COLUMN IF NOT EXISTS`). Rollback is `DROP COLUMN IF EXISTS`.
- **`app/api/submit-lead/route.ts`** — accepts `sms_consent?: boolean` from the request body and stores it in all 3 lead-insert paths (platform lead, `confirm_advisor_id` fast-path, auto-match).
- **`lib/submit-lead-client.ts`** — adds `sms_consent?: boolean` to `SubmitLeadPayload` so UI callers can opt users in at point-of-collection.
- **Tests** — 2 new cases in `__tests__/api/submit-lead.test.ts` verifying the field passes through (true) and defaults to false when omitted.

**What's already green (not in this PR):**
- SSR cookie consent (`iv_consent` mirror cookie): already in `lib/consent.ts` with "audit §5 #20" comment
- Unified unsubscribe: already at `app/api/unsubscribe/route.ts`

**Note:** This PR only adds the DB column and records the consent value. The UI change (adding a visible, unchecked SMS consent checkbox to lead capture forms) is a follow-up UX task.

## Tier

**Tier C** — new schema migration + route handler change. Announcing intent per merge policy.

Intent: merge once CI is green and 15-minute observation window passes without STOP.

Refs: `docs/audits/NEW-FEATURES-GREEN-QUEUE.md` NF-20
Audit: `docs/audits/2026-05-20-new-features-audit.md` §5 #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)