### PR TITLE
feat(audit): three read-only sentinels — schema-ref, financial-invariant, cross-tenant RLS

### DIFF
--- a/.github/workflows/bots-nightly.yml
+++ b/.github/workflows/bots-nightly.yml
@@ -81,6 +81,16 @@ jobs:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: npm run audit:financial-invariants
+      - name: Cross-tenant RLS fuzzer (authenticated IDOR)
+        if: always()
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          BOTS_RLS_USER_A_EMAIL: ${{ secrets.BOTS_RLS_USER_A_EMAIL }}
+          BOTS_RLS_USER_A_PASSWORD: ${{ secrets.BOTS_RLS_USER_A_PASSWORD }}
+          BOTS_RLS_USER_B_EMAIL: ${{ secrets.BOTS_RLS_USER_B_EMAIL }}
+          BOTS_RLS_USER_B_PASSWORD: ${{ secrets.BOTS_RLS_USER_B_PASSWORD }}
+        run: npm run audit:cross-tenant-rls
       - name: Upload reports
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/bots-nightly.yml
+++ b/.github/workflows/bots-nightly.yml
@@ -69,6 +69,12 @@ jobs:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: npm run bots:data
+      - name: Schema-reference sentinel (phantom .from()/.rpc())
+        if: always()
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+        run: npm run audit:schema-refs
       - name: Upload reports
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/bots-nightly.yml
+++ b/.github/workflows/bots-nightly.yml
@@ -75,6 +75,12 @@ jobs:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
         run: npm run audit:schema-refs
+      - name: Financial-invariant sentinel (ledger / billing / payments)
+        if: always()
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: npm run audit:financial-invariants
       - name: Upload reports
         if: always()
         uses: actions/upload-artifact@v4

--- a/.schemarefallowlist
+++ b/.schemarefallowlist
@@ -1,0 +1,63 @@
+# Schema-reference allowlist — consumed by scripts/check-schema-references.mjs
+#
+# Each line is a `.from()`/`.rpc()` target that application code references but
+# that does NOT exist in the LIVE database schema. Format: `from:name` / `rpc:name`
+# (bare names default to `from:`). A `# reason` after the entry documents why.
+#
+# These are a KNOWN BACKLOG, not new regressions — the sentinel ships with them
+# allowlisted (mirroring .driftallowlist) so it goes green today and its job is
+# to BLOCK NEW phantom references from here on. Each entry is a latent runtime
+# 500 against the current database: either the table lives in a migration that
+# hasn't been applied to this project, or the relation was renamed/dropped and
+# the calling code still points at the old name. Burn this list down by either
+# applying the missing migration or fixing the reference, then delete the line.
+
+# ── Startups vertical (tables absent from live; whole feature is unmigrated) ──
+from:startup_profiles
+from:startup_rounds
+from:startup_sessions
+from:startup_data_room_access
+from:startup_data_room_files
+from:startup_investor_inquiries
+from:esic_verifications
+
+# ── Academy / courses (live has courses/course_lessons/course_progress, no enrollments) ──
+from:course_enrollments
+
+# ── IPO watchlist + alerts (ipo_offers exists; watchlist/alert tables don't) ──
+from:ipo_watchlist
+from:ipo_alert_sends
+
+# ── Investment loan-rates feature (no investment_loan_rates relation live) ──
+from:investment_loan_rates
+
+# ── Referrals / review incentives ──
+from:referrals
+from:incentive_reviews
+
+# ── Push + personalized digest send logs ──
+from:push_send_log
+from:digest_sends
+
+# ── Revenue / payments (live has marketplace_payments + sponsored_placement_*; these names differ) ──
+from:sponsorship_orders
+from:stripe_payouts
+from:broker_campaigns
+
+# ── Pro tier + outbound API (live has outbound_webhook_*; api_* consumer tables differ) ──
+from:pro_subscribers
+from:api_consumer_webhooks
+from:api_key_subscriptions
+from:consumer_webhook_deliveries
+rpc:get_active_pro_count
+
+# ── Advisor search alerts + firm analytics (live has advisor_profile_views, not professional_views) ──
+from:advisor_search_alerts
+from:professional_views
+
+# ── Misc renamed/dropped relations ──
+from:deals_of_month
+from:saved_broker_comparisons              # live: user_saved_comparisons
+from:user_profiles                         # live: profiles
+from:wholesale_investor_certifications
+from:versus_votes                          # live: debate_votes / versus_editorials

--- a/__tests__/scripts/check-cross-tenant-rls.test.ts
+++ b/__tests__/scripts/check-cross-tenant-rls.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests for scripts/check-cross-tenant-rls.mjs.
+ *
+ * Exercises the pure leak detector + the table registry. main() is the
+ * creds-gated auth/REST wrapper, covered by the CI job where two test-user
+ * credentials are present.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { join } from "node:path";
+
+const gatePath = join(process.cwd(), "scripts/check-cross-tenant-rls.mjs");
+
+let foreignRows: (
+  rows: Record<string, unknown>[],
+  ownerCol: string,
+  selfId: string,
+) => Record<string, unknown>[];
+let USER_OWNED_TABLES: { table: string; ownerCol: string }[];
+
+beforeAll(async () => {
+  const m = await import(gatePath);
+  foreignRows = m.foreignRows;
+  USER_OWNED_TABLES = m.USER_OWNED_TABLES;
+});
+
+describe("foreignRows", () => {
+  it("returns nothing when every row belongs to the caller", () => {
+    const rows = [{ user_id: "u1" }, { user_id: "u1" }];
+    expect(foreignRows(rows, "user_id", "u1")).toEqual([]);
+  });
+
+  it("flags rows owned by another user (the leak)", () => {
+    const rows = [{ user_id: "u1" }, { user_id: "u2" }, { user_id: "u1" }];
+    expect(foreignRows(rows, "user_id", "u1")).toEqual([{ user_id: "u2" }]);
+  });
+
+  it("compares as strings so numeric/uuid id types don't false-pass", () => {
+    expect(foreignRows([{ user_id: 2 }], "user_id", "1")).toEqual([{ user_id: 2 }]);
+    expect(foreignRows([{ user_id: 1 }], "user_id", "1")).toEqual([]);
+  });
+
+  it("honours the configured owner column (auth_user_id)", () => {
+    const rows = [{ auth_user_id: "me" }, { auth_user_id: "other" }];
+    expect(foreignRows(rows, "auth_user_id", "me")).toEqual([{ auth_user_id: "other" }]);
+  });
+
+  it("treats an empty result set as isolated (deny-all / no rows)", () => {
+    expect(foreignRows([], "user_id", "u1")).toEqual([]);
+  });
+});
+
+describe("USER_OWNED_TABLES registry", () => {
+  it("is non-empty and every entry has a table + ownerCol", () => {
+    expect(USER_OWNED_TABLES.length).toBeGreaterThan(0);
+    for (const e of USER_OWNED_TABLES) {
+      expect(typeof e.table).toBe("string");
+      expect(e.table.length).toBeGreaterThan(0);
+      expect(["user_id", "auth_user_id"]).toContain(e.ownerCol);
+    }
+  });
+
+  it("has no duplicate table entries", () => {
+    const names = USER_OWNED_TABLES.map((e) => e.table);
+    expect(new Set(names).size).toBe(names.length);
+  });
+});

--- a/__tests__/scripts/check-financial-invariants.test.ts
+++ b/__tests__/scripts/check-financial-invariants.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for scripts/check-financial-invariants.mjs.
+ *
+ * Exercises the pure invariant evaluators (no network). main() is the
+ * creds-gated REST wrapper, covered by the CI job where the service-role key
+ * is present.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { join } from "node:path";
+
+const gatePath = join(process.cwd(), "scripts/check-financial-invariants.mjs");
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+let negativeBalances: (rows: any[]) => number[];
+let runningBalanceMismatches: (rows: any[]) => number[];
+let orphanLedgerRows: (rows: any[], ids: number[] | Set<number>) => number[];
+let malformedBookingAmounts: (rows: any[]) => number[];
+let paidBookingsWithoutIntent: (rows: any[]) => number[];
+let paidBillingWithoutRef: (rows: any[]) => number[];
+let negativeBillingAmounts: (rows: any[]) => number[];
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+beforeAll(async () => {
+  const m = await import(gatePath);
+  ({
+    negativeBalances,
+    runningBalanceMismatches,
+    orphanLedgerRows,
+    malformedBookingAmounts,
+    paidBookingsWithoutIntent,
+    paidBillingWithoutRef,
+    negativeBillingAmounts,
+  } = m);
+});
+
+describe("negativeBalances", () => {
+  it("flags rows whose balance dropped below zero", () => {
+    expect(
+      negativeBalances([
+        { id: 1, professional_id: 1, amount_cents: 100, balance_after_cents: 100 },
+        { id: 2, professional_id: 1, amount_cents: -250, balance_after_cents: -150 },
+      ]),
+    ).toEqual([2]);
+  });
+});
+
+describe("runningBalanceMismatches", () => {
+  it("passes when each row's balance equals the cumulative sum (per advisor)", () => {
+    const rows = [
+      { id: 1, professional_id: 7, amount_cents: 500, balance_after_cents: 500 },
+      { id: 2, professional_id: 7, amount_cents: -200, balance_after_cents: 300 },
+      { id: 3, professional_id: 9, amount_cents: 1000, balance_after_cents: 1000 },
+    ];
+    expect(runningBalanceMismatches(rows)).toEqual([]);
+  });
+
+  it("flags a row where the stored balance drifted from the running sum (CAS race)", () => {
+    const rows = [
+      { id: 1, professional_id: 7, amount_cents: 500, balance_after_cents: 500 },
+      // A lost update: second debit applied but balance not decremented.
+      { id: 2, professional_id: 7, amount_cents: -200, balance_after_cents: 500 },
+    ];
+    expect(runningBalanceMismatches(rows)).toEqual([2]);
+  });
+
+  it("orders by id, not array order, before summing", () => {
+    const rows = [
+      { id: 2, professional_id: 1, amount_cents: -200, balance_after_cents: 300 },
+      { id: 1, professional_id: 1, amount_cents: 500, balance_after_cents: 500 },
+    ];
+    expect(runningBalanceMismatches(rows)).toEqual([]);
+  });
+});
+
+describe("orphanLedgerRows", () => {
+  it("flags ledger rows pointing at a non-existent professional", () => {
+    const rows = [
+      { id: 1, professional_id: 7, amount_cents: 1, balance_after_cents: 1 },
+      { id: 2, professional_id: 99, amount_cents: 1, balance_after_cents: 2 },
+      { id: 3, professional_id: null, amount_cents: 1, balance_after_cents: 3 },
+    ];
+    expect(orphanLedgerRows(rows, new Set([7]))).toEqual([2, 3]);
+  });
+});
+
+describe("malformedBookingAmounts", () => {
+  it("flags negative amounts and fees exceeding the charge", () => {
+    const rows = [
+      { id: 1, amount_cents: 1000, platform_fee_cents: 200 },
+      { id: 2, amount_cents: 1000, platform_fee_cents: 1200 },
+      { id: 3, amount_cents: -5, platform_fee_cents: 0 },
+    ];
+    expect(malformedBookingAmounts(rows)).toEqual([2, 3]);
+  });
+});
+
+describe("paidBookingsWithoutIntent", () => {
+  it("flags settled payments missing a Stripe intent, ignores pending", () => {
+    const rows = [
+      { id: 1, status: "paid", stripe_payment_intent_id: "pi_1" },
+      { id: 2, status: "captured", stripe_payment_intent_id: null },
+      { id: 3, status: "pending", stripe_payment_intent_id: null },
+    ];
+    expect(paidBookingsWithoutIntent(rows)).toEqual([2]);
+  });
+});
+
+describe("paidBillingWithoutRef", () => {
+  it("flags paid billing rows missing paid_at or stripe ref", () => {
+    const rows = [
+      { id: 1, status: "paid", paid_at: "2026-01-01", stripe_payment_intent_id: "pi_1" },
+      { id: 2, status: "paid", paid_at: null, stripe_payment_intent_id: "pi_2" },
+      { id: 3, status: "paid", paid_at: "2026-01-01", stripe_payment_intent_id: null },
+      { id: 4, status: "pending", paid_at: null, stripe_payment_intent_id: null },
+    ];
+    expect(paidBillingWithoutRef(rows)).toEqual([2, 3]);
+  });
+});
+
+describe("negativeBillingAmounts", () => {
+  it("flags negative billing amounts", () => {
+    expect(negativeBillingAmounts([{ id: 1, amount_cents: -10 }, { id: 2, amount_cents: 0 }])).toEqual([1]);
+  });
+});

--- a/__tests__/scripts/check-schema-references.test.ts
+++ b/__tests__/scripts/check-schema-references.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for scripts/check-schema-references.mjs — the phantom-table sentinel.
+ *
+ * Exercises the exported pure helpers directly (no network, no child process).
+ * The main() runner is a thin wrapper whose end-to-end behaviour is covered by
+ * the creds-gated CI job; the parsing logic that determines a pass/fail lives
+ * in these helpers, so that's what we assert.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { join } from "node:path";
+
+const gatePath = join(process.cwd(), "scripts/check-schema-references.mjs");
+
+let parseOpenApiSchema: (doc: unknown) => { relations: Set<string>; functions: Set<string> };
+let findSchemaRefs: (code: string) => { kind: "from" | "rpc"; name: string; line: number }[];
+let parseAllowlist: (text: string) => Set<string>;
+let isKnown: (
+  ref: { kind: "from" | "rpc"; name: string },
+  schema: { relations: Set<string>; functions: Set<string> },
+) => boolean;
+
+beforeAll(async () => {
+  const mod = await import(gatePath);
+  parseOpenApiSchema = mod.parseOpenApiSchema;
+  findSchemaRefs = mod.findSchemaRefs;
+  parseAllowlist = mod.parseAllowlist;
+  isKnown = mod.isKnown;
+});
+
+describe("parseOpenApiSchema", () => {
+  it("reads relations from Swagger 2 `definitions` and RPCs from `/rpc/*` paths", () => {
+    const { relations, functions } = parseOpenApiSchema({
+      definitions: { brokers: {}, professionals: {}, advisor_billing: {} },
+      paths: { "/brokers": {}, "/rpc/get_active_count": {}, "/rpc/score_quiz": {} },
+    });
+    expect(relations.has("brokers")).toBe(true);
+    expect(relations.has("advisor_billing")).toBe(true);
+    expect(functions.has("get_active_count")).toBe(true);
+    expect(functions.has("score_quiz")).toBe(true);
+    expect(relations.has("get_active_count")).toBe(false);
+  });
+
+  it("supports OpenAPI 3 `components.schemas`", () => {
+    const { relations } = parseOpenApiSchema({ components: { schemas: { leads: {} } }, paths: {} });
+    expect(relations.has("leads")).toBe(true);
+  });
+
+  it("ignores non-identifier definition keys (e.g. synthetic rpc arg schemas)", () => {
+    const { relations } = parseOpenApiSchema({ definitions: { brokers: {}, "(rpc) foo": {} }, paths: {} });
+    expect(relations.has("brokers")).toBe(true);
+    expect(relations.size).toBe(1);
+  });
+});
+
+describe("findSchemaRefs", () => {
+  it("captures .from() and .rpc() string-literal targets with line numbers", () => {
+    const code = ['const a = supabase.from("brokers");', 'await db.rpc("score_quiz");'].join("\n");
+    const refs = findSchemaRefs(code);
+    expect(refs).toEqual([
+      { kind: "from", name: "brokers", line: 1 },
+      { kind: "rpc", name: "score_quiz", line: 2 },
+    ]);
+  });
+
+  it("strips a public. schema qualifier", () => {
+    expect(findSchemaRefs('x.from("public.brokers")')[0]).toMatchObject({ name: "brokers" });
+  });
+
+  it("skips JS builtins (Array.from / Buffer.from)", () => {
+    const refs = findSchemaRefs('const xs = Array.from("abc"); Buffer.from("zz");');
+    expect(refs).toEqual([]);
+  });
+
+  it("skips dynamic args (variables and template interpolation)", () => {
+    const code = "a.from(tableName); b.from(`weights_${kind}`); c.from(`${t}`);";
+    expect(findSchemaRefs(code)).toEqual([]);
+  });
+
+  it("does not treat a bare .from(\"public\") as a relation", () => {
+    expect(findSchemaRefs('x.from("public")')).toEqual([]);
+  });
+
+  it("handles chained calls after a paren (createClient().from(...))", () => {
+    expect(findSchemaRefs('createAdminClient().from("weights")')[0]).toMatchObject({
+      kind: "from",
+      name: "weights",
+    });
+  });
+});
+
+describe("parseAllowlist", () => {
+  it("parses prefixed + bare entries and ignores comments/blanks", () => {
+    const set = parseAllowlist(["from:weights # backlog", "rpc:foo", "bare_table", "  # comment", ""].join("\n"));
+    expect(set.has("from:weights")).toBe(true);
+    expect(set.has("rpc:foo")).toBe(true);
+    expect(set.has("from:bare_table")).toBe(true); // bare defaults to from:
+    expect(set.size).toBe(3);
+  });
+});
+
+describe("isKnown", () => {
+  const schema = { relations: new Set(["brokers"]), functions: new Set(["score_quiz"]) };
+  it("resolves from-refs against relations and rpc-refs against functions", () => {
+    expect(isKnown({ kind: "from", name: "brokers" }, schema)).toBe(true);
+    expect(isKnown({ kind: "from", name: "score_quiz" }, schema)).toBe(false); // fn isn't a relation
+    expect(isKnown({ kind: "rpc", name: "score_quiz" }, schema)).toBe(true);
+    expect(isKnown({ kind: "from", name: "ghost_table" }, schema)).toBe(false);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "audit:dated-stats": "node scripts/check-stale-dated-stats.mjs",
     "audit:rls-migrations": "node scripts/check-rls-migrations.mjs",
     "audit:drift-types": "node scripts/check-database-types-drift.mjs",
+    "audit:schema-refs": "node scripts/check-schema-references.mjs",
     "audit:unapplied-migrations": "node scripts/audit/unapplied-migrations.mjs",
     "audit:console-calls": "node scripts/check-console-calls.mjs",
     "audit:duplicate-functions": "node scripts/check-duplicate-functions.mjs",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "audit:drift-types": "node scripts/check-database-types-drift.mjs",
     "audit:schema-refs": "node scripts/check-schema-references.mjs",
     "audit:financial-invariants": "node scripts/check-financial-invariants.mjs",
+    "audit:cross-tenant-rls": "node scripts/check-cross-tenant-rls.mjs",
     "audit:unapplied-migrations": "node scripts/audit/unapplied-migrations.mjs",
     "audit:console-calls": "node scripts/check-console-calls.mjs",
     "audit:duplicate-functions": "node scripts/check-duplicate-functions.mjs",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "audit:rls-migrations": "node scripts/check-rls-migrations.mjs",
     "audit:drift-types": "node scripts/check-database-types-drift.mjs",
     "audit:schema-refs": "node scripts/check-schema-references.mjs",
+    "audit:financial-invariants": "node scripts/check-financial-invariants.mjs",
     "audit:unapplied-migrations": "node scripts/audit/unapplied-migrations.mjs",
     "audit:console-calls": "node scripts/check-console-calls.mjs",
     "audit:duplicate-functions": "node scripts/check-duplicate-functions.mjs",

--- a/scripts/check-cross-tenant-rls.mjs
+++ b/scripts/check-cross-tenant-rls.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+// @ts-check
+import { fileURLToPath } from "node:url";
+/**
+ * Cross-tenant RLS fuzzer — authenticated IDOR probe.
+ *
+ * The existing bots:idor probe proves the ANON role can't read sensitive
+ * tables. This proves the harder, more dangerous case: an AUTHENTICATED user
+ * cannot read ANOTHER user's rows. It signs in two real test users (A, B) and,
+ * for every user-owned table, fetches what each can see through PostgREST and
+ * asserts every returned row belongs to the caller. A row owned by the other
+ * user — or anyone else — is a tenant-isolation breach (the RLS policy is
+ * missing `auth.uid()` scoping or uses a permissive `USING (true)`).
+ *
+ * Read-only: it only SELECTs with each user's own JWT (no writes, no service
+ * role, $0). Strongest when the two test users each already have some rows
+ * (seed via `npm run bots:seed-users`); with empty accounts it still catches a
+ * policy that leaks *other* users' rows.
+ *
+ * Creds-gated: skips cleanly unless URL + anon key + both users' credentials
+ * are present.
+ *   NEXT_PUBLIC_SUPABASE_URL=… NEXT_PUBLIC_SUPABASE_ANON_KEY=… \
+ *   BOTS_RLS_USER_A_EMAIL=… BOTS_RLS_USER_A_PASSWORD=… \
+ *   BOTS_RLS_USER_B_EMAIL=… BOTS_RLS_USER_B_PASSWORD=… npm run audit:cross-tenant-rls
+ *
+ * Exit: 0 isolated / skipped · 1 a cross-tenant leak · 2 setup error.
+ */
+
+/**
+ * User-owned tables and the column that must equal the caller's auth uid.
+ * Derived from the live schema (information_schema). Add a row here when a new
+ * per-user table ships.
+ * @type {{ table: string, ownerCol: string }[]}
+ */
+export const USER_OWNED_TABLES = [
+  { table: "user_bookmarks", ownerCol: "user_id" },
+  { table: "user_quiz_history", ownerCol: "user_id" },
+  { table: "user_lists", ownerCol: "user_id" },
+  { table: "user_documents", ownerCol: "user_id" },
+  { table: "user_watchlist_items", ownerCol: "user_id" },
+  { table: "user_calculator_state", ownerCol: "user_id" },
+  { table: "user_saved_comparisons", ownerCol: "user_id" },
+  { table: "user_shortlisted_brokers", ownerCol: "user_id" },
+  { table: "user_current_products", ownerCol: "user_id" },
+  { table: "user_term_deposits", ownerCol: "user_id" },
+  { table: "user_daily_checkins", ownerCol: "user_id" },
+  { table: "user_notifications", ownerCol: "user_id" },
+  { table: "manual_balances", ownerCol: "user_id" },
+  { table: "saved_searches", ownerCol: "user_id" },
+  { table: "notification_preferences", ownerCol: "user_id" },
+  { table: "watchlist_alert_preferences", ownerCol: "user_id" },
+  { table: "investor_goals", ownerCol: "auth_user_id" },
+];
+
+// ---------------------------------------------------------------------------
+// Pure logic — exported for unit tests
+// ---------------------------------------------------------------------------
+
+/**
+ * Given the rows a caller could read, return the ones that DON'T belong to them
+ * — i.e. cross-tenant leaks. A non-empty result means RLS failed to scope the
+ * table to the authenticated user.
+ *
+ * @param {Record<string, unknown>[]} rows
+ * @param {string} ownerCol
+ * @param {string} selfId  the caller's auth uid
+ * @returns {Record<string, unknown>[]}
+ */
+export function foreignRows(rows, ownerCol, selfId) {
+  return rows.filter((r) => String(r[ownerCol]) !== String(selfId));
+}
+
+// ---------------------------------------------------------------------------
+// Auth + fetch + runner
+// ---------------------------------------------------------------------------
+
+async function signIn(base, anonKey, email, password) {
+  const res = await fetch(`${base}/auth/v1/token?grant_type=password`, {
+    method: "POST",
+    headers: { apikey: anonKey, "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password }),
+    signal: AbortSignal.timeout(20_000),
+  });
+  if (!res.ok) throw new Error(`sign-in failed for ${email}: ${res.status}`);
+  const json = await res.json();
+  if (!json.access_token || !json.user?.id) throw new Error(`sign-in for ${email} returned no token/user`);
+  return { token: json.access_token, userId: json.user.id };
+}
+
+async function readAs(base, anonKey, token, table, ownerCol) {
+  const res = await fetch(`${base}/rest/v1/${table}?select=${ownerCol}&limit=500`, {
+    headers: { apikey: anonKey, Authorization: `Bearer ${token}` },
+    signal: AbortSignal.timeout(20_000),
+  });
+  if (!res.ok) {
+    // A 401/403/404 is fine (deny-all or table hidden) — it's the OPPOSITE of a
+    // leak. Return empty so it counts as isolated.
+    return [];
+  }
+  return res.json();
+}
+
+async function main() {
+  const base = (process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL || "").replace(/\/$/, "");
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY;
+  const a = { email: process.env.BOTS_RLS_USER_A_EMAIL, password: process.env.BOTS_RLS_USER_A_PASSWORD };
+  const b = { email: process.env.BOTS_RLS_USER_B_EMAIL, password: process.env.BOTS_RLS_USER_B_PASSWORD };
+  if (!base || !anonKey || !a.email || !a.password || !b.email || !b.password) {
+    console.log("[cross-tenant-rls] missing creds (URL + anon key + two test users) — skipping.");
+    process.exit(0);
+  }
+
+  let userA, userB;
+  try {
+    [userA, userB] = await Promise.all([
+      signIn(base, anonKey, a.email, a.password),
+      signIn(base, anonKey, b.email, b.password),
+    ]);
+  } catch (e) {
+    console.error("[cross-tenant-rls] auth error:", e instanceof Error ? e.message : e);
+    process.exit(2);
+  }
+  if (userA.userId === userB.userId) {
+    console.error("[cross-tenant-rls] both credentials resolve to the same user — need two distinct accounts.");
+    process.exit(2);
+  }
+
+  /** @type {{ table: string, actor: string, leaked: number }[]} */
+  const leaks = [];
+  let checks = 0;
+  for (const { table, ownerCol } of USER_OWNED_TABLES) {
+    for (const actor of [userA, userB]) {
+      checks++;
+      const rows = await readAs(base, anonKey, actor.token, table, ownerCol);
+      const foreign = foreignRows(rows, ownerCol, actor.userId);
+      if (foreign.length > 0) leaks.push({ table, actor: actor.userId, leaked: foreign.length });
+    }
+  }
+
+  if (leaks.length === 0) {
+    console.log(`[cross-tenant-rls] ✅ no cross-tenant leaks across ${USER_OWNED_TABLES.length} tables (${checks} authed reads, 2 users).`);
+    process.exit(0);
+  }
+  console.error(`[cross-tenant-rls] 🔴 ${leaks.length} tenant-isolation breach(es):\n`);
+  for (const l of leaks) console.error(`  ${l.table}: user ${l.actor} could read ${l.leaked} row(s) owned by someone else`);
+  console.error("\nFix: the table's RLS SELECT policy must scope to auth.uid() (no USING (true)).");
+  process.exit(1);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => { console.error("[cross-tenant-rls] fatal:", err); process.exit(2); });
+}

--- a/scripts/check-financial-invariants.mjs
+++ b/scripts/check-financial-invariants.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+// @ts-check
+import { fileURLToPath } from "node:url";
+/**
+ * Financial-invariant sentinel — money-path reconciliation (read-only).
+ *
+ * Asserts a set of hard invariants over the live financial tables that should
+ * NEVER be violated regardless of code path or race. These guard exactly the
+ * bugs that have hit this codebase: credit over-spend (negative balances),
+ * compare-and-set ledger races (running balance drifting from the cumulative
+ * sum), and orphaned / malformed payment rows.
+ *
+ * Invariants:
+ *   1. advisor_credit_ledger.balance_after_cents >= 0            (no over-spend)
+ *   2. per-advisor running Σ(amount_cents) == balance_after_cents (CAS integrity)
+ *   3. every ledger row's professional_id exists in professionals (no orphans)
+ *   4. booking_payments: platform_fee_cents <= amount_cents, amount_cents >= 0
+ *   5. booking_payments paid/captured ⇒ stripe_payment_intent_id present
+ *   6. advisor_billing status=paid ⇒ paid_at AND stripe_payment_intent_id set
+ *   7. advisor_billing.amount_cents >= 0
+ *
+ * Read-only: it only SELECTs (no writes, no Stripe calls, $0). Reads are
+ * service-role because these tables are deny-all / service-role-only RLS.
+ * Creds-gated: skips cleanly without SUPABASE_SERVICE_ROLE_KEY + URL.
+ *
+ *   SUPABASE_SERVICE_ROLE_KEY=… NEXT_PUBLIC_SUPABASE_URL=… npm run audit:financial-invariants
+ *
+ * Exit: 0 all invariants hold / skipped · 1 a violation · 2 setup error.
+ */
+
+// ---------------------------------------------------------------------------
+// Pure invariant evaluators — exported for unit tests (no I/O)
+// ---------------------------------------------------------------------------
+
+/** @typedef {{ id:number, professional_id:number|null, amount_cents:number, balance_after_cents:number }} LedgerRow */
+
+/** 1. Balances must never go negative. @param {LedgerRow[]} rows */
+export function negativeBalances(rows) {
+  return rows.filter((r) => Number(r.balance_after_cents) < 0).map((r) => r.id);
+}
+
+/**
+ * 2. For each advisor, the stored balance_after_cents on every row must equal
+ * the cumulative sum of amount_cents up to and including that row (ordered by
+ * id). A mismatch means a lost/duplicated update — the CAS race class.
+ * @param {LedgerRow[]} rows
+ */
+export function runningBalanceMismatches(rows) {
+  /** @type {Map<number, LedgerRow[]>} */
+  const byAdvisor = new Map();
+  for (const r of rows) {
+    const k = Number(r.professional_id);
+    (byAdvisor.get(k) ?? byAdvisor.set(k, []).get(k)).push(r);
+  }
+  /** @type {number[]} */
+  const bad = [];
+  for (const list of byAdvisor.values()) {
+    list.sort((a, b) => a.id - b.id);
+    let running = 0;
+    for (const r of list) {
+      running += Number(r.amount_cents);
+      if (running !== Number(r.balance_after_cents)) bad.push(r.id);
+    }
+  }
+  return bad;
+}
+
+/** 3. Ledger rows whose professional_id isn't a known professional. */
+export function orphanLedgerRows(ledgerRows, professionalIds) {
+  const known = professionalIds instanceof Set ? professionalIds : new Set(professionalIds);
+  return ledgerRows.filter((r) => r.professional_id == null || !known.has(Number(r.professional_id))).map((r) => r.id);
+}
+
+/** 4. Booking payments where the platform fee exceeds the charge or amount < 0. */
+export function malformedBookingAmounts(rows) {
+  return rows
+    .filter((r) => Number(r.amount_cents) < 0 || Number(r.platform_fee_cents ?? 0) > Number(r.amount_cents ?? 0))
+    .map((r) => r.id);
+}
+
+const PAID_STATES = new Set(["paid", "captured", "succeeded"]);
+
+/** 5. A settled booking payment must carry a Stripe payment-intent id. */
+export function paidBookingsWithoutIntent(rows) {
+  return rows.filter((r) => PAID_STATES.has(String(r.status)) && !r.stripe_payment_intent_id).map((r) => r.id);
+}
+
+/** 6. advisor_billing marked paid must have paid_at AND a Stripe reference. */
+export function paidBillingWithoutRef(rows) {
+  return rows.filter((r) => String(r.status) === "paid" && (!r.paid_at || !r.stripe_payment_intent_id)).map((r) => r.id);
+}
+
+/** 7. advisor_billing amounts must be non-negative. */
+export function negativeBillingAmounts(rows) {
+  return rows.filter((r) => Number(r.amount_cents) < 0).map((r) => r.id);
+}
+
+// ---------------------------------------------------------------------------
+// Live data fetch (PostgREST, service-role) + runner
+// ---------------------------------------------------------------------------
+
+/** Fetch all rows of a table (paginated) selecting only the given columns. */
+async function fetchAll(base, key, table, select) {
+  const rows = [];
+  const pageSize = 1000;
+  for (let from = 0; ; from += pageSize) {
+    const res = await fetch(`${base}/rest/v1/${table}?select=${select}`, {
+      headers: {
+        apikey: key,
+        Authorization: `Bearer ${key}`,
+        Range: `${from}-${from + pageSize - 1}`,
+        "Range-Unit": "items",
+      },
+      signal: AbortSignal.timeout(20_000),
+    });
+    if (!res.ok) throw new Error(`${table}: ${res.status} ${res.statusText}`);
+    const batch = await res.json();
+    rows.push(...batch);
+    if (batch.length < pageSize) break;
+  }
+  return rows;
+}
+
+async function main() {
+  const base = (process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL || "").replace(/\/$/, "");
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!base || !key) {
+    console.log("[financial-invariants] no SUPABASE_SERVICE_ROLE_KEY — skipping (service-role needed for deny-all financial tables).");
+    process.exit(0);
+  }
+
+  let ledger, billing, bookingPays, professionals;
+  try {
+    [ledger, billing, bookingPays, professionals] = await Promise.all([
+      fetchAll(base, key, "advisor_credit_ledger", "id,professional_id,amount_cents,balance_after_cents"),
+      fetchAll(base, key, "advisor_billing", "id,status,amount_cents,paid_at,stripe_payment_intent_id"),
+      fetchAll(base, key, "booking_payments", "id,status,amount_cents,platform_fee_cents,stripe_payment_intent_id"),
+      fetchAll(base, key, "professionals", "id"),
+    ]);
+  } catch (e) {
+    console.error("[financial-invariants] fetch failed:", e instanceof Error ? e.message : e);
+    process.exit(2);
+  }
+
+  const profIds = new Set(professionals.map((p) => Number(p.id)));
+  const checks = [
+    { name: "ledger balance never negative", ids: negativeBalances(ledger) },
+    { name: "ledger running balance == Σ amount_cents (CAS integrity)", ids: runningBalanceMismatches(ledger) },
+    { name: "ledger rows reference a real professional", ids: orphanLedgerRows(ledger, profIds) },
+    { name: "booking_payments fee <= amount and amount >= 0", ids: malformedBookingAmounts(bookingPays) },
+    { name: "settled booking_payments have a Stripe intent", ids: paidBookingsWithoutIntent(bookingPays) },
+    { name: "paid advisor_billing has paid_at + Stripe ref", ids: paidBillingWithoutRef(billing) },
+    { name: "advisor_billing amount never negative", ids: negativeBillingAmounts(billing) },
+  ];
+
+  const failed = checks.filter((c) => c.ids.length > 0);
+  for (const c of checks) {
+    console.log(`  ${c.ids.length === 0 ? "✅" : "🔴"} ${c.name}${c.ids.length ? ` — ${c.ids.length} violation(s): ids ${c.ids.slice(0, 20).join(", ")}` : ""}`);
+  }
+  console.log(`[financial-invariants] ${failed.length === 0 ? "ALL HOLD" : failed.length + " INVARIANT(S) VIOLATED"} (ledger ${ledger.length}, billing ${billing.length}, booking_payments ${bookingPays.length}).`);
+  process.exit(failed.length > 0 ? 1 : 0);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => { console.error("[financial-invariants] fatal:", err); process.exit(2); });
+}

--- a/scripts/check-schema-references.mjs
+++ b/scripts/check-schema-references.mjs
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+// @ts-check
+import { fileURLToPath } from "node:url";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+/**
+ * Schema-reference sentinel — phantom-table / phantom-RPC gate.
+ *
+ * Fails if application code calls `.from("<table>")` or `.rpc("<fn>")` with a
+ * string literal that does NOT exist in the LIVE database schema.
+ *
+ * Why this matters: a `.from("table_that_does_not_exist")` does not fail at
+ * build or type-check time — PostgREST returns a runtime error and the route
+ * 500s in production. That is exactly how the `versus_votes`/`weights`/
+ * `booking_payments` outages happened: code shipped referencing relations that
+ * weren't in the schema, and nothing caught it until the live endpoint threw.
+ *
+ * Source of truth = the LIVE schema, fetched from PostgREST's OpenAPI document
+ * (`{SUPABASE_URL}/rest/v1/`). We deliberately do NOT use lib/database.types.ts
+ * — in this repo it lags the live schema by hundreds of tables (the migration
+ * drift backlog), so a types-based check is ~all false positives. The OpenAPI
+ * doc enumerates every table/view (`definitions`) and RPC (`/rpc/*` paths)
+ * actually exposed by the running database.
+ *
+ * Creds-gated: with no SUPABASE creds it SKIPS cleanly (exit 0) — same posture
+ * as bots:idor / bots:data, so it never red-fails a fork/PR without secrets.
+ *
+ * Usage:
+ *   NEXT_PUBLIC_SUPABASE_URL=… NEXT_PUBLIC_SUPABASE_ANON_KEY=… npm run audit:schema-refs
+ *   SUPABASE_SCHEMA_JSON=path/to/openapi.json npm run audit:schema-refs   # offline
+ *
+ * Escape hatch — `.schemarefallowlist` at repo root, one entry per line:
+ *   from:some_relation   # justification (runtime-created, other schema, …)
+ *   rpc:some_fn          # justification
+ * Bare names default to `from:`. Comments (`#`) and blanks ignored.
+ *
+ * Cost: $0 — one OpenAPI GET + static file scan, no LLM.
+ * Exit: 0 clean / skipped · 1 a phantom reference · 2 setup error.
+ */
+
+const ALLOWLIST_FILE = ".schemarefallowlist";
+const SCAN_DIRS = ["app", "lib", "components"];
+const SCAN_EXT = new Set([".ts", ".tsx"]);
+// Don't scan generated types, the audit scripts (they hold table names in
+// strings/regex), or tests (mock builders, fixture strings).
+const SKIP = [/^lib\/database\.types\.ts$/, /(^|\/)__tests__\//, /\.test\.[tj]sx?$/, /(^|\/)scripts\//];
+
+// ---------------------------------------------------------------------------
+// Core logic — exported for unit tests (pure, no I/O)
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a PostgREST OpenAPI/Swagger document into the set of relation names
+ * (tables + views, the valid `.from()` targets) and function names (valid
+ * `.rpc()` targets). Handles Swagger 2 (`definitions`) and OpenAPI 3
+ * (`components.schemas`); RPCs are the `/rpc/<fn>` paths.
+ *
+ * @param {any} doc  parsed OpenAPI JSON
+ * @returns {{ relations: Set<string>, functions: Set<string> }}
+ */
+export function parseOpenApiSchema(doc) {
+  const relations = new Set();
+  const functions = new Set();
+  const defs = doc?.definitions ?? doc?.components?.schemas ?? {};
+  for (const name of Object.keys(defs)) {
+    // PostgREST exposes a synthetic `(rpc args)` definition per function and a
+    // root entry; only real relations are bare identifiers.
+    if (/^[a-z_][a-z0-9_]*$/.test(name)) relations.add(name);
+  }
+  for (const p of Object.keys(doc?.paths ?? {})) {
+    const m = /^\/rpc\/([a-z_][a-z0-9_]*)$/.exec(p);
+    if (m) functions.add(m[1]);
+  }
+  return { relations, functions };
+}
+
+/**
+ * Find `.from("x")` and `.rpc("x")` string-literal references in a source
+ * string. Skips dynamic args (variables, template interpolation) and JS
+ * builtins like `Array.from(...)` / `Buffer.from(...)` (PascalCase receiver).
+ *
+ * @param {string} code
+ * @returns {{ kind: "from"|"rpc", name: string, line: number }[]}
+ */
+export function findSchemaRefs(code) {
+  /** @type {{ kind: "from"|"rpc", name: string, line: number }[]} */
+  const refs = [];
+  const re = /([A-Za-z_$][\w$]*)?\s*\.(from|rpc)\(\s*(["'`])((?:public\.)?[a-z_][a-z0-9_]*)\3\s*\)/g;
+  let m;
+  while ((m = re.exec(code)) !== null) {
+    const receiver = m[1];
+    if (receiver && /^[A-Z]/.test(receiver)) continue; // Array.from / Buffer.from
+    const kind = /** @type {"from"|"rpc"} */ (m[2]);
+    const name = m[4].replace(/^public\./, "");
+    if (name === "public") continue; // `.from("public")` is never a relation
+    const line = code.slice(0, m.index).split("\n").length;
+    refs.push({ kind, name, line });
+  }
+  return refs;
+}
+
+/**
+ * @param {string} text
+ * @returns {Set<string>} keys like `from:name` / `rpc:name`
+ */
+export function parseAllowlist(text) {
+  const out = new Set();
+  for (const raw of text.split("\n")) {
+    const line = raw.replace(/#.*$/, "").trim();
+    if (!line) continue;
+    out.add(/^(from|rpc):/.test(line) ? line : `from:${line}`);
+  }
+  return out;
+}
+
+/**
+ * @param {{ kind: "from"|"rpc", name: string }} ref
+ * @param {{ relations: Set<string>, functions: Set<string> }} schema
+ */
+export function isKnown(ref, schema) {
+  return ref.kind === "from" ? schema.relations.has(ref.name) : schema.functions.has(ref.name);
+}
+
+// ---------------------------------------------------------------------------
+// Schema acquisition + file walking
+// ---------------------------------------------------------------------------
+
+async function loadLiveSchema() {
+  // Offline path for local verification / tests.
+  if (process.env.SUPABASE_SCHEMA_JSON) {
+    const doc = JSON.parse(await fs.readFile(process.env.SUPABASE_SCHEMA_JSON, "utf8"));
+    return parseOpenApiSchema(doc);
+  }
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+  const key =
+    process.env.SUPABASE_SERVICE_ROLE_KEY ||
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
+    process.env.SUPABASE_ANON_KEY;
+  if (!url || !key) return null; // creds-gated skip
+  const res = await fetch(`${url.replace(/\/$/, "")}/rest/v1/`, {
+    headers: { apikey: key, Authorization: `Bearer ${key}` },
+    signal: AbortSignal.timeout(20_000),
+  });
+  if (!res.ok) throw new Error(`OpenAPI fetch ${res.status} ${res.statusText}`);
+  return parseOpenApiSchema(await res.json());
+}
+
+/** @param {string} dir @returns {Promise<string[]>} */
+async function walk(dir) {
+  /** @type {string[]} */
+  const out = [];
+  let entries;
+  try { entries = await fs.readdir(dir, { withFileTypes: true }); }
+  catch { return out; }
+  for (const e of entries) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      if (e.name === "node_modules" || e.name === ".next") continue;
+      out.push(...(await walk(full)));
+    } else if (SCAN_EXT.has(path.extname(e.name))) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+async function main() {
+  const root = process.cwd();
+
+  let schema;
+  try { schema = await loadLiveSchema(); }
+  catch (e) { console.error("[schema-refs] could not load live schema:", e instanceof Error ? e.message : e); process.exit(2); }
+  if (!schema) {
+    console.log("[schema-refs] no SUPABASE creds — skipping (set NEXT_PUBLIC_SUPABASE_URL + a key to enable).");
+    process.exit(0);
+  }
+  if (schema.relations.size === 0) {
+    console.error("[schema-refs] live schema returned 0 relations — refusing to run (would false-flag everything).");
+    process.exit(2);
+  }
+
+  let allowlist = new Set();
+  try { allowlist = parseAllowlist(await fs.readFile(path.join(root, ALLOWLIST_FILE), "utf8")); }
+  catch { /* optional */ }
+
+  const files = (await Promise.all(SCAN_DIRS.map((d) => walk(d)))).flat();
+  /** @type {{ file: string, line: number, kind: string, name: string }[]} */
+  const violations = [];
+  let scanned = 0, refCount = 0;
+  for (const file of files) {
+    const rel = path.relative(root, file).split(path.sep).join("/");
+    if (SKIP.some((re) => re.test(rel))) continue;
+    scanned++;
+    const code = await fs.readFile(file, "utf8");
+    for (const ref of findSchemaRefs(code)) {
+      refCount++;
+      if (isKnown(ref, schema)) continue;
+      if (allowlist.has(`${ref.kind}:${ref.name}`)) continue;
+      violations.push({ file: rel, line: ref.line, kind: ref.kind, name: ref.name });
+    }
+  }
+
+  if (violations.length === 0) {
+    console.log(`[schema-refs] ✅ ${refCount} references across ${scanned} files all resolve against the live schema (${schema.relations.size} relations, ${schema.functions.size} functions, ${allowlist.size} allowlisted).`);
+    process.exit(0);
+  }
+
+  console.error(`[schema-refs] 🔴 ${violations.length} reference(s) to relations/functions absent from the LIVE schema:\n`);
+  for (const v of violations) console.error(`  ${v.file}:${v.line}  .${v.kind}("${v.name}")  — not in live schema`);
+  console.error(`\nFix: correct the name / ship the migration, or allowlist in \`${ALLOWLIST_FILE}\` with a reason.`);
+  process.exit(1);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => { console.error("[schema-refs] fatal:", err); process.exit(2); });
+}


### PR DESCRIPTION
Three new creds-gated, $0, read-only audit monitors that guard failure classes which have actually bitten this codebase. Each has a unit-tested pure core and runs in the bots fleet's daily *light* job (creds-gated → skips cleanly where a secret is absent).

## 1. Schema-reference sentinel (`audit:schema-refs`)
Fails when code calls `.from("table")` / `.rpc("fn")` with a literal absent from the **live** schema — the phantom-relation class that 500s in prod (`weights`, `versus_votes`, `booking_payments`). Source of truth is the live PostgREST OpenAPI doc, **not** `lib/database.types.ts` (which lags by hundreds of tables here). Run against live it surfaced **116 phantom references / 29 relations + 1 RPC** (whole `startups`/`courses`/`ipo`/`loan-rate`/`referrals` features point at unmigrated or renamed tables) — seeded into `.schemarefallowlist` as a documented backlog so the gate ships green and blocks *new* drift. 11 unit cases.

## 2. Financial-invariant sentinel (`audit:financial-invariants`)
Read-only assertions over the live financial tables: ledger balance never negative; per-advisor running Σ(amount_cents) == `balance_after_cents` (CAS integrity); no orphan ledger rows; `booking_payments` fee ≤ amount & amount ≥ 0; settled payments carry a Stripe intent; paid `advisor_billing` has `paid_at` + ref. Guards the credit-overspend / seat / payment bugs fixed earlier. **All seven verified to hold against the live DB (0 violations)** — the running-balance check confirms the ledger CAS fix is healthy in prod. Service-role reads. 9 unit cases.

## 3. Cross-tenant RLS fuzzer (`audit:cross-tenant-rls`)
Complements `bots:idor` (anon-only) by testing the dangerous case: an **authenticated** user must never read another user's rows. Signs in two test users and asserts every row each can read across **17 user-owned tables** (registry derived from the live schema) belongs to the caller. Read-only, each user's own JWT. 7 unit cases.

> Stacked on #1440; the diff narrows once it merges.

https://claude.ai/code/session_014hduVwZpij3yXcH6Ct8hVo