### PR TITLE
feat(cron): Netlify Scheduled Function bridge to restore the cron fleet (no Vercel)

### DIFF
--- a/__tests__/lib/cron-match.test.ts
+++ b/__tests__/lib/cron-match.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { cronMatches } from "@/lib/cron-match";
+
+// All assertions use explicit UTC instants. Date(Date.UTC(y,m,d,h,mi)).
+const at = (h: number, mi: number, d = 15, mon = 5, y = 2026) =>
+  new Date(Date.UTC(y, mon, d, h, mi));
+
+describe("cronMatches — schedules used in vercel.json", () => {
+  it("*/15 matches minutes 0,15,30,45 only", () => {
+    expect(cronMatches("*/15 * * * *", at(10, 0))).toBe(true);
+    expect(cronMatches("*/15 * * * *", at(10, 15))).toBe(true);
+    expect(cronMatches("*/15 * * * *", at(10, 45))).toBe(true);
+    expect(cronMatches("*/15 * * * *", at(10, 14))).toBe(false);
+    expect(cronMatches("*/15 * * * *", at(10, 5))).toBe(false);
+  });
+
+  it("'0,30' matches minutes 0 and 30", () => {
+    expect(cronMatches("0,30 * * * *", at(3, 0))).toBe(true);
+    expect(cronMatches("0,30 * * * *", at(3, 30))).toBe(true);
+    expect(cronMatches("0,30 * * * *", at(3, 15))).toBe(false);
+  });
+
+  it("hourly-5 (minute 5, any hour) matches only at :05", () => {
+    expect(cronMatches("5 * * * *", at(0, 5))).toBe(true);
+    expect(cronMatches("5 * * * *", at(23, 5))).toBe(true);
+    expect(cronMatches("5 * * * *", at(23, 6))).toBe(false);
+  });
+
+  it("daily-2 (0 2 * * *) matches only at 02:00 UTC", () => {
+    expect(cronMatches("0 2 * * *", at(2, 0))).toBe(true);
+    expect(cronMatches("0 2 * * *", at(2, 1))).toBe(false);
+    expect(cronMatches("0 2 * * *", at(3, 0))).toBe(false);
+  });
+
+  it("daily-1-30 (30 1 * * *) matches only at 01:30 UTC", () => {
+    expect(cronMatches("30 1 * * *", at(1, 30))).toBe(true);
+    expect(cronMatches("30 1 * * *", at(1, 0))).toBe(false);
+    expect(cronMatches("30 1 * * *", at(2, 30))).toBe(false);
+  });
+
+  it("supports ranges and day-of-week", () => {
+    // 0 9 * * 1-5  → 09:00 on weekdays. 2026-06-15 is a Monday (UTC).
+    expect(cronMatches("0 9 * * 1-5", at(9, 0, 15, 5))).toBe(true);
+    // 2026-06-14 is a Sunday.
+    expect(cronMatches("0 9 * * 1-5", at(9, 0, 14, 5))).toBe(false);
+  });
+
+  it("rejects malformed expressions instead of throwing", () => {
+    expect(cronMatches("not a cron", at(0, 0))).toBe(false);
+    expect(cronMatches("* * *", at(0, 0))).toBe(false);
+    expect(cronMatches("", at(0, 0))).toBe(false);
+  });
+
+  it("wildcard matches every minute", () => {
+    expect(cronMatches("* * * * *", at(7, 23))).toBe(true);
+  });
+});

--- a/lib/cron-match.ts
+++ b/lib/cron-match.ts
@@ -1,0 +1,79 @@
+/**
+ * Minimal 5-field cron expression matcher (minute hour day-of-month month
+ * day-of-week). Supports the forms used by this project's schedules:
+ *   *            wildcard
+ *   N            a single value
+ *   A,B,C        a value list
+ *   A-B          an inclusive range
+ *   * / N         a step (e.g. "* / 15")  (written without the space)
+ *
+ * Used by the Netlify scheduled-function cron bridge (netlify/functions/
+ * cron-tick) to decide which vercel.json schedules are due "now" while
+ * production runs on the Netlify mirror (Vercel Cron is parked). Pure +
+ * dependency-free so it is trivially unit-testable and edge/runtime-agnostic.
+ *
+ * Day-of-week is 0-6 with Sunday = 0 (cron standard). Both DOM and DOW
+ * restricting is treated as OR (cron's historical quirk); the project only
+ * uses "*" for both today, so this is for completeness.
+ */
+
+function fieldMatches(field: string, value: number, min: number, max: number): boolean {
+  if (field === "*") return true;
+  for (const part of field.split(",")) {
+    if (part.includes("/")) {
+      const [range, stepStr] = part.split("/");
+      const step = Number(stepStr);
+      if (!Number.isFinite(step) || step <= 0) continue;
+      let lo = min;
+      let hi = max;
+      if (range && range !== "*") {
+        if (range.includes("-")) {
+          const [a, b] = range.split("-").map(Number);
+          lo = a;
+          hi = b;
+        } else {
+          lo = Number(range);
+          hi = max;
+        }
+      }
+      for (let v = lo; v <= hi; v += step) {
+        if (v === value) return true;
+      }
+      continue;
+    }
+    if (part.includes("-")) {
+      const [a, b] = part.split("-").map(Number);
+      if (value >= a && value <= b) return true;
+      continue;
+    }
+    if (Number(part) === value) return true;
+  }
+  return false;
+}
+
+/**
+ * True when `expr` (a standard 5-field cron string) is due at `date` (UTC).
+ * Returns false for malformed expressions rather than throwing.
+ */
+export function cronMatches(expr: string, date: Date): boolean {
+  const fields = expr.trim().split(/\s+/);
+  if (fields.length !== 5) return false;
+  const [minF, hourF, domF, monF, dowF] = fields;
+  const minute = date.getUTCMinutes();
+  const hour = date.getUTCHours();
+  const dom = date.getUTCDate();
+  const mon = date.getUTCMonth() + 1; // 1-12
+  const dow = date.getUTCDay(); // 0-6, Sun=0
+
+  if (!fieldMatches(minF, minute, 0, 59)) return false;
+  if (!fieldMatches(hourF, hour, 0, 23)) return false;
+  if (!fieldMatches(monF, mon, 1, 12)) return false;
+
+  // DOM/DOW OR-semantics when both are restricted.
+  const domRestricted = domF !== "*";
+  const dowRestricted = dowF !== "*";
+  if (domRestricted && dowRestricted) {
+    return fieldMatches(domF, dom, 1, 31) || fieldMatches(dowF, dow, 0, 6);
+  }
+  return fieldMatches(domF, dom, 1, 31) && fieldMatches(dowF, dow, 0, 6);
+}

--- a/netlify.toml
+++ b/netlify.toml
@@ -45,3 +45,13 @@
 # Likewise no [build.processing] override: skip_processing is the legacy
 # post-processor toggle and does not apply to Next-runtime output, so it was
 # noise. Removing it keeps this file to only what actually changes behaviour.
+
+# ── Interim cron bridge (while Vercel Cron is parked) ───────────────────────
+# The 40 schedules in vercel.json don't run on Netlify. netlify/functions/
+# cron-tick.mts is a Scheduled Function that ticks every minute and calls the
+# due /api/cron/dispatch/* routes (Bearer CRON_SECRET). SAFE BY DEFAULT: it
+# no-ops unless CRON_BRIDGE_ENABLED="true" is set in the Netlify env. Remove
+# this block once Vercel is unparked.
+[functions]
+  directory = "netlify/functions"
+  node_bundler = "esbuild"

--- a/netlify/functions/cron-tick.mts
+++ b/netlify/functions/cron-tick.mts
@@ -1,0 +1,49 @@
+// Netlify Scheduled Function — interim cron bridge while production runs on the
+// Netlify mirror and Vercel Cron is parked (see netlify.toml header).
+//
+// The 40 schedules live only in vercel.json and stopped firing when prod moved
+// off Vercel (cron fleet dark since 2026-05-23 — docs/audits/CRON-HEALTH). This
+// ticks every minute, finds the vercel.json crons due "now", and calls the same
+// /api/cron/dispatch/<group> routes they already target — reusing 100% of the
+// existing cron logic (each is requireCronAuth-gated; we send the Bearer).
+//
+// SAFE BY DEFAULT: does nothing unless CRON_BRIDGE_ENABLED === "true" in the
+// Netlify env. Flip it on deliberately. It only dispatches jobs DUE at the
+// current tick — cron never backfills missed runs, so enabling resumes the
+// normal forward cadence (no 13-day catch-up flood).
+//
+// Retire this once Vercel is unparked (Vercel Cron resumes from vercel.json).
+
+import { cronMatches } from "../../lib/cron-match.ts";
+import vercelConfig from "../../vercel.json" with { type: "json" };
+
+type CronEntry = { path: string; schedule: string };
+
+export default async function handler(): Promise<Response> {
+  if (process.env.CRON_BRIDGE_ENABLED !== "true") {
+    return new Response("cron bridge disabled", { status: 200 });
+  }
+  const secret = process.env.CRON_SECRET;
+  const base = process.env.URL || process.env.DEPLOY_PRIME_URL;
+  if (!secret || !base) {
+    return new Response("missing CRON_SECRET or site URL", { status: 500 });
+  }
+
+  const now = new Date();
+  const crons = (vercelConfig as { crons?: CronEntry[] }).crons ?? [];
+  const due = crons.filter((c) => cronMatches(c.schedule, now));
+
+  const results = await Promise.allSettled(
+    due.map((c) =>
+      fetch(`${base}${c.path}`, {
+        method: "GET",
+        headers: { Authorization: `Bearer ${secret}` },
+      }),
+    ),
+  );
+
+  const ok = results.filter((r) => r.status === "fulfilled").length;
+  return new Response(`dispatched ${ok}/${due.length} due jobs`, { status: 200 });
+}
+
+export const config = { schedule: "* * * * *" };


### PR DESCRIPTION
## Restores the dark cron fleet on Netlify — no Vercel needed

Answering the right question ("could you use Netlify until we swap back?"): yes. Production runs on the Netlify mirror, but the 40 schedules live only in `vercel.json` (Vercel Cron), so the fleet has been **dark since ~2026-05-23** (`docs/audits/CRON-HEALTH`). This brings it back on Netlify in the interim.

### How
- **`netlify/functions/cron-tick.mts`** — a Scheduled Function ticking every minute. It finds the `vercel.json` crons due *now* (`lib/cron-match`) and calls the same `/api/cron/dispatch/<group>` routes with `Authorization: Bearer ${CRON_SECRET}`. **Reuses 100% of the existing cron logic** — no handler rewrite, no drift (it reads `vercel.json` directly).
- **`lib/cron-match.ts`** — tiny dependency-free 5-field cron matcher (8 unit tests).
- **`netlify.toml`** — declares the functions dir.

### Safe by default
- No-ops unless **`CRON_BRIDGE_ENABLED="true"`** in the Netlify env → re-activating the fleet is a deliberate switch, not an accident of merging.
- Only dispatches jobs **due at each tick** — cron never backfills missed runs, so enabling resumes the normal forward cadence (**no 13-day catch-up flood** of emails/payments).
- Not type-coupled to the app (`.mts` isn't matched by the app tsconfig; Netlify bundles it via esbuild).

### To enable (when you're ready)
Set in the Netlify site env: `CRON_SECRET` (same value the routes verify) and `CRON_BRIDGE_ENABLED=true`. Retire this block once Vercel is unparked (Vercel Cron resumes from `vercel.json`).

### Verification
`lib/cron-match` 8/8 tests ✓ · `tsc` ✓ · lint ✓ · pre-push ✓.

This corrects my earlier framing that the cron outage was blocked on Vercel — it wasn't.


---
_Generated by [Claude Code](https://claude.ai/code/session_014hduVwZpij3yXcH6Ct8hVo)_