### PR TITLE
test(security): broker-exposure regression guard + RLS anon-read verification (#6/#9)

### DIFF
--- a/__tests__/lib/broker-field-exposure.test.ts
+++ b/__tests__/lib/broker-field-exposure.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { stripInternalBrokerFields } from "@/lib/request-cache";
+import type { Broker } from "@/lib/types";
+
+// Regression guard for the recurring broker-commercial-field exposure class
+// (#1408 broker detail, #1411 quiz, #1413 wealth-stack). If any of these
+// internal economics fields stops being stripped, anon clients leak them.
+const INTERNAL_FIELDS = [
+  "cpa_value",
+  "affiliate_priority",
+  "monthly_sponsorship_fee",
+  "commission_type",
+  "commission_value",
+  "estimated_epc",
+  "promoted_placement",
+] as const;
+
+describe("broker field exposure guard", () => {
+  it("stripInternalBrokerFields removes every internal commercial field", () => {
+    const dirty = Object.fromEntries(INTERNAL_FIELDS.map((f) => [f, 123]));
+    const cleaned = stripInternalBrokerFields({
+      slug: "stake",
+      name: "Stake",
+      rating: 4.5,
+      ...dirty,
+    } as unknown as Broker) as unknown as Record<string, unknown>;
+    for (const f of INTERNAL_FIELDS) {
+      expect(cleaned, `${f} must be stripped`).not.toHaveProperty(f);
+    }
+    // Non-sensitive display fields survive.
+    expect(cleaned.slug).toBe("stake");
+    expect(cleaned.name).toBe("Stake");
+    expect(cleaned.rating).toBe(4.5);
+  });
+});

--- a/docs/audits/RLS-VERIFICATION-2026-06-05.md
+++ b/docs/audits/RLS-VERIFICATION-2026-06-05.md
@@ -1,0 +1,32 @@
+# RLS anon-read verification — 2026-06-05
+
+Session #9. A writable test DB isn't available in this container, so the RLS
+isolation fixes from the security sessions (#1410 round 1, #1431 round 2,
+booking/auth-token locks, #1432 weights) were verified the authoritative way:
+executing a live `set role anon` row-count probe against production (the same
+method that originally found the leaks). A locked table returning 0 rows to the
+`anon` role proves anon can no longer read it.
+
+## Result — every locked table returns 0 rows to anon
+
+| Table | anon rows | Fix |
+|---|---:|---|
+| advisor_applications | 0 | is_admin() (#1431) |
+| advisor_bookings | 0 | route→service-role + lock (#1431) |
+| advisor_auth_tokens | 0 | verify→service-role + lock (#1431) |
+| api_keys | 0 | service_role (#1431) |
+| user_portfolios | 0 | service_role (#1431) |
+| data_license_subscribers | 0 | service_role (#1431) |
+| lead_disputes | 0 | is_admin() (#1431) |
+| advisor_billing | 0 | is_admin() (#1410) |
+| fee_alert_subscriptions | 0 | is_admin() (#1410) |
+| weights | 0 | service_role (#1432) |
+
+Probe: `SET ROLE anon; SELECT count(*) FROM public.<table>;` per table, run via
+the Supabase MCP against project guggzyqceattncjwvgyc. All returned 0.
+
+## CI regression guard
+A pure-unit guard for the related broker-commercial-field exposure class ships in
+`__tests__/lib/broker-field-exposure.test.ts` (asserts `stripInternalBrokerFields`
+strips all 7 internal fields). A DB-backed RLS isolation test belongs in the
+`*.int.test.ts` suite once a sandbox Supabase is provisioned — tracked.


### PR DESCRIPTION
Closes out #6 and #9 of the hardening program with green-on-main artifacts.

**#6 — broker-field exposure regression guard** (`__tests__/lib/broker-field-exposure.test.ts`): asserts `stripInternalBrokerFields` removes all 7 internal commercial fields. Guards the recurring broker-economics leak class (#1408/#1411/#1413).

**#9 — RLS anon-read verification** (`docs/audits/RLS-VERIFICATION-2026-06-05.md`): live `SET ROLE anon` probe confirming all 10 locked tables return 0 rows to anon (#1410 + #1431 + #1432).

`tsc` ✓ · lint ✓ · test ✓ · pre-push ✓.

---
_Generated by [Claude Code](https://claude.ai/code/session_014hduVwZpij3yXcH6Ct8hVo)_