### PR TITLE
feat(invest): make /invest/&lt;slug&gt;/listings the one canonical sector page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ npm run test:watch                 # watch mode
 | Affiliate links + benefit CTAs + star rendering | `lib/tracking.ts`                                      |
 | Sponsorship ranking helpers                  | `lib/sponsorship.ts`                                      |
 | Vertical config (pillar pages, categories)   | `lib/verticals.ts`                                        |
+| Canonical sector-listings href + which sectors have a `/listings` page | `lib/invest-listing-routes.ts` (`categoryListingsHref`, `LISTING_PAGE_SLUGS`) — each /invest sector has ONE home: `/invest/<slug>/listings`; the legacy `/invest?category=<slug>` filter 307-redirects there in `proxy.ts`. Link sectors via this helper, never hand-write `?category=`. |
 | Country Mode (priority chain, filters, supply thresholds) | `lib/country-mode/` + `lib/intent-context.ts` + `lib/foreign-investment-country-data.ts` (see `docs/architecture/country-mode.md`) |
 | Locale registry + path helpers               | `lib/i18n/locales.ts`, `lib/i18n/dictionaries.ts`         |
 | Schema.org JSON-LD builders                  | `lib/schema-markup.ts`                                    |

--- a/__tests__/api/listings-route.test.ts
+++ b/__tests__/api/listings-route.test.ts
@@ -99,10 +99,19 @@ describe("GET /api/listings", () => {
     expect(types[2]).toBe("standard");
   });
 
-  it("applies vertical filter when provided", async () => {
+  it("applies vertical filter when provided (alias-aware .in)", async () => {
     const b = setupQuery([]);
     await GET(makeGet({ vertical: "property" }));
-    expect(b.eq).toHaveBeenCalledWith("vertical", "property");
+    // A vertical with no drift variants resolves to a single-element .in().
+    expect(b.in).toHaveBeenCalledWith("vertical", ["property"]);
+  });
+
+  it("expands a drift-aliased vertical to all its raw variants", async () => {
+    const b = setupQuery([]);
+    await GET(makeGet({ vertical: "energy" }));
+    // energy ↔ renewable-energy is a known seed-drift pair; the API must
+    // match the site's alias-aware bucketing (lib/listing-url).
+    expect(b.in).toHaveBeenCalledWith("vertical", ["energy", "renewable-energy"]);
   });
 
   it("applies state filter when provided", async () => {

--- a/__tests__/lib/invest-categories.test.ts
+++ b/__tests__/lib/invest-categories.test.ts
@@ -21,7 +21,13 @@ describe("invest-categories data integrity", () => {
     for (const cat of cats) {
       expect(cat.slug).toBeTruthy();
       expect(cat.label).toBeTruthy();
-      expect(cat.dbVerticals.length).toBeGreaterThan(0);
+      // income-assets is a placeholder sector with no distinct DB vertical
+      // seeded yet — it intentionally carries an empty dbVerticals (the old
+      // ["business"] value collided with buy-business). Its listings page
+      // renders a graceful empty state until a vertical/sub_category exists.
+      if (cat.slug !== "income-assets") {
+        expect(cat.dbVerticals.length).toBeGreaterThan(0);
+      }
       expect(cat.color).toBeDefined();
       expect(cat.title).toBeTruthy();
       expect(cat.h1).toBeTruthy();

--- a/__tests__/lib/invest-listing-routes.test.ts
+++ b/__tests__/lib/invest-listing-routes.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import {
+  STATIC_LISTING_SLUGS,
+  GENERIC_LISTING_SLUGS,
+  LISTING_PAGE_SLUGS,
+  hasListingsPage,
+  categoryListingsHref,
+} from "@/lib/invest-listing-routes";
+import { getOpportunityCategories } from "@/lib/invest-categories";
+
+describe("invest-listing-routes", () => {
+  // Drift guard: every opportunity category must be classified as either
+  // static-page or generic-route, and nothing else. If someone adds a new
+  // opportunity category without giving it a listings page, this fails.
+  it("LISTING_PAGE_SLUGS is exactly the set of opportunity categories", () => {
+    const opportunity = getOpportunityCategories()
+      .map((c) => c.slug)
+      .sort();
+    const routed = [...LISTING_PAGE_SLUGS].sort();
+    expect(routed).toEqual(opportunity);
+  });
+
+  it("static and generic slug sets are disjoint", () => {
+    const generic = new Set<string>(GENERIC_LISTING_SLUGS);
+    const overlap = STATIC_LISTING_SLUGS.filter((s) => generic.has(s));
+    expect(overlap).toEqual([]);
+  });
+
+  it("hasListingsPage: true for opportunity sectors, false otherwise", () => {
+    expect(hasListingsPage("mining")).toBe(true); // static page
+    expect(hasListingsPage("income-assets")).toBe(true); // generic route
+    expect(hasListingsPage("gold")).toBe(false); // guide, not opportunity
+    expect(hasListingsPage("not-a-slug")).toBe(false);
+  });
+
+  describe("categoryListingsHref", () => {
+    it("returns the canonical path page for a sector with a page", () => {
+      expect(categoryListingsHref("mining")).toBe("/invest/mining/listings");
+      expect(categoryListingsHref("bullion")).toBe("/invest/bullion/listings");
+    });
+
+    it("appends carried filters and drops category/sub/empty values", () => {
+      expect(
+        categoryListingsHref("mining", { state: "WA", price: "", category: "x", sub: "y" }),
+      ).toBe("/invest/mining/listings?state=WA");
+    });
+
+    it("falls back to the marketplace filter for an unknown slug", () => {
+      expect(categoryListingsHref("mystery")).toBe("/invest?category=mystery");
+    });
+
+    it("fallback carries non-category filters too", () => {
+      expect(categoryListingsHref("mystery", { state: "NSW" })).toBe(
+        "/invest?state=NSW&category=mystery",
+      );
+    });
+  });
+});

--- a/__tests__/lib/proxy-category-redirect.test.ts
+++ b/__tests__/lib/proxy-category-redirect.test.ts
@@ -1,0 +1,62 @@
+/**
+ * UX-unification (2026-06): /invest?category=<slug> collapses onto the
+ * canonical /invest/<slug>/listings page so each sector has ONE URL.
+ * These tests exercise that redirect in proxy.ts.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@supabase/ssr", () => ({ createServerClient: vi.fn() }));
+vi.mock("@/lib/admin-mfa-cookie-edge", () => ({
+  verifyMfaCookieEdge: vi.fn().mockResolvedValue(false),
+  MFA_COOKIE_NAME: "admin_mfa_verified",
+}));
+
+async function run(url: string) {
+  const { proxy } = await import("@/proxy");
+  return proxy(new NextRequest(url));
+}
+
+describe("proxy.ts — /invest?category= canonicalisation", () => {
+  it("307-redirects a static-page sector to its canonical listings page", async () => {
+    const res = await run("https://invest.com.au/invest?category=mining");
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe(
+      "https://invest.com.au/invest/mining/listings",
+    );
+  });
+
+  it("redirects a generic-route sector (no bespoke page) too", async () => {
+    const res = await run("https://invest.com.au/invest?category=bullion");
+    expect(res.status).toBe(307);
+    expect(new URL(res.headers.get("location")!).pathname).toBe(
+      "/invest/bullion/listings",
+    );
+  });
+
+  it("preserves other filter params and drops the category param", async () => {
+    const res = await run(
+      "https://invest.com.au/invest?category=mining&state=WA&sub=lithium",
+    );
+    const loc = new URL(res.headers.get("location")!);
+    expect(loc.pathname).toBe("/invest/mining/listings");
+    expect(loc.searchParams.get("state")).toBe("WA");
+    expect(loc.searchParams.get("sub")).toBe("lithium");
+    expect(loc.searchParams.get("category")).toBeNull();
+  });
+
+  it("does NOT redirect category=all (the unfiltered marketplace)", async () => {
+    const res = await run("https://invest.com.au/invest?category=all");
+    expect(res.status).not.toBe(307);
+  });
+
+  it("does NOT redirect a non-opportunity category (e.g. a guide slug)", async () => {
+    const res = await run("https://invest.com.au/invest?category=gold");
+    expect(res.status).not.toBe(307);
+  });
+
+  it("does NOT redirect /invest with no category param", async () => {
+    const res = await run("https://invest.com.au/invest");
+    expect(res.status).not.toBe(307);
+  });
+});

--- a/app/api/listings/route.ts
+++ b/app/api/listings/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { logger } from "@/lib/logger";
 import { isAllowed, ipKey } from "@/lib/rate-limit-db";
+import { rawVerticalVariants } from "@/lib/listing-url";
 
 const log = logger("listings");
 
@@ -50,7 +51,12 @@ export async function GET(request: NextRequest) {
       .eq("status", "active");
 
     if (vertical) {
-      query = query.eq("vertical", vertical);
+      // Match the site's alias-aware bucketing (lib/listing-url): several
+      // seed waves stored drifted vertical strings (e.g. "renewable-energy"
+      // for "energy", "funds" for "fund"). `.eq` undercounted vs the pages,
+      // which use rawVerticalVariants. Use the same expansion here so the
+      // public API agrees with /invest/<slug>/listings.
+      query = query.in("vertical", rawVerticalVariants(vertical));
     }
 
     if (state) {

--- a/app/how-to-invest-in/[vertical]/page.tsx
+++ b/app/how-to-invest-in/[vertical]/page.tsx
@@ -7,6 +7,7 @@ import {
   getCategoryDbFilter,
 } from "@/lib/invest-categories";
 import { getInvestGuide } from "@/lib/invest-guides";
+import { categoryListingsHref } from "@/lib/invest-listing-routes";
 import { getInvestGuideListings } from "@/lib/invest-guide-data";
 import { absoluteUrl, breadcrumbJsonLd, CURRENT_YEAR, UPDATED_LABEL, SITE_NAME } from "@/lib/seo";
 import { faqJsonLd } from "@/lib/schema-markup";
@@ -77,12 +78,12 @@ export default async function HowToInvestPage({
   const breadcrumb = breadcrumbJsonLd([
     { name: "Home", url: absoluteUrl("/") },
     { name: "Invest", url: absoluteUrl("/invest") },
-    { name: cat.label, url: absoluteUrl(`/invest?category=${cat.slug}`) },
+    { name: cat.label, url: absoluteUrl(categoryListingsHref(cat.slug)) },
     { name: `How to invest` },
   ]);
   const faqSchema = faqJsonLd(faqs.map((f) => ({ q: f.question, a: f.answer })));
 
-  const browseHref = `/invest?category=${cat.slug}`;
+  const browseHref = categoryListingsHref(cat.slug);
 
   return (
     <>

--- a/app/invest-in/[state]/page.tsx
+++ b/app/invest-in/[state]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { STATE_SURCHARGES } from "@/lib/firb-data";
 import { getInvestStateData } from "@/lib/invest-state-data";
 import { getInvestCategoryBySlug } from "@/lib/invest-categories";
+import { categoryListingsHref } from "@/lib/invest-listing-routes";
 import { absoluteUrl, breadcrumbJsonLd, CURRENT_YEAR, UPDATED_LABEL, SITE_NAME } from "@/lib/seo";
 import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
 import InvestListingCard from "@/components/InvestListingCard";
@@ -145,7 +146,7 @@ export default async function InvestInStatePage({
                 return (
                   <Link
                     key={slug}
-                    href={`/invest?category=${slug}&state=${st.code}`}
+                    href={categoryListingsHref(slug, { state: st.code })}
                     className="inline-flex items-center gap-1.5 rounded-full bg-slate-50 hover:bg-emerald-50 border border-slate-200 hover:border-emerald-200 px-3 py-1.5 text-xs font-semibold text-slate-700 transition-colors capitalize"
                   >
                     {label}

--- a/app/invest/[slug]/listings/page.tsx
+++ b/app/invest/[slug]/listings/page.tsx
@@ -1,0 +1,121 @@
+import type { Metadata } from "next";
+import { Suspense } from "react";
+import { notFound } from "next/navigation";
+import { breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
+import {
+  getAllInvestCategories,
+  getInvestCategoryBySlug,
+  getCategoryDbFilter,
+} from "@/lib/invest-categories";
+import {
+  fetchListingsByVertical,
+  countListingsByVertical,
+} from "@/lib/investment-listings-query";
+import type { InvestListingVertical } from "@/lib/types";
+import { GENERIC_LISTING_SLUGS } from "@/lib/invest-listing-routes";
+import InvestListingsClient from "@/components/InvestListingsClient";
+import SubCategoryNav from "@/components/SubCategoryNav";
+
+export const revalidate = 300;
+
+// Only the opportunity categories that have NO bespoke static
+// `app/invest/<slug>/listings/page.tsx` are served here. The 14 static
+// pages take routing precedence; this generic route fills the gaps so
+// EVERY opportunity sector has one canonical `/listings` destination
+// (the target of the `?category=` → `/listings` redirect in proxy.ts).
+export function generateStaticParams() {
+  return GENERIC_LISTING_SLUGS.map((slug) => ({ slug }));
+}
+
+// Anything not pre-listed is either a static page (handled elsewhere) or
+// not a real listings sector — 404 rather than render an empty mystery page.
+export const dynamicParams = false;
+
+/** Shared resolver: the category for this slug, or 404. */
+function resolveCategory(slug: string) {
+  const cat = getInvestCategoryBySlug(slug);
+  if (!cat || cat.intent !== "opportunity") notFound();
+  return cat;
+}
+
+/** Listings for a category via its canonical DB filter (alias-aware). */
+async function fetchCategoryListings(slug: string) {
+  const cat = resolveCategory(slug);
+  const filter = getCategoryDbFilter(cat);
+  const vertical = filter.verticals[0];
+  if (!vertical) return [];
+  return fetchListingsByVertical(
+    vertical as InvestListingVertical,
+    filter.subCategories ? { subCategories: filter.subCategories } : {},
+  );
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const cat = getInvestCategoryBySlug(slug);
+  if (!cat || cat.intent !== "opportunity") return { robots: { index: false } };
+
+  const filter = getCategoryDbFilter(cat);
+  const vertical = filter.verticals[0];
+  const count = vertical
+    ? await countListingsByVertical(
+        vertical as InvestListingVertical,
+        filter.subCategories ? { subCategories: filter.subCategories } : {},
+      )
+    : 0;
+  const countLabel = count > 0 ? `${count} ` : "";
+
+  return {
+    title: cat.title,
+    description: cat.metaDescription,
+    alternates: { canonical: `${SITE_URL}/invest/${slug}/listings` },
+    openGraph: {
+      title: `${cat.label} Investment Opportunities — ${countLabel}Active Listings`,
+      description: cat.metaDescription,
+      url: `${SITE_URL}/invest/${slug}/listings`,
+    },
+  };
+}
+
+export default async function GenericCategoryListingsPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const cat = resolveCategory(slug);
+  const listings = await fetchCategoryListings(slug);
+  const categoryTabs = getAllInvestCategories().map((c) => ({ slug: c.slug, label: c.label }));
+
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: `${SITE_URL}/` },
+    { name: "Invest", url: `${SITE_URL}/invest` },
+    { name: cat.label, url: `${SITE_URL}/invest/${slug}` },
+    { name: "Opportunities" },
+  ]);
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
+      />
+      <div className="container-custom pt-6">
+        <SubCategoryNav category={cat} />
+      </div>
+      <Suspense fallback={<div className="py-12 text-center text-slate-400">Loading listings...</div>}>
+        <InvestListingsClient
+          listings={listings}
+          categories={categoryTabs}
+          lockedCategory={slug}
+          pageTitle={`${cat.label} Investment Listings`}
+          pageSubtitle={cat.intro}
+        />
+      </Suspense>
+    </>
+  );
+}

--- a/app/invest/page.tsx
+++ b/app/invest/page.tsx
@@ -18,6 +18,7 @@ import {
 import type { InvestmentListing } from "@/lib/types";
 import { logger } from "@/lib/logger";
 import { listingUrl, categoryForListing } from "@/lib/listing-url";
+import { categoryListingsHref } from "@/lib/invest-listing-routes";
 import InvestListingsClient from "@/components/InvestListingsClient";
 import GetMatchedEmbed from "@/components/get-matched/GetMatchedEmbed";
 import { loadInvestPageContext } from "@/lib/listing-page-context";
@@ -330,7 +331,7 @@ export default async function InvestMarketplacePage() {
                 return (
                   <Link
                     key={cat.slug}
-                    href={`/invest?category=${cat.slug}`}
+                    href={categoryListingsHref(cat.slug)}
                     className={`group relative block rounded-xl border bg-white p-3 md:p-4 transition-all duration-200 hover:shadow-lg hover:scale-[1.01] ${accent.card}`}
                   >
                     <div className="flex items-start gap-2 mb-2">

--- a/app/smsf/property/page.tsx
+++ b/app/smsf/property/page.tsx
@@ -4,6 +4,7 @@ import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR, UPDATED_LABEL, absoluteUrl } 
 import { faqJsonLd } from "@/lib/schema-markup";
 import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
 import InvestOpportunitiesCallout from "@/components/invest/InvestOpportunitiesCallout";
+import { categoryListingsHref } from "@/lib/invest-listing-routes";
 
 export const revalidate = 86400;
 
@@ -826,9 +827,9 @@ export default function SmsfPropertyPage() {
             icon="building"
             heading="SMSF-eligible property & income opportunities"
             blurb="Browse commercial property, SDA (NDIS) housing and other LRBA-compatible assets suited to SMSF acquisition — many flagged SMSF-eligible with bare-trust-ready structures. Use the after-tax return estimator on each listing to model the 15% accumulation vs 0% pension outcome."
-            href="/invest?category=commercial-property"
+            href={categoryListingsHref("commercial-property")}
             ctaLabel="Browse SMSF-eligible listings"
-            secondary={{ label: "SDA / NDIS housing", href: "/invest?category=sda-housing" }}
+            secondary={{ label: "SDA / NDIS housing", href: categoryListingsHref("sda-housing") }}
           />
         </section>
 

--- a/components/InvestListingsClient.tsx
+++ b/components/InvestListingsClient.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
 import type { InvestmentListing, ListingKind } from "@/lib/types";
 import { categoryForListing } from "@/lib/listing-url";
+import { categoryListingsHref } from "@/lib/invest-listing-routes";
 import {
   TICKET_BUCKETS,
   ticketBucketByKey,
@@ -180,6 +181,19 @@ export default function InvestListingsClient({
   const submitSearch = useCallback((q: string) => {
     setParams({ q: q.trim() });
   }, [setParams]);
+
+  // Marketplace sector selection → navigate to the sector's canonical
+  // `/invest/<slug>/listings` page (the single sector destination) rather
+  // than filtering in place. Active filters are carried across so a user
+  // who set State/Budget/etc. before picking a sector keeps them. Only
+  // wired on the unlocked marketplace (locked vertical pages hide Sector).
+  const selectCategory = useCallback((slug: string) => {
+    const carry: Record<string, string> = {};
+    searchParams.forEach((v, k) => {
+      if (k !== "category" && k !== "sub" && v) carry[k] = v;
+    });
+    router.push(categoryListingsHref(slug, carry));
+  }, [router, searchParams]);
 
   // ── Derived sub-categories for the active category ──
   const subCategories = useMemo(() => {
@@ -556,6 +570,7 @@ export default function InvestListingsClient({
               activeChips={activeChips}
               onClearAll={clearAllFilters}
               showSector={!lockedCategory}
+              onSelectCategory={lockedCategory ? undefined : selectCategory}
             />
           </div>
 

--- a/components/invest/MarketplaceFilterBar.tsx
+++ b/components/invest/MarketplaceFilterBar.tsx
@@ -83,6 +83,14 @@ export interface MarketplaceFilterBarProps {
   onClearAll: () => void;
   /** Hide the Sector pill on vertical pages where the category is locked. */
   showSector?: boolean;
+  /**
+   * Marketplace-only: navigate to a sector's canonical
+   * `/invest/<slug>/listings` page instead of applying an in-place
+   * `?category=` filter. When provided, picking a sector leaves the
+   * cross-sector marketplace for the dedicated sector page (the single
+   * canonical destination). Omitted on locked vertical pages.
+   */
+  onSelectCategory?: (slug: string) => void;
 }
 
 export default function MarketplaceFilterBar({
@@ -98,6 +106,7 @@ export default function MarketplaceFilterBar({
   activeChips,
   onClearAll,
   showSector = true,
+  onSelectCategory,
 }: MarketplaceFilterBarProps) {
   const [open, setOpen] = useState<string | null>(null);
   const toggle = useCallback((id: string) => setOpen((o) => (o === id ? null : id)), []);
@@ -242,9 +251,17 @@ export default function MarketplaceFilterBar({
                     <button
                       key={c.slug}
                       type="button"
-                      disabled={count === 0}
+                      // When navigating to a dedicated page, never disable —
+                      // the marketplace count (categoryForListing-based) can
+                      // read 0 for sub-category sectors that DO have a page
+                      // with listings (e.g. royalties).
+                      disabled={!onSelectCategory && count === 0}
                       onClick={() => {
-                        setParams({ category: selected ? "" : c.slug, sub: "" });
+                        if (onSelectCategory) {
+                          onSelectCategory(c.slug);
+                        } else {
+                          setParams({ category: selected ? "" : c.slug, sub: "" });
+                        }
                         close();
                       }}
                       className={`flex items-center justify-between gap-1 px-2.5 py-2 rounded-lg border text-xs font-semibold disabled:opacity-40 transition-colors ${

--- a/lib/invest-categories.ts
+++ b/lib/invest-categories.ts
@@ -1143,7 +1143,12 @@ const categoriesRaw: Omit<InvestCategory, "intent">[] = [
   {
     slug: "income-assets",
     label: "Income-Asset Businesses",
-    dbVerticals: ["business"],
+    // No distinct DB vertical is seeded for income-assets yet. The old
+    // ["business"] value collided with the buy-business category (same
+    // vertical), so the /invest/income-assets/listings page surfaced
+    // unrelated business-for-sale rows. Empty until a dedicated vertical
+    // or sub_category is seeded — the page shows a graceful empty state.
+    dbVerticals: [],
     color: {
       bg: "bg-emerald-50",
       border: "border-emerald-200",

--- a/lib/invest-listing-routes.ts
+++ b/lib/invest-listing-routes.ts
@@ -1,0 +1,102 @@
+/**
+ * Single source of truth for "which /invest category has a canonical
+ * `/invest/<slug>/listings` page, and how do I link to it".
+ *
+ * Background (the UX-unification, 2026-06): the marketplace historically
+ * exposed each sector two ways — the path page `/invest/<slug>/listings`
+ * (indexable, self-canonical, server-rendered with only that sector) AND
+ * the query-param filter state `/invest?category=<slug>` (canonicalised
+ * away to `/invest`). Two live URLs for the same listings read as
+ * duplication and confused users. We now treat the path page as the ONE
+ * canonical sector destination and route every "browse a sector" intent
+ * there; `/invest?category=<slug>` 307-redirects to it (see `proxy.ts`).
+ *
+ * This module is intentionally tiny and dependency-free so it is safe to
+ * import into the Edge middleware (`proxy.ts`) without dragging the
+ * ~2k-line `lib/invest-categories.ts` into the edge bundle. The slug sets
+ * below are kept in lock-step with the opportunity categories by
+ * `__tests__/lib/invest-listing-routes.test.ts`, which fails if a new
+ * opportunity category is added without being classified here.
+ */
+
+/**
+ * Opportunity slugs with a hand-built static page at
+ * `app/invest/<slug>/listings/page.tsx`. These take routing precedence
+ * over the generic `[slug]/listings` route.
+ */
+export const STATIC_LISTING_SLUGS = [
+  "buy-business",
+  "franchise",
+  "mining",
+  "farmland",
+  "commercial-property",
+  "renewable-energy",
+  "startups",
+  "alternatives",
+  "private-credit",
+  "infrastructure",
+  "funds",
+  "pre-ipo",
+  "private-equity",
+  "royalties",
+] as const;
+
+/**
+ * Opportunity slugs served by the generic `app/invest/[slug]/listings`
+ * route (no bespoke static page). Keep in sync with that route's
+ * `generateStaticParams`.
+ */
+export const GENERIC_LISTING_SLUGS = [
+  "income-assets",
+  "bullion",
+  "water-rights",
+  "carbon-credits",
+  "sda-housing",
+] as const;
+
+/** Every opportunity slug that resolves to a real `/listings` page. */
+export const LISTING_PAGE_SLUGS: ReadonlySet<string> = new Set<string>([
+  ...STATIC_LISTING_SLUGS,
+  ...GENERIC_LISTING_SLUGS,
+]);
+
+/** Whether `slug` has a canonical `/invest/<slug>/listings` page. */
+export function hasListingsPage(slug: string): boolean {
+  return LISTING_PAGE_SLUGS.has(slug);
+}
+
+/**
+ * Canonical href for browsing a sector's listings.
+ *
+ * - Slugs with a real page → `/invest/<slug>/listings` (the canonical
+ *   destination), with any extra filter params appended.
+ * - Unknown slugs → graceful fallback to the marketplace filter state
+ *   `/invest?category=<slug>` so a caller can never produce a 404.
+ *
+ * `params` carries through active filters (state, price, q, kind, …) so a
+ * user who picks a sector after setting other filters keeps them.
+ */
+export function categoryListingsHref(
+  slug: string,
+  params?: Record<string, string> | URLSearchParams,
+): string {
+  const search = new URLSearchParams();
+  if (params) {
+    const entries =
+      params instanceof URLSearchParams ? params.entries() : Object.entries(params);
+    for (const [k, v] of entries) {
+      // Never carry the category dimension itself into a path page (it's
+      // already encoded in the path) or into the fallback (added below).
+      if (k === "category" || k === "sub" || !v) continue;
+      search.set(k, v);
+    }
+  }
+  const qs = search.toString();
+
+  if (hasListingsPage(slug)) {
+    return `/invest/${slug}/listings${qs ? `?${qs}` : ""}`;
+  }
+  // Fallback: marketplace filter state.
+  search.set("category", slug);
+  return `/invest?${search.toString()}`;
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -2,6 +2,7 @@ import { createServerClient } from '@supabase/ssr'
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 import { verifyMfaCookieEdge, MFA_COOKIE_NAME } from '@/lib/admin-mfa-cookie-edge'
+import { LISTING_PAGE_SLUGS } from '@/lib/invest-listing-routes'
 
 // Admin paths where the MFA step-up page itself lives — must never be
 // gated, otherwise they redirect to themselves infinitely.
@@ -44,6 +45,26 @@ export async function proxy(request: NextRequest) {
     request.headers.get('x-request-id') ||
     request.headers.get('x-vercel-id') ||
     crypto.randomUUID()
+
+  // ── Marketplace sector canonicalisation ────────────────────────
+  // Each /invest sector has ONE canonical home: the path page
+  // `/invest/<slug>/listings`. The legacy `/invest?category=<slug>`
+  // filter state rendered the same listings at a second URL (the source
+  // of the "why are there two pages?" confusion). Collapse it onto the
+  // canonical page so there's a single destination. Other filter params
+  // (state, price, sub, q, …) are preserved. 307 (temporary) keeps this
+  // fully reversible; the target page self-canonicalises for SEO.
+  if (pathname === '/invest') {
+    const category = request.nextUrl.searchParams.get('category')
+    if (category && LISTING_PAGE_SLUGS.has(category)) {
+      const url = request.nextUrl.clone()
+      url.pathname = `/invest/${category}/listings`
+      url.searchParams.delete('category')
+      const redirect = NextResponse.redirect(url, 307)
+      redirect.headers.set('x-request-id', requestId)
+      return redirect
+    }
+  }
 
   // ── Cron route protection ──────────────────────────────────────
   // Vercel cron jobs send a Bearer token — reject unauthorized callers.


### PR DESCRIPTION
## Why

Each `/invest` sector was reachable two ways that rendered the *same* listings:

- `/invest/<slug>/listings` — the path page (indexable, self-canonical, server-rendered with only that sector)
- `/invest?category=<slug>` — a query-param filter state (canonicalised away to `/invest`)

Two live URLs for the same content read as duplication and confused users. The filtered marketplace also kept its big **"184 live opportunities"** hero while the results below showed far fewer (e.g. 5 for mining) — a self-contradicting view. Investigation also surfaced that the in-app links were split (the "Browse by sector" grid went to `?category=`, the pillar pages went to `/listings`), some fund-sub sectors (e.g. royalties) showed **0** under `?category=` but had listings on their dedicated page, and the public `/api/listings` count disagreed with the pages due to `vertical` seed-drift.

This unifies on the **path page as the single sector destination**.

## What changed

- **`proxy.ts`** 307-redirects `/invest?category=<slug>` → `/invest/<slug>/listings` for every opportunity sector, preserving other filter params (`state`, `price`, `sub`, `q`, …). The dissonant filtered-hero state no longer renders.
- **New generic route `app/invest/[slug]/listings`** gives the 5 opportunity sectors with no bespoke page (income-assets, bullion, water-rights, carbon-credits, sda-housing) a real, consistent listings page, so links/redirects never 404. Reuses the shared `getCategoryDbFilter`, so it matches the 14 existing static pages (which keep routing precedence and are untouched).
- **`lib/invest-listing-routes.ts`** — single source of truth for the canonical sector href + which sectors have a page. The "Browse by sector" grid, the in-bar **Sector** selector, and cross-links (`/invest-in/[state]`, `/smsf/property`, `/how-to-invest-in/[vertical]`) all route through `categoryListingsHref()` instead of hand-writing `?category=`.
- **`/api/listings`** expands the vertical filter via `rawVerticalVariants` (alias-aware `.in`) so the public API count agrees with the pages (`fund`/`funds`, `energy`/`renewable-energy` drift).
- **`income-assets`** had `dbVerticals: ["business"]`, which collided with the buy-business category (same vertical) and surfaced unrelated business-for-sale rows; set to `[]` so its page shows a graceful empty state.

## Verified (prod build + `next start`)

- `type-check`, `lint` (0 errors), full `next build` (2760 pages) all green; new + affected unit tests pass.
- `/invest?category=mining` → **307** `/invest/mining/listings`; `&state=WA&sub=lithium` preserved; `?category=all` and guide slugs not redirected.
- New pages 200 + indexable + self-canonical; unknown/guide slugs render the not-found UI with `robots=noindex`.

## Notes

- Touches **`proxy.ts`** (Tier C per `docs/audits/MERGE_AUTHORIZATION.md`).
- Unknown slugs under `/invest/*/listings` return the not-found UI with a **200** status (soft-404) — this is the *existing* behavior of the sibling `[subcategory]` route on Next 16, not introduced here; `noindex` keeps them out of search. Hard-404 status for these dynamic listing routes is a separate, repo-wide follow-up.

Rollback: revert this commit. The proxy redirect is 307 (temporary, not permanently cached); the generic route + helper are additive; the 14 static listings pages are untouched.

https://claude.ai/code/session_019aPVcfri9PgMADCrTGTPyT

---
_Generated by [Claude Code](https://claude.ai/code/session_019aPVcfri9PgMADCrTGTPyT)_