### PR TITLE
fix(marketplace): repair canonicals, copy & dead provider links on directory pages

### DIFF
--- a/__tests__/lib/advisor-profile-links.test.ts
+++ b/__tests__/lib/advisor-profile-links.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Regression guard for the dead-link class fixed alongside the marketplace
+ * rebuild.
+ *
+ * Individual advisor / professional profiles live at `/advisor/<slug>`
+ * (singular). `/advisors/<x>` is the *category* directory route
+ * (`app/advisors/[type]`), so linking a person slug there renders
+ * "Advisor Category Not Found" — a soft-404 (HTTP 200, `noindex`). These
+ * files all linked person slugs to the plural route; they now use the
+ * singular profile route. This test stops the footgun from creeping back.
+ *
+ * Files that legitimately link to *category* slugs are intentionally excluded
+ * (e.g. the SMSF checker's `/advisors/smsf-specialists`, `app/sitemap.ts`,
+ * the `/advisors/[type]` route itself, and the plural `/api/v1/advisors/...`
+ * REST endpoints).
+ */
+const FILES_WITH_PROFILE_LINKS = [
+  "app/marketplace/[intent]/[state]/page.tsx",
+  "components/country-mode/CountryExpertsPreview.tsx",
+  "components/SmartRecommendationsStrip.tsx",
+  "app/find/[advisor-type]/[city]/page.tsx",
+  "app/firm-portal/performance/FirmPerformanceClient.tsx",
+  "app/office-hours/[id]/page.tsx",
+  "app/api/cron/saved-search-alerts/route.ts",
+  "app/api/cron/personalized-morning-brief/route.ts",
+  "app/lists/[slug]/page.tsx",
+  "app/account/verified/VerifiedClient.tsx",
+];
+
+describe("advisor profile links use the singular /advisor/<slug> route", () => {
+  for (const rel of FILES_WITH_PROFILE_LINKS) {
+    it(`${rel} does not link a person slug to the /advisors/ category route`, () => {
+      const src = readFileSync(join(process.cwd(), rel), "utf8");
+      // a person-slug interpolation into the plural route is the dead-link bug
+      expect(src).not.toContain("/advisors/${");
+    });
+  }
+});

--- a/__tests__/lib/getmatched/intent-presentation.test.ts
+++ b/__tests__/lib/getmatched/intent-presentation.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import {
+  PROVIDER_NOUNS,
+  providerNounForIntent,
+  complianceVariantForIntent,
+} from "@/lib/getmatched/intent-presentation";
+import { FALLBACK_INTENTS } from "@/lib/getmatched/fallbacks";
+
+describe("providerNounForIntent", () => {
+  it("prefers the admin-editable DB value", () => {
+    expect(
+      providerNounForIntent({ slug: "opportunity_assessment", provider_noun: "deal review pros" }),
+    ).toBe("deal review pros");
+  });
+
+  it("falls back to the code map by slug when the DB value is null", () => {
+    expect(
+      providerNounForIntent({ slug: "opportunity_assessment", provider_noun: null }),
+    ).toBe("opportunity assessment specialists");
+  });
+
+  it("ignores blank/whitespace DB values", () => {
+    expect(
+      providerNounForIntent({ slug: "opportunity_assessment", provider_noun: "   " }),
+    ).toBe("opportunity assessment specialists");
+  });
+
+  it("uses a grammatical generic for an unknown slug", () => {
+    expect(providerNounForIntent({ slug: "brand_new_intent" })).toBe("verified providers");
+  });
+});
+
+describe("PROVIDER_NOUNS completeness", () => {
+  it("covers every shipped fallback-intent slug", () => {
+    for (const intent of FALLBACK_INTENTS) {
+      expect(PROVIDER_NOUNS[intent.slug], `missing provider_noun for "${intent.slug}"`).toBeTruthy();
+    }
+  });
+
+  it("covers the NZ intents seeded by mm26", () => {
+    expect(PROVIDER_NOUNS["nz_kiwisaver"]).toBeTruthy();
+    expect(PROVIDER_NOUNS["nz_property_buy"]).toBeTruthy();
+  });
+
+  it("nouns slot into 'Best <noun> in <state>' — no leading imperative verb", () => {
+    const imperatives = new Set([
+      "assess", "buy", "get", "compare", "start", "post", "prepare", "earn", "browse", "optimise",
+    ]);
+    for (const [slug, noun] of Object.entries(PROVIDER_NOUNS)) {
+      expect(noun.length, slug).toBeGreaterThan(3);
+      const firstWord = noun.split(/\s+/)[0]!.toLowerCase();
+      expect(imperatives.has(firstWord), `"${noun}" (${slug}) starts with an imperative verb`).toBe(false);
+    }
+  });
+});
+
+describe("complianceVariantForIntent", () => {
+  it("maps each asset class to the right ASIC risk-warning variant", () => {
+    expect(complianceVariantForIntent({ slug: "crypto" })).toBe("crypto");
+    expect(complianceVariantForIntent({ slug: "trade" })).toBe("cfd");
+    expect(complianceVariantForIntent({ slug: "foreign_investor" })).toBe("firb");
+    expect(complianceVariantForIntent({ slug: "commercial_property" })).toBe("property");
+    expect(complianceVariantForIntent({ slug: "nz_property_buy" })).toBe("property");
+  });
+
+  it("defaults to the general-advice variant", () => {
+    expect(complianceVariantForIntent({ slug: "opportunity_assessment" })).toBe("default");
+    expect(complianceVariantForIntent({ slug: "financial_advice" })).toBe("default");
+  });
+});

--- a/__tests__/lib/seo/best-pages.test.ts
+++ b/__tests__/lib/seo/best-pages.test.ts
@@ -27,29 +27,48 @@ describe("getStateBySlug", () => {
 });
 
 describe("bestPageMeta", () => {
-  it("includes state in title when state is provided", () => {
+  const noun = "opportunity assessment specialists";
+
+  it("uses the provider noun (not the imperative label) in the title and H1", () => {
     const m = bestPageMeta({
-      intentLabel: "SMSF Property Advice",
+      intentSlug: "opportunity_assessment",
+      intentNoun: noun,
       state: AUSTRALIAN_STATES[0]!,
     });
-    expect(m.title).toContain("SMSF Property Advice");
-    expect(m.title).toContain("New South Wales");
-    expect(m.h1).toBe("Best SMSF Property Advice in New South Wales");
+    expect(m.h1).toBe("Best opportunity assessment specialists in New South Wales");
+    expect(m.title).toContain("Best opportunity assessment specialists in New South Wales");
+    // never the broken "Best Assess an opportunity in ..." copy
+    expect(m.h1).not.toContain("Assess an opportunity");
   });
 
-  it("uses 'Australia' when no state", () => {
-    const m = bestPageMeta({ intentLabel: "Financial Advice" });
-    expect(m.title).toContain("Australia");
-    expect(m.h1).toBe("Best Financial Advice in Australia");
+  it("uses 'Australia' and the all-AU canonical when no state is given", () => {
+    const m = bestPageMeta({ intentSlug: "financial_advice", intentNoun: "financial advisers" });
+    expect(m.h1).toBe("Best financial advisers in Australia");
+    expect(m.canonical).toContain("/marketplace/financial_advice");
+    expect(m.canonical).not.toContain("/nsw");
   });
 
-  it("emits an absolute canonical URL", () => {
+  it("builds the canonical from the SLUG, not the slugified noun (noindex-404 regression)", () => {
     const m = bestPageMeta({
-      intentLabel: "Financial Advice",
+      intentSlug: "opportunity_assessment",
+      intentNoun: noun,
       state: AUSTRALIAN_STATES[0]!,
     });
     expect(m.canonical).toMatch(/^https?:\/\//);
-    expect(m.canonical).toContain("/marketplace/financial-advice/nsw");
+    expect(m.canonical).toContain("/marketplace/opportunity_assessment/nsw");
+    // the old bug slugified the label/noun → "assess-an-opportunity" / "...-specialists"
+    expect(m.canonical).not.toContain("assess-an-opportunity");
+    expect(m.canonical).not.toContain("specialists");
+  });
+
+  it("does not double-brand the title (the layout title template adds the brand)", () => {
+    const m = bestPageMeta({
+      intentSlug: "financial_advice",
+      intentNoun: "financial advisers",
+      state: AUSTRALIAN_STATES[0]!,
+    });
+    expect(m.title).not.toContain("| Invest.com.au");
+    expect(m.title).not.toContain("Invest.com.au");
   });
 });
 
@@ -67,11 +86,17 @@ describe("generateBestCombos", () => {
 
 describe("defaultFaqs", () => {
   it("returns 3 Q&A items", () => {
-    expect(defaultFaqs("Financial Advice").length).toBe(3);
+    expect(defaultFaqs("financial advisers").length).toBe(3);
   });
 
   it("mentions the state name when provided", () => {
-    const faqs = defaultFaqs("SMSF help", "Queensland");
+    const faqs = defaultFaqs("SMSF property specialists", "Queensland");
     expect(faqs.some((f) => f.q.includes("Queensland"))).toBe(true);
+  });
+
+  it("reads grammatically with the provider noun", () => {
+    const faqs = defaultFaqs("opportunity assessment specialists", "New South Wales");
+    expect(faqs[0]!.q).toContain("opportunity assessment specialists");
+    expect(faqs[0]!.q).not.toContain("Assess an opportunity");
   });
 });

--- a/app/account/verified/VerifiedClient.tsx
+++ b/app/account/verified/VerifiedClient.tsx
@@ -16,7 +16,7 @@ const TYPE_CONFIG: Record<
 > = {
   broker: { label: "Broker", emoji: "🏦", href: (ref) => `/brokers/${ref}` },
   etf: { label: "ETF", emoji: "📈", href: (ref) => `/etf/${ref}` },
-  advisor: { label: "Advisor", emoji: "🎓", href: (ref) => `/advisors/${ref}` },
+  advisor: { label: "Advisor", emoji: "🎓", href: (ref) => `/advisor/${ref}` },
   property: { label: "Property", emoji: "🏠", href: (ref) => `/property/${ref}` },
 };
 

--- a/app/api/cron/personalized-morning-brief/route.ts
+++ b/app/api/cron/personalized-morning-brief/route.ts
@@ -293,7 +293,7 @@ async function buildAdvisorSection(supabase: any, userId: string, since: string)
     const slug = p.professionals?.slug ?? "";
     const title = escapeHtml(p.title ?? p.body?.slice(0, 80) ?? "New post");
     return `<li style="margin-bottom:10px;font-size:14px;color:#334155">
-      <a href="${BASE_URL}/advisors/${slug}" style="color:#0f172a;font-weight:600;text-decoration:none">${name}</a>
+      <a href="${BASE_URL}/advisor/${slug}" style="color:#0f172a;font-weight:600;text-decoration:none">${name}</a>
       <span style="color:#64748b"> shared: </span>
       <span>${title}</span>
     </li>`;

--- a/app/api/cron/saved-search-alerts/route.ts
+++ b/app/api/cron/saved-search-alerts/route.ts
@@ -85,7 +85,7 @@ async function matchAdvisors(filters: Record<string, unknown>): Promise<MatchedP
     id: r.id as number,
     name: (r.name as string) || "Advisor",
     slug: (r.slug as string) || "",
-    href: `/advisors/${(r.slug as string) || ""}`,
+    href: `/advisor/${(r.slug as string) || ""}`,
   }));
 }
 

--- a/app/find/[advisor-type]/[city]/page.tsx
+++ b/app/find/[advisor-type]/[city]/page.tsx
@@ -187,7 +187,7 @@ function AdvisorCard({ advisor }: { advisor: AdvisorRow }) {
         <div className="flex items-start justify-between gap-2 flex-wrap">
           <div>
             <Link
-              href={`/advisors/${advisor.slug}`}
+              href={`/advisor/${advisor.slug}`}
               className="font-semibold text-slate-900 hover:text-blue-600 transition-colors"
             >
               {advisor.name}
@@ -214,7 +214,7 @@ function AdvisorCard({ advisor }: { advisor: AdvisorRow }) {
             )}
           </div>
           <Link
-            href={`/advisors/${advisor.slug}`}
+            href={`/advisor/${advisor.slug}`}
             className="shrink-0 text-sm bg-blue-600 text-white px-3 py-1.5 rounded-lg hover:bg-blue-700 transition-colors"
           >
             View Profile
@@ -282,7 +282,7 @@ export default async function FindAdvisorPage({ params }: Props) {
       item: {
         "@type": "LocalBusiness",
         name: a.name,
-        url: absoluteUrl(`/advisors/${a.slug}`),
+        url: absoluteUrl(`/advisor/${a.slug}`),
         ...(a.location_suburb ? { address: { "@type": "PostalAddress", addressLocality: a.location_suburb, addressCountry: "AU" } } : {}),
         ...(a.rating !== null && a.review_count !== null && a.review_count > 0
           ? { aggregateRating: { "@type": "AggregateRating", ratingValue: a.rating, reviewCount: a.review_count } }

--- a/app/firm-portal/performance/FirmPerformanceClient.tsx
+++ b/app/firm-portal/performance/FirmPerformanceClient.tsx
@@ -64,7 +64,7 @@ function MemberRow({ m, rank }: { m: MemberMetrics; rank: number }) {
           )}
           <div className="min-w-0">
             <Link
-              href={`/advisors/${m.slug}`}
+              href={`/advisor/${m.slug}`}
               target="_blank"
               rel="noopener noreferrer"
               className="text-sm font-semibold text-slate-800 hover:text-violet-700 truncate block"

--- a/app/lists/[slug]/page.tsx
+++ b/app/lists/[slug]/page.tsx
@@ -57,7 +57,7 @@ const ITEM_TYPE_CONFIG: Record<string, { label: string; emoji: string; href: (re
   broker: { label: "Broker / Platform", emoji: "📈", href: (r) => `/brokers/${r}` },
   etf: { label: "ETF", emoji: "📊", href: (r) => `/etfs/${r}` },
   article: { label: "Article", emoji: "📰", href: (r) => `/article/${r}` },
-  advisor: { label: "Advisor", emoji: "🧑‍💼", href: (r) => `/advisors/${r}` },
+  advisor: { label: "Advisor", emoji: "🧑‍💼", href: (r) => `/advisor/${r}` },
   property: { label: "Property", emoji: "🏠", href: (r) => `/property/${r}` },
 };
 

--- a/app/marketplace/[intent]/[state]/page.tsx
+++ b/app/marketplace/[intent]/[state]/page.tsx
@@ -10,7 +10,13 @@ import {
 } from "@/lib/seo/best-pages";
 import { absoluteUrl, breadcrumbJsonLd } from "@/lib/seo";
 import { getEnabledIntents, getIntent } from "@/lib/getmatched/intents";
+import {
+  complianceVariantForIntent,
+  providerNounForIntent,
+} from "@/lib/getmatched/intent-presentation";
+import { faqJsonLd, itemListJsonLd } from "@/lib/schema-markup";
 import { createClient } from "@/lib/supabase/server";
+import ComplianceFooter from "@/components/ComplianceFooter";
 
 export const revalidate = 86400;
 
@@ -23,16 +29,47 @@ interface PageProps {
   params: Promise<{ intent: string; state: string }>;
 }
 
+interface ProCard {
+  id: number;
+  slug: string | null;
+  name: string;
+  verified: boolean | null;
+  rating: number | null;
+  firm_name: string | null;
+  location_suburb: string | null;
+  location_display: string | null;
+  avg_response_minutes: number | null;
+}
+
+/** "~45 min" / "~3 hrs" / "within a day" — friendly response-time chip. */
+function formatResponse(mins: number | null): string | null {
+  if (!mins || mins <= 0) return null;
+  if (mins < 90) return `Replies in ~${Math.round(mins)} min`;
+  const hrs = Math.round(mins / 60);
+  if (hrs < 24) return `Replies in ~${hrs} hr${hrs === 1 ? "" : "s"}`;
+  return "Usually replies within a day";
+}
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { intent: intentSlug, state: stateSlug } = await params;
   const intent = await getIntent(intentSlug);
   const state = getStateBySlug(stateSlug);
   if (!intent || !state) return { title: "Not found" };
-  const meta = bestPageMeta({ intentLabel: intent.label, state });
+  const meta = bestPageMeta({
+    intentSlug: intent.slug,
+    intentNoun: providerNounForIntent(intent),
+    state,
+  });
   return {
     title: meta.title,
     description: meta.description,
     alternates: { canonical: meta.canonical },
+    openGraph: {
+      title: meta.title,
+      description: meta.description,
+      url: meta.canonical,
+      type: "website",
+    },
   };
 }
 
@@ -42,26 +79,50 @@ export default async function FindIntentStatePage({ params }: PageProps) {
   const state = getStateBySlug(stateSlug);
   if (!intent || !state) notFound();
 
-  const meta = bestPageMeta({ intentLabel: intent.label, state });
+  const noun = providerNounForIntent(intent);
+  const meta = bestPageMeta({ intentSlug: intent.slug, intentNoun: noun, state });
+  const faqs = defaultFaqs(noun, state.fullName);
+
+  // Verified providers for this state. Public read (anon SELECT policy).
+  const supabase = await createClient();
+  const { data: prosRaw } = await supabase
+    .from("professionals")
+    .select(
+      "id, slug, name, verified, rating, firm_name, location_suburb, location_display, avg_response_minutes, location_state, profile_quality_gate, status",
+    )
+    .eq("status", "active")
+    .eq("location_state", state.code)
+    .in("profile_quality_gate", ["passed", "pending"])
+    .order("verified", { ascending: false })
+    .order("rating", { ascending: false, nullsFirst: false })
+    .limit(8);
+  const pros = (prosRaw ?? []) as ProCard[];
+
+  // A few sibling categories for internal linking, same state.
+  const allIntents = await getEnabledIntents();
+  const related = allIntents.filter((i) => i.slug !== intent.slug).slice(0, 6);
+
   const breadcrumb = breadcrumbJsonLd([
     { name: "Home", url: absoluteUrl("/") },
     { name: "Marketplace", url: absoluteUrl("/marketplace") },
     { name: intent.label, url: absoluteUrl(`/marketplace/${intent.slug}`) },
     { name: state.fullName, url: meta.canonical },
   ]);
-  const faqs = defaultFaqs(intent.label, state.fullName);
-
-  // Pull a small set of verified providers for this state. Anon-readable.
-  const supabase = await createClient();
-  const { data: pros } = await supabase
-    .from("professionals")
-    .select("id, slug, name, verified, rating, location_state, profile_quality_gate, status")
-    .eq("status", "active")
-    .eq("location_state", state.code)
-    .in("profile_quality_gate", ["passed", "pending"])
-    .order("verified", { ascending: false })
-    .order("rating", { ascending: false })
-    .limit(8);
+  const faqLd = faqJsonLd(faqs);
+  const listLd =
+    pros.filter((p) => p.slug).length > 0
+      ? itemListJsonLd(
+          meta.h1,
+          pros
+            .filter((p) => p.slug)
+            .map((p, i) => ({
+              position: i + 1,
+              name: p.name,
+              url: `/advisor/${p.slug}`,
+              description: p.firm_name ?? undefined,
+            })),
+        )
+      : null;
 
   return (
     <main className="max-w-3xl mx-auto px-4 sm:px-6 py-10">
@@ -69,87 +130,194 @@ export default async function FindIntentStatePage({ params }: PageProps) {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
-      <nav className="text-xs text-slate-500 mb-3">
+      {faqLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
+        />
+      )}
+      {listLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(listLd) }}
+        />
+      )}
+
+      <nav aria-label="Breadcrumb" className="text-xs text-slate-500 mb-3">
         <Link href="/" className="hover:underline">Home</Link>
-        <span className="mx-2">/</span>
-        <Link href="/marketplace" className="hover:underline">Find</Link>
-        <span className="mx-2">/</span>
+        <span className="mx-2" aria-hidden="true">/</span>
+        <Link href="/marketplace" className="hover:underline">Marketplace</Link>
+        <span className="mx-2" aria-hidden="true">/</span>
         <Link href={`/marketplace/${intent.slug}`} className="hover:underline">{intent.label}</Link>
-        <span className="mx-2">/</span>
+        <span className="mx-2" aria-hidden="true">/</span>
         <span className="text-slate-700">{state.fullName}</span>
       </nav>
 
-      <h1 className="text-2xl sm:text-3xl font-extrabold text-slate-900 mb-2">{meta.h1}</h1>
-      {intent.description && (
-        <p className="text-slate-600 mb-6 leading-relaxed">{intent.description}</p>
-      )}
+      {/* Hero */}
+      <header className="mb-8">
+        <h1 className="text-2xl sm:text-3xl font-extrabold text-slate-900 mb-2">
+          {meta.h1}
+        </h1>
+        {intent.description && (
+          <p className="text-slate-600 leading-relaxed">{intent.description}</p>
+        )}
+        <p className="text-slate-500 text-sm mt-2 leading-relaxed">
+          Browse verified {noun} in {state.fullName}, or tell us what you need
+          and we&apos;ll match you with the right one — free, and you stay
+          anonymous until you choose to share your details.
+        </p>
+        <div className="flex flex-wrap items-center gap-3 mt-5">
+          <Link
+            href={`/get-matched?intent=${intent.slug}&state=${state.code}`}
+            className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold text-sm px-5 py-2.5 rounded-xl transition-colors"
+          >
+            Get matched <span aria-hidden="true">→</span>
+          </Link>
+          <Link
+            href="/advisors"
+            className="inline-flex items-center gap-2 text-sm font-semibold text-slate-700 hover:text-amber-700 px-2 py-2.5"
+          >
+            Browse all verified providers
+          </Link>
+        </div>
+      </header>
 
-      <Link
-        href={`/get-matched?intent=${intent.slug}&state=${state.code}`}
-        className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold text-sm px-5 py-2.5 rounded-xl mb-8"
-      >
-        Get matched →
-      </Link>
+      {/* How it works */}
+      <section aria-labelledby="how-it-works" className="mb-10">
+        <h2 id="how-it-works" className="sr-only">How getting matched works</h2>
+        <ol className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          {[
+            { n: 1, t: "Tell us what you need", d: "A few quick questions — about 2 minutes. Free, no signup." },
+            { n: 2, t: `We match you with verified ${noun}`, d: `Ranked by outcome score, response time, and tier — in ${state.fullName}.` },
+            { n: 3, t: "They come to you", d: "Providers pay to respond. You stay anonymous until you choose to share details." },
+          ].map((s) => (
+            <li key={s.n} className="bg-white border border-slate-200 rounded-xl p-4">
+              <span className="inline-flex items-center justify-center w-7 h-7 rounded-full bg-amber-100 text-amber-800 text-sm font-bold mb-2">
+                {s.n}
+              </span>
+              <p className="font-semibold text-slate-900 text-sm">{s.t}</p>
+              <p className="text-xs text-slate-500 mt-1 leading-relaxed">{s.d}</p>
+            </li>
+          ))}
+        </ol>
+      </section>
 
-      <section>
-        <h2 className="text-base font-bold text-slate-900 mb-3">
-          Verified providers in {state.fullName}
+      {/* Providers */}
+      <section aria-labelledby="providers-heading">
+        <h2 id="providers-heading" className="text-base font-bold text-slate-900 mb-3">
+          Verified {noun} in {state.fullName}
         </h2>
-        {pros && pros.length > 0 ? (
+        {pros.length > 0 ? (
           <ul className="space-y-2">
-            {(pros as Array<{ id: number; slug: string | null; name: string; verified: boolean; rating: number | null }>).map((p) => (
-              <li key={p.id}>
-                <Link
-                  href={p.slug ? `/advisors/${p.slug}` : `/advisors`}
-                  className="block bg-white border border-slate-200 rounded-xl p-4 hover:border-amber-300"
-                >
-                  <div className="flex items-center justify-between gap-2">
-                    <p className="font-semibold text-slate-900 min-w-0 truncate">{p.name}</p>
-                    {p.verified && (
-                      <span className="text-[10px] uppercase tracking-widest bg-emerald-100 text-emerald-800 px-2 py-0.5 rounded shrink-0">
-                        Verified
-                      </span>
+            {pros.map((p) => {
+              const reply = formatResponse(p.avg_response_minutes);
+              const place = p.location_suburb || p.location_display;
+              return (
+                <li key={p.id}>
+                  <Link
+                    href={p.slug ? `/advisor/${p.slug}` : "/advisors"}
+                    className="block bg-white border border-slate-200 rounded-xl p-4 hover:border-amber-300 hover:shadow-sm transition-all"
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <p className="font-semibold text-slate-900 min-w-0 truncate">{p.name}</p>
+                      {p.verified && (
+                        <span className="text-[10px] uppercase tracking-widest bg-emerald-100 text-emerald-800 px-2 py-0.5 rounded shrink-0">
+                          Verified
+                        </span>
+                      )}
+                    </div>
+                    {(p.firm_name || place) && (
+                      <p className="text-xs text-slate-500 mt-0.5 truncate">
+                        {[p.firm_name, place].filter(Boolean).join(" · ")}
+                      </p>
                     )}
-                  </div>
-                  {p.rating != null && (
-                    <p className="text-xs text-slate-500 mt-1">
-                      Rating {p.rating.toFixed(1)} / 5
-                    </p>
-                  )}
+                    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1.5">
+                      {p.rating != null && (
+                        <span className="text-xs text-slate-500">
+                          <span aria-hidden="true">★</span> {p.rating.toFixed(1)} / 5
+                        </span>
+                      )}
+                      {reply && (
+                        <span className="text-xs text-emerald-700">{reply}</span>
+                      )}
+                    </div>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        ) : (
+          <div className="bg-white border border-slate-200 rounded-xl p-5 text-center">
+            <p className="text-sm text-slate-600">
+              No verified {noun} listed in {state.fullName} yet.
+            </p>
+            <p className="text-sm text-slate-500 mt-1">
+              Get matched and we&apos;ll route your request to the right
+              provider, or browse the rest of Australia.
+            </p>
+            <div className="flex flex-wrap justify-center gap-3 mt-4">
+              <Link
+                href={`/get-matched?intent=${intent.slug}&state=${state.code}`}
+                className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold text-sm px-5 py-2.5 rounded-xl transition-colors"
+              >
+                Get matched <span aria-hidden="true">→</span>
+              </Link>
+              <Link
+                href={`/marketplace/${intent.slug}`}
+                className="inline-flex items-center text-sm font-semibold text-amber-700 hover:underline px-2 py-2.5"
+              >
+                Browse all of Australia →
+              </Link>
+            </div>
+          </div>
+        )}
+      </section>
+
+      {/* Related categories */}
+      {related.length > 0 && (
+        <section aria-labelledby="related-heading" className="mt-10">
+          <h2 id="related-heading" className="text-base font-bold text-slate-900 mb-3">
+            Other categories in {state.fullName}
+          </h2>
+          <ul className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            {related.map((r) => (
+              <li key={r.slug}>
+                <Link
+                  href={`/marketplace/${r.slug}/${state.slug}`}
+                  className="block bg-white border border-slate-200 rounded-xl px-4 py-3 text-sm text-slate-700 hover:border-amber-300 hover:bg-amber-50 transition-colors capitalize"
+                >
+                  {providerNounForIntent(r)}
                 </Link>
               </li>
             ))}
           </ul>
-        ) : (
-          <p className="text-sm text-slate-500">
-            No verified providers in {state.fullName} yet for this category.{" "}
-            <Link href={`/marketplace/${intent.slug}`} className="text-amber-700 underline">
-              Browse all of Australia →
-            </Link>
-          </p>
-        )}
-      </section>
+        </section>
+      )}
 
-      <section className="mt-10">
-        <h2 className="text-base font-bold text-slate-900 mb-3">
-          Other states
+      {/* Other states */}
+      <section aria-labelledby="states-heading" className="mt-10">
+        <h2 id="states-heading" className="text-base font-bold text-slate-900 mb-3">
+          {noun} in other states
         </h2>
         <ul className="flex flex-wrap gap-2">
           {AUSTRALIAN_STATES.filter((s) => s.slug !== state.slug).map((s) => (
             <li key={s.slug}>
               <Link
                 href={`/marketplace/${intent.slug}/${s.slug}`}
-                className="text-xs text-slate-700 bg-slate-100 hover:bg-amber-50 px-3 py-1.5 rounded-lg"
+                className="text-xs text-slate-700 bg-slate-100 hover:bg-amber-50 px-3 py-1.5 rounded-lg transition-colors"
               >
-                {s.code}
+                {s.fullName}
               </Link>
             </li>
           ))}
         </ul>
       </section>
 
-      <section className="mt-10">
-        <h2 className="text-base font-bold text-slate-900 mb-3">FAQs</h2>
+      {/* FAQs */}
+      <section aria-labelledby="faq-heading" className="mt-10">
+        <h2 id="faq-heading" className="text-base font-bold text-slate-900 mb-3">
+          Frequently asked questions
+        </h2>
         <div className="space-y-3">
           {faqs.map((f) => (
             <details key={f.q} className="bg-white border border-slate-200 rounded-xl p-4">
@@ -162,10 +330,7 @@ export default async function FindIntentStatePage({ params }: PageProps) {
         </div>
       </section>
 
-      <p className="text-[11px] text-slate-400 mt-8">
-        General information only. Verified providers deliver their services
-        under their own AFSL or professional licence.
-      </p>
+      <ComplianceFooter variant={complianceVariantForIntent(intent)} />
     </main>
   );
 }

--- a/app/marketplace/[intent]/page.tsx
+++ b/app/marketplace/[intent]/page.tsx
@@ -4,6 +4,12 @@ import { notFound } from "next/navigation";
 import { AUSTRALIAN_STATES, bestPageMeta, defaultFaqs } from "@/lib/seo/best-pages";
 import { absoluteUrl, breadcrumbJsonLd } from "@/lib/seo";
 import { getEnabledIntents, getIntent } from "@/lib/getmatched/intents";
+import {
+  complianceVariantForIntent,
+  providerNounForIntent,
+} from "@/lib/getmatched/intent-presentation";
+import { faqJsonLd } from "@/lib/schema-markup";
+import ComplianceFooter from "@/components/ComplianceFooter";
 
 export const revalidate = 86400;
 
@@ -20,11 +26,20 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const { intent: intentSlug } = await params;
   const intent = await getIntent(intentSlug);
   if (!intent) return { title: "Not found" };
-  const meta = bestPageMeta({ intentLabel: intent.label });
+  const meta = bestPageMeta({
+    intentSlug: intent.slug,
+    intentNoun: providerNounForIntent(intent),
+  });
   return {
     title: meta.title,
     description: meta.description,
     alternates: { canonical: meta.canonical },
+    openGraph: {
+      title: meta.title,
+      description: meta.description,
+      url: meta.canonical,
+      type: "website",
+    },
   };
 }
 
@@ -33,13 +48,19 @@ export default async function FindIntentPage({ params }: PageProps) {
   const intent = await getIntent(intentSlug);
   if (!intent) notFound();
 
-  const meta = bestPageMeta({ intentLabel: intent.label });
+  const noun = providerNounForIntent(intent);
+  const meta = bestPageMeta({ intentSlug: intent.slug, intentNoun: noun });
+  const faqs = defaultFaqs(noun);
+
+  const allIntents = await getEnabledIntents();
+  const related = allIntents.filter((i) => i.slug !== intent.slug).slice(0, 6);
+
   const breadcrumb = breadcrumbJsonLd([
     { name: "Home", url: absoluteUrl("/") },
     { name: "Marketplace", url: absoluteUrl("/marketplace") },
     { name: intent.label, url: meta.canonical },
   ]);
-  const faqs = defaultFaqs(intent.label);
+  const faqLd = faqJsonLd(faqs);
 
   return (
     <main className="max-w-3xl mx-auto px-4 sm:px-6 py-10">
@@ -47,35 +68,59 @@ export default async function FindIntentPage({ params }: PageProps) {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
-      <nav className="text-xs text-slate-500 mb-3">
-        <Link href="/" className="hover:underline">Home</Link>
-        <span className="mx-2">/</span>
-        <Link href="/marketplace" className="hover:underline">Find</Link>
-        <span className="mx-2">/</span>
-        <span className="text-slate-700">{intent.label}</span>
-      </nav>
-      <h1 className="text-2xl sm:text-3xl font-extrabold text-slate-900 mb-2">{meta.h1}</h1>
-      {intent.description && (
-        <p className="text-slate-600 mb-6 leading-relaxed">{intent.description}</p>
+      {faqLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }}
+        />
       )}
 
-      <Link
-        href={`/get-matched?intent=${intent.slug}`}
-        className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold text-sm px-5 py-2.5 rounded-xl mb-8"
-      >
-        Get matched →
-      </Link>
+      <nav aria-label="Breadcrumb" className="text-xs text-slate-500 mb-3">
+        <Link href="/" className="hover:underline">Home</Link>
+        <span className="mx-2" aria-hidden="true">/</span>
+        <Link href="/marketplace" className="hover:underline">Marketplace</Link>
+        <span className="mx-2" aria-hidden="true">/</span>
+        <span className="text-slate-700">{intent.label}</span>
+      </nav>
 
-      <section>
-        <h2 className="text-base font-bold text-slate-900 mb-3">
-          Browse by state
+      <header className="mb-8">
+        <h1 className="text-2xl sm:text-3xl font-extrabold text-slate-900 mb-2">
+          {meta.h1}
+        </h1>
+        {intent.description && (
+          <p className="text-slate-600 leading-relaxed">{intent.description}</p>
+        )}
+        <p className="text-slate-500 text-sm mt-2 leading-relaxed">
+          Pick your state to see verified {noun} near you, or get matched and
+          we&apos;ll route your request to the right provider — free, and you
+          stay anonymous until you choose to share your details.
+        </p>
+        <div className="flex flex-wrap items-center gap-3 mt-5">
+          <Link
+            href={`/get-matched?intent=${intent.slug}`}
+            className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold text-sm px-5 py-2.5 rounded-xl transition-colors"
+          >
+            Get matched <span aria-hidden="true">→</span>
+          </Link>
+          <Link
+            href="/advisors"
+            className="inline-flex items-center gap-2 text-sm font-semibold text-slate-700 hover:text-amber-700 px-2 py-2.5"
+          >
+            Browse all verified providers
+          </Link>
+        </div>
+      </header>
+
+      <section aria-labelledby="states-heading">
+        <h2 id="states-heading" className="text-base font-bold text-slate-900 mb-3">
+          Browse {noun} by state
         </h2>
         <ul className="grid grid-cols-2 sm:grid-cols-4 gap-2">
           {AUSTRALIAN_STATES.map((s) => (
             <li key={s.slug}>
               <Link
                 href={`/marketplace/${intent.slug}/${s.slug}`}
-                className="block bg-white border border-slate-200 rounded-xl px-3 py-2 text-sm text-slate-700 hover:border-amber-300 hover:bg-amber-50"
+                className="block bg-white border border-slate-200 rounded-xl px-3 py-2 text-sm text-slate-700 hover:border-amber-300 hover:bg-amber-50 transition-colors"
               >
                 {s.fullName}
               </Link>
@@ -84,8 +129,30 @@ export default async function FindIntentPage({ params }: PageProps) {
         </ul>
       </section>
 
-      <section className="mt-10">
-        <h2 className="text-base font-bold text-slate-900 mb-3">FAQs</h2>
+      {related.length > 0 && (
+        <section aria-labelledby="related-heading" className="mt-10">
+          <h2 id="related-heading" className="text-base font-bold text-slate-900 mb-3">
+            Other categories
+          </h2>
+          <ul className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            {related.map((r) => (
+              <li key={r.slug}>
+                <Link
+                  href={`/marketplace/${r.slug}`}
+                  className="block bg-white border border-slate-200 rounded-xl px-4 py-3 text-sm text-slate-700 hover:border-amber-300 hover:bg-amber-50 transition-colors capitalize"
+                >
+                  {providerNounForIntent(r)}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      <section aria-labelledby="faq-heading" className="mt-10">
+        <h2 id="faq-heading" className="text-base font-bold text-slate-900 mb-3">
+          Frequently asked questions
+        </h2>
         <div className="space-y-3">
           {faqs.map((f) => (
             <details key={f.q} className="bg-white border border-slate-200 rounded-xl p-4">
@@ -98,10 +165,7 @@ export default async function FindIntentPage({ params }: PageProps) {
         </div>
       </section>
 
-      <p className="text-[11px] text-slate-400 mt-8">
-        General information only. Verified providers deliver their services
-        under their own AFSL or professional licence.
-      </p>
+      <ComplianceFooter variant={complianceVariantForIntent(intent)} />
     </main>
   );
 }

--- a/app/marketplace/page.tsx
+++ b/app/marketplace/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { AUSTRALIAN_STATES } from "@/lib/seo/best-pages";
 import { absoluteUrl, breadcrumbJsonLd, CURRENT_YEAR } from "@/lib/seo";
 import { getEnabledIntents } from "@/lib/getmatched/intents";
+import { providerNounForIntent } from "@/lib/getmatched/intent-presentation";
 
 export const revalidate = 86400;
 
@@ -42,9 +43,12 @@ export default async function FindHubPage() {
       <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
         {intents.map((intent) => (
           <div key={intent.slug} className="bg-white border border-slate-200 rounded-2xl p-5">
-            <h2 className="text-base font-bold text-slate-900 mb-1.5">
+            <h2 className="text-base font-bold text-slate-900">
               {intent.label}
             </h2>
+            <p className="text-xs text-slate-500 mb-1.5">
+              Verified {providerNounForIntent(intent)}
+            </p>
             <ul className="grid grid-cols-2 gap-1.5 mt-2">
               {AUSTRALIAN_STATES.map((s) => (
                 <li key={s.slug}>

--- a/app/office-hours/[id]/page.tsx
+++ b/app/office-hours/[id]/page.tsx
@@ -232,7 +232,7 @@ export default async function OfficeHoursSessionPage({
               <p className="text-sm text-slate-600">
                 with{" "}
                 <Link
-                  href={`/advisors/${advisor.slug}`}
+                  href={`/advisor/${advisor.slug}`}
                   className="font-semibold text-indigo-600 hover:underline"
                 >
                   {advisor.name}

--- a/components/SmartRecommendationsStrip.tsx
+++ b/components/SmartRecommendationsStrip.tsx
@@ -202,7 +202,7 @@ export default async function SmartRecommendationsStrip() {
     items: ranked.slice(0, MIN_ITEMS_TO_SHOW).map((a) => ({
       slug: a.slug,
       name: a.name,
-      href: `/advisors/${a.slug}`,
+      href: `/advisor/${a.slug}`,
       avatar: a.photo_url,
       sub: a.firm_name ?? a.type,
     })),

--- a/components/country-mode/CountryExpertsPreview.tsx
+++ b/components/country-mode/CountryExpertsPreview.tsx
@@ -92,7 +92,7 @@ export default async function CountryExpertsPreview() {
           {visible.map((e) => (
             <li key={e.slug}>
               <TrackedCountryLink
-                href={`/advisors/${e.slug}`}
+                href={`/advisor/${e.slug}`}
                 eventName="country_expert_click"
                 country={code}
                 targetId={e.slug}

--- a/lib/getmatched/intent-presentation.ts
+++ b/lib/getmatched/intent-presentation.ts
@@ -1,0 +1,100 @@
+/**
+ * Presentation helpers for rendering an intent on the
+ * /marketplace/[intent]/[state] directory pages.
+ *
+ * Two concerns live here:
+ *
+ *  1. `providerNounForIntent` — intent `label`s are imperative chip copy
+ *     ("Assess an opportunity", "Buy a business") that read as broken English
+ *     in a "Best {x} in {state}" heading. Each intent maps to a plural
+ *     *provider noun* ("opportunity assessment specialists") that slots in
+ *     cleanly. The DB column `intent_taxonomy.provider_noun` (added in
+ *     migration 20260907020000_gm03_intent_provider_noun.sql) is the
+ *     admin-editable source of truth; this map mirrors it for the
+ *     code-defined fallback path and as a safety net while the migration
+ *     propagates.
+ *
+ *  2. `complianceVariantForIntent` — picks the correct ASIC risk-warning
+ *     variant for <ComplianceFooter /> from the intent's asset class (crypto,
+ *     CFDs, property, foreign/FIRB) so each directory page shows the right
+ *     disclosure rather than a generic one.
+ */
+type ComplianceVariant = "default" | "cfd" | "crypto" | "property" | "firb";
+
+/**
+ * Provider noun per intent slug. Mirror of the `intent_taxonomy.provider_noun`
+ * backfill in gm03. Keyed loosely by string so NZ + any future admin-added
+ * slugs resolve without a type change; the completeness test in
+ * `intent-presentation.test.ts` asserts every shipped slug is covered.
+ */
+export const PROVIDER_NOUNS: Record<string, string> = {
+  // 13 retail goals (gm02)
+  grow: "investing specialists",
+  income: "income & dividend specialists",
+  crypto: "crypto investing specialists",
+  trade: "trading & CFD specialists",
+  automate: "robo-investing specialists",
+  super: "super & SMSF specialists",
+  property: "property investment specialists",
+  home: "mortgage brokers",
+  alt_assets: "alternative asset specialists",
+  royalties: "royalty & income-asset specialists",
+  pre_ipo: "pre-IPO & wholesale deal specialists",
+  help: "financial experts",
+  browse: "investment specialists",
+  // niche / advisor / brief slugs (gm01)
+  compare_platform: "investing platform specialists",
+  start_investing: "specialists for new investors",
+  smsf_property: "SMSF property specialists",
+  buy_property: "buyer's agents",
+  opportunity_assessment: "opportunity assessment specialists",
+  business_acquisition: "business acquisition advisers",
+  commercial_property: "commercial property specialists",
+  foreign_investor: "foreign investment (FIRB) specialists",
+  expat_investing: "expat investment specialists",
+  financial_advice: "financial advisers",
+  tax_help: "tax accountants",
+  mortgage_help: "mortgage brokers",
+  legal_help: "property & investment lawyers",
+  second_opinion: "independent review specialists",
+  listing_owner: "business & asset sale specialists",
+  listing_readiness: "listing preparation specialists",
+  not_sure: "investment specialists",
+  // NZ intents (mm26)
+  nz_kiwisaver: "KiwiSaver advisers",
+  nz_property_buy: "NZ property specialists",
+};
+
+/**
+ * Resolve the directory noun for an intent: prefer the admin-editable DB
+ * value, then the code map, then a safe generic so a brand-new intent never
+ * renders broken copy ("Best verified providers in NSW").
+ */
+export function providerNounForIntent(intent: {
+  slug: string;
+  provider_noun?: string | null;
+}): string {
+  return (
+    intent.provider_noun?.trim() ||
+    PROVIDER_NOUNS[intent.slug] ||
+    "verified providers"
+  );
+}
+
+const COMPLIANCE_VARIANTS: Record<string, ComplianceVariant> = {
+  crypto: "crypto",
+  trade: "cfd",
+  property: "property",
+  buy_property: "property",
+  smsf_property: "property",
+  commercial_property: "property",
+  nz_property_buy: "property",
+  foreign_investor: "firb",
+};
+
+/** Pick the ASIC risk-warning variant for <ComplianceFooter /> per intent. */
+export function complianceVariantForIntent(intent: {
+  slug: string;
+}): ComplianceVariant {
+  return COMPLIANCE_VARIANTS[intent.slug] ?? "default";
+}

--- a/lib/getmatched/types.ts
+++ b/lib/getmatched/types.ts
@@ -117,6 +117,15 @@ export interface IntentDef {
   slug: IntentSlug;
   label: string;
   description: string | null;
+  /**
+   * Plural, directory-grade noun for the /marketplace/[intent]/[state] SEO
+   * pages (e.g. "opportunity assessment specialists"). The `label` is
+   * imperative chip copy ("Assess an opportunity") that reads as broken
+   * English in a "Best {x} in {state}" heading. Admin-editable in the DB;
+   * resolved via `providerNounForIntent`, which falls back to the code map
+   * when null. See `lib/getmatched/intent-presentation.ts`.
+   */
+  provider_noun?: string | null;
   default_route: RouteType;
   default_brief_template: string | null;
   risk_level: "low" | "medium" | "high";
@@ -206,7 +215,8 @@ export interface TopMatch {
   one_line_why: string;
   cta_label: string;
   /** Absolute or relative URL — affiliate-tracked link for brokers,
-   *  /advisors/<slug> for advisors. */
+   *  /advisor/<slug> (singular) for advisors. NB: /advisors/<x> is the
+   *  category directory route, not a profile. */
   cta_href: string;
   vertical: Vertical | null;
   /** 1 = best match (hero card), 2-N = runner-ups (slim comparison cards).

--- a/lib/seo/best-pages.ts
+++ b/lib/seo/best-pages.ts
@@ -1,9 +1,18 @@
 /**
  * Programmatic SEO helpers for /marketplace/[intent]/[state] landing pages.
  *
- * Pure functions for deriving titles, descriptions, and breadcrumb data
- * from an intent + state combo. The DB-touching parts live in the page
- * modules; this file is unit-testable in isolation.
+ * Pure functions for deriving titles, descriptions, and breadcrumb data from
+ * an intent + state combo. The DB-touching parts live in the page modules;
+ * this file is unit-testable in isolation.
+ *
+ * `bestPageMeta` takes the intent **slug** and a **provider noun** separately
+ * and on purpose:
+ *   - the slug ("opportunity_assessment") builds the canonical URL, which MUST
+ *     match the route that `generateStaticParams` actually emits;
+ *   - the noun ("opportunity assessment specialists") builds the human copy.
+ * Deriving the canonical from the (slugified) noun was the bug that pointed
+ * every page's canonical at a non-existent, `noindex` URL — see
+ * `lib/getmatched/intent-presentation.ts` for where the noun comes from.
  */
 import { absoluteUrl, CURRENT_YEAR } from "@/lib/seo";
 
@@ -36,28 +45,25 @@ export interface BestPageMeta {
 }
 
 export function bestPageMeta(input: {
-  intentLabel: string;
+  /** Intent slug — drives the canonical URL (must match the live route). */
+  intentSlug: string;
+  /** Plural provider noun — drives the title/H1/description copy. */
+  intentNoun: string;
   state?: AustralianState | null;
 }): BestPageMeta {
-  const { intentLabel, state } = input;
-  if (state) {
-    return {
-      title: `Best ${intentLabel} in ${state.fullName} (${CURRENT_YEAR}) | Invest.com.au`,
-      description: `Compare verified ${intentLabel} providers in ${state.fullName}. Browse profiles, request a Match, or send an Investor Brief.`,
-      canonical: absoluteUrl(`/marketplace/${slugify(intentLabel)}/${state.slug}`),
-      h1: `Best ${intentLabel} in ${state.fullName}`,
-    };
-  }
+  const { intentSlug, intentNoun, state } = input;
+  const where = state ? state.fullName : "Australia";
+  const path = state
+    ? `/marketplace/${intentSlug}/${state.slug}`
+    : `/marketplace/${intentSlug}`;
+  // No "| Invest.com.au" suffix here — the root layout's title template
+  // (`%s — Invest.com.au`) appends the brand, so adding it again double-brands.
   return {
-    title: `Best ${intentLabel} in Australia (${CURRENT_YEAR}) | Invest.com.au`,
-    description: `Compare verified ${intentLabel} providers across Australia. Browse profiles, request a Match, or send an Investor Brief.`,
-    canonical: absoluteUrl(`/marketplace/${slugify(intentLabel)}`),
-    h1: `Best ${intentLabel} in Australia`,
+    title: `Best ${intentNoun} in ${where} (${CURRENT_YEAR})`,
+    description: `Compare verified ${intentNoun} in ${where} on Invest.com.au. Browse profiles, get matched, or send an Investor Brief — free to browse, and providers come to you.`,
+    canonical: absoluteUrl(path),
+    h1: `Best ${intentNoun} in ${where}`,
   };
-}
-
-function slugify(s: string): string {
-  return s.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
 }
 
 /**
@@ -78,22 +84,24 @@ export function generateBestCombos(
 
 /**
  * Default FAQ block — 3 generic Q&A that work for any intent/state combo.
- * Admins can override per-intent via a future content table.
+ * Takes the provider *noun* (not the intent label) so the questions read as
+ * grammatical English. Admins can override per-intent via a future content
+ * table.
  */
 export interface FaqItem {
   q: string;
   a: string;
 }
 
-export function defaultFaqs(intentLabel: string, stateName?: string): FaqItem[] {
+export function defaultFaqs(intentNoun: string, stateName?: string): FaqItem[] {
   const where = stateName ? ` in ${stateName}` : " across Australia";
   return [
     {
-      q: `How does Invest.com.au find verified ${intentLabel} providers${where}?`,
-      a: "Every provider in our marketplace passes identity verification, licence checks (where applicable), and is regularly re-verified. Verified-outcome scoring (from completed engagements) ranks higher providers above newer ones.",
+      q: `How does Invest.com.au verify ${intentNoun}${where}?`,
+      a: "Every provider in our marketplace passes identity verification, licence checks (where applicable), and is regularly re-verified. Verified-outcome scoring (from completed engagements) ranks established providers above newer ones.",
     },
     {
-      q: `What does it cost to get matched with a ${intentLabel} provider?`,
+      q: `What does it cost to get matched with ${intentNoun}${where}?`,
       a: "Browsing and getting matched is free. Providers pay credits to accept your Match Request, so you never pay just to make contact. Engagement fees (if any) are set by the provider you choose to work with.",
     },
     {

--- a/supabase/migrations/20260907020000_gm03_intent_provider_noun.sql
+++ b/supabase/migrations/20260907020000_gm03_intent_provider_noun.sql
@@ -1,0 +1,69 @@
+-- ============================================================================
+-- Migration: 20260907020000_gm03_intent_provider_noun.sql
+-- Purpose: Add `provider_noun` to intent_taxonomy — a plural, directory-grade
+--          noun for each intent, used by the /marketplace/[intent]/[state] SEO
+--          pages. Intent `label`s are imperative chip copy ("Assess an
+--          opportunity") that render as broken English in "Best {x} in {state}"
+--          headings; `provider_noun` ("opportunity assessment specialists")
+--          slots in cleanly. Mirrors lib/getmatched/intent-presentation.ts
+--          (PROVIDER_NOUNS); admins can override per-intent here afterwards.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS + UPDATEs keyed by slug, guarded so a
+--             re-run never clobbers an admin override. Safe to re-apply.
+-- RLS: unchanged — column added to an existing table that already has RLS
+--      ("Public can read enabled intents" SELECT + service_role FOR ALL from
+--      20260724_gm01_get_matched_router.sql).
+--
+-- Rollback: ALTER TABLE public.intent_taxonomy DROP COLUMN IF EXISTS provider_noun;
+-- Risk: low — additive nullable column + idempotent content backfill.
+-- ============================================================================
+
+BEGIN;
+
+ALTER TABLE public.intent_taxonomy
+  ADD COLUMN IF NOT EXISTS provider_noun text;
+
+UPDATE public.intent_taxonomy AS t
+SET provider_noun = v.noun,
+    updated_at = now()
+FROM (VALUES
+  -- 13 retail goals (gm02)
+  ('grow',                  'investing specialists'),
+  ('income',                'income & dividend specialists'),
+  ('crypto',                'crypto investing specialists'),
+  ('trade',                 'trading & CFD specialists'),
+  ('automate',              'robo-investing specialists'),
+  ('super',                 'super & SMSF specialists'),
+  ('property',              'property investment specialists'),
+  ('home',                  'mortgage brokers'),
+  ('alt_assets',            'alternative asset specialists'),
+  ('royalties',             'royalty & income-asset specialists'),
+  ('pre_ipo',               'pre-IPO & wholesale deal specialists'),
+  ('help',                  'financial experts'),
+  ('browse',                'investment specialists'),
+  -- niche / advisor / brief slugs (gm01)
+  ('compare_platform',      'investing platform specialists'),
+  ('start_investing',       'specialists for new investors'),
+  ('smsf_property',         'SMSF property specialists'),
+  ('buy_property',          'buyer''s agents'),
+  ('opportunity_assessment','opportunity assessment specialists'),
+  ('business_acquisition',  'business acquisition advisers'),
+  ('commercial_property',   'commercial property specialists'),
+  ('foreign_investor',      'foreign investment (FIRB) specialists'),
+  ('expat_investing',       'expat investment specialists'),
+  ('financial_advice',      'financial advisers'),
+  ('tax_help',              'tax accountants'),
+  ('mortgage_help',         'mortgage brokers'),
+  ('legal_help',            'property & investment lawyers'),
+  ('second_opinion',        'independent review specialists'),
+  ('listing_owner',         'business & asset sale specialists'),
+  ('listing_readiness',     'listing preparation specialists'),
+  ('not_sure',              'investment specialists'),
+  -- NZ intents (mm26)
+  ('nz_kiwisaver',          'KiwiSaver advisers'),
+  ('nz_property_buy',       'NZ property specialists')
+) AS v(slug, noun)
+WHERE t.slug = v.slug
+  AND (t.provider_noun IS NULL OR t.provider_noun = '');
+
+COMMIT;


### PR DESCRIPTION
## Why

Investigating `/marketplace/opportunity_assessment/nsw` (a Get-Matched 2.0 / Provider-Marketplace programmatic SEO page) surfaced three defects live on the prod mirror, across the whole ~170-page `[intent]/[state]` tree. Verified with a headless-browser bot run + fetch probes before fixing.

## Bugs fixed

1. **Self-deindexing canonical.** `bestPageMeta` built the canonical from the *slugified label*, so every page set `rel=canonical` → `/marketplace/assess-an-opportunity/nsw`, which returns **"Not found" + `noindex`**. Google was being told to drop the indexable page. Canonicals now use the intent **slug** (the real route).
2. **Broken copy.** H1/title/FAQs read **"Best Assess an opportunity in New South Wales"** — the imperative chip *label* dropped into a "Best {x}" frame. Introduced a per-intent **`provider_noun`** ("opportunity assessment specialists") as an admin-editable DB column (`gm03`) mirrored by a code map + resolver, so it renders **"Best opportunity assessment specialists in New South Wales"**. Also removed the double-brand suffix (`… | Invest.com.au — Invest.com.au`) — the root layout title template already appends the brand.
3. **Dead provider links.** Cards linked to `/advisors/<slug>`, but that's the **category** route → soft-404 *"Advisor Category Not Found"*. Profiles live at `/advisor/<slug>` (singular). Fixed here **and across the same bug class**: recommendations strip, country-experts preview, find-advisor pages (incl. JSON-LD `url`), firm portal, office hours, saved-list/verified link mappers, and two cron email templates.

## Quality lift

Rebuilt the `[intent]` and `[intent]/[state]` pages: richer verified-provider cards (firm, suburb, response time), a "how it works" strip, related-category + other-state internal linking, **FAQPage + ItemList JSON-LD**, OpenGraph, the right per-asset-class **`ComplianceFooter`** variant (FIRB / crypto / CFD / property), and accessible markup.

## Verification

- `npm run type-check` ✅ · ESLint (`--max-warnings 0`) ✅ · **337 unit tests** ✅ (incl. 31 new)
- New tests lock the canonical/copy regressions, the `provider_noun` resolver + slug completeness, and a guard keeping person slugs off the `/advisors/` category route.
- The code renders correctly **before** the migration applies (fallback noun map), so deploy order is not load-bearing.

## Notes / follow-ups

- `lib/database.types.ts` is generated — regenerate from the migration post-merge to pick up `intent_taxonomy.provider_noun` (nothing reads it through the generated type today).
- Pre-existing, out of scope: NZ intents (`nz_kiwisaver`, `nz_property_buy`) are still generated against AU states by `generateStaticParams` (now grammatical, but geographically odd) — worth a future filter by `available_in_countries`.

https://claude.ai/code/session_01WZrTbm7AFu1hcRUnTxV8Pr

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZrTbm7AFu1hcRUnTxV8Pr)_