### PR TITLE
fix(db): make reapplied professionals FI-flag backfill type-aware

### DIFF
--- a/supabase/migrations/20260907030000_reapply_professionals_fi_flags.sql
+++ b/supabase/migrations/20260907030000_reapply_professionals_fi_flags.sql
@@ -2,14 +2,14 @@
 -- Migration: 20260907030000_reapply_professionals_fi_flags.sql
 -- Purpose: Re-apply the `professionals` foreign-investment flag columns from
 --          20260322_foreign_investment_flags.sql, which only PARTIALLY applied
---          to the live database. DB introspection (2026-06-07) confirms the
+--          to the live database. DB introspection (2026-06-07) confirmed the
 --          brokers columns and the foreign_investment_dta table are present, but
 --          professionals.{international_tax_specialist, firb_specialist,
---          migration_agent, migration_agent_marn} are MISSING.
+--          migration_agent, migration_agent_marn} were MISSING.
 --
 --          Their absence makes any advisor read that projects them fail at the
 --          query layer. On /advisor/[slug] the page's primary
---          `.select(ADVISOR_PUBLIC_COLUMNS).single()` therefore returns null →
+--          `.select(ADVISOR_PUBLIC_COLUMNS).single()` therefore returns null ->
 --          notFound(), which surfaced as React #419 + "Advisor Not Found" on
 --          EVERY advisor profile. The same missing columns also break
 --          /advisors/firb-specialists, /advisors/international-tax-specialists
@@ -20,16 +20,32 @@
 --          because that version is already recorded as applied, so the migrate
 --          workflow will not re-run it; a new version will apply.
 --
--- Idempotent: ADD COLUMN IF NOT EXISTS + backfill UPDATEs (re-runnable).
---             Mirrors the professionals block of 20260322 one-for-one.
--- RLS: unchanged — adds columns to the existing RLS-enabled professionals table.
--- Rollback (non-destructive — columns carry safe defaults):
+-- jsonb correction (2026-06-07): the LIVE `professionals.specialties` column is
+--   `jsonb` (schema drift vs the migrations-defined `text[]`). The original
+--   backfill predicate `'International Tax' = ANY(specialties)` therefore errors
+--   on prod with `42809: op ANY/ALL (array) requires array on right side`, and
+--   because the migration is wrapped in BEGIN/COMMIT that error rolled the whole
+--   thing back -- so the four ADD COLUMNs never persisted either. The backfill
+--   below is now type-aware: it uses jsonb containment (@>) when `specialties`
+--   is jsonb and the array predicate (= ANY) otherwise, so it is safe on both
+--   the live (jsonb) database and a migrations-only rebuild (text[]). PL/pgSQL
+--   only plans the branch it actually takes, so the unused predicate never
+--   parses against the wrong column type.
+--
+--   The columns + backfill were applied to prod on 2026-06-07 via an idempotent
+--   direct apply, recorded under this same version (20260907030000), so this
+--   file will not re-run there; it is corrected here so a future replay (e.g. a
+--   fresh environment built from migrations) cannot fail.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS + idempotent, type-aware backfill.
+-- RLS: unchanged -- adds columns to the existing RLS-enabled professionals table.
+-- Rollback (non-destructive -- columns carry safe defaults):
 --   ALTER TABLE public.professionals
 --     DROP COLUMN IF EXISTS international_tax_specialist,
 --     DROP COLUMN IF EXISTS firb_specialist,
 --     DROP COLUMN IF EXISTS migration_agent,
 --     DROP COLUMN IF EXISTS migration_agent_marn;
--- Risk: low — additive boolean/text columns with safe defaults + idempotent backfill.
+-- Risk: low -- additive boolean/text columns with safe defaults + idempotent backfill.
 -- ============================================================================
 
 BEGIN;
@@ -49,20 +65,45 @@ COMMENT ON COLUMN public.professionals.migration_agent IS
 COMMENT ON COLUMN public.professionals.migration_agent_marn IS
   'Migration Agent Registration Number (MARN) for registered migration agents.';
 
--- Backfill specialty flags (mirrors 20260322; idempotent — re-running sets the
--- same rows). Tax agents flagged with the International Tax specialty:
-UPDATE public.professionals
-SET international_tax_specialist = true
-WHERE 'International Tax' = ANY(specialties)
-  AND status = 'active';
+-- Type-aware backfill (mirrors 20260322; idempotent -- re-running sets the same
+-- rows). The live `specialties` column is jsonb; a migrations-only rebuild may
+-- have it as text[]. Pick the predicate that matches the actual column type so
+-- the migration is safe in both worlds.
+DO $$
+DECLARE
+  v_specialties_type text;
+BEGIN
+  SELECT data_type INTO v_specialties_type
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND table_name = 'professionals'
+    AND column_name = 'specialties';
 
--- Property advisors / buyer's agents flagged with a FIRB / foreign-buyer specialty:
-UPDATE public.professionals
-SET firb_specialist = true
-WHERE (
-  'FIRB & Foreign Investment' = ANY(specialties)
-  OR 'Foreign Buyer Assistance' = ANY(specialties)
-)
-AND status = 'active';
+  IF v_specialties_type = 'jsonb' THEN
+    -- Tax agents flagged with the International Tax specialty:
+    UPDATE public.professionals
+      SET international_tax_specialist = true
+      WHERE specialties @> '["International Tax"]'::jsonb
+        AND status = 'active';
+    -- Property advisors / buyer's agents flagged with a FIRB / foreign-buyer specialty:
+    UPDATE public.professionals
+      SET firb_specialist = true
+      WHERE (specialties @> '["FIRB & Foreign Investment"]'::jsonb
+          OR specialties @> '["Foreign Buyer Assistance"]'::jsonb)
+        AND status = 'active';
+  ELSIF v_specialties_type = 'ARRAY' THEN
+    -- Tax agents flagged with the International Tax specialty:
+    UPDATE public.professionals
+      SET international_tax_specialist = true
+      WHERE 'International Tax' = ANY(specialties)
+        AND status = 'active';
+    -- Property advisors / buyer's agents flagged with a FIRB / foreign-buyer specialty:
+    UPDATE public.professionals
+      SET firb_specialist = true
+      WHERE ('FIRB & Foreign Investment' = ANY(specialties)
+          OR 'Foreign Buyer Assistance' = ANY(specialties))
+        AND status = 'active';
+  END IF;
+END $$;
 
 COMMIT;


### PR DESCRIPTION
## Why

Follow-up to #1458. That migration was meant to re-add the four `professionals` foreign-investment flag columns, but its backfill used a `text[]` predicate:

```sql
UPDATE public.professionals SET international_tax_specialist = true
WHERE 'International Tax' = ANY(specialties) AND status = 'active';
```

The **live** `professionals.specialties` column is `jsonb` (schema drift vs the migrations-defined `text[]`), so on prod that line raises:

```
ERROR: 42809: op ANY/ALL (array) requires array on right side
```

Because the migration is wrapped in `BEGIN/COMMIT`, the error rolled back the whole transaction — the four `ADD COLUMN`s never persisted, and every `/advisor/[slug]` kept throwing React #419 / "Advisor Not Found" (plus the three specialist directories, quiz results, and v1 advisor APIs). The post-merge "Supabase migrate" run went green without applying anything, which masked it.

## What this does

Replaces the two backfill `UPDATE`s with a **type-aware `DO` block**: jsonb containment (`@>`) when `specialties` is `jsonb`, the array predicate (`= ANY`) otherwise. PL/pgSQL only plans the branch it executes, so the unused predicate never parses against the wrong column type — the file is now safe on both the live (jsonb) database and a migrations-only rebuild (text[]). The `ADD COLUMN IF NOT EXISTS` statements are unchanged.

## Prod state (already remediated)

Prod was healed out-of-band on 2026-06-07: the corrected SQL (additive columns + jsonb backfill) was applied via an idempotent direct apply and **recorded under this same version (`20260907030000`)**, so this file will **not** re-run against prod. Verified post-apply: 4 columns present, advisor projection selects cleanly, `international_tax_specialist` set on 1 active advisor (FIRB matched 0). This PR is repo hygiene — it makes the committed migration match what's live and prevents a future fresh-environment replay from failing on the same bug.

## Out of scope (flagged separately)

The `.github/workflows/supabase-migrate.yml` job reported `success` on the #1458 merge without applying the migration. That false-green is the likely engine behind the standing migration drift and warrants its own investigation (touches CI workflows — Tier C).

---
_Generated by [Claude Code](https://claude.ai/code/session_01WZrTbm7AFu1hcRUnTxV8Pr)_