### PR TITLE
fix(invest): match drifted verticals when resolving listing detail (follow-up to #1461)

### DIFF
--- a/app/invest/[slug]/listings/[subcategory]/page.tsx
+++ b/app/invest/[slug]/listings/[subcategory]/page.tsx
@@ -23,7 +23,7 @@ import InvestListingCard from "@/components/InvestListingCard";
 import ListingsEmptyState from "@/components/ListingsEmptyState";
 import ListingDetailView from "@/components/invest/ListingDetailView";
 import { fetchRelatedListings } from "@/lib/investment-listings-query";
-import { listingUrl } from "@/lib/listing-url";
+import { listingUrl, rawVerticalVariants } from "@/lib/listing-url";
 import ScrollReveal from "@/components/ScrollReveal";
 import SubCategoryNav from "@/components/SubCategoryNav";
 
@@ -60,7 +60,7 @@ export async function generateMetadata({
       const { data: listing } = await supabase
         .from("investment_listings")
         .select("title, description")
-        .in("vertical", filter.verticals)
+        .in("vertical", filter.verticals.flatMap(rawVerticalVariants))
         .eq("slug", subcategory)
         .eq("status", "active")
         .maybeSingle();
@@ -119,7 +119,7 @@ export default async function InvestSubcategoryListingsPage({
       const { data: listingRaw } = await supabaseForDetail
         .from("investment_listings")
         .select("*")
-        .in("vertical", detailFilter.verticals)
+        .in("vertical", detailFilter.verticals.flatMap(rawVerticalVariants))
         .eq("slug", subcategory)
         .eq("status", "active")
         .maybeSingle();
@@ -152,7 +152,7 @@ export default async function InvestSubcategoryListingsPage({
     .from("investment_listings")
     .select("*")
     .eq("status", "active")
-    .in("vertical", filter.verticals)
+    .in("vertical", filter.verticals.flatMap(rawVerticalVariants))
     .eq("sub_category", sub.dbValue)
     .order("created_at", { ascending: false });
 


### PR DESCRIPTION
## Follow-up to #1461

#1461 stopped the 500 on listing-detail pages and added a graceful empty state, but the **detail still didn't render** for many fund/PE/royalties listings: the single-listing lookup filtered by the category's **canonical** `dbVerticals` (e.g. `["fund"]`), while a lot of listings carry a **drifted vertical** (`"funds"`, `"renewable-energy"`, …) from earlier seed waves. So e.g. `/invest/funds/listings/bronte-capital-amalthea` (vertical `"funds"`) returned 200 but showed the empty state instead of the listing.

Verified on the live mirror after #1461 deployed: detail URLs are 200 (no 500 ✓) but render empty; `bronte` and `goodman` are both in the drifted `vertical=funds` set.

## Fix

Expand the vertical filter via `rawVerticalVariants(...)` — the same alias-aware expansion the sector listing pages already use (`fetchListingsByVertical`) — in:
- the single-listing lookup (page render),
- its `generateMetadata` lookup,
- the subcategory listings query (so funds *subcategory* pages also match drift).

Drifted-vertical listings now resolve and render their detail. `type-check` clean; query-only change.

Rollback: revert this commit.

https://claude.ai/code/session_019aPVcfri9PgMADCrTGTPyT

---
_Generated by [Claude Code](https://claude.ai/code/session_019aPVcfri9PgMADCrTGTPyT)_