### PR TITLE
fix(wealth-stack): create missing `weights` table; read it via service-role (rebased)

### DIFF
--- a/__tests__/api/wealth-stack.test.ts
+++ b/__tests__/api/wealth-stack.test.ts
@@ -15,9 +15,10 @@ function makeBuilder(result: unknown = { data: [], error: null }) {
   return b;
 }
 
-const { mockIsAllowed, mockFrom, mockBuildWealthStack, mockIsValidEmail, mockIsDisposableEmail, mockSendEmail } = vi.hoisted(() => ({
+const { mockIsAllowed, mockFrom, mockAdminFrom, mockBuildWealthStack, mockIsValidEmail, mockIsDisposableEmail, mockSendEmail } = vi.hoisted(() => ({
   mockIsAllowed: vi.fn(async () => true),
   mockFrom: vi.fn(),
+  mockAdminFrom: vi.fn(),
   mockBuildWealthStack: vi.fn(() => ({
     stackId: "stack_abc123",
     components: [],
@@ -46,6 +47,10 @@ vi.mock("@/lib/supabase/server", () => ({
     auth: { getUser: vi.fn(async () => ({ data: { user: null }, error: null })) },
     from: mockFrom,
   })),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
 }));
 
 vi.mock("@/lib/wealth-stack", () => ({
@@ -85,6 +90,7 @@ describe("/api/wealth-stack", () => {
     mockIsDisposableEmail.mockReturnValue(false);
     // Default: brokers and weights return empty arrays
     mockFrom.mockImplementation(() => makeBuilder({ data: [], error: null }));
+    mockAdminFrom.mockImplementation(() => makeBuilder({ data: [], error: null }));
   });
 
   it("returns 429 when rate limited", async () => {

--- a/app/api/wealth-stack/route.ts
+++ b/app/api/wealth-stack/route.ts
@@ -4,6 +4,9 @@ import { randomBytes } from "crypto";
 
 import { createClient } from "@/lib/supabase/server";
 import { stripInternalBrokerFields } from "@/lib/request-cache";
+// `weights` is service-role-only RLS (commercially-sensitive ranking weights);
+// this public route reads it server-side and returns only aggregated results.
+import { createAdminClient } from "@/lib/supabase/admin";
 import { isAllowed, ipKey } from "@/lib/rate-limit-db";
 import { sendEmail } from "@/lib/resend";
 import { isValidEmail, isDisposableEmail } from "@/lib/validate-email";
@@ -74,9 +77,12 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: brokerErr.message }, { status: 500 });
   }
 
-  // Quiz weights live in the public `weights` table, keyed by broker slug.
-  // The exact shape mirrors scoreQuizResults: { [slug]: QuizWeights }.
-  const { data: weightRows, error: weightErr } = await supabase
+  // Ranking weights live in the `weights` table, keyed by broker slug (shape
+  // mirrors scoreQuizResults: { [slug]: QuizWeights }). Like quiz_weights these
+  // are commercially sensitive and the table is service-role-only RLS, so read
+  // it with the admin client (server-side; only aggregated stack results are
+  // returned to the browser).
+  const { data: weightRows, error: weightErr } = await createAdminClient()
     .from("weights")
     .select("broker_slug, weights");
 

--- a/supabase/migrations/20260831050000_create_weights_table.sql
+++ b/supabase/migrations/20260831050000_create_weights_table.sql
@@ -1,0 +1,19 @@
+-- Create the missing `weights` table — APPLIED TO PROD 2026-06-05.
+-- app/api/wealth-stack reads from("weights").select("broker_slug, weights"), but
+-- the table was never created → the wealth-stack ("Revenue #1") POST 500s on
+-- every build (docs/audits/SCHEMA-DRIFT). Created with the exact shape the route
+-- expects; empty by default (scorer falls back to rating order until seeded —
+-- functional, no 500). Commercially-sensitive ranking weights like quiz_weights,
+-- so RLS is service-role-only and wealth-stack reads it via the admin client.
+-- Idempotent. Rollback: drop table public.weights;
+create table if not exists public.weights (
+  broker_slug text primary key,
+  weights     jsonb not null default '{}'::jsonb,
+  updated_at  timestamptz not null default now()
+);
+alter table public.weights enable row level security;
+drop policy if exists "service_role manages weights" on public.weights;
+create policy "service_role manages weights" on public.weights
+  for all to public
+  using ((select auth.role()) = 'service_role')
+  with check ((select auth.role()) = 'service_role');


### PR DESCRIPTION
Rebase of #1432 (was CONFLICTING after main moved) onto current main.

**Session #5 (schema-drift remediation).** `app/api/wealth-stack` read `from("weights")` — a table that **never existed** — so the wealth-stack ("Revenue #1") POST 500'd on every request. Created `weights` (`broker_slug` pk, `weights` jsonb) with the exact shape the route expects; **empty by default** so the scorer falls back to rating order (functional, no 500) until seeded. Like `quiz_weights` it's commercially-sensitive ranking data → **service-role-only RLS**, and the route now reads it via `createAdminClient`.

Also adds `createAdminClient` mock in `__tests__/api/wealth-stack.test.ts` (previously missing, caused test failures when route switched to admin client).

**Applied to prod**; migration committed for parity.

**Founder note:** seed `weights` (or repoint to `quiz_weights`) for tuned stack rankings — empty = rating-based fallback today.

**Closes #1432**

## Test plan

- [ ] `npm run type-check` — passes (pre-push confirmed)
- [ ] `npm test -- __tests__/api/wealth-stack.test.ts` — 8/8 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)