### PR TITLE
fix(a11y): raise contrast on /compare stacked-logo pill (axe sweep, WCAG AA)

### DIFF
--- a/app/compare/CompareClient.tsx
+++ b/app/compare/CompareClient.tsx
@@ -420,7 +420,7 @@ export default function CompareClient({ brokers }: { brokers: Broker[] }) {
         })}
         {logos.length > max && (
           <span
-            className="rounded-full border-2 border-white bg-slate-100 text-slate-500 flex items-center justify-center shrink-0 shadow-sm"
+            className="rounded-full border-2 border-white bg-slate-100 text-slate-600 flex items-center justify-center shrink-0 shadow-sm"
             style={{
               width: size, height: size,
               marginLeft: -overlap,


### PR DESCRIPTION
**Session #10 — a11y.** Ran axe-core (WCAG 2.1 AA) against the live site across 6 key routes. Dominant issue: **color-contrast**, with **~130 nodes on `/compare`** — almost all the stacked-logo "+N more" overflow pill: `text-slate-500` on `bg-slate-100` = **4.34:1**, just under the 4.5:1 AA threshold. Fixed at source → `text-slate-600` (~6.9:1); one token, every instance.

**Remaining axe findings (queued):** the amber ".com.au" wordmark (`text-amber-500` on white, 2.14:1 — brand text, low priority) and a `definition-list` structure violation on `/super`. A full a11y + Lighthouse sweep is best re-run against a fresh deploy once the open PRs land (live mirror is a build behind `main`).

---
_Generated by [Claude Code](https://claude.ai/code/session_014hduVwZpij3yXcH6Ct8hVo)_