### PR TITLE
fix(security): close 2nd-wave anon-read leaks (advisor_applications PII + api_keys/portfolios) — applied

### DIFF
--- a/__tests__/api/advisor-auth-verify-review.test.ts
+++ b/__tests__/api/advisor-auth-verify-review.test.ts
@@ -116,14 +116,14 @@ describe("POST /api/advisor-auth/verify", () => {
   });
 
   it("401 — token not found in advisor_auth_tokens", async () => {
-    mockServerFrom.mockReturnValueOnce(chain({ data: null }));
+    mockAdminFrom.mockReturnValueOnce(chain({ data: null }));
     const res = await verifyPost({ token: "bad-token" });
     expect(res.status).toBe(401);
     expect(await res.json()).toMatchObject({ error: "Invalid or expired link" });
   });
 
   it("401 — token already used", async () => {
-    mockServerFrom.mockReturnValueOnce(
+    mockAdminFrom.mockReturnValueOnce(
       chain({ data: { ...AUTH_TOKEN, used_at: PAST } }),
     );
     const res = await verifyPost({ token: "used-token" });
@@ -132,7 +132,7 @@ describe("POST /api/advisor-auth/verify", () => {
   });
 
   it("401 — token is expired (expires_at in the past)", async () => {
-    mockServerFrom.mockReturnValueOnce(
+    mockAdminFrom.mockReturnValueOnce(
       chain({ data: { ...AUTH_TOKEN, expires_at: PAST } }),
     );
     const res = await verifyPost({ token: "expired-token" });
@@ -141,7 +141,7 @@ describe("POST /api/advisor-auth/verify", () => {
   });
 
   it("200 — success: marks token used, creates session, sets HttpOnly cookie", async () => {
-    mockServerFrom
+    mockAdminFrom
       .mockReturnValueOnce(chain({ data: AUTH_TOKEN })) // token lookup
       .mockReturnValueOnce(chain({ data: null })) // update used_at
       .mockReturnValueOnce(chain({ data: null })) // insert session

--- a/__tests__/api/advisor-booking.test.ts
+++ b/__tests__/api/advisor-booking.test.ts
@@ -18,6 +18,11 @@ vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn(async () => ({ from: serverFromMock })),
 }));
 
+const adminFromMock = vi.fn();
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: adminFromMock })),
+}));
+
 const fetchMock = vi.fn<() => Promise<Response>>();
 vi.stubGlobal("fetch", fetchMock);
 
@@ -95,7 +100,7 @@ describe("GET /api/advisor-booking", () => {
   it("returns existingBookings when date param is provided", async () => {
     serverFromMock.mockReturnValueOnce(chain({ data: ACTIVE_ADVISOR }));
     serverFromMock.mockReturnValueOnce(chain({ data: [] })); // schedule
-    serverFromMock.mockReturnValueOnce(chain({ data: [{ booking_time: "10:00" }, { booking_time: "14:00" }] }));
+    adminFromMock.mockReturnValueOnce(chain({ data: [{ booking_time: "10:00" }, { booking_time: "14:00" }] }));
     const res = await GET(getReq({ advisor: "bob-sydney", date: "2026-05-10" }));
     expect(res.status).toBe(200);
     expect((await res.json()).existingBookings).toEqual(["10:00", "14:00"]);
@@ -141,21 +146,21 @@ describe("POST /api/advisor-booking", () => {
 
   it("returns 409 when slot is already taken", async () => {
     serverFromMock.mockReturnValueOnce(chain({ data: ACTIVE_ADVISOR }));
-    serverFromMock.mockReturnValueOnce(chain({ data: { id: 99 } })); // slot taken
+    adminFromMock.mockReturnValueOnce(chain({ data: { id: 99 } })); // slot taken
     expect((await POST(postReq(VALID_POST))).status).toBe(409);
   });
 
   it("returns 500 when booking insert fails", async () => {
     serverFromMock.mockReturnValueOnce(chain({ data: ACTIVE_ADVISOR }));
-    serverFromMock.mockReturnValueOnce(chain({ data: null })); // slot free
-    serverFromMock.mockReturnValueOnce(chain({ data: null, error: { message: "db error" } })); // insert fails
+    adminFromMock.mockReturnValueOnce(chain({ data: null })); // slot free
+    adminFromMock.mockReturnValueOnce(chain({ data: null, error: { message: "db error" } })); // insert fails
     expect((await POST(postReq(VALID_POST))).status).toBe(500);
   });
 
   it("returns 200 on success without RESEND_API_KEY", async () => {
     serverFromMock.mockReturnValueOnce(chain({ data: ACTIVE_ADVISOR }));
-    serverFromMock.mockReturnValueOnce(chain({ data: null })); // slot free
-    serverFromMock.mockReturnValueOnce(chain({ data: { id: 42 }, error: null })); // booking
+    adminFromMock.mockReturnValueOnce(chain({ data: null })); // slot free
+    adminFromMock.mockReturnValueOnce(chain({ data: { id: 42 }, error: null })); // booking
     serverFromMock.mockReturnValueOnce(chain({ error: null })); // lead insert
     const res = await POST(postReq(VALID_POST));
     expect(res.status).toBe(200);
@@ -166,9 +171,9 @@ describe("POST /api/advisor-booking", () => {
   it("returns 200 with RESEND_API_KEY and fires two confirmation emails", async () => {
     process.env.RESEND_API_KEY = "re_test_key";
     serverFromMock.mockReturnValueOnce(chain({ data: ACTIVE_ADVISOR }));
-    serverFromMock.mockReturnValueOnce(chain({ data: null }));
-    serverFromMock.mockReturnValueOnce(chain({ data: { id: 42 }, error: null }));
-    serverFromMock.mockReturnValueOnce(chain({ error: null }));
+    adminFromMock.mockReturnValueOnce(chain({ data: null })); // slot free
+    adminFromMock.mockReturnValueOnce(chain({ data: { id: 42 }, error: null })); // booking
+    serverFromMock.mockReturnValueOnce(chain({ error: null })); // lead insert
     const res = await POST(postReq(VALID_POST));
     expect(res.status).toBe(200);
     expect(fetchMock).toHaveBeenCalledTimes(2); // advisor + investor

--- a/__tests__/api/advisor-dashboard.test.ts
+++ b/__tests__/api/advisor-dashboard.test.ts
@@ -5,9 +5,14 @@ import { createChainableBuilder } from "@/__tests__/helpers";
 // ── Mocks ──────────────────────────────────────────────────────────────────────
 
 const mockFrom = vi.fn();
+const adminFromMock = vi.fn();
 
 vi.mock("@/lib/supabase/server", () => ({
   createClient: vi.fn(async () => ({ from: mockFrom })),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: adminFromMock })),
 }));
 
 vi.mock("@/lib/logger", () => ({
@@ -103,6 +108,15 @@ function makeReview(rating: number) {
 describe("GET /api/advisor-dashboard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // advisor_bookings is fetched via createAdminClient — default to empty result
+    adminFromMock.mockImplementation(() => {
+      const b = createChainableBuilder("advisor_bookings");
+      b.then = vi.fn((cb: (v: { data: unknown[]; error: null }) => void) => {
+        cb({ data: [], error: null });
+        return Promise.resolve();
+      });
+      return b;
+    });
   });
 
   it("returns 401 when no advisor_session cookie", async () => {

--- a/app/api/advisor-auth/verify/route.ts
+++ b/app/api/advisor-auth/verify/route.ts
@@ -1,5 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@/lib/supabase/server";
+// Magic-link verification is a server-side auth operation for an UNauthenticated
+// caller (no Supabase JWT). It reads/updates advisor_auth_tokens (locked to
+// non-anon) and inserts into advisor_sessions (deny-all by design), so it uses
+// the service-role client throughout. The token value in the body is the secret
+// being verified; rate-limited above.
+import { createAdminClient } from "@/lib/supabase/admin";
 import { randomBytes } from "crypto";
 import { logger } from "@/lib/logger";
 import { isAllowed, ipKey } from "@/lib/rate-limit-db";
@@ -18,7 +23,7 @@ export async function POST(request: NextRequest) {
     const { token } = await request.json();
     if (!token) return NextResponse.json({ error: "Token required" }, { status: 400 });
 
-    const supabase = await createClient();
+    const supabase = createAdminClient();
 
     // Find valid token
     const { data: authToken } = await supabase

--- a/app/api/advisor-booking/route.ts
+++ b/app/api/advisor-booking/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { createClient } from "@/lib/supabase/server";
+// advisor_bookings holds investor PII (name/email/phone) + confirmation_token
+// and is locked to non-anon RLS. This public route's availability/dedup reads
+// and the insert are server-side logic returning only booking_time / id (never
+// PII), so they use the service-role client; anon visitors never read the table.
+import { createAdminClient } from "@/lib/supabase/admin";
 import { isRateLimited } from "@/lib/rate-limit";
 import { escapeHtml } from "@/lib/html-escape";
 import { getSiteUrl } from "@/lib/url";
@@ -56,7 +61,7 @@ export async function GET(request: NextRequest) {
   // If a specific date requested, check existing bookings
   let existingBookings: string[] = [];
   if (dateStr) {
-    const { data: booked } = await supabase
+    const { data: booked } = await createAdminClient()
       .from("advisor_bookings")
       .select("booking_time")
       .eq("professional_id", advisor.id)
@@ -93,6 +98,7 @@ export async function POST(request: NextRequest) {
     }
 
     const supabase = await createClient();
+    const admin = createAdminClient();
 
     const { data: advisor } = await supabase
       .from("professionals")
@@ -105,8 +111,8 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Booking not available" }, { status: 400 });
     }
 
-    // Check slot not already taken
-    const { data: existing } = await supabase
+    // Check slot not already taken (service-role: advisor_bookings is non-anon)
+    const { data: existing } = await admin
       .from("advisor_bookings")
       .select("id")
       .eq("professional_id", advisor.id)
@@ -118,7 +124,7 @@ export async function POST(request: NextRequest) {
     if (existing) return NextResponse.json({ error: "This time slot is no longer available" }, { status: 409 });
 
     // Create booking
-    const { data: booking, error } = await supabase
+    const { data: booking, error } = await admin
       .from("advisor_bookings")
       .insert({
         professional_id: advisor.id,

--- a/app/api/advisor-dashboard/route.ts
+++ b/app/api/advisor-dashboard/route.ts
@@ -1,5 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+// advisor_bookings is non-anon RLS; this route authenticates via the custom
+// advisor_session cookie (no Supabase JWT), so its booking read uses the
+// service-role client, scoped in-query to the validated advisorId.
+import { createAdminClient } from "@/lib/supabase/admin";
 
 async function getAdvisorId(request: NextRequest): Promise<number | null> {
   const sessionToken = request.cookies.get("advisor_session")?.value;
@@ -71,8 +75,9 @@ export async function GET(request: NextRequest) {
       .eq("professional_id", advisorId)
       .eq("status", "approved")
       .order("created_at", { ascending: false }),
-    // Bookings count (for booking clicks stat)
-    supabase
+    // Bookings count (for booking clicks stat) — service-role: non-anon table,
+    // scoped to the validated advisorId.
+    createAdminClient()
       .from("advisor_bookings")
       .select("id, created_at")
       .eq("professional_id", advisorId)

--- a/supabase/migrations/20260831020000_fix_anon_read_leaks_round2.sql
+++ b/supabase/migrations/20260831020000_fix_anon_read_leaks_round2.sql
@@ -1,0 +1,58 @@
+-- Round 2 anon-read RLS remediation — APPLIED TO PROD 2026-06-05.
+--
+-- A second multi-role IDOR sweep (live `set role anon` row-count probe) found
+-- one CONFIRMED active anon leak and several permissive `public`/`USING(true)`
+-- policies on sensitive/secret tables that the first sweep (#1410) didn't cover:
+--
+--   * advisor_applications   — anon saw 2 rows of applicant PII (name/email/
+--                              phone/AFSL). CONFIRMED ACTIVE. P0.
+--   * api_keys               — "Service manage api keys" ALL public USING(true)
+--                              on API secrets (0 rows now; catastrophic latent).
+--   * user_portfolios        — "Read own portfolio" USING(true) public on
+--                              email-keyed financial data (broken own-row policy).
+--   * data_license_subscribers — ALL public USING(true) on subscriber PII.
+--   * lead_disputes          — "Anyone can read disputes" public USING(true).
+--
+-- Readers verified server-side (service-role / admin routes / authed-own via
+-- /api/portfolio, /api/admin/*, crons), so denying anon does not break the app.
+-- Verified post-apply: anon row-count = 0 on all five.
+--
+-- Idempotent. Rollback: recreate the dropped USING(true) policies (NOT
+-- recommended — re-opens the leak).
+--
+-- ⚠️ DELIBERATELY EXCLUDED (need a code change FIRST, else they break):
+--   * advisor_auth_tokens — app/api/advisor-auth/verify reads it via the
+--     anon-context server client (magic-link clicker has no session). Must
+--     switch that read to createAdminClient BEFORE locking, or login breaks.
+--   * advisor_bookings — ACTIVE leak (5 rows: investor_name/email/phone +
+--     confirmation_token). app/api/advisor-booking reads it via anon to compute
+--     slot availability/dedup. Must switch those reads to createAdminClient
+--     (service-role) BEFORE locking, or public booking breaks. URGENT follow-up.
+
+drop policy if exists "Anyone can read applications" on public.advisor_applications;
+drop policy if exists "Admins read applications" on public.advisor_applications;
+create policy "Admins read applications" on public.advisor_applications
+  for select to public using (public.is_admin());
+
+drop policy if exists "Service manage api keys" on public.api_keys;
+create policy "Service manage api keys" on public.api_keys
+  for all to public
+  using ((select auth.role()) = 'service_role')
+  with check ((select auth.role()) = 'service_role');
+
+drop policy if exists "Read own portfolio" on public.user_portfolios;
+create policy "Service manage portfolios" on public.user_portfolios
+  for all to public
+  using ((select auth.role()) = 'service_role')
+  with check ((select auth.role()) = 'service_role');
+
+drop policy if exists "Service role manages data subs" on public.data_license_subscribers;
+create policy "Service role manages data subs" on public.data_license_subscribers
+  for all to public
+  using ((select auth.role()) = 'service_role')
+  with check ((select auth.role()) = 'service_role');
+
+drop policy if exists "Anyone can read disputes" on public.lead_disputes;
+drop policy if exists "Admins read disputes" on public.lead_disputes;
+create policy "Admins read disputes" on public.lead_disputes
+  for select to public using (public.is_admin());

--- a/supabase/migrations/20260831030000_lock_advisor_bookings_anon_read.sql
+++ b/supabase/migrations/20260831030000_lock_advisor_bookings_anon_read.sql
@@ -1,0 +1,15 @@
+-- Lock advisor_bookings anon read — APPLIED TO PROD 2026-06-05.
+--
+-- "Public can read bookings" USING(true) exposed investor PII (investor_name,
+-- investor_email, investor_phone) + confirmation_token to anyone with the anon
+-- key — confirmed active (5 rows visible to anon). Its only readers — the
+-- public booking route (availability/dedup/insert) and the advisor dashboard
+-- (count) — were switched to the service-role client in the same change, so
+-- anon no longer needs to read this table.
+--
+-- Deny anon; admins read via is_admin(); service-role bypasses RLS.
+-- Idempotent. Rollback: recreate the USING(true) policy (re-opens the leak).
+drop policy if exists "Public can read bookings" on public.advisor_bookings;
+drop policy if exists "Admins read bookings" on public.advisor_bookings;
+create policy "Admins read bookings" on public.advisor_bookings
+  for select to public using (public.is_admin());

--- a/supabase/migrations/20260831040000_lock_advisor_auth_tokens_anon_read.sql
+++ b/supabase/migrations/20260831040000_lock_advisor_auth_tokens_anon_read.sql
@@ -1,0 +1,16 @@
+-- Lock advisor_auth_tokens anon read — APPLIED TO PROD 2026-06-05.
+--
+-- "Anyone can read auth tokens" SELECT public USING(true) made magic-link auth
+-- tokens anon-readable (0 rows at probe time, but account takeover the moment a
+-- token exists). All readers now use the service-role client:
+--   * app/api/advisor-auth/verify — switched to createAdminClient (it's a
+--     server-side auth op for an unauthenticated caller; also inserts into
+--     advisor_sessions which is deny-all by design).
+--   * admin/advisor-applications, cron/cleanup — already service-role.
+-- Deny anon; service-role bypasses RLS. Idempotent. Rollback: recreate USING(true).
+drop policy if exists "Anyone can read auth tokens" on public.advisor_auth_tokens;
+drop policy if exists "Service manage auth tokens" on public.advisor_auth_tokens;
+create policy "Service manage auth tokens" on public.advisor_auth_tokens
+  for all to public
+  using ((select auth.role()) = 'service_role')
+  with check ((select auth.role()) = 'service_role');


### PR DESCRIPTION
## Active anon-PII leak closed (applied to prod)

**Session #4 (live IDOR/authorization probe).** A second multi-role sweep — live `set role anon` row-count probing, which catches what static policy analysis misses — found a **confirmed active leak** plus critical latent ones the first sweep (#1410) didn't reach:

| Table | Anon rows | Issue |
|---|---|---|
| `advisor_applications` | **2 (live)** | applicant PII (name/email/phone/AFSL) world-readable |
| `api_keys` | 0 | `ALL public USING(true)` on **API secrets** — catastrophic latent |
| `user_portfolios` | 0 | policy named "Read own" but `USING(true)` → all financial rows |
| `data_license_subscribers` | 0 | `ALL public USING(true)` on subscriber PII |
| `lead_disputes` | 0 | `Anyone can read disputes` public |

**Applied to prod** (active breach; readers verified server-side so non-breaking; reversible): `advisor_applications`+`lead_disputes` → `is_admin()`; `api_keys`/`user_portfolios`/`data_license_subscribers` → `service_role`. Verified post-apply: anon row-count **= 0** on all five. Migration committed for parity.

## ⚠️ Two excluded — need a code change first (URGENT follow-up)
Both read via the **anon-context server client**, so locking them naively breaks the flow:
- **`advisor_bookings`** — **ACTIVE leak** (5 rows: `investor_name/email/phone` + `confirmation_token`). `advisor-booking` reads it via anon for slot availability. Fix = switch those reads to `createAdminClient`, then lock. **Top priority.**
- **`advisor_auth_tokens`** — `advisor-auth/verify` reads the magic-link token via anon (clicker has no session). Fix = switch to `createAdminClient`, then lock (else login breaks).

Doing the `advisor_bookings` combo-fix next.


---
_Generated by [Claude Code](https://claude.ai/code/session_014hduVwZpij3yXcH6Ct8hVo)_