### PR TITLE
refactor(versus): Zod-validate vote body (remove unvalidated-req-json opt-out)

### DIFF
--- a/app/api/versus/vote/route.ts
+++ b/app/api/versus/vote/route.ts
@@ -1,10 +1,17 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { createHash } from "crypto";
 import { logger } from "@/lib/logger";
 import { isAllowed, ipKey } from "@/lib/rate-limit-db";
 
 const log = logger("versus:vote");
+
+const VoteBody = z.object({
+  broker_a_slug: z.string().min(1).max(120),
+  broker_b_slug: z.string().min(1).max(120),
+  chosen_slug: z.string().min(1).max(120),
+});
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -79,20 +86,14 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Too many votes — slow down" }, { status: 429 });
     }
 
-    // eslint-disable-next-line invest/no-unvalidated-req-json -- pre-existing; Zod backfill is E-04 stream territory, out of scope for SSOT cleanup PR
-    const body = await request.json();
-    const { broker_a_slug, broker_b_slug, chosen_slug } = body as {
-      broker_a_slug: string;
-      broker_b_slug: string;
-      chosen_slug: string;
-    };
-
-    if (!broker_a_slug || !broker_b_slug || !chosen_slug) {
+    const parsed = VoteBody.safeParse(await request.json().catch(() => null));
+    if (!parsed.success) {
       return NextResponse.json(
         { error: "broker_a_slug, broker_b_slug, and chosen_slug are required" },
         { status: 400 }
       );
     }
+    const { broker_a_slug, broker_b_slug, chosen_slug } = parsed.data;
 
     // Chosen must be one of the two
     if (chosen_slug !== broker_a_slug && chosen_slug !== broker_b_slug) {


### PR DESCRIPTION
Session #8 (input-validation sweep) sample. `/api/versus/vote` read `req.json()` behind an `eslint-disable invest/no-unvalidated-req-json` and hand-cast the body. Replaced with a Zod schema (bounded slug strings) + `safeParse`, removing the opt-out. One of **36** routes that currently opt out of body validation (full list in the MEGASESSION-PROGRAM doc) — this is the pattern for the rest.

---
_Generated by [Claude Code](https://claude.ai/code/session_014hduVwZpij3yXcH6Ct8hVo)_