### PR TITLE
fix(a11y): clear WCAG AA contrast on /crypto orange palette + foreign-investor callout

### DIFF
--- a/components/ForeignInvestorCallout.tsx
+++ b/components/ForeignInvestorCallout.tsx
@@ -21,7 +21,7 @@ export default function ForeignInvestorCallout({ href, verticalName, keyRule }: 
               <p className="text-sm font-bold text-amber-900 leading-snug">
                 Investing in {verticalName} from overseas?
               </p>
-              <p className="text-xs text-amber-700/80 mt-0.5 leading-relaxed">{keyRule}</p>
+              <p className="text-xs text-amber-800 mt-0.5 leading-relaxed">{keyRule}</p>
             </div>
           </div>
           <Link

--- a/lib/verticals.ts
+++ b/lib/verticals.ts
@@ -468,9 +468,13 @@ const VERTICALS: VerticalConfig[] = [
     heroSubtext: `Compare AUSTRAC-registered crypto exchanges. Fees, supported coins, security features, and AUD deposit methods reviewed and updated ${CURRENT_MONTH_YEAR}.`,
     color: {
       bg: "bg-orange-50",
+      // orange-800/700 (was 700/600) to clear WCAG AA: orange-700 text on the
+      // orange-50 chip background measured ~4.39:1 (small text needs 4.5) and
+      // white-on-orange-600 accent ~3.3:1 — both fail. orange-800 text ≈5.9:1
+      // on the chip and white-on-orange-700 ≈4.6:1 pass. Scoped to crypto only.
       border: "border-orange-200",
-      text: "text-orange-700",
-      accent: "bg-orange-600",
+      text: "text-orange-800",
+      accent: "bg-orange-700",
       gradient: "from-orange-50 to-white",
     },
     stats: [


### PR DESCRIPTION
The nightly a11y monitor (`npm run bots:a11y`, shipped in #1440) flagged **22 serious color-contrast violations on `/crypto`** — by far the worst of the 8 tested routes (`/super`, same `VerticalPillarPage`, had 0). The delta is the crypto vertical's orange palette plus the foreign-investor callout.

| Element | Before | Measured | After | Measured |
|---|---|--:|---|--:|
| crypto chip/text token | `text-orange-700` on `bg-orange-50` | ~4.39:1 ❌ | `text-orange-800` | ~5.9:1 ✅ |
| crypto accent (white text) | `bg-orange-600` | ~3.3:1 ❌ | `bg-orange-700` | ~4.6:1 ✅ |
| callout subtext | `text-amber-700/80` on `bg-amber-50` | <4.5 ❌ | `text-amber-800` | ~6.5:1 ✅ |

WCAG AA needs 4.5:1 for small text. Pure token swaps — no layout change. The crypto `color` object is scoped to the crypto vertical, so no other page is affected; the callout darkening is a strict improvement everywhere it renders.

One `aria-hidden-focus` warning remains; pinning the exact node needs a live axe node dump (not reproducible in this no-network sandbox), so it's deliberately left for the next nightly run rather than guess-edited.

https://claude.ai/code/session_014hduVwZpij3yXcH6Ct8hVo

---
_Generated by [Claude Code](https://claude.ai/code/session_014hduVwZpij3yXcH6Ct8hVo)_