### PR TITLE
feat(db): migration-ledger reconciliation plan + filename/ledger guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -519,6 +519,28 @@ jobs:
           GITHUB_BASE_REF: ${{ github.base_ref }}
         run: node scripts/check-rls-migrations.mjs
 
+  migration-filename-gate:
+    name: Migration filename gate (unique 14-digit version)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: github.event_name == 'pull_request'
+    # Why this exists: the Supabase CLI keys migrations on the leading digits of
+    # the filename. The legacy tree mixed 3-/8-/14-digit versions and produced
+    # 50 colliding date-only prefixes, which is a load-bearing reason the tree
+    # can no longer be `db push`ed against prod (see
+    # docs/runbooks/MIGRATION_LEDGER_RECONCILIATION.md). This gate stops the rot
+    # from growing: every NEW migration must carry a unique 14-digit timestamp.
+    # PR-scoped (added files only), so it never red-fails on the legacy files —
+    # those are retired by the baseline-squash, not by this gate.
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Check new migration filenames use a unique 14-digit timestamp
+        env:
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: node scripts/check-migration-filenames.mjs
+
   database-types-drift-gate:
     name: Database types drift gate (lib/database.types.ts vs migrations)
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,14 +62,31 @@ severity (see `docs/audits/MERGE_AUTHORIZATION.md`).
 
 ## Database changes
 
-- All schema changes go through `supabase/migrations/<date>_<name>.sql`.
-- Migration naming: `YYYYMMDD_short_name.sql` (e.g. `20260427_add_health_pings.sql`).
+- All schema changes go through `supabase/migrations/<version>_<name>.sql`.
+- **Migration naming: a unique full 14-digit timestamp**
+  `YYYYMMDDHHMMSS_short_name.sql` (e.g. `20260427093500_add_health_pings.sql`).
+  Generate the prefix with `date -u +%Y%m%d%H%M%S`. The old 8-digit date-only
+  convention (`YYYYMMDD_…`) is **retired** — the Supabase CLI keys migrations on
+  the leading digits, and date-only prefixes collide when two migrations land
+  the same day, which is a load-bearing cause of the ledger fork
+  (`docs/audits/DB-STATE-2026-06-07.md`). The `audit:migration-filenames` gate
+  enforces this on new files.
 - Every migration must be **idempotent** — wrap in `IF NOT EXISTS` /
   `IF EXISTS` so it can be re-run safely.
 - Every migration must include a top-of-file comment documenting the
   rollback strategy. See [docs/runbooks/database-rollback.md](docs/runbooks/database-rollback.md).
 - New tables holding user data **must** have RLS enabled with explicit
-  policies. CI does not catch this — please be careful.
+  policies (the `rls-migrations-gate` checks new tables).
+- **Apply path:** migrations land in prod via the `supabase-migrate.yml`
+  pipeline on merge to `main` — **not** via ad-hoc Supabase MCP `apply_migration`
+  or dashboard SQL. Out-of-band applies are what forked the ledger from the
+  tree; if you must hotfix prod directly, immediately back it with a tracked
+  migration file. Until the ledger is reconciled
+  (`docs/runbooks/MIGRATION_LEDGER_RECONCILIATION.md`), **never run
+  `supabase db push`** against this project.
+- After a schema change reaches prod, regenerate types: `npm run db:types`, and
+  commit `lib/database.types.ts`. New code that calls `.from("x")` must reference
+  a relation that exists live (the `audit:schema-refs` sentinel catches phantoms).
 
 ## Tests
 

--- a/__tests__/integration/migration-filenames-gate.int.test.ts
+++ b/__tests__/integration/migration-filenames-gate.int.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Integration test for scripts/check-migration-filenames.mjs — the parts the
+ * pure-function unit tests can't reach: the git acquisition + the gate's actual
+ * exit codes. Spawns the real gate against a throwaway git repo.
+ *
+ * Guards the load-bearing fixes:
+ *  - archive/** files are filtered out of the active set (directory pathspec +
+ *    dirname filter),
+ *  - a rename to a bad name is caught regardless of the caller's diff.renames
+ *    config (the gate forces diff.renames=false),
+ *  - an unresolvable base ref skips loudly (exit 0 + warning), never a false fail,
+ *  - violations exit 1, clean PRs exit 0.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+const GATE = join(process.cwd(), "scripts/check-migration-filenames.mjs");
+let repo: string;
+
+function git(args: string[]): string {
+  return execFileSync("git", args, { cwd: repo, encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] });
+}
+
+function writeFileEnsuring(relPath: string, body = "-- noop\n"): void {
+  const abs = join(repo, relPath);
+  mkdirSync(dirname(abs), { recursive: true });
+  writeFileSync(abs, body);
+}
+
+function commitAll(msg: string): void {
+  git(["add", "-A"]);
+  git(["commit", "-q", "-m", msg]);
+}
+
+/** Reset the feature branch to a clean copy of main. */
+function freshBranch(): void {
+  git(["checkout", "-q", "-B", "feature", "main"]);
+  git(["reset", "-q", "--hard", "main"]);
+  git(["clean", "-fdq"]);
+}
+
+/** Run the real gate against the temp repo; return its exit code + combined
+ *  output. spawnSync captures stdout AND stderr regardless of exit code (the
+ *  gate's skip/violation messages go to stderr). */
+function runGate(env: Record<string, string> = {}): { code: number; out: string } {
+  const r = spawnSync("node", [GATE], {
+    cwd: repo,
+    encoding: "utf8",
+    env: { ...process.env, GITHUB_BASE_REF: "main", ...env },
+  });
+  return { code: r.status ?? 1, out: `${r.stdout ?? ""}${r.stderr ?? ""}` };
+}
+
+beforeAll(() => {
+  repo = mkdtempSync(join(tmpdir(), "miggate-"));
+  git(["init", "-q"]);
+  git(["checkout", "-q", "-b", "main"]);
+  git(["config", "user.email", "t@example.com"]);
+  git(["config", "user.name", "t"]);
+  git(["config", "commit.gpgsign", "false"]);
+  writeFileEnsuring("supabase/migrations/20260101000000_base.sql");
+  commitAll("base");
+});
+
+afterAll(() => {
+  if (repo) rmSync(repo, { recursive: true, force: true });
+});
+
+describe("migration-filename gate (integration)", () => {
+  it("passes (exit 0) when the added migration has a unique 14-digit version", () => {
+    freshBranch();
+    writeFileEnsuring("supabase/migrations/20260202000000_good.sql");
+    commitAll("good");
+    expect(runGate().code).toBe(0);
+  });
+
+  it("fails (exit 1) on an 8-digit date-only version and names the file", () => {
+    freshBranch();
+    writeFileEnsuring("supabase/migrations/20260202_bad.sql");
+    commitAll("bad");
+    const r = runGate();
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("20260202_bad.sql");
+  });
+
+  it("ignores files added under archive/** (passes even with a bad archived name)", () => {
+    freshBranch();
+    writeFileEnsuring("supabase/migrations/archive/999_legacy.sql");
+    commitAll("archive a legacy file");
+    expect(runGate().code).toBe(0);
+  });
+
+  it("catches a rename to a bad name even when diff.renames is enabled", () => {
+    freshBranch();
+    git(["config", "diff.renames", "true"]); // hostile config the gate must override
+    git([
+      "mv",
+      "supabase/migrations/20260101000000_base.sql",
+      "supabase/migrations/20260303_renamedbad.sql",
+    ]);
+    commitAll("rename to bad name");
+    const r = runGate();
+    git(["config", "--unset", "diff.renames"]);
+    expect(r.code).toBe(1);
+    expect(r.out).toContain("20260303_renamedbad.sql");
+  });
+
+  it("skips loudly (exit 0 + warning) when the base ref can't be resolved", () => {
+    freshBranch();
+    writeFileEnsuring("supabase/migrations/20260202_bad.sql");
+    commitAll("bad but unresolvable base");
+    const r = runGate({ GITHUB_BASE_REF: "no-such-ref-xyz" });
+    expect(r.code).toBe(0);
+    expect(r.out).toContain("not resolvable");
+  });
+});

--- a/__tests__/scripts/check-migration-filenames.test.ts
+++ b/__tests__/scripts/check-migration-filenames.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests for scripts/check-migration-filenames.mjs — the version-hygiene gate.
+ *
+ * Exercises the exported pure helpers directly (no git, no fs). The main()
+ * runner is a thin wrapper around these; the pass/fail logic lives here.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { join } from "node:path";
+
+const gatePath = join(process.cwd(), "scripts/check-migration-filenames.mjs");
+
+let parseMigrationVersion: (filename: string) => {
+  base: string;
+  version: string;
+  is14: boolean;
+  hasDigits: boolean;
+};
+let computeFilenameViolations: (
+  addedBasenames: string[],
+  existingVersions: Set<string>,
+) => { file: string; version: string; kind: "format" | "collision-existing" | "collision-added" }[];
+
+beforeAll(async () => {
+  const mod = await import(gatePath);
+  parseMigrationVersion = mod.parseMigrationVersion;
+  computeFilenameViolations = mod.computeFilenameViolations;
+});
+
+describe("parseMigrationVersion", () => {
+  it("extracts a 14-digit timestamp version and flags it valid", () => {
+    const r = parseMigrationVersion("supabase/migrations/20260603120000_a02_backfill.sql");
+    expect(r).toMatchObject({ version: "20260603120000", is14: true, hasDigits: true });
+  });
+
+  it("flags 8-digit date-only versions as not-14", () => {
+    expect(parseMigrationVersion("20260702_x.sql")).toMatchObject({ version: "20260702", is14: false });
+  });
+
+  it("flags 3-digit numbered versions as not-14", () => {
+    expect(parseMigrationVersion("001_initial.sql")).toMatchObject({ version: "001", is14: false });
+  });
+
+  it("handles a filename with no leading digits", () => {
+    expect(parseMigrationVersion("baseline_schema.sql")).toMatchObject({ version: "", hasDigits: false, is14: false });
+  });
+});
+
+describe("computeFilenameViolations", () => {
+  it("passes a unique 14-digit timestamp", () => {
+    const v = computeFilenameViolations(["20260607093000_versus_votes.sql"], new Set(["20260101000000"]));
+    expect(v).toEqual([]);
+  });
+
+  it("flags a non-14-digit (date-only) version as a format violation", () => {
+    const v = computeFilenameViolations(["20260702_loan_rates.sql"], new Set());
+    expect(v).toEqual([{ file: "20260702_loan_rates.sql", version: "20260702", kind: "format" }]);
+  });
+
+  it("flags a 3-digit numbered file as a format violation", () => {
+    const v = computeFilenameViolations(["011_thing.sql"], new Set());
+    expect(v[0]).toMatchObject({ kind: "format", version: "011" });
+  });
+
+  it("flags a collision with an existing tree version", () => {
+    const v = computeFilenameViolations(
+      ["20260603120000_dupe.sql"],
+      new Set(["20260603120000"]),
+    );
+    expect(v).toEqual([{ file: "20260603120000_dupe.sql", version: "20260603120000", kind: "collision-existing" }]);
+  });
+
+  it("flags two added files sharing the same version", () => {
+    const v = computeFilenameViolations(
+      ["20260607120000_a.sql", "20260607120000_b.sql"],
+      new Set(),
+    );
+    expect(v).toEqual([{ file: "20260607120000_b.sql", version: "20260607120000", kind: "collision-added" }]);
+  });
+
+  it("reports a missing version as format with a readable placeholder", () => {
+    const v = computeFilenameViolations(["baseline.sql"], new Set());
+    expect(v[0]).toMatchObject({ kind: "format", version: "(none)" });
+  });
+});

--- a/__tests__/scripts/check-migration-filenames.test.ts
+++ b/__tests__/scripts/check-migration-filenames.test.ts
@@ -81,4 +81,59 @@ describe("computeFilenameViolations", () => {
     const v = computeFilenameViolations(["baseline.sql"], new Set());
     expect(v[0]).toMatchObject({ kind: "format", version: "(none)" });
   });
+
+  it("flags a 15-digit (over-length) version as a format violation", () => {
+    const v = computeFilenameViolations(["202606031200000_x.sql"], new Set());
+    expect(v[0]).toMatchObject({ kind: "format", version: "202606031200000" });
+  });
+
+  it("flags a zero-padded 16-digit version as a format violation", () => {
+    const v = computeFilenameViolations(["0020260603120000_x.sql"], new Set());
+    expect(v[0]).toMatchObject({ kind: "format", version: "0020260603120000" });
+  });
+
+  it("among three added files, flags only the later of two colliding (A/C share, B distinct)", () => {
+    const v = computeFilenameViolations(
+      ["20260607120000_a.sql", "20260607130000_b.sql", "20260607120000_c.sql"],
+      new Set(),
+    );
+    expect(v).toEqual([
+      { file: "20260607120000_c.sql", version: "20260607120000", kind: "collision-added" },
+    ]);
+  });
+
+  it("when an added file collides with BOTH an existing and another added, existing wins (precedence)", () => {
+    const v = computeFilenameViolations(
+      ["20260607120000_a.sql", "20260607120000_b.sql"],
+      new Set(["20260607120000"]),
+    );
+    // Both added files collide with the existing version → both collision-existing;
+    // neither is downgraded to collision-added.
+    expect(v).toEqual([
+      { file: "20260607120000_a.sql", version: "20260607120000", kind: "collision-existing" },
+      { file: "20260607120000_b.sql", version: "20260607120000", kind: "collision-existing" },
+    ]);
+  });
+});
+
+describe("parseMigrationVersion — suffix & length edge cases", () => {
+  it("strips a split .up.sql / .down.sql suffix when extracting version + base", () => {
+    expect(parseMigrationVersion("supabase/migrations/20260101000000_x.up.sql")).toMatchObject({
+      version: "20260101000000",
+      base: "20260101000000_x",
+      is14: true,
+    });
+    expect(parseMigrationVersion("20260101000000_x.down.sql")).toMatchObject({
+      version: "20260101000000",
+      base: "20260101000000_x",
+    });
+  });
+
+  it("tolerates an uppercase .SQL extension", () => {
+    expect(parseMigrationVersion("20260101000000_x.SQL")).toMatchObject({ version: "20260101000000", is14: true });
+  });
+
+  it("treats a 15-digit leading run as not-14 (over-length)", () => {
+    expect(parseMigrationVersion("202606031200000_x.sql")).toMatchObject({ is14: false, hasDigits: true });
+  });
 });

--- a/__tests__/scripts/ledger-drift.test.ts
+++ b/__tests__/scripts/ledger-drift.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for scripts/audit/ledger-drift.mjs — the migration-ledger drift audit.
+ *
+ * Exercises the exported pure helpers. The main() runner reads files and is
+ * always exit-0 (audit, not gate); the diff logic is what's asserted here.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { join } from "node:path";
+
+const modPath = join(process.cwd(), "scripts/audit/ledger-drift.mjs");
+
+let versionOf: (filename: string) => string;
+let parseLedger: (doc: unknown) => Set<string>;
+let computeLedgerDrift: (
+  localVersions: string[],
+  ledgerVersions: Set<string>,
+) => {
+  localDistinct: number;
+  ledgerDistinct: number;
+  both: string[];
+  localOnly: string[];
+  ledgerOnly: string[];
+};
+let versionToFiles: (basenames: string[]) => Map<string, string[]>;
+
+beforeAll(async () => {
+  const mod = await import(modPath);
+  versionOf = mod.versionOf;
+  parseLedger = mod.parseLedger;
+  computeLedgerDrift = mod.computeLedgerDrift;
+  versionToFiles = mod.versionToFiles;
+});
+
+describe("versionOf", () => {
+  it("reads leading digits from a filename or path", () => {
+    expect(versionOf("supabase/migrations/20260603120000_x.sql")).toBe("20260603120000");
+    expect(versionOf("001_initial.sql")).toBe("001");
+    expect(versionOf("no_digits.sql")).toBe("");
+  });
+});
+
+describe("parseLedger", () => {
+  it("parses a raw json_agg array of {version,name}", () => {
+    const s = parseLedger([
+      { version: "20260101000000", name: "a" },
+      { version: "20260102000000", name: "b" },
+    ]);
+    expect(s.has("20260101000000")).toBe(true);
+    expect(s.size).toBe(2);
+  });
+
+  it("parses a wrapped { ledger: [...] } object", () => {
+    const s = parseLedger({ ledger: [{ version: "20260101000000", name: "a" }] });
+    expect([...s]).toEqual(["20260101000000"]);
+  });
+
+  it("parses a plain array of version strings", () => {
+    expect([...parseLedger(["20260101000000", "20260102000000"])]).toHaveLength(2);
+  });
+
+  it("returns empty for junk", () => {
+    expect(parseLedger(null).size).toBe(0);
+    expect(parseLedger({ nope: 1 }).size).toBe(0);
+  });
+});
+
+describe("computeLedgerDrift", () => {
+  it("splits versions into both / localOnly / ledgerOnly", () => {
+    const d = computeLedgerDrift(["a", "b", "c"], new Set(["b", "c", "d"]));
+    expect(d.both).toEqual(["b", "c"]);
+    expect(d.localOnly).toEqual(["a"]);
+    expect(d.ledgerOnly).toEqual(["d"]);
+    expect(d.localDistinct).toBe(3);
+    expect(d.ledgerDistinct).toBe(3);
+  });
+
+  it("reports full reconciliation when sets are equal", () => {
+    const d = computeLedgerDrift(["a", "b"], new Set(["a", "b"]));
+    expect(d.localOnly).toEqual([]);
+    expect(d.ledgerOnly).toEqual([]);
+  });
+});
+
+describe("versionToFiles", () => {
+  it("groups files by version so collisions are visible", () => {
+    const m = versionToFiles(["20260413_a.sql", "20260413_b.sql", "20260414120000_c.sql"]);
+    expect(m.get("20260413")).toEqual(["20260413_a.sql", "20260413_b.sql"]);
+    expect(m.get("20260414120000")).toEqual(["20260414120000_c.sql"]);
+  });
+});

--- a/__tests__/scripts/ledger-drift.test.ts
+++ b/__tests__/scripts/ledger-drift.test.ts
@@ -87,4 +87,46 @@ describe("versionToFiles", () => {
     expect(m.get("20260413")).toEqual(["20260413_a.sql", "20260413_b.sql"]);
     expect(m.get("20260414120000")).toEqual(["20260414120000_c.sql"]);
   });
+
+  it("buckets non-versioned files under '' so callers can exclude them from collisions", () => {
+    const m = versionToFiles(["baseline_schema.sql", "seed.sql", "20260101000000_a.sql"]);
+    expect(m.get("")).toEqual(["baseline_schema.sql", "seed.sql"]);
+    // Mirrors the predicate in main(): version "" is never a real collision.
+    const collisions = [...m.entries()].filter(([v, files]) => v && files.length > 1);
+    expect(collisions).toEqual([]);
+  });
+});
+
+describe("parseLedger — robustness", () => {
+  it("coerces a numeric version to string instead of silently dropping it", () => {
+    const s = parseLedger([{ version: 20260101000000, name: "a" }]);
+    expect(s.has("20260101000000")).toBe(true);
+    expect(s.size).toBe(1);
+  });
+
+  it("dedups repeated versions (Set semantics)", () => {
+    expect(parseLedger(["v1", "v1", "v2"]).size).toBe(2);
+  });
+});
+
+describe("computeLedgerDrift — edge cases", () => {
+  it("empty local + non-empty ledger → everything is ledgerOnly, not reconciled", () => {
+    const d = computeLedgerDrift([], new Set(["v1", "v2"]));
+    expect(d.localOnly).toEqual([]);
+    expect(d.both).toEqual([]);
+    expect(d.ledgerOnly).toEqual(["v1", "v2"]);
+  });
+
+  it("emits versions in lexicographic (string) order, not numeric", () => {
+    const versions = ["20260102000000", "001", "20260102"];
+    const d = computeLedgerDrift(versions, new Set(versions));
+    expect(d.both).toEqual(["001", "20260102", "20260102000000"]);
+  });
+});
+
+describe("versionOf — directory prefix", () => {
+  it("ignores any directory prefix, including archive/", () => {
+    expect(versionOf("archive/20260101000000_x.sql")).toBe("20260101000000");
+    expect(versionOf("supabase/migrations/archive/20260101000000_x.sql")).toBe("20260101000000");
+  });
 });

--- a/docs/audits/DB-STATE-2026-06-07.md
+++ b/docs/audits/DB-STATE-2026-06-07.md
@@ -116,7 +116,7 @@ become stale and get removed.
 | `audit:unapplied-migrations` | migration `CREATE TABLE`s present in types | audit tool (non-gating) |
 | `audit:rls-migrations` | new `CREATE TABLE` has RLS | green, blocking, PR-scoped |
 | **`audit:migration-filenames`** (new, this PR) | new migration uses a unique 14-digit version | green, blocking, PR-scoped |
-| **`audit:ledger-drift`** (new, this PR) | local tree vs prod ledger divergence | audit tool (non-gating) |
+| **`audit:ledger-drift`** (new, this PR) | local tree vs prod ledger divergence | on-demand audit — needs a prod ledger dump, **not CI-wired** (run during reconciliation) |
 | `supabase-migrate.yml` | applies migrations on push to main | **silent no-op (secrets unset)** → #1463 makes it fail loudly |
 
 ## Compliance fences (never-autonomous — Tier E)

--- a/docs/audits/DB-STATE-2026-06-07.md
+++ b/docs/audits/DB-STATE-2026-06-07.md
@@ -1,0 +1,129 @@
+# Database state — consolidated source of truth (2026-06-07)
+
+This supersedes the *diagnosis* portions of `drift-list.md` (2026-04-30),
+`SCHEMA-DRIFT-2026-06-05.md`, and `docs/runbooks/MIGRATION_DEPLOY_BACKLOG.md`
+(2026-05-26). It is the single, current picture of the database situation,
+measured directly against the live project (`guggzyqceattncjwvgyc`,
+eu-west-1) on 2026-06-07. The *fix* lives in
+`docs/runbooks/MIGRATION_LEDGER_RECONCILIATION.md`.
+
+> **Headline:** the database is **not** "118 migrations behind main." The local
+> migration tree and the production migration **ledger have forked almost
+> completely** (5 of 250 local versions are tracked in prod). `supabase db push`
+> is therefore **unsafe** — it would attempt ~245 migrations whose schema mostly
+> already exists in prod under different version keys, including ~35
+> non-idempotent data backfills and a CSF/Tier-E migration. The schema *content*,
+> by contrast, is ~98% converged and RLS is comprehensive — so this is a
+> **history-reconciliation + pipeline-repair** job, not a schema rebuild.
+
+## How we got here (root cause)
+
+`supabase-migrate.yml` is meant to `supabase db push` on every push to `main`.
+But `SUPABASE_PROJECT_REF` and `SUPABASE_DB_PASSWORD` were never set (only
+`SUPABASE_ACCESS_TOKEN`), so its secret-precheck set `skip=true` and the job
+**reported green while applying nothing — for months** (confirmed in PR #1463).
+Every migration that *is* in prod got there via out-of-band `apply_migration`
+(Supabase MCP) / direct SQL, each with a freshly generated timestamp version.
+Result: prod's ledger and the committed files describe the same schema but share
+almost no version keys, and the CLI can no longer reconcile them.
+
+## The numbers (measured 2026-06-07)
+
+### Migration ledger (history) — the core break
+| Metric | Value |
+|---|---|
+| Prod `schema_migrations` rows | **439** (0 duplicate versions) |
+| Local migration files | **404** |
+| Distinct local CLI-parsed versions | **250** |
+| Local versions **also in prod ledger** | **5** |
+| Local versions **not in prod** (a `db push` would attempt) | **245** |
+| Prod versions **not in any local file** (applied out-of-band) | **434** |
+
+Local filename version formats are inconsistent and unsafe for the CLI:
+**151** files use a 14-digit timestamp, **243** use an 8-digit date-only prefix,
+**10** use a 3-digit number — and **50 distinct date-only prefixes map to more
+than one file**, i.e. hard version collisions. (Reproduce: `npm run
+audit:ledger-drift` and `node scripts/check-migration-filenames.mjs --all`.)
+
+### Schema content (the good news)
+| Metric | Value |
+|---|---|
+| Prod public tables | **415** |
+| Prod public views | **11** |
+| Tables with RLS enabled | **414 / 415** (only `spatial_ref_sys` — PostGIS, benign) |
+| Tables with zero policies | **1** (`spatial_ref_sys`) |
+| Local-defined tables that exist live in prod | **397 / ~412** |
+
+So the migration tree and prod agree on ~98% of tables, and the security
+posture (RLS) is already comprehensive. Stream A / issue #214 (the
+types-vs-migrations gate) is effectively done: the static
+`audit:drift-types` gate is **green** with only 17 allowlisted entries.
+
+### `lib/database.types.ts` is stale
+Committed types declare **352** tables; prod has **415** → the file lags by ~63
+tables. The live-diff CI job (`supabase-types-drift`) is **warning-only** and
+**skips without secrets**, so it never blocks — which is why the lag persisted
+and why feature work (PR #1459, Fin's in-app charts) keeps deferring "until the
+types-drift check is green."
+
+## What is actually missing or wrong (the real, small backlog)
+
+### A. Tables referenced in code but absent in prod → live 500s
+The `versus_votes` class. As of 2026-06-05 the `.from()` probe found **31**;
+several were hand-applied 06-06 (`weights`, `ipo_offers`, `booking_payments`).
+The phantom-relation sentinel (`audit:schema-refs` + `.schemarefallowlist`)
+tracks the current set. Still-missing, by category:
+
+| Category | Relations | Disposition |
+|---|---|---|
+| **Startup portal (CSF)** | `startup_profiles`, `startup_rounds`, `startup_sessions`, `startup_data_room_files`, `startup_data_room_access`, `startup_investor_inquiries`, `esic_verifications` | **HOLD — Tier E + legal.** Equity-crowdfunding/s708 territory on `REGULATORY-AVOID-LIST.md`. Do **not** apply without founder + legal sign-off. |
+| **Wholesale cert (s708)** | `wholesale_investor_certifications` | **HOLD — legal.** Tied to the #1459 D4 "wholesale-only" decision (needs sign-off). |
+| **Live bug** | `versus_votes` (code; prod has `debate_votes`/`versus_editorials`) | Apply the existing `*_create_versus_votes.sql` via the pipeline, or repoint code. Every `/versus/*` vote widget 500s today. |
+| **Minor features** | `api_consumer_webhooks`, `consumer_webhook_deliveries`, `api_key_subscriptions`, `ipo_watchlist`, `ipo_alert_sends`, `investment_loan_rates` | Apply via the pipeline (post-reconciliation), or gate the crons. |
+| **Naming mismatches** | `user_profiles`→`profiles`, `course_enrollments`, `referrals`, `pro_subscribers`, `professional_views`, `broker_campaigns`, … | Fix the reference (rename in code), not the schema. |
+
+### B. Column / type & data drift (not visible to table-level gates)
+- `professionals.specialties` is `jsonb` **live** vs `text[]` in migrations —
+  caused the #1458 → React #419 advisor outage.
+- Listing `vertical` values drift (`"funds"` vs `"fund"`; PR #1461/#1462).
+
+### C. Zombie tables in prod (retirement candidates — verify before dropping)
+Exist in prod with no local `CREATE TABLE`, zero current code `.from()` refs in
+the 04-30 audit. **Verify row count + zero references, then drop via a tracked
+migration** (do not assume):
+`trading_signals`, `trading_positions`, `trading_performance_daily`,
+`sentiment_signals`, `article_moderation_log` (superseded by
+`advisor_article_moderation_log`), `investor_journey_touchpoints` (superseded by
+`attribution_touches`), `foreign_investment_flags` (renamed to
+`foreign_investment_dta`), `data_license_subscribers`.
+Plus investigate `migration_plan` (a prod table with no migration file — likely
+an out-of-band tracking artifact).
+
+### D. Allowlisted real tables still needing a backfill migration
+In prod + `.driftallowlist` but no `CREATE TABLE` in the tree:
+`portfolio_alerts`, `portfolio_calculations`, `portfolio_fee_snapshots`,
+`portfolio_holdings`, `user_portfolios`, `marketplace_placements`,
+`switch_stories`, `course_purchases`. The baseline-squash captures these
+automatically (the baseline is dumped from live prod); the allowlist lines then
+become stale and get removed.
+
+## Current CI / guardrail status
+| Mechanism | What it checks | Status |
+|---|---|---|
+| `audit:drift-types` (`database-types-drift-gate`) | types tables ⊆ migration `CREATE TABLE`s | **green, blocking** |
+| `supabase-types-drift` | live schema vs committed types (regen diff) | **warning-only, skips w/o secrets** |
+| `audit:schema-refs` | `.from()`/`.rpc()` literals exist in live schema | exists, creds-gated, allowlist seeded |
+| `audit:unapplied-migrations` | migration `CREATE TABLE`s present in types | audit tool (non-gating) |
+| `audit:rls-migrations` | new `CREATE TABLE` has RLS | green, blocking, PR-scoped |
+| **`audit:migration-filenames`** (new, this PR) | new migration uses a unique 14-digit version | green, blocking, PR-scoped |
+| **`audit:ledger-drift`** (new, this PR) | local tree vs prod ledger divergence | audit tool (non-gating) |
+| `supabase-migrate.yml` | applies migrations on push to main | **silent no-op (secrets unset)** → #1463 makes it fail loudly |
+
+## Compliance fences (never-autonomous — Tier E)
+- **Startup portal / CSF** (`startup_*`, `esic_verifications`) and **wholesale
+  cert / s708** (`wholesale_investor_certifications`): founder **+ legal**
+  sign-off required before they are applied or un-gated
+  (`REGULATORY-AVOID-LIST.md`). The reconciliation explicitly excludes them.
+- **Enabling auto-apply** (adding `SUPABASE_PROJECT_REF` + `SUPABASE_DB_PASSWORD`)
+  must wait until **after** the baseline-squash — otherwise `db push --include-all`
+  replays the 245-file backlog including the CSF migration and ~35 backfills.

--- a/docs/audits/STATUS-REPORT-2026-06-08.md
+++ b/docs/audits/STATUS-REPORT-2026-06-08.md
@@ -1,0 +1,201 @@
+# Platform Status Report — 2026-06-08
+
+> Verified status snapshot produced by cross-referencing the in-repo trackers
+> against **live GitHub PR state** (open + merged) and the live Supabase schema.
+> Supersedes ad-hoc status claims in the per-stream docs where they conflict —
+> see §2 (the trackers lag reality by ~2 weeks).
+>
+> Method: `gh`/MCP PR inventory (16 open, 36 merged since 2026-06-06) +
+> `git` branch analysis + the migration-ledger investigation in
+> `docs/audits/DB-STATE-2026-06-07.md`. Every PR number below was confirmed
+> against the live API on 2026-06-08, not copied from a tracker.
+
+## 1. Executive summary
+
+- **Platform is ~75–80% launch-ready.** All known P0/P1 bugs from the 2026-06-02
+  QA campaign are fixed. Remaining launch gaps are founder-gated (pen test,
+  SOC 2 vendor, legal sign-off) — see §6.
+- **The #1 infrastructure blocker is database migration-ledger drift.** The
+  recent `/invest` listings firefight (~13 PRs, #1457→#1470) was almost entirely
+  *symptoms* of this drift ("re-apply missing column", "match drifted verticals").
+  The root-cause fix is staged in PR #1466 (this branch); the irreversible
+  baseline-squash itself is founder-gated (Tier E).
+- **The in-repo status trackers are materially stale** (§2). They cite PRs that
+  merged or closed 2+ weeks ago (#948–#959, #1132–#1141). This report is the
+  reconciled ground truth.
+- **9 financial-correctness PRs (#1369–#1381) plus a bots/UX PR (#1451) are
+  ready and idle** awaiting a merge decision; deep review in §4.
+
+## 2. Key finding — the trackers lag reality
+
+| Tracker | Claims | Reality (verified 2026-06-08) |
+|---|---|---|
+| `DIRECTORY_UX_UNIFICATION.md` | Phases 2–6 blocked behind PRs #955–#957 | Those PRs are gone; the directory work shipped as **#1452–#1455** (merged 06-06). A new 23-item UX backlog is open in **#1451**. |
+| `BUILD-EVERYTHING-QUEUE.md` | 29 bootstrap PRs #1132–#1141 in-flight | All long-merged/closed; **loop never wired to a cron** — staged, never run. |
+| `REMEDIATION_QUEUE.md` | iter 590, "ALL-BLOCKED" (05-29) | Loop kept producing merges through 06-07; queue entry not refreshed. |
+| `pre-launch-wave-status.md` | idle since 05-25 | Accurate — wave is complete (27/28), W2.15 CDR blocked. |
+
+**Action taken in this pass:** added this report as the reconciled source of
+truth and corrected the migration docs (`MIGRATION_LEDGER_RECONCILIATION.md`,
+`DB-STATE`, the superseded `MIGRATION_DEPLOY_BACKLOG.md`). The machine-managed
+loop tracker (`REMEDIATION_QUEUE.md`, written by the cloud audit-remediation
+routines every ~7 min) is intentionally **left to its owning loop** to avoid a
+write race — its staleness is noted here instead.
+
+## 3. Recent activity — 36 PRs merged 2026-06-06 → 2026-06-07
+
+| Cluster | PRs | Note |
+|---|---|---|
+| `/invest` listings firefight | #1457, #1458, #1460, #1461, #1462, #1464, #1465, #1467, #1468, #1469, #1470 (+ CI guard #1463) | **Drift symptoms** — see §5 |
+| Directory UX surface-consistency | #1452, #1453, #1454, #1455 | Shared `DirectoryHero`, /compare + /advisors adoption |
+| Bots / QA fleet, GEO, a11y, security | #1440–#1450 | Monitors, Speakable schema, anon-read leak fixes, contrast |
+| DB/CI hardening | #1463 (fail-loud migrate secrets), #1458/#1460 (re-apply FI flag) | Drift-driven |
+
+**Insight (the through-line):** #1458/#1460 ("re-apply missing professionals
+FI-flag column"), #1462/#1469 ("match drifted verticals"), and #1463 ("fail
+loudly when migrate secrets unset") are all the same root cause: the local
+migration tree has diverged from the live DB, so features silently break and get
+hand-patched. **PR #1466 fixes the root cause** (baseline-squash + drift gates),
+which is why it is the highest-leverage item on the board.
+
+## 4. Open PR inventory — 16 (7 draft, 9 ready)
+
+Every PR below was deep-reviewed (CI status, mergeability, correctness, tier).
+**Authorship note:** the financial/UX/listings PRs are on the `Funs7575`
+(founder) account; per `MERGE_AUTHORIZATION.md` founder-authored PRs are out of
+autonomous scope, and all of them additionally carry explicit founder/legal
+preconditions — so **none were merged autonomously**. The Vercel "Account is
+blocked" red on these PRs is a billing block, not a CI failure; the signal that
+matters is the `Lint · Type-check · Test · Build` job.
+
+### 4.1 Financial-integrity PRs (Tier C→D — all HELD)
+
+All correct-by-review unless noted. Each requires founder/legal sign-off; two
+also have failing CI to fix first.
+
+| PR | What | CI | Disposition |
+|---|---|---|---|
+| #1369 | Claw back granted credit on cash refund | 🟢 green | **HOLD** — founder must ratify the *allow-negative-balance* clawback policy; then mergeable |
+| #1371 | Gate referral-accept on tier + balance | 🟢 green | **HOLD** (client-money) — flag: adds `success_bonus_award` to floored kinds = success-tier revenue-behaviour change |
+| #1374 | Grant 3 free leads (honour configured 0) | 🟢 green | **NEAR-READY** — only needs founder to confirm the 2→3 free-lead pricing decision; then Tier-C announce-and-merge. Fixes a real falsy-zero bug. |
+| #1378 | Deterministic `reference_id` for downgrade proration | 🟢 green | **HOLD (Tier D)** — `needs-founder-decision` label + reconcile already-double-credited advisors. Residual: same-day re-downgrade under-credits (key omits target tier). |
+| #1379 | Clamp proration `daysRemaining` to `[0, cycleDays]` | 🟢 green | **HOLD** — lowest-risk (pure fn, kills an active ~12× over-credit on annual subs); best first founder approval. Annual proration still under-credits (deferred). |
+| #1377 | Atomic balance mutation (RPC) + negative guard | 🔴 **fail (7 tests)** + conflicts | **NEEDS-WORK + HOLD** — core opt-lock already on main (redundant); add `.rpc` to shared test mock, fix 7 failing tests, re-justify dispute-resolver `refund→escalate`, rebase |
+| #1380 | Marketplace webhook idempotency + fail-closed secret | 🟢 green | **HOLD** — confirm `STRIPE_MARKETPLACE_WEBHOOK_SECRET` is provisioned in live env *before* merge (else webhook 500s) |
+| #1381 | Gate auto-recharge "succeeded" notification on PI status | 🔴 **fail (2 tsc)** | **NEEDS-WORK + HOLD** — fix 2 `tsc` errors in `__tests__/lib/briefs/auto-recharge.test.ts` (annotate `eligibleProRow(): ProRow` / cast `null`). Latent: no webhook grants credit for raw PI — notification still optimistic |
+
+### 4.2 Stale drafts → CLOSE (founder authorization requested, §AskUser)
+
+History was **re-rooted/force-pushed**; #1272/#1273/#1159 share an orphaned root
+(`git merge-tree` → "refusing to merge unrelated histories") — **unrebaseable**.
+
+| PR | What | Why close |
+|---|---|---|
+| #1439 | Auto-revert of #1432 (weights table) | Original healthy on main; merging would re-break wealth-stack POST (500). Bot-authored noise; red is Vercel billing. |
+| #1446 | Auto-revert of #1444 (bots lifecycle) | Workflow live & healthy on main; pure QA tooling; same false red. |
+| #1272 | Wave 1–4 audit (183 files) | Unrelated history (unmergeable); largely superseded. Re-derive any unique items fresh. |
+| #1273 | Fresh audit Opus 4.8 (196 files) | Unrelated history; partly landed. **Salvage candidates → fresh PRs:** `RATE_LIMIT_HARD_FAIL` fail-closed toggle (`lib/rate-limit.ts`), delete dead `lib/json-ld.ts` SSOT-trap, preserve the audit doc. |
+| #1159 | `iv_active_kind` cookie via Route Handler | Already fixed differently on main (`bestEffortSetActiveKind()` in `lib/portal-gate.ts`). |
+
+### 4.3 UX / bots / listings
+
+| PR | Disposition |
+|---|---|
+| #1451 (ready) | **Fix 1 line → Tier-A merge.** `__tests__/bots/coverage-flows.test.ts:18` asserts `toBe(10)` after flow count rose to 18. Ships 8 bot flows + `docs/strategy/UX_BACKLOG.md` (22 outstanding advisor UX items — see §4.4). Refresh backlog: drop ADV-004 (pagination already shipped), re-verify ADV-002. |
+| #1459 (draft, dirty) | **Carve out the safe non-migration parts** (4 strategy docs + 3 Phase-0 404/redirect/copy fixes + the increment-1 **anonymous-submission auth gate** + 2 tests) into a rebased PR — Tier-A docs + Tier-C auth gate, CI-green, no DB. **Leave the `20260907040000_…ownership.sql` migration + increment-2 blocked behind the Tier-E baseline-squash.** Do NOT `db push`/`apply_migration`. D4/s708 gate stays unbuilt pending legal (`LISTINGS_S708_LEGAL_BRIEF.md`). |
+| #1466 (this branch) | The ledger root-cause fix. Hardened + rebased this pass — see §7. |
+
+### 4.4 Outstanding advisor-UX backlog (deduplicated, verified vs main)
+
+22 items in `docs/strategy/UX_BACKLOG.md` (P1→P3). **Confirmed already done (drop):**
+ADV-004 (directory pagination — `AdvisorsClient.tsx` has full paging), plus
+DIRECTORY QW2/QW3/QW5/QW6 + SC-1..7. **Verify-first:** ADV-002 (booking CTA exists
+in the client component already). **Genuinely outstanding quick wins** (≤½ day):
+ADV-003 (silent portal errors → banner), ADV-008 (quiz progress save), ADV-012
+(community notify CTA), ADV-014 (article share), ADV-015 (OTP countdown), ADV-016
+(mobile "Filters (3)" label), ADV-017 (for-advisors FAQ), ADV-018/019 (freshness
+stamps), ADV-022 (joined-this-week). **Larger (P1):** ADV-001 (portal onboarding
+wizard), ADV-005 (for-advisors testimonials), ADV-006 (mobile tab overflow),
+ADV-007 (quiz match-explanation), ADV-011 (reviews load-more — `advisor/[slug]/page.tsx:109` `.limit(20)`).
+
+## 5. The migration-ledger drift (root cause) — status
+
+- **Diagnosis of record:** `docs/audits/DB-STATE-2026-06-07.md` (415 live tables
+  vs 352 in committed types pre-fix; 404 legacy migration files; only ~5 tracked
+  in the prod ledger).
+- **Plan of record:** `docs/runbooks/MIGRATION_LEDGER_RECONCILIATION.md` (Path A
+  baseline-squash).
+- **Shipped in PR #1466 (this branch):**
+  - `scripts/check-migration-filenames.mjs` — CI gate, unique 14-digit versions
+  - `scripts/audit/ledger-drift.mjs` — local-vs-ledger drift audit
+  - `scripts/db/baseline-squash.sh` — guarded helper (stops before irreversible step)
+  - Regenerated `lib/database.types.ts` (352→415 tables; type-check clean)
+  - CI wiring, tests, CONTRIBUTING discipline, FIN_NOTEBOOK decision record
+- **Founder-gated (Tier E, never autonomous):** the baseline-squash execution +
+  `migration repair` + enabling auto-apply. Teed up; *revisit 2026-06-21*.
+- **Code-quality hardening of the above:** see §7.
+
+## 6. Consolidated founder-gated blockers
+
+1. **DB ledger baseline-squash** (Tier E) — unblocks #1459 + all table-adding
+   features. *Revisit 2026-06-21.*
+2. **CDR accreditation** — blocks pre-launch W2.15 + remediation BB-04. Fin's lane.
+3. **Launch-readiness:** pen test, vuln scan, SOC 2 vendor (Vanta/Drata), legal
+   sign-off on launch copy + Privacy Policy + ToS, soak/load test.
+4. **New-features decisions (4):** BriefChatPanel expose/delete, `AFSL_LOOKUP_URL`
+   env, SMS consent record, content seed vs noindex.
+5. **20h-sprint founder briefs (3):** SocialProofCounter (ACL s18 misleading
+   conduct), `/admin` security headers (CSP regression caution), refund
+   under-credit (may be addressed by #1369 — see §4).
+
+## 7. Code quality — #1466 hardening (done this pass)
+
+An adversarial code-review of the reconciliation tooling found 2 critical, 5
+major, and several minor issues plus prod-safety doc gaps. **All were fixed on
+this branch** (commit `harden(db): …`), verified by type-check + lint + tests:
+
+| Sev | Issue | Fix |
+|---|---|---|
+| CRIT | CSF/s708 globs matched only today's 3 filenames → future capital-raising migrations silently archived | Broadened to token-level (`*startup*`, `*s708*`, `*esic*`, `*crowdfund*`, `*csf*`, `*wholesale*`, `*sophisticated*`) |
+| CRIT | `ledger-drift` printed "✅ reconciled" off an empty/failed dump (the job's exit gate) | Empty dump → refuse to certify; `ledgerEmpty` added to `--json` |
+| MAJ | Filename gate relied on accidental glob×pathspec; archive filter was undocumented-load-bearing | Directory pathspec + explicit load-bearing dirname filter; comment corrected |
+| MAJ | Rename-to-bad-name escaped the gate when `diff.renames=true` | Force `-c diff.renames=false` |
+| MAJ | `baseline-squash.sh` could half-archive on an untracked `.sql` | Fail on untracked; move tracked-only via `git ls-files`; recovery hint |
+| MAJ | Gate false-passed locally with no `origin` remote | Resolve `origin/<ref>`→`<ref>` with a loud skip |
+| MIN | `--ledger` ate the next flag; numeric versions dropped; non-versioned files faux-collided; dup parser logic | Validate flag; coerce to string; filter `""`; extract shared `scripts/lib/migration-version.mjs` |
+| DOC | Runbook `${TS}` didn't survive between steps (prod ledger write); risky ledger collapse shown first | Re-derive `TS` from baseline filename; safe path is now default, collapse demoted to enumerated optional; partial-archive rollback documented |
+
+**Tests:** 18 → **37** (added pure-function edge cases + a real integration test
+that spawns the gate against a temp git repo: archive filtering, config-proof
+rename detection, base-ref fallback, exit codes). Branch rebased onto current
+`main` (merge, no force-push); drift gate, filename gate, type-check, lint all green.
+
+## 8. Recommended action plan (sequenced)
+
+**Done this pass (autonomous, in-scope):** hardened the #1466 tooling to
+production quality (§7); produced this verified report; rebased #1466 onto
+`main` (merge, no force-push); kept CI green. **No open PR was merged or closed**
+— every open financial/UX/listings PR is on the founder account and/or carries
+an explicit founder/legal precondition (§4), and closing PRs is the founder's
+call; they are teed up below.
+
+**Founder decisions queued (low-effort, high-leverage first):**
+1. **Authorize the 5 stale-draft closes** (#1439, #1446, #1272, #1273, #1159 —
+   §4.2). All verified safe to close; #1273 has 2 salvage items worth a fresh PR.
+2. **#1451** — approve the 1-line test fix + Tier-A merge (ships the bot suite +
+   UX backlog). **#1459** — approve the non-migration carve-out.
+3. **Financial PRs** (§4.1) — ratify in this order: #1379 (lowest-risk),
+   #1374 (confirm 3-free-leads), then #1369/#1371/#1378/#1380; fix CI on
+   #1377/#1381 first.
+4. **Schedule the Tier-E baseline-squash** (§5) — the #1 unblocker.
+5. **Decide** the 4 new-features items + 3 sprint briefs (§6).
+
+**Founder, pre-launch:** pen test, SOC 2 vendor (Vanta/Drata), legal sign-off on
+launch copy + Privacy Policy + ToS, soak/load test.
+
+## Appendix A — full merged-since-06-06 list
+
+#1428, #1430, #1431, #1432, #1433, #1434, #1435, #1436, #1437, #1440, #1441,
+#1442, #1443, #1444, #1445, #1446(rev), #1447, #1448, #1449, #1450, #1451,
+#1452, #1453, #1454, #1455, #1456, #1457, #1458, #1460, #1461, #1462, #1463,
+#1464, #1465, #1467, #1468, #1469, #1470.

--- a/docs/runbooks/MIGRATION_DEPLOY_BACKLOG.md
+++ b/docs/runbooks/MIGRATION_DEPLOY_BACKLOG.md
@@ -1,6 +1,28 @@
 # Runbook: Deploy the migration backlog + clear "Supabase types drift"
 
-**Status:** prep only — no changes have been applied to the production database by this runbook.
+> ## 🛑 SUPERSEDED — DO NOT FOLLOW (2026-06-07)
+>
+> This runbook's core action — `supabase db push` to apply "118 pending
+> migrations" — is **dangerous and based on a model that is no longer true**.
+> Measured 2026-06-07: only **5 of 250** local migration versions are tracked in
+> the prod ledger, so `db push` would attempt **~245** migrations — re-creating
+> existing tables and **re-running ~35 non-idempotent data backfills**, plus the
+> CSF/Tier-E startup-portal migration. The schema content is already ~98% in
+> prod; the real problem is a **forked migration ledger** caused by the
+> `supabase-migrate.yml` workflow silently no-op'ing for months (its secrets were
+> unset — see PR #1463).
+>
+> **Use instead:**
+> - **State:** `docs/audits/DB-STATE-2026-06-07.md`
+> - **Fix:** `docs/runbooks/MIGRATION_LEDGER_RECONCILIATION.md` (baseline-squash)
+>
+> The historical content below is retained for the per-migration notes and the
+> compliance-hold record only.
+
+---
+
+**Status:** ⚠️ SUPERSEDED — historical reference only. The original "prep only"
+status and the `db push` procedure below must not be executed.
 **Prepared:** 2026-05-26. **Project ref:** `guggzyqceattncjwvgyc` (invest-com-au, eu-west-1).
 
 ## Why this exists

--- a/docs/runbooks/MIGRATION_LEDGER_RECONCILIATION.md
+++ b/docs/runbooks/MIGRATION_LEDGER_RECONCILIATION.md
@@ -87,22 +87,40 @@ cp /tmp/prod_public.sql "supabase/migrations/${TS}_baseline_schema.sql"
 Mark every currently-applied prod version as applied for the new file set, then
 make the baseline the floor. With the CLI:
 ```bash
+# Re-derive TS from the baseline filename — Step 2's shell variable does NOT
+# survive into a new session, and an empty "${TS}" here would mis-target the
+# prod ledger write below:
+TS=$(ls supabase/migrations/*_baseline_schema.sql | sed -E 's#.*/([0-9]{14})_.*#\1#')
+test -n "$TS" || { echo "could not derive baseline TS — abort"; exit 1; }
+
 # Pull the remote ledger and reconcile. `migration repair` writes
 # supabase_migrations.schema_migrations WITHOUT running SQL.
 supabase migration list --linked            # inspect remote vs local
 supabase migration repair --status applied "${TS}"   # baseline = applied
-# Then mark the archived legacy versions as reverted/untracked so the CLI does
-# not consider them pending (they are superseded by the baseline):
-#   supabase migration repair --status reverted <legacy_version> ...
 ```
-**Goal state:** `supabase migration list` shows the baseline as the single
-applied floor and **no pending migrations**. Re-run the pre-flight diff — both
-`local-only` and `ledger-only` should collapse to ~0.
+**Default (recommended): stop here.** Keep the existing prod ledger rows as they
+are — the baseline is idempotent `CREATE … IF NOT EXISTS`, and the only invariant
+that matters is that **`supabase db push --dry-run` reports nothing pending**.
+Verify that, then continue to step 4.
 
-> If you prefer to keep the full prod ledger rows intact and only add the
-> baseline, that also works (the baseline is idempotent `CREATE … IF NOT
-> EXISTS`); the essential invariant is **`supabase db push` reports nothing
-> pending** afterwards.
+<details><summary>Optional (advanced, riskier): collapse to a single-floor ledger</summary>
+
+Only do this if you specifically want `migration list` to show exactly one
+applied floor. With 400+ prod-only rows, **do not hand-wave it** — enumerate the
+superseded versions explicitly and review the list before writing:
+```bash
+# every prod ledger version except the baseline, one per line:
+supabase migration list --linked | awk 'NR>2 {print $1}' | grep -v "^${TS}$"
+# review that output, then for EACH version you intend to retire:
+#   supabase migration repair --status reverted <version>
+```
+This only rewrites `schema_migrations` rows (no table SQL runs); the step-0
+snapshot is your restore point if the ledger ends up wrong.
+</details>
+
+**Goal state:** `supabase migration list` shows the baseline applied and **no
+pending migrations**. Re-run the pre-flight diff — both `local-only` and
+`ledger-only` should collapse to ~0 (and `ledger_empty` must be false).
 
 ### 4. Regenerate types from prod (clears the standing warning)
 ```bash
@@ -161,3 +179,7 @@ supabase branches delete reconcile-verify
   from the step-0 snapshot if needed. No table data is touched by repair.
 - Step 6 (drops) is the only data-destructive step — the step-0 snapshot is the
   floor; do drops in a separate, clearly-labelled PR after the rest is verified.
+- If `scripts/db/baseline-squash.sh` aborts mid-archive, the `git mv`s are
+  **staged but not committed** (and the script now refuses to start with an
+  untracked `.sql` present, which is the usual cause). Inspect with `git status`;
+  `git reset --hard` undoes the partial move cleanly.

--- a/docs/runbooks/MIGRATION_LEDGER_RECONCILIATION.md
+++ b/docs/runbooks/MIGRATION_LEDGER_RECONCILIATION.md
@@ -1,0 +1,158 @@
+# Runbook: reconcile the migration ledger (baseline-squash)
+
+**Status:** procedure — destructive prod steps are gated and marked
+🛑 (founder-supervised) / ⚖️ (founder + legal). Nothing here runs in CI.
+**Project ref:** `guggzyqceattncjwvgyc` (invest-com-au, eu-west-1).
+**Authoritative state:** `docs/audits/DB-STATE-2026-06-07.md`.
+
+## Why this replaces `MIGRATION_DEPLOY_BACKLOG.md`
+
+That runbook says "prod is 118 migrations behind; run `supabase db push`." That
+model is wrong and the action is **destructive**. The local tree and the prod
+ledger have forked: only **5 of 250** local versions are tracked in prod, so
+`supabase db push` would attempt **~245** migrations — re-creating tables that
+already exist and **re-running ~35 non-idempotent data backfills**, plus the
+CSF/Tier-E startup-portal migration. Do not run `db push` against this project
+until the steps below are complete.
+
+The schema *content* is ~98% already in prod and RLS is comprehensive (414/415).
+So we do **not** rebuild the schema — we **re-baseline the history** so the tree,
+the ledger, and the types describe the same thing, then resume a normal pipeline.
+
+## Strategy: Path A — baseline-squash (chosen)
+
+Treat **live prod as the source of truth** (it is what serves traffic). Collapse
+the 404 legacy files into one baseline migration equal to the current prod
+schema, mark that baseline as already-applied in the prod ledger, archive the
+legacy files, and go forward normally from there.
+
+Rejected — **Path B (incremental `migration repair` of all 404 files)**: with 50
+colliding date-only versions, 3 incompatible version formats, and 434 prod-only
+ledger rows, per-file repair is thousands of ambiguous operations and does not
+fix the structural naming mess. Not viable at this divergence.
+
+## Pre-flight (read-only — safe to run now)
+
+```bash
+# Local divergence snapshot (no DB needed):
+npm run audit:ledger-drift                 # tree stats + collisions
+node scripts/check-migration-filenames.mjs --all
+
+# Dump the prod ledger (service-role; Supabase MCP execute_sql or psql):
+#   SELECT json_agg(json_build_object('version',version,'name',name) ORDER BY version)
+#   FROM supabase_migrations.schema_migrations;
+# Save as ledger.json, then diff the tree against the real ledger:
+SUPABASE_MIGRATIONS_JSON=ledger.json npm run audit:ledger-drift
+# Expect (today): local-only ~245, ledger-only ~434. After this runbook: ~0 / ~0.
+```
+
+## Procedure
+
+### 0. 🛑 Snapshot prod — non-negotiable
+Supabase Dashboard → Database → Backups → take a fresh snapshot (or
+`pg_dump`/PITR confirmed). 35 ledger entries are data backfills; this is the
+rollback floor for everything below.
+
+### 1. Freeze the apply paths
+- Confirm **`SUPABASE_PROJECT_REF` / `SUPABASE_DB_PASSWORD` remain unset** in
+  GitHub Actions secrets, so `supabase-migrate.yml` cannot fire. (Land PR #1463
+  first so a no-op can't masquerade as success.)
+- Pause ad-hoc `apply_migration` (Supabase MCP) except the steps in this runbook.
+
+### 2. Capture the true prod schema as the baseline
+```bash
+supabase link --project-ref guggzyqceattncjwvgyc
+# Schema only (no data), public schema, as the baseline body:
+supabase db dump --linked --schema public -f /tmp/prod_public.sql
+# (Repeat for any non-public app schemas you own, if applicable.)
+```
+Create the baseline migration with a single fresh 14-digit timestamp:
+```bash
+TS=$(date -u +%Y%m%d%H%M%S)
+mkdir -p supabase/migrations/archive
+git mv supabase/migrations/*.sql supabase/migrations/archive/   # preserve history, out of the active set
+# Assemble the baseline from the dump (review it — strip owner/grant noise,
+# ensure RLS + policies are included, idempotent CREATEs):
+cp /tmp/prod_public.sql "supabase/migrations/${TS}_baseline_schema.sql"
+```
+> The archive dir is intentionally **not** scanned by the migration gates, so
+> the legacy files stop counting the moment they move there.
+
+### 3. 🛑 Reconcile the ledger to the baseline (prod)
+Mark every currently-applied prod version as applied for the new file set, then
+make the baseline the floor. With the CLI:
+```bash
+# Pull the remote ledger and reconcile. `migration repair` writes
+# supabase_migrations.schema_migrations WITHOUT running SQL.
+supabase migration list --linked            # inspect remote vs local
+supabase migration repair --status applied "${TS}"   # baseline = applied
+# Then mark the archived legacy versions as reverted/untracked so the CLI does
+# not consider them pending (they are superseded by the baseline):
+#   supabase migration repair --status reverted <legacy_version> ...
+```
+**Goal state:** `supabase migration list` shows the baseline as the single
+applied floor and **no pending migrations**. Re-run the pre-flight diff — both
+`local-only` and `ledger-only` should collapse to ~0.
+
+> If you prefer to keep the full prod ledger rows intact and only add the
+> baseline, that also works (the baseline is idempotent `CREATE … IF NOT
+> EXISTS`); the essential invariant is **`supabase db push` reports nothing
+> pending** afterwards.
+
+### 4. Regenerate types from prod (clears the standing warning)
+```bash
+npm run db:types        # supabase gen types typescript --project-id … > lib/database.types.ts
+git add lib/database.types.ts
+```
+Use the repo's canonical script (not MCP) so the output is byte-consistent with
+what the next `db:types` produces. Run `npm run type-check` and fix any errors
+the truthful types surface (e.g. `professionals.specialties` jsonb vs text[]).
+
+### 5. Drain the real backlog as forward migrations (NOT via MCP)
+Through the now-trusted pipeline, each a unique 14-digit file:
+- **Apply** `versus_votes` (live bug), then `api_consumer_webhooks` +
+  `consumer_webhook_deliveries`, `api_key_subscriptions`, `ipo_watchlist` +
+  `ipo_alert_sends`, `investment_loan_rates`.
+- **Fix** the naming-mismatch `.from()` refs in code (`user_profiles`→`profiles`,
+  etc.) and burn down `.schemarefallowlist`.
+- ⚖️ **HOLD** `startup_*`, `esic_verifications`, `wholesale_investor_certifications`
+  (CSF / s708) — founder + legal only. They stay out of the active set.
+
+### 6. Retire the zombies (verify first, then drop)
+For each candidate (`trading_*`, `sentiment_signals`, `article_moderation_log`,
+`investor_journey_touchpoints`, `foreign_investment_flags`,
+`data_license_subscribers`; investigate `migration_plan`):
+```sql
+SELECT count(*) FROM public.<table>;   -- confirm empty / dead
+```
+and confirm zero `.from("<table>")` refs, then ship one
+`DROP TABLE IF EXISTS public.<table>;` migration. Remove the corresponding lines
+from `lib/database.types.ts` (via `db:types`) and `.driftallowlist`.
+
+### 7. 🛑 Re-enable the pipeline (only after steps 2–4)
+Now that "pending" == the real forward set, set `SUPABASE_PROJECT_REF` +
+`SUPABASE_DB_PASSWORD` in Actions secrets so `supabase-migrate.yml` applies on
+merge. **Permanently fence the CSF migration**: keep it in `archive/` (or a
+separate, dispatch-only path) so `db push --include-all` can never sweep it in.
+
+### 8. Verify reproducibility (the proof the job is done)
+```bash
+supabase branches create reconcile-verify    # builds a fresh DB from the tree
+# Point a staging build at the branch; smoke-test search / cert / webhook /
+# billing / advisor. A fresh env from the baseline must equal prod.
+supabase branches delete reconcile-verify
+```
+
+## Done when
+- `supabase db push --dry-run` reports **nothing pending**.
+- `SUPABASE_MIGRATIONS_JSON=… npm run audit:ledger-drift` → local-only 0, ledger-only 0.
+- `lib/database.types.ts` matches live (the `supabase-types-drift` job is clean).
+- A preview branch built from the tree matches prod.
+- CSF/wholesale tables remain held; auto-apply enabled with the CSF fence in place.
+
+## Rollback
+- Steps 2–6 are file/branch changes on a PR — revert the PR.
+- Step 3 (ledger repair) only rewrites `schema_migrations` rows; restore them
+  from the step-0 snapshot if needed. No table data is touched by repair.
+- Step 6 (drops) is the only data-destructive step — the step-0 snapshot is the
+  floor; do drops in a separate, clearly-labelled PR after the rest is verified.

--- a/docs/runbooks/MIGRATION_LEDGER_RECONCILIATION.md
+++ b/docs/runbooks/MIGRATION_LEDGER_RECONCILIATION.md
@@ -48,6 +48,11 @@ SUPABASE_MIGRATIONS_JSON=ledger.json npm run audit:ledger-drift
 
 ## Procedure
 
+> **Helper:** `scripts/db/baseline-squash.sh` automates the safe, reversible
+> local steps (2 + the archive) and prints the prod commands to run by hand. Run
+> it dry first; `SNAPSHOT_CONFIRMED=1 scripts/db/baseline-squash.sh --execute`
+> after step 0. It stops before the irreversible `migration repair`.
+
 ### 0. 🛑 Snapshot prod — non-negotiable
 Supabase Dashboard → Database → Backups → take a fresh snapshot (or
 `pg_dump`/PITR confirmed). 35 ledger entries are data backfills; this is the

--- a/docs/strategy/FIN_NOTEBOOK.md
+++ b/docs/strategy/FIN_NOTEBOOK.md
@@ -14,6 +14,49 @@
 
 ## Active strategic decisions log
 
+### 2026-06-07 — Database migration ledger: forked, not "behind"; decision = baseline-squash
+
+Deep-dive of the standing "database backlog" (was framed as "118 migrations
+behind main; run `db push`"). That framing is **wrong and dangerous**. Measured
+against live prod:
+
+- The local migration tree and the prod `schema_migrations` **ledger have
+  forked**: only **5 of 250** local versions are tracked in prod; **245** local
+  versions are untracked; **434** prod ledger rows have no local file. A
+  `supabase db push` would attempt ~245 migrations (re-creating existing tables,
+  re-running ~35 non-idempotent backfills, sweeping in the CSF migration).
+- **Root cause:** `supabase-migrate.yml` silently no-op'd for **months** (its
+  `PROJECT_REF`/`DB_PASSWORD` secrets were unset → green-but-applied-nothing; see
+  PR #1463). Every prod migration was applied **out-of-band via MCP**, each with
+  a fresh timestamp, so the ledger never matched the files.
+- **Good news:** schema *content* is ~98% converged (397/412 local tables live)
+  and RLS is comprehensive (414/415). So this is **history reconciliation +
+  pipeline repair**, not a schema rebuild.
+
+**Decision — Path A: baseline-squash.** Treat live prod as source of truth; dump
+it to one baseline migration; archive the 404 legacy files; `migration repair`
+the ledger so the tree == ledger == types; then resume a normal pipeline.
+Rejected Path B (per-file `migration repair`) — infeasible against 50 colliding
+date-only versions + 3 version formats. Full procedure:
+`docs/runbooks/MIGRATION_LEDGER_RECONCILIATION.md`; state of record:
+`docs/audits/DB-STATE-2026-06-07.md`.
+
+**Shipped this session (safe, repo-only):** corrected runbook + DB-state doc;
+deprecated the dangerous `MIGRATION_DEPLOY_BACKLOG.md`; `audit:migration-filenames`
+gate (blocks new non-14-digit / colliding versions) + `audit:ledger-drift` audit;
+CONTRIBUTING migration discipline (14-digit timestamps; apply via pipeline, not
+MCP; never `db push` pre-reconciliation).
+
+**Founder-gated (Tier E — not done autonomously):** the prod baseline-squash +
+ledger repair, the zombie-table drops, and **enabling auto-apply** (adding the
+two secrets) — all must wait until *after* the baseline, else `db push
+--include-all` replays the backlog. **⚖️ Legal-gated:** the startup-portal (CSF)
+and wholesale-cert (s708) tables stay held per `REGULATORY-AVOID-LIST.md`.
+
+**Revisit:** 2026-06-21 — has the baseline-squash been scheduled? Until it is,
+every new feature needing a table keeps hitting the same wall (PR #1459, in-app
+charts). This is now the #1 infrastructure blocker.
+
 ### 2026-06-03 — Bot-QA system: ranked roadmap for the next big projects
 
 Context: the AI-Journey bot found a real P1 in one run (`/api/versus/vote` 500s

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -121,7 +121,9 @@ export type Database = {
           fulfilled_at: string | null
           id: number
           ip_address: unknown
+          pii_redacted_at: string | null
           reason: string | null
+          reminder_sent_at: string | null
           requested_at: string
           scheduled_purge_at: string
           status: string
@@ -136,7 +138,9 @@ export type Database = {
           fulfilled_at?: string | null
           id?: number
           ip_address?: unknown
+          pii_redacted_at?: string | null
           reason?: string | null
+          reminder_sent_at?: string | null
           requested_at?: string
           scheduled_purge_at: string
           status?: string
@@ -151,7 +155,9 @@ export type Database = {
           fulfilled_at?: string | null
           id?: number
           ip_address?: unknown
+          pii_redacted_at?: string | null
           reason?: string | null
+          reminder_sent_at?: string | null
           requested_at?: string
           scheduled_purge_at?: string
           status?: string
@@ -661,6 +667,7 @@ export type Database = {
           bid_amount: number
           created_at: string
           id: number
+          retract_reason: string | null
           status: string
         }
         Insert: {
@@ -669,6 +676,7 @@ export type Database = {
           bid_amount: number
           created_at?: string
           id?: number
+          retract_reason?: string | null
           status?: string
         }
         Update: {
@@ -677,6 +685,7 @@ export type Database = {
           bid_amount?: number
           created_at?: string
           id?: number
+          retract_reason?: string | null
           status?: string
         }
         Relationships: [
@@ -710,6 +719,9 @@ export type Database = {
           accepted_by_professional_id: number | null
           accepted_by_team_id: number | null
           advisor_types: string[]
+          ai_quality_reason: string | null
+          ai_quality_score: number | null
+          auto_broadened_at: string | null
           brief_payload: Json
           brief_template: string | null
           budget_band: string | null
@@ -717,18 +729,26 @@ export type Database = {
           contact_name: string | null
           contact_phone: string | null
           created_at: string
+          created_by_user_id: string | null
           ends_at: string
+          expiry_reminder_sent_at: string | null
           flow_type: string
           id: number
           is_public: boolean
           job_description: string | null
           job_title: string
+          last_stale_check_at: string | null
           linked_action_plan_id: number | null
           listing_id: number | null
           location: string | null
           provider_preference: string | null
           referrer_advisor_id: number | null
+          reopened_count: number
+          review_request_sent_at: string | null
           risk_flags: string[]
+          risk_review_decided_by: string | null
+          risk_review_decision_reason: string | null
+          risk_review_resolved_at: string | null
           risk_review_status: string
           routing_mode: string | null
           slug: string
@@ -745,6 +765,9 @@ export type Database = {
           accepted_by_professional_id?: number | null
           accepted_by_team_id?: number | null
           advisor_types?: string[]
+          ai_quality_reason?: string | null
+          ai_quality_score?: number | null
+          auto_broadened_at?: string | null
           brief_payload?: Json
           brief_template?: string | null
           budget_band?: string | null
@@ -752,18 +775,26 @@ export type Database = {
           contact_name?: string | null
           contact_phone?: string | null
           created_at?: string
+          created_by_user_id?: string | null
           ends_at: string
+          expiry_reminder_sent_at?: string | null
           flow_type?: string
           id?: number
           is_public?: boolean
           job_description?: string | null
           job_title: string
+          last_stale_check_at?: string | null
           linked_action_plan_id?: number | null
           listing_id?: number | null
           location?: string | null
           provider_preference?: string | null
           referrer_advisor_id?: number | null
+          reopened_count?: number
+          review_request_sent_at?: string | null
           risk_flags?: string[]
+          risk_review_decided_by?: string | null
+          risk_review_decision_reason?: string | null
+          risk_review_resolved_at?: string | null
           risk_review_status?: string
           routing_mode?: string | null
           slug: string
@@ -780,6 +811,9 @@ export type Database = {
           accepted_by_professional_id?: number | null
           accepted_by_team_id?: number | null
           advisor_types?: string[]
+          ai_quality_reason?: string | null
+          ai_quality_score?: number | null
+          auto_broadened_at?: string | null
           brief_payload?: Json
           brief_template?: string | null
           budget_band?: string | null
@@ -787,18 +821,26 @@ export type Database = {
           contact_name?: string | null
           contact_phone?: string | null
           created_at?: string
+          created_by_user_id?: string | null
           ends_at?: string
+          expiry_reminder_sent_at?: string | null
           flow_type?: string
           id?: number
           is_public?: boolean
           job_description?: string | null
           job_title?: string
+          last_stale_check_at?: string | null
           linked_action_plan_id?: number | null
           listing_id?: number | null
           location?: string | null
           provider_preference?: string | null
           referrer_advisor_id?: number | null
+          reopened_count?: number
+          review_request_sent_at?: string | null
           risk_flags?: string[]
+          risk_review_decided_by?: string | null
+          risk_review_decision_reason?: string | null
+          risk_review_resolved_at?: string | null
           risk_review_status?: string
           routing_mode?: string | null
           slug?: string
@@ -931,6 +973,45 @@ export type Database = {
           },
           {
             foreignKeyName: "advisor_auth_tokens_professional_id_fkey"
+            columns: ["professional_id"]
+            isOneToOne: false
+            referencedRelation: "professionals"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      advisor_badges: {
+        Row: {
+          badge_type: string
+          earned_at: string
+          id: number
+          metadata: Json | null
+          professional_id: number
+        }
+        Insert: {
+          badge_type: string
+          earned_at?: string
+          id?: number
+          metadata?: Json | null
+          professional_id: number
+        }
+        Update: {
+          badge_type?: string
+          earned_at?: string
+          id?: number
+          metadata?: Json | null
+          professional_id?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "advisor_badges_professional_id_fkey"
+            columns: ["professional_id"]
+            isOneToOne: false
+            referencedRelation: "admin_advisor_health"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "advisor_badges_professional_id_fkey"
             columns: ["professional_id"]
             isOneToOne: false
             referencedRelation: "professionals"
@@ -1180,6 +1261,117 @@ export type Database = {
           },
         ]
       }
+      advisor_case_studies: {
+        Row: {
+          approach: string
+          client_type: string
+          created_at: string
+          id: number
+          outcome: string
+          outcome_type: string
+          professional_id: number
+          situation: string
+          status: string
+          title: string
+          updated_at: string
+        }
+        Insert: {
+          approach: string
+          client_type?: string
+          created_at?: string
+          id?: number
+          outcome: string
+          outcome_type?: string
+          professional_id: number
+          situation: string
+          status?: string
+          title: string
+          updated_at?: string
+        }
+        Update: {
+          approach?: string
+          client_type?: string
+          created_at?: string
+          id?: number
+          outcome?: string
+          outcome_type?: string
+          professional_id?: number
+          situation?: string
+          status?: string
+          title?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "advisor_case_studies_professional_id_fkey"
+            columns: ["professional_id"]
+            isOneToOne: false
+            referencedRelation: "admin_advisor_health"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "advisor_case_studies_professional_id_fkey"
+            columns: ["professional_id"]
+            isOneToOne: false
+            referencedRelation: "professionals"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      advisor_certifications: {
+        Row: {
+          cert_url: string | null
+          created_at: string
+          credential_id: string | null
+          expires_at: string | null
+          id: number
+          is_active: boolean
+          issued_at: string | null
+          issuer: string
+          name: string
+          professional_id: number
+        }
+        Insert: {
+          cert_url?: string | null
+          created_at?: string
+          credential_id?: string | null
+          expires_at?: string | null
+          id?: number
+          is_active?: boolean
+          issued_at?: string | null
+          issuer: string
+          name: string
+          professional_id: number
+        }
+        Update: {
+          cert_url?: string | null
+          created_at?: string
+          credential_id?: string | null
+          expires_at?: string | null
+          id?: number
+          is_active?: boolean
+          issued_at?: string | null
+          issuer?: string
+          name?: string
+          professional_id?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "advisor_certifications_professional_id_fkey"
+            columns: ["professional_id"]
+            isOneToOne: false
+            referencedRelation: "admin_advisor_health"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "advisor_certifications_professional_id_fkey"
+            columns: ["professional_id"]
+            isOneToOne: false
+            referencedRelation: "professionals"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       advisor_content_subscriptions: {
         Row: {
           advisor_firm_id: string | null
@@ -1330,6 +1522,168 @@ export type Database = {
           },
         ]
       }
+      advisor_endorsements: {
+        Row: {
+          created_at: string
+          id: number
+          professional_id: number
+          skill: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: number
+          professional_id: number
+          skill: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: number
+          professional_id?: number
+          skill?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "advisor_endorsements_professional_id_fkey"
+            columns: ["professional_id"]
+            isOneToOne: false
+            referencedRelation: "admin_advisor_health"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "advisor_endorsements_professional_id_fkey"
+            columns: ["professional_id"]
+            isOneToOne: false
+            referencedRelation: "professionals"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      advisor_event_rsvps: {
+        Row: {
+          event_id: number
+          id: number
+          registered_at: string
+          status: string
+          user_email: string
+          user_id: string
+          user_name: string | null
+        }
+        Insert: {
+          event_id: number
+          id?: number
+          registered_at?: string
+          status?: string
+          user_email: string
+          user_id: string
+          user_name?: string | null
+        }
+        Update: {
+          event_id?: number
+          id?: number
+          registered_at?: string
+          status?: string
+          user_email?: string
+          user_id?: string
+          user_name?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "advisor_event_rsvps_event_id_fkey"
+            columns: ["event_id"]
+            isOneToOne: false
+            referencedRelation: "advisor_events"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      advisor_events: {
+        Row: {
+          cover_image_url: string | null
+          created_at: string
+          description: string | null
+          ends_at: string | null
+          event_type: string
+          id: number
+          location: string | null
+          max_attendees: number | null
+          meeting_url: string | null
+          organisation_id: number | null
+          price_cents: number
+          professional_id: number
+          rsvp_count: number
+          starts_at: string
+          status: string
+          timezone: string
+          title: string
+          updated_at: string
+        }
+        Insert: {
+          cover_image_url?: string | null
+          created_at?: string
+          description?: string | null
+          ends_at?: string | null
+          event_type?: string
+          id?: number
+          location?: string | null
+          max_attendees?: number | null
+          meeting_url?: string | null
+          organisation_id?: number | null
+          price_cents?: number
+          professional_id: number
+          rsvp_count?: number
+          starts_at: string
+          status?: string
+          timezone?: string
+          title: string
+          updated_at?: string
+        }
+        Update: {
+          cover_image_url?: string | null
+          created_at?: string
+          description?: string | null
+          ends_at?: string | null
+          event_type?: string
+          id?: number
+          location?: string | null
+          max_attendees?: number | null
+          meeting_url?: string | null
+          organisation_id?: number | null
+          price_cents?: number
+          professional_id?: number
+          rsvp_count?: number
+          starts_at?: string
+          status?: string
+          timezone?: string
+          title?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "advisor_events_organisation_id_fkey"
+            columns: ["organisation_id"]
+            isOneToOne: false
+            referencedRelation: "organisations"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "advisor_events_professional_id_fkey"
+            columns: ["professional_id"]
+            isOneToOne: false
+            referencedRelation: "admin_advisor_health"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "advisor_events_professional_id_fkey"
+            columns: ["professional_id"]
+            isOneToOne: false
+            referencedRelation: "professionals"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       advisor_firm_invitations: {
         Row: {
           accepted_at: string | null
@@ -1408,9 +1762,15 @@ export type Database = {
           admin_professional_id: number | null
           afsl_number: string | null
           bio: string | null
+          case_studies: Json
           created_at: string | null
           email: string | null
+          enhanced_since: string | null
+          featured_services: Json
+          header_image_url: string | null
+          highlight_stats: Json
           id: number
+          is_enhanced: boolean
           location_display: string | null
           location_state: string | null
           location_suburb: string | null
@@ -1420,6 +1780,7 @@ export type Database = {
           phone: string | null
           slug: string
           status: string
+          tagline: string | null
           updated_at: string | null
           website: string | null
         }
@@ -1429,9 +1790,15 @@ export type Database = {
           admin_professional_id?: number | null
           afsl_number?: string | null
           bio?: string | null
+          case_studies?: Json
           created_at?: string | null
           email?: string | null
+          enhanced_since?: string | null
+          featured_services?: Json
+          header_image_url?: string | null
+          highlight_stats?: Json
           id?: number
+          is_enhanced?: boolean
           location_display?: string | null
           location_state?: string | null
           location_suburb?: string | null
@@ -1441,6 +1808,7 @@ export type Database = {
           phone?: string | null
           slug: string
           status?: string
+          tagline?: string | null
           updated_at?: string | null
           website?: string | null
         }
@@ -1450,9 +1818,15 @@ export type Database = {
           admin_professional_id?: number | null
           afsl_number?: string | null
           bio?: string | null
+          case_studies?: Json
           created_at?: string | null
           email?: string | null
+          enhanced_since?: string | null
+          featured_services?: Json
+          header_image_url?: string | null
+          highlight_stats?: Json
           id?: number
+          is_enhanced?: boolean
           location_display?: string | null
           location_state?: string | null
           location_suburb?: string | null
@@ -1462,6 +1836,7 @@ export type Database = {
           phone?: string | null
           slug?: string
           status?: string
+          tagline?: string | null
           updated_at?: string | null
           website?: string | null
         }
@@ -1476,6 +1851,42 @@ export type Database = {
           {
             foreignKeyName: "advisor_firms_admin_professional_id_fkey"
             columns: ["admin_professional_id"]
+            isOneToOne: false
+            referencedRelation: "professionals"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      advisor_follows: {
+        Row: {
+          created_at: string
+          follower_user_id: string
+          following_professional_id: number
+          id: number
+        }
+        Insert: {
+          created_at?: string
+          follower_user_id: string
+          following_professional_id: number
+          id?: number
+        }
+        Update: {
+          created_at?: string
+          follower_user_id?: string
+          following_professional_id?: number
+          id?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "advisor_follows_following_professional_id_fkey"
+            columns: ["following_professional_id"]
+            isOneToOne: false
+            referencedRelation: "admin_advisor_health"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "advisor_follows_following_professional_id_fkey"
+            columns: ["following_professional_id"]
             isOneToOne: false
             referencedRelation: "professionals"
             referencedColumns: ["id"]
@@ -1530,6 +1941,42 @@ export type Database = {
         }
         Relationships: []
       }
+      advisor_ideal_clients: {
+        Row: {
+          criteria: Json
+          id: number
+          professional_id: number
+          updated_at: string
+        }
+        Insert: {
+          criteria?: Json
+          id?: number
+          professional_id: number
+          updated_at?: string
+        }
+        Update: {
+          criteria?: Json
+          id?: number
+          professional_id?: number
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "advisor_ideal_clients_professional_id_fkey"
+            columns: ["professional_id"]
+            isOneToOne: true
+            referencedRelation: "admin_advisor_health"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "advisor_ideal_clients_professional_id_fkey"
+            columns: ["professional_id"]
+            isOneToOne: true
+            referencedRelation: "professionals"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       advisor_kyc_documents: {
         Row: {
           document_type: string
@@ -1580,6 +2027,63 @@ export type Database = {
           verified_by?: string | null
         }
         Relationships: []
+      }
+      advisor_leaderboard_monthly: {
+        Row: {
+          avg_rating: number | null
+          badge_count: number
+          id: number
+          professional_id: number
+          profile_score: number
+          rank: number
+          response_score: number
+          review_count: number
+          score: number
+          updated_at: string
+          year_month: string
+        }
+        Insert: {
+          avg_rating?: number | null
+          badge_count?: number
+          id?: number
+          professional_id: number
+          profile_score?: number
+          rank: number
+          response_score?: number
+          review_count?: number
+          score?: number
+          updated_at?: string
+          year_month: string
+        }
+        Update: {
+          avg_rating?: number | null
+          badge_count?: number
+          id?: number
+          professional_id?: number
+          profile_score?: number
+          rank?: number
+          response_score?: number
+          review_count?: number
+          score?: number
+          updated_at?: string
+          year_month?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "advisor_leaderboard_monthly_professional_id_fkey"
+            columns: ["professional_id"]
+            isOneToOne: false
+            referencedRelation: "admin_advisor_health"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "advisor_leaderboard_monthly_professional_id_fkey"
+            columns: ["professional_id"]
+            isOneToOne: false
+            referencedRelation: "professionals"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       advisor_metrics_daily: {
         Row: {
@@ -1635,6 +2139,158 @@ export type Database = {
           },
         ]
       }
+      advisor_office_hours: {
+        Row: {
+          advisor_id: number
+          created_at: string
+          description: string | null
+          ends_at: string | null
+          id: number
+          is_published: boolean
+          max_questions: number
+          rsvp_count: number
+          scheduled_at: string
+          status: string
+          title: string
+          updated_at: string
+        }
+        Insert: {
+          advisor_id: number
+          created_at?: string
+          description?: string | null
+          ends_at?: string | null
+          id?: number
+          is_published?: boolean
+          max_questions?: number
+          rsvp_count?: number
+          scheduled_at: string
+          status?: string
+          title: string
+          updated_at?: string
+        }
+        Update: {
+          advisor_id?: number
+          created_at?: string
+          description?: string | null
+          ends_at?: string | null
+          id?: number
+          is_published?: boolean
+          max_questions?: number
+          rsvp_count?: number
+          scheduled_at?: string
+          status?: string
+          title?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "advisor_office_hours_advisor_id_fkey"
+            columns: ["advisor_id"]
+            isOneToOne: false
+            referencedRelation: "admin_advisor_health"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "advisor_office_hours_advisor_id_fkey"
+            columns: ["advisor_id"]
+            isOneToOne: false
+            referencedRelation: "professionals"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      advisor_post_reactions: {
+        Row: {
+          created_at: string
+          id: number
+          post_id: number
+          reaction_type: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: number
+          post_id: number
+          reaction_type?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: number
+          post_id?: number
+          reaction_type?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "advisor_post_reactions_post_id_fkey"
+            columns: ["post_id"]
+            isOneToOne: false
+            referencedRelation: "advisor_posts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      advisor_posts: {
+        Row: {
+          body: string
+          comment_count: number
+          created_at: string
+          id: number
+          image_url: string | null
+          link_title: string | null
+          link_url: string | null
+          post_type: string
+          professional_id: number
+          reaction_count: number
+          status: string
+          updated_at: string
+        }
+        Insert: {
+          body: string
+          comment_count?: number
+          created_at?: string
+          id?: number
+          image_url?: string | null
+          link_title?: string | null
+          link_url?: string | null
+          post_type?: string
+          professional_id: number
+          reaction_count?: number
+          status?: string
+          updated_at?: string
+        }
+        Update: {
+          body?: string
+          comment_count?: number
+          created_at?: string
+          id?: number
+          image_url?: string | null
+          link_title?: string | null
+          link_url?: string | null
+          post_type?: string
+          professional_id?: number
+          reaction_count?: number
+          status?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "advisor_posts_professional_id_fkey"
+            columns: ["professional_id"]
+            isOneToOne: false
+            referencedRelation: "admin_advisor_health"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "advisor_posts_professional_id_fkey"
+            columns: ["professional_id"]
+            isOneToOne: false
+            referencedRelation: "professionals"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       advisor_profile_views: {
         Row: {
           id: number
@@ -1664,6 +2320,60 @@ export type Database = {
           },
           {
             foreignKeyName: "advisor_profile_views_professional_id_fkey"
+            columns: ["professional_id"]
+            isOneToOne: false
+            referencedRelation: "professionals"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      advisor_services: {
+        Row: {
+          created_at: string
+          description: string | null
+          id: number
+          is_active: boolean
+          name: string
+          price_from_cents: number | null
+          price_to_cents: number | null
+          price_type: string
+          professional_id: number
+          sort_order: number
+        }
+        Insert: {
+          created_at?: string
+          description?: string | null
+          id?: number
+          is_active?: boolean
+          name: string
+          price_from_cents?: number | null
+          price_to_cents?: number | null
+          price_type?: string
+          professional_id: number
+          sort_order?: number
+        }
+        Update: {
+          created_at?: string
+          description?: string | null
+          id?: number
+          is_active?: boolean
+          name?: string
+          price_from_cents?: number | null
+          price_to_cents?: number | null
+          price_type?: string
+          professional_id?: number
+          sort_order?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "advisor_services_professional_id_fkey"
+            columns: ["professional_id"]
+            isOneToOne: false
+            referencedRelation: "admin_advisor_health"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "advisor_services_professional_id_fkey"
             columns: ["professional_id"]
             isOneToOne: false
             referencedRelation: "professionals"
@@ -1766,6 +2476,45 @@ export type Database = {
           name?: string
         }
         Relationships: []
+      }
+      advisor_user_match_scores: {
+        Row: {
+          computed_at: string
+          id: number
+          match_percent: number
+          professional_id: number
+          user_id: string
+        }
+        Insert: {
+          computed_at?: string
+          id?: number
+          match_percent: number
+          professional_id: number
+          user_id: string
+        }
+        Update: {
+          computed_at?: string
+          id?: number
+          match_percent?: number
+          professional_id?: number
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "advisor_user_match_scores_professional_id_fkey"
+            columns: ["professional_id"]
+            isOneToOne: false
+            referencedRelation: "admin_advisor_health"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "advisor_user_match_scores_professional_id_fkey"
+            columns: ["professional_id"]
+            isOneToOne: false
+            referencedRelation: "professionals"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       advisor_verification_log: {
         Row: {
@@ -2965,6 +3714,7 @@ export type Database = {
           author_image: string | null
           author_linkedin: string | null
           author_name: string | null
+          author_photo_url: string | null
           author_title: string | null
           author_twitter: string | null
           category: string | null
@@ -2981,6 +3731,7 @@ export type Database = {
           last_audited_at: string | null
           last_reviewed_at: string | null
           last_reviewed_by: string | null
+          link_density_override: number | null
           meta_description: string | null
           meta_title: string | null
           needs_update: boolean | null
@@ -2994,6 +3745,7 @@ export type Database = {
           related_verticals: string[] | null
           reviewed_at: string | null
           reviewer_id: number | null
+          search_vec: unknown
           sections: Json | null
           slug: string
           staleness_score: number | null
@@ -3012,6 +3764,7 @@ export type Database = {
           author_image?: string | null
           author_linkedin?: string | null
           author_name?: string | null
+          author_photo_url?: string | null
           author_title?: string | null
           author_twitter?: string | null
           category?: string | null
@@ -3028,6 +3781,7 @@ export type Database = {
           last_audited_at?: string | null
           last_reviewed_at?: string | null
           last_reviewed_by?: string | null
+          link_density_override?: number | null
           meta_description?: string | null
           meta_title?: string | null
           needs_update?: boolean | null
@@ -3041,6 +3795,7 @@ export type Database = {
           related_verticals?: string[] | null
           reviewed_at?: string | null
           reviewer_id?: number | null
+          search_vec?: unknown
           sections?: Json | null
           slug: string
           staleness_score?: number | null
@@ -3059,6 +3814,7 @@ export type Database = {
           author_image?: string | null
           author_linkedin?: string | null
           author_name?: string | null
+          author_photo_url?: string | null
           author_title?: string | null
           author_twitter?: string | null
           category?: string | null
@@ -3075,6 +3831,7 @@ export type Database = {
           last_audited_at?: string | null
           last_reviewed_at?: string | null
           last_reviewed_by?: string | null
+          link_density_override?: number | null
           meta_description?: string | null
           meta_title?: string | null
           needs_update?: boolean | null
@@ -3088,6 +3845,7 @@ export type Database = {
           related_verticals?: string[] | null
           reviewed_at?: string | null
           reviewer_id?: number | null
+          search_vec?: unknown
           sections?: Json | null
           slug?: string
           staleness_score?: number | null
@@ -3420,6 +4178,82 @@ export type Database = {
           updated_at?: string
         }
         Relationships: []
+      }
+      booking_payments: {
+        Row: {
+          amount_cents: number
+          consumer_email: string
+          consumer_user_id: string | null
+          created_at: string
+          currency: string
+          description: string | null
+          id: number
+          metadata: Json
+          platform_fee_cents: number
+          professional_id: number
+          slot_id: number
+          status: string
+          stripe_checkout_session_id: string | null
+          stripe_payment_intent_id: string | null
+          updated_at: string
+        }
+        Insert: {
+          amount_cents: number
+          consumer_email: string
+          consumer_user_id?: string | null
+          created_at?: string
+          currency?: string
+          description?: string | null
+          id?: number
+          metadata?: Json
+          platform_fee_cents: number
+          professional_id: number
+          slot_id: number
+          status?: string
+          stripe_checkout_session_id?: string | null
+          stripe_payment_intent_id?: string | null
+          updated_at?: string
+        }
+        Update: {
+          amount_cents?: number
+          consumer_email?: string
+          consumer_user_id?: string | null
+          created_at?: string
+          currency?: string
+          description?: string | null
+          id?: number
+          metadata?: Json
+          platform_fee_cents?: number
+          professional_id?: number
+          slot_id?: number
+          status?: string
+          stripe_checkout_session_id?: string | null
+          stripe_payment_intent_id?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "booking_payments_professional_id_fkey"
+            columns: ["professional_id"]
+            isOneToOne: false
+            referencedRelation: "admin_advisor_health"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "booking_payments_professional_id_fkey"
+            columns: ["professional_id"]
+            isOneToOne: false
+            referencedRelation: "professionals"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "booking_payments_slot_id_fkey"
+            columns: ["slot_id"]
+            isOneToOne: false
+            referencedRelation: "advisor_booking_appointments"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       brief_credit_prices: {
         Row: {
@@ -3925,6 +4759,7 @@ export type Database = {
           broker_slug: string
           company_name: string | null
           created_at: string | null
+          deleted_at: string | null
           email: string
           email_preferences: Json | null
           full_name: string
@@ -3934,6 +4769,7 @@ export type Database = {
           package_id: number | null
           package_started_at: string | null
           phone: string | null
+          pii_redacted_at: string | null
           postback_api_key: string | null
           role: string
           status: string
@@ -3947,6 +4783,7 @@ export type Database = {
           broker_slug: string
           company_name?: string | null
           created_at?: string | null
+          deleted_at?: string | null
           email: string
           email_preferences?: Json | null
           full_name: string
@@ -3956,6 +4793,7 @@ export type Database = {
           package_id?: number | null
           package_started_at?: string | null
           phone?: string | null
+          pii_redacted_at?: string | null
           postback_api_key?: string | null
           role?: string
           status?: string
@@ -3969,6 +4807,7 @@ export type Database = {
           broker_slug?: string
           company_name?: string | null
           created_at?: string | null
+          deleted_at?: string | null
           email?: string
           email_preferences?: Json | null
           full_name?: string
@@ -3978,6 +4817,7 @@ export type Database = {
           package_id?: number | null
           package_started_at?: string | null
           phone?: string | null
+          pii_redacted_at?: string | null
           postback_api_key?: string | null
           role?: string
           status?: string
@@ -4171,6 +5011,42 @@ export type Database = {
             referencedColumns: ["id"]
           },
         ]
+      }
+      broker_health_score_history: {
+        Row: {
+          broker_slug: string
+          captured_at: string
+          client_money_score: number | null
+          financial_stability_score: number | null
+          id: number
+          insurance_score: number | null
+          overall_score: number
+          platform_reliability_score: number | null
+          regulatory_score: number | null
+        }
+        Insert: {
+          broker_slug: string
+          captured_at?: string
+          client_money_score?: number | null
+          financial_stability_score?: number | null
+          id?: never
+          insurance_score?: number | null
+          overall_score: number
+          platform_reliability_score?: number | null
+          regulatory_score?: number | null
+        }
+        Update: {
+          broker_slug?: string
+          captured_at?: string
+          client_money_score?: number | null
+          financial_stability_score?: number | null
+          id?: never
+          insurance_score?: number | null
+          overall_score?: number
+          platform_reliability_score?: number | null
+          regulatory_score?: number | null
+        }
+        Relationships: []
       }
       broker_health_scores: {
         Row: {
@@ -4460,6 +5336,44 @@ export type Database = {
         }
         Relationships: []
       }
+      broker_reliability_reports: {
+        Row: {
+          broker_id: number
+          created_at: string
+          description: string | null
+          event_type: string
+          id: string
+          status: string
+          user_id: string
+        }
+        Insert: {
+          broker_id: number
+          created_at?: string
+          description?: string | null
+          event_type: string
+          id?: string
+          status?: string
+          user_id: string
+        }
+        Update: {
+          broker_id?: number
+          created_at?: string
+          description?: string | null
+          event_type?: string
+          id?: string
+          status?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "broker_reliability_reports_broker_id_fkey"
+            columns: ["broker_id"]
+            isOneToOne: false
+            referencedRelation: "brokers"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       broker_review_invites: {
         Row: {
           broker_id: number | null
@@ -4718,6 +5632,7 @@ export type Database = {
       brokers: {
         Row: {
           accepts_non_residents: boolean | null
+          accepts_temporary_residents: boolean | null
           advertising_terms_accepted_at: string | null
           advertising_terms_version: string | null
           affiliate_priority: string | null
@@ -4730,6 +5645,7 @@ export type Database = {
           commission_type: string | null
           commission_value: number | null
           cons: Json | null
+          country_eligibility: Json
           cpa_value: number | null
           created_at: string | null
           cta_text: string | null
@@ -4777,9 +5693,11 @@ export type Database = {
           pros: Json | null
           rating: number | null
           regulated_by: string | null
+          requires_australian_address: boolean | null
           review_content: string | null
           reviewed_at: string | null
           reviewer_id: number | null
+          search_vec: unknown
           slug: string
           smsf_support: boolean | null
           sponsored: boolean | null
@@ -4797,6 +5715,7 @@ export type Database = {
         }
         Insert: {
           accepts_non_residents?: boolean | null
+          accepts_temporary_residents?: boolean | null
           advertising_terms_accepted_at?: string | null
           advertising_terms_version?: string | null
           affiliate_priority?: string | null
@@ -4809,6 +5728,7 @@ export type Database = {
           commission_type?: string | null
           commission_value?: number | null
           cons?: Json | null
+          country_eligibility?: Json
           cpa_value?: number | null
           created_at?: string | null
           cta_text?: string | null
@@ -4856,9 +5776,11 @@ export type Database = {
           pros?: Json | null
           rating?: number | null
           regulated_by?: string | null
+          requires_australian_address?: boolean | null
           review_content?: string | null
           reviewed_at?: string | null
           reviewer_id?: number | null
+          search_vec?: unknown
           slug: string
           smsf_support?: boolean | null
           sponsored?: boolean | null
@@ -4876,6 +5798,7 @@ export type Database = {
         }
         Update: {
           accepts_non_residents?: boolean | null
+          accepts_temporary_residents?: boolean | null
           advertising_terms_accepted_at?: string | null
           advertising_terms_version?: string | null
           affiliate_priority?: string | null
@@ -4888,6 +5811,7 @@ export type Database = {
           commission_type?: string | null
           commission_value?: number | null
           cons?: Json | null
+          country_eligibility?: Json
           cpa_value?: number | null
           created_at?: string | null
           cta_text?: string | null
@@ -4935,9 +5859,11 @@ export type Database = {
           pros?: Json | null
           rating?: number | null
           regulated_by?: string | null
+          requires_australian_address?: boolean | null
           review_content?: string | null
           reviewed_at?: string | null
           reviewer_id?: number | null
+          search_vec?: unknown
           slug?: string
           smsf_support?: boolean | null
           sponsored?: boolean | null
@@ -5018,10 +5944,12 @@ export type Database = {
           auth_user_id: string
           business_name: string
           created_at: string
+          deleted_at: string | null
           employees_band: string | null
           id: number
           industry: string | null
           legal_name: string | null
+          pii_redacted_at: string | null
           primary_state: string | null
           revenue_band: string | null
           status: string
@@ -5034,10 +5962,12 @@ export type Database = {
           auth_user_id: string
           business_name: string
           created_at?: string
+          deleted_at?: string | null
           employees_band?: string | null
           id?: never
           industry?: string | null
           legal_name?: string | null
+          pii_redacted_at?: string | null
           primary_state?: string | null
           revenue_band?: string | null
           status?: string
@@ -5050,10 +5980,12 @@ export type Database = {
           auth_user_id?: string
           business_name?: string
           created_at?: string
+          deleted_at?: string | null
           employees_band?: string | null
           id?: never
           industry?: string | null
           legal_name?: string | null
+          pii_redacted_at?: string | null
           primary_state?: string | null
           revenue_band?: string | null
           status?: string
@@ -5667,6 +6599,167 @@ export type Database = {
           value?: number
         }
         Relationships: []
+      }
+      club_invitations: {
+        Row: {
+          club_id: string
+          created_at: string
+          expires_at: string
+          id: string
+          invite_token: string
+          invited_by_user_id: string
+          used_at: string | null
+        }
+        Insert: {
+          club_id: string
+          created_at?: string
+          expires_at?: string
+          id?: string
+          invite_token?: string
+          invited_by_user_id: string
+          used_at?: string | null
+        }
+        Update: {
+          club_id?: string
+          created_at?: string
+          expires_at?: string
+          id?: string
+          invite_token?: string
+          invited_by_user_id?: string
+          used_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "club_invitations_club_id_fkey"
+            columns: ["club_id"]
+            isOneToOne: false
+            referencedRelation: "investment_clubs"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      club_members: {
+        Row: {
+          club_id: string
+          display_name: string
+          id: string
+          joined_at: string
+          role: string
+          user_id: string
+        }
+        Insert: {
+          club_id: string
+          display_name: string
+          id?: string
+          joined_at?: string
+          role?: string
+          user_id: string
+        }
+        Update: {
+          club_id?: string
+          display_name?: string
+          id?: string
+          joined_at?: string
+          role?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "club_members_club_id_fkey"
+            columns: ["club_id"]
+            isOneToOne: false
+            referencedRelation: "investment_clubs"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      club_messages: {
+        Row: {
+          author_member_id: string
+          body: string
+          club_id: string
+          created_at: string
+          id: string
+        }
+        Insert: {
+          author_member_id: string
+          body: string
+          club_id: string
+          created_at?: string
+          id?: string
+        }
+        Update: {
+          author_member_id?: string
+          body?: string
+          club_id?: string
+          created_at?: string
+          id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "club_messages_author_member_id_fkey"
+            columns: ["author_member_id"]
+            isOneToOne: false
+            referencedRelation: "club_members"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "club_messages_club_id_fkey"
+            columns: ["club_id"]
+            isOneToOne: false
+            referencedRelation: "investment_clubs"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      club_watchlist_items: {
+        Row: {
+          added_by_member_id: string
+          broker_id: number
+          club_id: string
+          created_at: string
+          id: string
+          notes: string | null
+        }
+        Insert: {
+          added_by_member_id: string
+          broker_id: number
+          club_id: string
+          created_at?: string
+          id?: string
+          notes?: string | null
+        }
+        Update: {
+          added_by_member_id?: string
+          broker_id?: number
+          club_id?: string
+          created_at?: string
+          id?: string
+          notes?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "club_watchlist_items_added_by_member_id_fkey"
+            columns: ["added_by_member_id"]
+            isOneToOne: false
+            referencedRelation: "club_members"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "club_watchlist_items_broker_id_fkey"
+            columns: ["broker_id"]
+            isOneToOne: false
+            referencedRelation: "brokers"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "club_watchlist_items_club_id_fkey"
+            columns: ["club_id"]
+            isOneToOne: false
+            referencedRelation: "investment_clubs"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       cobranded_products: {
         Row: {
@@ -6604,6 +7697,80 @@ export type Database = {
         }
         Relationships: []
       }
+      course_certificates: {
+        Row: {
+          certificate_number: string
+          completion_score: number | null
+          course_id: number
+          cpd_category: string | null
+          cpd_hours: number | null
+          created_at: string
+          holder_display_name: string | null
+          id: string
+          issued_at: string
+          professional_id: number | null
+          purchase_id: number | null
+          user_id: string | null
+        }
+        Insert: {
+          certificate_number: string
+          completion_score?: number | null
+          course_id: number
+          cpd_category?: string | null
+          cpd_hours?: number | null
+          created_at?: string
+          holder_display_name?: string | null
+          id?: string
+          issued_at?: string
+          professional_id?: number | null
+          purchase_id?: number | null
+          user_id?: string | null
+        }
+        Update: {
+          certificate_number?: string
+          completion_score?: number | null
+          course_id?: number
+          cpd_category?: string | null
+          cpd_hours?: number | null
+          created_at?: string
+          holder_display_name?: string | null
+          id?: string
+          issued_at?: string
+          professional_id?: number | null
+          purchase_id?: number | null
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "course_certificates_course_id_fkey"
+            columns: ["course_id"]
+            isOneToOne: false
+            referencedRelation: "courses"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "course_certificates_professional_id_fkey"
+            columns: ["professional_id"]
+            isOneToOne: false
+            referencedRelation: "admin_advisor_health"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "course_certificates_professional_id_fkey"
+            columns: ["professional_id"]
+            isOneToOne: false
+            referencedRelation: "professionals"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "course_certificates_purchase_id_fkey"
+            columns: ["purchase_id"]
+            isOneToOne: false
+            referencedRelation: "course_purchases"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       course_lessons: {
         Row: {
           content: string | null
@@ -6795,85 +7962,274 @@ export type Database = {
           },
         ]
       }
+      course_reviews: {
+        Row: {
+          body: string | null
+          course_id: number
+          created_at: string
+          headline: string | null
+          id: number
+          is_verified_purchase: boolean
+          purchase_id: number | null
+          rating: number
+          status: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          body?: string | null
+          course_id: number
+          created_at?: string
+          headline?: string | null
+          id?: number
+          is_verified_purchase?: boolean
+          purchase_id?: number | null
+          rating: number
+          status?: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          body?: string | null
+          course_id?: number
+          created_at?: string
+          headline?: string | null
+          id?: number
+          is_verified_purchase?: boolean
+          purchase_id?: number | null
+          rating?: number
+          status?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "course_reviews_course_id_fkey"
+            columns: ["course_id"]
+            isOneToOne: false
+            referencedRelation: "courses"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "course_reviews_purchase_id_fkey"
+            columns: ["purchase_id"]
+            isOneToOne: false
+            referencedRelation: "course_purchases"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       courses: {
         Row: {
+          advisor_professional_id: number | null
+          avg_rating: number | null
           cover_image_url: string | null
+          cpd_category: string | null
+          cpd_hours: number | null
           created_at: string | null
           creator_id: number | null
+          creator_kind: string
           currency: string
           description: string | null
           estimated_hours: number | null
           featured: boolean | null
           guarantee: string | null
           id: number
+          is_advisor_created: boolean
+          is_cpd_eligible: boolean
           level: string | null
+          organisation_id: number | null
           price: number
           pro_price: number | null
           published_at: string | null
+          rejection_reason: string | null
           revenue_share_percent: number
+          review_count: number
           slug: string
           sort_order: number | null
           status: string
           stripe_price_id: string | null
           stripe_pro_price_id: string | null
+          submitted_at: string | null
           subtitle: string | null
           title: string
           updated_at: string | null
         }
         Insert: {
+          advisor_professional_id?: number | null
+          avg_rating?: number | null
           cover_image_url?: string | null
+          cpd_category?: string | null
+          cpd_hours?: number | null
           created_at?: string | null
           creator_id?: number | null
+          creator_kind?: string
           currency?: string
           description?: string | null
           estimated_hours?: number | null
           featured?: boolean | null
           guarantee?: string | null
           id?: number
+          is_advisor_created?: boolean
+          is_cpd_eligible?: boolean
           level?: string | null
+          organisation_id?: number | null
           price?: number
           pro_price?: number | null
           published_at?: string | null
+          rejection_reason?: string | null
           revenue_share_percent?: number
+          review_count?: number
           slug: string
           sort_order?: number | null
           status?: string
           stripe_price_id?: string | null
           stripe_pro_price_id?: string | null
+          submitted_at?: string | null
           subtitle?: string | null
           title: string
           updated_at?: string | null
         }
         Update: {
+          advisor_professional_id?: number | null
+          avg_rating?: number | null
           cover_image_url?: string | null
+          cpd_category?: string | null
+          cpd_hours?: number | null
           created_at?: string | null
           creator_id?: number | null
+          creator_kind?: string
           currency?: string
           description?: string | null
           estimated_hours?: number | null
           featured?: boolean | null
           guarantee?: string | null
           id?: number
+          is_advisor_created?: boolean
+          is_cpd_eligible?: boolean
           level?: string | null
+          organisation_id?: number | null
           price?: number
           pro_price?: number | null
           published_at?: string | null
+          rejection_reason?: string | null
           revenue_share_percent?: number
+          review_count?: number
           slug?: string
           sort_order?: number | null
           status?: string
           stripe_price_id?: string | null
           stripe_pro_price_id?: string | null
+          submitted_at?: string | null
           subtitle?: string | null
           title?: string
           updated_at?: string | null
         }
         Relationships: [
           {
+            foreignKeyName: "courses_advisor_professional_id_fkey"
+            columns: ["advisor_professional_id"]
+            isOneToOne: false
+            referencedRelation: "admin_advisor_health"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "courses_advisor_professional_id_fkey"
+            columns: ["advisor_professional_id"]
+            isOneToOne: false
+            referencedRelation: "professionals"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "courses_creator_id_fkey"
             columns: ["creator_id"]
             isOneToOne: false
             referencedRelation: "team_members"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "courses_organisation_id_fkey"
+            columns: ["organisation_id"]
+            isOneToOne: false
+            referencedRelation: "organisations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      cpd_credits: {
+        Row: {
+          certificate_id: string | null
+          certificate_issued_at: string | null
+          completed_at: string
+          course_id: number
+          cpd_category: string
+          cpd_year: number
+          created_at: string
+          hours_earned: number
+          id: string
+          professional_id: number
+          purchase_id: number | null
+        }
+        Insert: {
+          certificate_id?: string | null
+          certificate_issued_at?: string | null
+          completed_at?: string
+          course_id: number
+          cpd_category?: string
+          cpd_year: number
+          created_at?: string
+          hours_earned: number
+          id?: string
+          professional_id: number
+          purchase_id?: number | null
+        }
+        Update: {
+          certificate_id?: string | null
+          certificate_issued_at?: string | null
+          completed_at?: string
+          course_id?: number
+          cpd_category?: string
+          cpd_year?: number
+          created_at?: string
+          hours_earned?: number
+          id?: string
+          professional_id?: number
+          purchase_id?: number | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "cpd_credits_certificate_id_fkey"
+            columns: ["certificate_id"]
+            isOneToOne: false
+            referencedRelation: "course_certificates"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "cpd_credits_course_id_fkey"
+            columns: ["course_id"]
+            isOneToOne: false
+            referencedRelation: "courses"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "cpd_credits_professional_id_fkey"
+            columns: ["professional_id"]
+            isOneToOne: false
+            referencedRelation: "admin_advisor_health"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "cpd_credits_professional_id_fkey"
+            columns: ["professional_id"]
+            isOneToOne: false
+            referencedRelation: "professionals"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "cpd_credits_purchase_id_fkey"
+            columns: ["purchase_id"]
+            isOneToOne: false
+            referencedRelation: "course_purchases"
             referencedColumns: ["id"]
           },
         ]
@@ -7214,6 +8570,65 @@ export type Database = {
         }
         Relationships: []
       }
+      debate_votes: {
+        Row: {
+          id: number
+          position: string
+          thread_id: number
+          voted_at: string
+          voter_user_id: string
+        }
+        Insert: {
+          id?: number
+          position: string
+          thread_id: number
+          voted_at?: string
+          voter_user_id: string
+        }
+        Update: {
+          id?: number
+          position?: string
+          thread_id?: number
+          voted_at?: string
+          voter_user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "debate_votes_thread_id_fkey"
+            columns: ["thread_id"]
+            isOneToOne: false
+            referencedRelation: "forum_threads"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      decisions_digest_sends: {
+        Row: {
+          high_count: number
+          id: number
+          item_count: number
+          send_date: string
+          sent_at: string
+          user_id: string
+        }
+        Insert: {
+          high_count?: number
+          id?: number
+          item_count?: number
+          send_date: string
+          sent_at?: string
+          user_id: string
+        }
+        Update: {
+          high_count?: number
+          id?: number
+          item_count?: number
+          send_date?: string
+          sent_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
       developer_leads: {
         Row: {
           created_at: string | null
@@ -7466,6 +8881,7 @@ export type Database = {
       email_captures: {
         Row: {
           captured_at: string | null
+          context: Json | null
           email: string
           id: number
           last_annual_reminder: string | null
@@ -7488,6 +8904,7 @@ export type Database = {
         }
         Insert: {
           captured_at?: string | null
+          context?: Json | null
           email: string
           id?: number
           last_annual_reminder?: string | null
@@ -7510,6 +8927,7 @@ export type Database = {
         }
         Update: {
           captured_at?: string | null
+          context?: Json | null
           email?: string
           id?: number
           last_annual_reminder?: string | null
@@ -7631,6 +9049,72 @@ export type Database = {
           notes?: string | null
           reason?: string
           source?: string | null
+        }
+        Relationships: []
+      }
+      etf_distributions: {
+        Row: {
+          amount_cents: number | null
+          distribution_type: string
+          etf_name: string
+          etf_slug: string
+          ex_date: string
+          franking_pct: number
+          id: number
+          pay_date: string | null
+          updated_at: string
+        }
+        Insert: {
+          amount_cents?: number | null
+          distribution_type?: string
+          etf_name: string
+          etf_slug: string
+          ex_date: string
+          franking_pct?: number
+          id?: number
+          pay_date?: string | null
+          updated_at?: string
+        }
+        Update: {
+          amount_cents?: number | null
+          distribution_type?: string
+          etf_name?: string
+          etf_slug?: string
+          ex_date?: string
+          franking_pct?: number
+          id?: number
+          pay_date?: string | null
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      etf_holdings: {
+        Row: {
+          etf_name: string
+          etf_slug: string
+          id: number
+          security_name: string
+          ticker: string
+          updated_at: string
+          weight_bps: number
+        }
+        Insert: {
+          etf_name: string
+          etf_slug: string
+          id?: number
+          security_name: string
+          ticker: string
+          updated_at?: string
+          weight_bps: number
+        }
+        Update: {
+          etf_name?: string
+          etf_slug?: string
+          id?: number
+          security_name?: string
+          ticker?: string
+          updated_at?: string
+          weight_bps?: number
         }
         Relationships: []
       }
@@ -7949,6 +9433,7 @@ export type Database = {
           enabled: boolean
           flag_key: string
           id: number
+          last_evaluated_at: string | null
           rollout_pct: number
           segments: string[]
           updated_at: string
@@ -7963,6 +9448,7 @@ export type Database = {
           enabled?: boolean
           flag_key: string
           id?: number
+          last_evaluated_at?: string | null
           rollout_pct?: number
           segments?: string[]
           updated_at?: string
@@ -7977,6 +9463,7 @@ export type Database = {
           enabled?: boolean
           flag_key?: string
           id?: number
+          last_evaluated_at?: string | null
           rollout_pct?: number
           segments?: string[]
           updated_at?: string
@@ -8092,6 +9579,57 @@ export type Database = {
         }
         Relationships: []
       }
+      fee_index_snapshots: {
+        Row: {
+          asx_fee_sample: number
+          avg_asx_fee: number | null
+          avg_fx_spread: number | null
+          avg_us_fee: number | null
+          broker_count: number
+          computed_at: string
+          fx_spread_sample: number
+          id: number
+          median_asx_fee: number | null
+          median_fx_spread: number | null
+          median_us_fee: number | null
+          period: string
+          source: string
+          us_fee_sample: number
+        }
+        Insert: {
+          asx_fee_sample?: number
+          avg_asx_fee?: number | null
+          avg_fx_spread?: number | null
+          avg_us_fee?: number | null
+          broker_count?: number
+          computed_at?: string
+          fx_spread_sample?: number
+          id?: number
+          median_asx_fee?: number | null
+          median_fx_spread?: number | null
+          median_us_fee?: number | null
+          period: string
+          source?: string
+          us_fee_sample?: number
+        }
+        Update: {
+          asx_fee_sample?: number
+          avg_asx_fee?: number | null
+          avg_fx_spread?: number | null
+          avg_us_fee?: number | null
+          broker_count?: number
+          computed_at?: string
+          fx_spread_sample?: number
+          id?: number
+          median_asx_fee?: number | null
+          median_fx_spread?: number | null
+          median_us_fee?: number | null
+          period?: string
+          source?: string
+          us_fee_sample?: number
+        }
+        Relationships: []
+      }
       fee_profiles: {
         Row: {
           asx_trades_per_month: number
@@ -8196,6 +9734,48 @@ export type Database = {
             referencedColumns: ["id"]
           },
         ]
+      }
+      feed_events: {
+        Row: {
+          actor_name: string | null
+          actor_slug: string | null
+          entity_slug: string | null
+          event_type: string
+          headline: string
+          id: string
+          image_url: string | null
+          published_at: string
+          ref_id: string
+          score_base: number
+          summary: string | null
+        }
+        Insert: {
+          actor_name?: string | null
+          actor_slug?: string | null
+          entity_slug?: string | null
+          event_type: string
+          headline: string
+          id?: string
+          image_url?: string | null
+          published_at?: string
+          ref_id: string
+          score_base?: number
+          summary?: string | null
+        }
+        Update: {
+          actor_name?: string | null
+          actor_slug?: string | null
+          entity_slug?: string | null
+          event_type?: string
+          headline?: string
+          id?: string
+          image_url?: string | null
+          published_at?: string
+          ref_id?: string
+          score_base?: number
+          summary?: string | null
+        }
+        Relationships: []
       }
       fi_change_log: {
         Row: {
@@ -8928,9 +10508,12 @@ export type Database = {
           author_name: string | null
           body: string
           created_at: string | null
+          debate_position: string | null
           id: number
+          is_anonymous: boolean
           is_moderator: boolean | null
           is_removed: boolean | null
+          post_type: string
           thread_id: number
           updated_at: string | null
           vote_score: number | null
@@ -8940,9 +10523,12 @@ export type Database = {
           author_name?: string | null
           body: string
           created_at?: string | null
+          debate_position?: string | null
           id?: number
+          is_anonymous?: boolean
           is_moderator?: boolean | null
           is_removed?: boolean | null
+          post_type?: string
           thread_id: number
           updated_at?: string | null
           vote_score?: number | null
@@ -8952,9 +10538,12 @@ export type Database = {
           author_name?: string | null
           body?: string
           created_at?: string | null
+          debate_position?: string | null
           id?: number
+          is_anonymous?: boolean
           is_moderator?: boolean | null
           is_removed?: boolean | null
+          post_type?: string
           thread_id?: number
           updated_at?: string | null
           vote_score?: number | null
@@ -8969,6 +10558,42 @@ export type Database = {
           },
         ]
       }
+      forum_reports: {
+        Row: {
+          created_at: string
+          id: number
+          reason: string | null
+          reporter_user_id: string
+          resolved_at: string | null
+          resolved_by: string | null
+          status: string
+          target_id: number
+          target_type: string
+        }
+        Insert: {
+          created_at?: string
+          id?: number
+          reason?: string | null
+          reporter_user_id: string
+          resolved_at?: string | null
+          resolved_by?: string | null
+          status?: string
+          target_id: number
+          target_type: string
+        }
+        Update: {
+          created_at?: string
+          id?: number
+          reason?: string | null
+          reporter_user_id?: string
+          resolved_at?: string | null
+          resolved_by?: string | null
+          status?: string
+          target_id?: number
+          target_type?: string
+        }
+        Relationships: []
+      }
       forum_threads: {
         Row: {
           author_id: string | null
@@ -8978,6 +10603,7 @@ export type Database = {
           category_slug: string
           created_at: string | null
           id: number
+          is_anonymous: boolean
           is_locked: boolean | null
           is_moderator: boolean | null
           is_pinned: boolean | null
@@ -8985,6 +10611,7 @@ export type Database = {
           last_reply_at: string | null
           reply_count: number | null
           slug: string
+          thread_type: string
           title: string
           updated_at: string | null
           view_count: number | null
@@ -8998,6 +10625,7 @@ export type Database = {
           category_slug: string
           created_at?: string | null
           id?: number
+          is_anonymous?: boolean
           is_locked?: boolean | null
           is_moderator?: boolean | null
           is_pinned?: boolean | null
@@ -9005,6 +10633,7 @@ export type Database = {
           last_reply_at?: string | null
           reply_count?: number | null
           slug: string
+          thread_type?: string
           title: string
           updated_at?: string | null
           view_count?: number | null
@@ -9018,6 +10647,7 @@ export type Database = {
           category_slug?: string
           created_at?: string | null
           id?: number
+          is_anonymous?: boolean
           is_locked?: boolean | null
           is_moderator?: boolean | null
           is_pinned?: boolean | null
@@ -9025,6 +10655,7 @@ export type Database = {
           last_reply_at?: string | null
           reply_count?: number | null
           slug?: string
+          thread_type?: string
           title?: string
           updated_at?: string | null
           view_count?: number | null
@@ -9838,6 +11469,66 @@ export type Database = {
           },
         ]
       }
+      invest_score_daily: {
+        Row: {
+          components: Json
+          created_at: string
+          date: string
+          id: string
+          label: string
+          score: number
+          updated_at: string
+        }
+        Insert: {
+          components?: Json
+          created_at?: string
+          date: string
+          id?: string
+          label: string
+          score: number
+          updated_at?: string
+        }
+        Update: {
+          components?: Json
+          created_at?: string
+          date?: string
+          id?: string
+          label?: string
+          score?: number
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      investment_clubs: {
+        Row: {
+          created_at: string
+          created_by: string
+          description: string | null
+          id: string
+          member_limit: number
+          name: string
+          slug: string
+        }
+        Insert: {
+          created_at?: string
+          created_by: string
+          description?: string | null
+          id?: string
+          member_limit?: number
+          name: string
+          slug: string
+        }
+        Update: {
+          created_at?: string
+          created_by?: string
+          description?: string | null
+          id?: string
+          member_limit?: number
+          name?: string
+          slug?: string
+        }
+        Relationships: []
+      }
       investment_listings: {
         Row: {
           admin_overridden_at: string | null
@@ -10009,23 +11700,74 @@ export type Database = {
         }
         Relationships: []
       }
+      investor_cohort_snapshots: {
+        Row: {
+          computed_at: string
+          conversion_rate: number | null
+          experience_level: string | null
+          id: number
+          inferred_vertical: string | null
+          investment_range: string | null
+          leads_captured: number
+          quiz_completions: number
+          top_utm_source: string | null
+          week_start: string
+        }
+        Insert: {
+          computed_at?: string
+          conversion_rate?: number | null
+          experience_level?: string | null
+          id?: number
+          inferred_vertical?: string | null
+          investment_range?: string | null
+          leads_captured?: number
+          quiz_completions?: number
+          top_utm_source?: string | null
+          week_start: string
+        }
+        Update: {
+          computed_at?: string
+          conversion_rate?: number | null
+          experience_level?: string | null
+          id?: number
+          inferred_vertical?: string | null
+          investment_range?: string | null
+          leads_captured?: number
+          quiz_completions?: number
+          top_utm_source?: string | null
+          week_start?: string
+        }
+        Relationships: []
+      }
       investor_drip_log: {
         Row: {
+          broker_recommendations: Json | null
+          clicked_at: string | null
           drip_number: number
+          drip_type: string | null
           email: string
           id: number
+          opened_at: string | null
           sent_at: string | null
         }
         Insert: {
+          broker_recommendations?: Json | null
+          clicked_at?: string | null
           drip_number: number
+          drip_type?: string | null
           email: string
           id?: number
+          opened_at?: string | null
           sent_at?: string | null
         }
         Update: {
+          broker_recommendations?: Json | null
+          clicked_at?: string | null
           drip_number?: number
+          drip_type?: string | null
           email?: string
           id?: number
+          opened_at?: string | null
           sent_at?: string | null
         }
         Relationships: []
@@ -10072,6 +11814,39 @@ export type Database = {
           target_cents?: number
           target_date?: string
           updated_at?: string
+        }
+        Relationships: []
+      }
+      investor_handoffs: {
+        Row: {
+          consumed_at: string | null
+          created_at: string
+          expires_at: string
+          holdings_snapshot_json: Json
+          id: string
+          intent: string
+          token: string
+          user_id: string
+        }
+        Insert: {
+          consumed_at?: string | null
+          created_at?: string
+          expires_at: string
+          holdings_snapshot_json?: Json
+          id?: string
+          intent?: string
+          token: string
+          user_id: string
+        }
+        Update: {
+          consumed_at?: string | null
+          created_at?: string
+          expires_at?: string
+          holdings_snapshot_json?: Json
+          id?: string
+          intent?: string
+          token?: string
+          user_id?: string
         }
         Relationships: []
       }
@@ -10215,6 +11990,7 @@ export type Database = {
           auth_user_id: string
           budget_band: string | null
           created_at: string
+          deleted_at: string | null
           display_name: string | null
           experience_level: string | null
           id: number
@@ -10226,6 +12002,7 @@ export type Database = {
           is_pre_retiree: boolean
           meta: Json
           mot_sent_at: string | null
+          pii_redacted_at: string | null
           primary_vertical: string | null
           updated_at: string
         }
@@ -10233,6 +12010,7 @@ export type Database = {
           auth_user_id: string
           budget_band?: string | null
           created_at?: string
+          deleted_at?: string | null
           display_name?: string | null
           experience_level?: string | null
           id?: never
@@ -10244,6 +12022,7 @@ export type Database = {
           is_pre_retiree?: boolean
           meta?: Json
           mot_sent_at?: string | null
+          pii_redacted_at?: string | null
           primary_vertical?: string | null
           updated_at?: string
         }
@@ -10251,6 +12030,7 @@ export type Database = {
           auth_user_id?: string
           budget_band?: string | null
           created_at?: string
+          deleted_at?: string | null
           display_name?: string | null
           experience_level?: string | null
           id?: never
@@ -10262,6 +12042,7 @@ export type Database = {
           is_pre_retiree?: boolean
           meta?: Json
           mot_sent_at?: string | null
+          pii_redacted_at?: string | null
           primary_vertical?: string | null
           updated_at?: string
         }
@@ -10329,6 +12110,161 @@ export type Database = {
           signup_count?: number
         }
         Relationships: []
+      }
+      ipo_offers: {
+        Row: {
+          amount_raised_cents: number | null
+          asx_code: string
+          company_name: string
+          created_at: string
+          description: string | null
+          first_day_return_pct: number | null
+          id: string
+          is_published: boolean
+          issue_price_cents: number | null
+          listing_date: string | null
+          minimum_application_cents: number | null
+          note: string | null
+          offer_close_date: string | null
+          offer_open_date: string | null
+          offer_type: string | null
+          prospectus_url: string | null
+          sector: string | null
+          status: string
+          updated_at: string
+        }
+        Insert: {
+          amount_raised_cents?: number | null
+          asx_code: string
+          company_name: string
+          created_at?: string
+          description?: string | null
+          first_day_return_pct?: number | null
+          id?: string
+          is_published?: boolean
+          issue_price_cents?: number | null
+          listing_date?: string | null
+          minimum_application_cents?: number | null
+          note?: string | null
+          offer_close_date?: string | null
+          offer_open_date?: string | null
+          offer_type?: string | null
+          prospectus_url?: string | null
+          sector?: string | null
+          status?: string
+          updated_at?: string
+        }
+        Update: {
+          amount_raised_cents?: number | null
+          asx_code?: string
+          company_name?: string
+          created_at?: string
+          description?: string | null
+          first_day_return_pct?: number | null
+          id?: string
+          is_published?: boolean
+          issue_price_cents?: number | null
+          listing_date?: string | null
+          minimum_application_cents?: number | null
+          note?: string | null
+          offer_close_date?: string | null
+          offer_open_date?: string | null
+          offer_type?: string | null
+          prospectus_url?: string | null
+          sector?: string | null
+          status?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      job_applications: {
+        Row: {
+          applicant_email: string
+          applicant_name: string
+          created_at: string
+          id: string
+          job_id: string
+          message: string
+        }
+        Insert: {
+          applicant_email: string
+          applicant_name: string
+          created_at?: string
+          id?: string
+          job_id: string
+          message: string
+        }
+        Update: {
+          applicant_email?: string
+          applicant_name?: string
+          created_at?: string
+          id?: string
+          job_id?: string
+          message?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "job_applications_job_id_fkey"
+            columns: ["job_id"]
+            isOneToOne: false
+            referencedRelation: "job_posts"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      job_posts: {
+        Row: {
+          created_at: string
+          created_by: string | null
+          description: string
+          firm_id: number
+          id: string
+          location: string
+          status: string
+          title: string
+          type: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          created_by?: string | null
+          description: string
+          firm_id: number
+          id?: string
+          location: string
+          status?: string
+          title: string
+          type?: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          created_by?: string | null
+          description?: string
+          firm_id?: number
+          id?: string
+          location?: string
+          status?: string
+          title?: string
+          type?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "job_posts_firm_id_fkey"
+            columns: ["firm_id"]
+            isOneToOne: false
+            referencedRelation: "advisor_firms"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "job_posts_firm_id_fkey"
+            columns: ["firm_id"]
+            isOneToOne: false
+            referencedRelation: "firm_credit_balance_summary"
+            referencedColumns: ["firm_id"]
+          },
+        ]
       }
       job_queue: {
         Row: {
@@ -10471,36 +12407,42 @@ export type Database = {
         Row: {
           advisor_type: string
           description: string | null
+          exclusive_price_cents: number | null
           featured_monthly_cents: number
           free_trial_leads: number
           id: number
           max_price_cents: number
           min_price_cents: number
           price_cents: number
+          qualified_price_cents: number | null
           updated_at: string | null
           updated_by: string | null
         }
         Insert: {
           advisor_type: string
           description?: string | null
+          exclusive_price_cents?: number | null
           featured_monthly_cents?: number
           free_trial_leads?: number
           id?: number
           max_price_cents?: number
           min_price_cents?: number
           price_cents: number
+          qualified_price_cents?: number | null
           updated_at?: string | null
           updated_by?: string | null
         }
         Update: {
           advisor_type?: string
           description?: string | null
+          exclusive_price_cents?: number | null
           featured_monthly_cents?: number
           free_trial_leads?: number
           id?: number
           max_price_cents?: number
           min_price_cents?: number
           price_cents?: number
+          qualified_price_cents?: number | null
           updated_at?: string | null
           updated_by?: string | null
         }
@@ -10568,6 +12510,7 @@ export type Database = {
       }
       leads: {
         Row: {
+          advisor_notified_at: string | null
           broker_id: number | null
           created_at: string | null
           id: number
@@ -10587,6 +12530,7 @@ export type Database = {
           utm_source: string | null
         }
         Insert: {
+          advisor_notified_at?: string | null
           broker_id?: number | null
           created_at?: string | null
           id?: number
@@ -10606,6 +12550,7 @@ export type Database = {
           utm_source?: string | null
         }
         Update: {
+          advisor_notified_at?: string | null
           broker_id?: number | null
           created_at?: string | null
           id?: number
@@ -10699,6 +12644,33 @@ export type Database = {
           status?: string
           title?: string
           updated_at?: string | null
+        }
+        Relationships: []
+      }
+      life_event_wizard_state: {
+        Row: {
+          form_data: Json
+          id: number
+          life_event_id: string
+          step: number
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          form_data?: Json
+          id?: number
+          life_event_id: string
+          step?: number
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          form_data?: Json
+          id?: number
+          life_event_id?: string
+          step?: number
+          updated_at?: string
+          user_id?: string
         }
         Relationships: []
       }
@@ -10876,27 +12848,33 @@ export type Database = {
         Row: {
           auth_user_id: string
           created_at: string
+          deleted_at: string | null
           display_name: string | null
           email_verified_at: string | null
           id: number
+          pii_redacted_at: string | null
           status: string
           updated_at: string
         }
         Insert: {
           auth_user_id: string
           created_at?: string
+          deleted_at?: string | null
           display_name?: string | null
           email_verified_at?: string | null
           id?: never
+          pii_redacted_at?: string | null
           status?: string
           updated_at?: string
         }
         Update: {
           auth_user_id?: string
           created_at?: string
+          deleted_at?: string | null
           display_name?: string | null
           email_verified_at?: string | null
           id?: never
+          pii_redacted_at?: string | null
           status?: string
           updated_at?: string
         }
@@ -11067,6 +13045,78 @@ export type Database = {
           last_failure_at?: string
           last_ip_hash?: string | null
           locked_until?: string | null
+        }
+        Relationships: []
+      }
+      manual_balances: {
+        Row: {
+          amount_cents: number
+          category: string
+          id: string
+          label: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          amount_cents?: number
+          category: string
+          id?: string
+          label: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          amount_cents?: number
+          category?: string
+          id?: string
+          label?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
+      market_events: {
+        Row: {
+          created_at: string
+          description: string
+          event_date: string
+          event_type: string
+          id: number
+          is_all_day: boolean
+          is_published: boolean
+          source_url: string
+          start_time: string | null
+          timezone: string
+          title: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          description?: string
+          event_date: string
+          event_type: string
+          id?: number
+          is_all_day?: boolean
+          is_published?: boolean
+          source_url?: string
+          start_time?: string | null
+          timezone?: string
+          title: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          description?: string
+          event_date?: string
+          event_type?: string
+          id?: number
+          is_all_day?: boolean
+          is_published?: boolean
+          source_url?: string
+          start_time?: string | null
+          timezone?: string
+          title?: string
+          updated_at?: string
         }
         Relationships: []
       }
@@ -11338,6 +13388,30 @@ export type Database = {
         }
         Relationships: []
       }
+      morning_brief_sends: {
+        Row: {
+          id: number
+          sections_included: string[]
+          send_date: string
+          sent_at: string
+          user_id: string
+        }
+        Insert: {
+          id?: number
+          sections_included?: string[]
+          send_date: string
+          sent_at?: string
+          user_id: string
+        }
+        Update: {
+          id?: number
+          sections_included?: string[]
+          send_date?: string
+          sent_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
       newsletter_editions: {
         Row: {
           articles_count: number
@@ -11544,34 +13618,40 @@ export type Database = {
       }
       notification_preferences: {
         Row: {
+          browser_push: boolean | null
           campaign_updates: boolean | null
           created_at: string | null
           deal_alerts: boolean | null
           fee_alerts: boolean | null
           id: string
           marketing: boolean | null
+          morning_brief: boolean
           updated_at: string | null
           user_id: string | null
           weekly_digest: boolean | null
         }
         Insert: {
+          browser_push?: boolean | null
           campaign_updates?: boolean | null
           created_at?: string | null
           deal_alerts?: boolean | null
           fee_alerts?: boolean | null
           id?: string
           marketing?: boolean | null
+          morning_brief?: boolean
           updated_at?: string | null
           user_id?: string | null
           weekly_digest?: boolean | null
         }
         Update: {
+          browser_push?: boolean | null
           campaign_updates?: boolean | null
           created_at?: string | null
           deal_alerts?: boolean | null
           fee_alerts?: boolean | null
           id?: string
           marketing?: boolean | null
+          morning_brief?: boolean
           updated_at?: string | null
           user_id?: string | null
           weekly_digest?: boolean | null
@@ -11614,6 +13694,290 @@ export type Database = {
           session_id?: string | null
           trigger?: string
           user_agent?: string | null
+        }
+        Relationships: []
+      }
+      office_hour_questions: {
+        Row: {
+          answer: string | null
+          answered_at: string | null
+          created_at: string
+          display_name: string
+          id: number
+          is_anonymous: boolean
+          is_removed: boolean
+          question: string
+          session_id: number
+          upvote_count: number
+          user_id: string | null
+        }
+        Insert: {
+          answer?: string | null
+          answered_at?: string | null
+          created_at?: string
+          display_name: string
+          id?: number
+          is_anonymous?: boolean
+          is_removed?: boolean
+          question: string
+          session_id: number
+          upvote_count?: number
+          user_id?: string | null
+        }
+        Update: {
+          answer?: string | null
+          answered_at?: string | null
+          created_at?: string
+          display_name?: string
+          id?: number
+          is_anonymous?: boolean
+          is_removed?: boolean
+          question?: string
+          session_id?: number
+          upvote_count?: number
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "office_hour_questions_session_id_fkey"
+            columns: ["session_id"]
+            isOneToOne: false
+            referencedRelation: "advisor_office_hours"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      office_hour_rsvps: {
+        Row: {
+          created_at: string
+          id: number
+          reminded_at: string | null
+          session_id: number
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: number
+          reminded_at?: string | null
+          session_id: number
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: number
+          reminded_at?: string | null
+          session_id?: number
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "office_hour_rsvps_session_id_fkey"
+            columns: ["session_id"]
+            isOneToOne: false
+            referencedRelation: "advisor_office_hours"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      office_hour_upvotes: {
+        Row: {
+          created_at: string
+          id: number
+          question_id: number
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: number
+          question_id: number
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: number
+          question_id?: number
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "office_hour_upvotes_question_id_fkey"
+            columns: ["question_id"]
+            isOneToOne: false
+            referencedRelation: "office_hour_questions"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      organisation_applications: {
+        Row: {
+          abn: string | null
+          bio: string | null
+          contact_email: string
+          contact_name: string
+          contact_phone: string | null
+          cpd_provider_number: string | null
+          created_at: string
+          id: number
+          organisation_name: string
+          organisation_type: string
+          rejection_reason: string | null
+          reviewed_at: string | null
+          status: string
+          website: string | null
+        }
+        Insert: {
+          abn?: string | null
+          bio?: string | null
+          contact_email: string
+          contact_name: string
+          contact_phone?: string | null
+          cpd_provider_number?: string | null
+          created_at?: string
+          id?: number
+          organisation_name: string
+          organisation_type: string
+          rejection_reason?: string | null
+          reviewed_at?: string | null
+          status?: string
+          website?: string | null
+        }
+        Update: {
+          abn?: string | null
+          bio?: string | null
+          contact_email?: string
+          contact_name?: string
+          contact_phone?: string | null
+          cpd_provider_number?: string | null
+          created_at?: string
+          id?: number
+          organisation_name?: string
+          organisation_type?: string
+          rejection_reason?: string | null
+          reviewed_at?: string | null
+          status?: string
+          website?: string | null
+        }
+        Relationships: []
+      }
+      organisation_members: {
+        Row: {
+          accepted_at: string | null
+          created_at: string
+          id: number
+          invited_at: string
+          invited_email: string
+          organisation_id: number
+          role: string
+          status: string
+          user_id: string | null
+        }
+        Insert: {
+          accepted_at?: string | null
+          created_at?: string
+          id?: number
+          invited_at?: string
+          invited_email: string
+          organisation_id: number
+          role?: string
+          status?: string
+          user_id?: string | null
+        }
+        Update: {
+          accepted_at?: string | null
+          created_at?: string
+          id?: number
+          invited_at?: string
+          invited_email?: string
+          organisation_id?: number
+          role?: string
+          status?: string
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "organisation_members_organisation_id_fkey"
+            columns: ["organisation_id"]
+            isOneToOne: false
+            referencedRelation: "organisations"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      organisations: {
+        Row: {
+          abn: string | null
+          acn: string | null
+          admin_user_id: string
+          bio: string | null
+          cpd_provider_number: string | null
+          created_at: string
+          email: string
+          id: number
+          location_state: string | null
+          logo_url: string | null
+          max_seats: number
+          name: string
+          organisation_type: string
+          phone: string | null
+          slug: string
+          status: string
+          stripe_connect_account_id: string | null
+          stripe_connect_payouts_enabled: boolean
+          stripe_connect_status: string
+          tier: string
+          updated_at: string
+          verification_status: string
+          website: string | null
+        }
+        Insert: {
+          abn?: string | null
+          acn?: string | null
+          admin_user_id: string
+          bio?: string | null
+          cpd_provider_number?: string | null
+          created_at?: string
+          email: string
+          id?: number
+          location_state?: string | null
+          logo_url?: string | null
+          max_seats?: number
+          name: string
+          organisation_type?: string
+          phone?: string | null
+          slug: string
+          status?: string
+          stripe_connect_account_id?: string | null
+          stripe_connect_payouts_enabled?: boolean
+          stripe_connect_status?: string
+          tier?: string
+          updated_at?: string
+          verification_status?: string
+          website?: string | null
+        }
+        Update: {
+          abn?: string | null
+          acn?: string | null
+          admin_user_id?: string
+          bio?: string | null
+          cpd_provider_number?: string | null
+          created_at?: string
+          email?: string
+          id?: number
+          location_state?: string | null
+          logo_url?: string | null
+          max_seats?: number
+          name?: string
+          organisation_type?: string
+          phone?: string | null
+          slug?: string
+          status?: string
+          stripe_connect_account_id?: string | null
+          stripe_connect_payouts_enabled?: boolean
+          stripe_connect_status?: string
+          tier?: string
+          updated_at?: string
+          verification_status?: string
+          website?: string | null
         }
         Relationships: []
       }
@@ -12198,6 +14562,42 @@ export type Database = {
           },
         ]
       }
+      principals: {
+        Row: {
+          auth_user_id: string | null
+          created_at: string
+          display_name: string
+          id: string
+          kind: string
+          metadata: Json
+          slug: string | null
+          status: string
+          updated_at: string
+        }
+        Insert: {
+          auth_user_id?: string | null
+          created_at?: string
+          display_name: string
+          id?: string
+          kind: string
+          metadata?: Json
+          slug?: string | null
+          status?: string
+          updated_at?: string
+        }
+        Update: {
+          auth_user_id?: string | null
+          created_at?: string
+          display_name?: string
+          id?: string
+          kind?: string
+          metadata?: Json
+          slug?: string | null
+          status?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
       privacy_data_requests: {
         Row: {
           completed_at: string | null
@@ -12686,9 +15086,34 @@ export type Database = {
         }
         Relationships: []
       }
+      product_user_verified: {
+        Row: {
+          id: number
+          product_ref: string
+          product_type: string
+          user_id: string
+          verified_at: string
+        }
+        Insert: {
+          id?: number
+          product_ref: string
+          product_type: string
+          user_id: string
+          verified_at?: string
+        }
+        Update: {
+          id?: number
+          product_ref?: string
+          product_type?: string
+          user_id?: string
+          verified_at?: string
+        }
+        Relationships: []
+      }
       professional_leads: {
         Row: {
           advisor_notes: string | null
+          advisor_nudge_sent_at: string | null
           bill_amount_cents: number | null
           billed: boolean | null
           contacted_at: string | null
@@ -12696,22 +15121,29 @@ export type Database = {
           created_at: string | null
           device_type: string | null
           id: number
+          lead_tier: string | null
           lead_value: number | null
           message: string | null
           next_action_at: string | null
           outcome: string | null
+          outcome_at: string | null
+          outcome_notes: string | null
           pipeline_stage: string
           post_drip_last_at: string | null
           post_drip_step: number | null
           professional_id: number
+          qualification_data: Json | null
           quality_band: string | null
           quality_score: number | null
           quality_signals: Json | null
           referrer: string | null
           responded_at: string | null
           response_time_minutes: number | null
+          review_requested_at: string | null
+          sale_price_cents: number | null
           source_page: string | null
           status: string | null
+          success_fee_cents: number | null
           updated_at: string | null
           user_email: string
           user_name: string
@@ -12722,6 +15154,7 @@ export type Database = {
         }
         Insert: {
           advisor_notes?: string | null
+          advisor_nudge_sent_at?: string | null
           bill_amount_cents?: number | null
           billed?: boolean | null
           contacted_at?: string | null
@@ -12729,22 +15162,29 @@ export type Database = {
           created_at?: string | null
           device_type?: string | null
           id?: number
+          lead_tier?: string | null
           lead_value?: number | null
           message?: string | null
           next_action_at?: string | null
           outcome?: string | null
+          outcome_at?: string | null
+          outcome_notes?: string | null
           pipeline_stage?: string
           post_drip_last_at?: string | null
           post_drip_step?: number | null
           professional_id: number
+          qualification_data?: Json | null
           quality_band?: string | null
           quality_score?: number | null
           quality_signals?: Json | null
           referrer?: string | null
           responded_at?: string | null
           response_time_minutes?: number | null
+          review_requested_at?: string | null
+          sale_price_cents?: number | null
           source_page?: string | null
           status?: string | null
+          success_fee_cents?: number | null
           updated_at?: string | null
           user_email: string
           user_name: string
@@ -12755,6 +15195,7 @@ export type Database = {
         }
         Update: {
           advisor_notes?: string | null
+          advisor_nudge_sent_at?: string | null
           bill_amount_cents?: number | null
           billed?: boolean | null
           contacted_at?: string | null
@@ -12762,22 +15203,29 @@ export type Database = {
           created_at?: string | null
           device_type?: string | null
           id?: number
+          lead_tier?: string | null
           lead_value?: number | null
           message?: string | null
           next_action_at?: string | null
           outcome?: string | null
+          outcome_at?: string | null
+          outcome_notes?: string | null
           pipeline_stage?: string
           post_drip_last_at?: string | null
           post_drip_step?: number | null
           professional_id?: number
+          qualification_data?: Json | null
           quality_band?: string | null
           quality_score?: number | null
           quality_signals?: Json | null
           referrer?: string | null
           responded_at?: string | null
           response_time_minutes?: number | null
+          review_requested_at?: string | null
+          sale_price_cents?: number | null
           source_page?: string | null
           status?: string | null
+          success_fee_cents?: number | null
           updated_at?: string | null
           user_email?: string
           user_name?: string
@@ -12958,7 +15406,9 @@ export type Database = {
         Row: {
           abn: string | null
           accepting_new_clients: boolean | null
+          accepts_briefs: boolean
           accepts_international: boolean | null
+          accepts_international_clients: boolean | null
           accepts_new_clients: boolean
           account_type: string | null
           acn: string | null
@@ -12968,22 +15418,31 @@ export type Database = {
           advisor_nudge_sent_at: string | null
           advisor_tier: string | null
           afsl_number: string | null
+          ai_generated_summary: string | null
+          ai_summary_generated_at: string | null
+          ai_summary_published: boolean
+          alert_preferences: Json
           aum_aud_billions: number | null
           aum_percentage: number | null
           auth_user_id: string | null
           auto_pause_reason: string | null
           auto_paused_at: string | null
+          availability_status: string
           available_in_countries: string[]
           avg_response_minutes: number | null
+          bid_templates: Json
           bio: string | null
           booking_enabled: boolean | null
           booking_intro: string | null
           booking_link: string | null
           content_license_accepted_at: string | null
           conversion_rate: number | null
+          country_eligibility: Json
           created_at: string | null
           credit_auto_topup: boolean | null
           credit_balance_cents: number
+          deleted_at: string | null
+          digest_opt_out: boolean
           education: Json | null
           email: string | null
           faqs: Json | null
@@ -12992,10 +15451,12 @@ export type Database = {
           fee_description: string | null
           fee_model: string | null
           fee_structure: string | null
+          firb_specialist: boolean | null
           firm_id: number | null
           firm_name: string | null
           firm_type: string | null
           flat_fee_cents: number | null
+          follower_count: number
           free_leads_used: number | null
           geog: unknown
           health_factors: Json | null
@@ -13006,11 +15467,13 @@ export type Database = {
           id: number
           ideal_client: string | null
           initial_consultation_free: boolean | null
+          international_tax_specialist: boolean | null
           intro_video_poster_url: string | null
           intro_video_url: string | null
           is_firm_admin: boolean | null
           is_sponsored: boolean
           languages: Json | null
+          languages_spoken: string[]
           last_drip_at: string | null
           last_lead_at: string | null
           last_lead_date: string | null
@@ -13034,23 +15497,33 @@ export type Database = {
           memberships: Json | null
           meta_description: string | null
           meta_title: string | null
+          migration_agent: boolean | null
+          migration_agent_marn: string | null
+          min_client_assets_band: string | null
           min_client_balance_cents: number | null
           min_investment_cents: number | null
           minimum_investment_cents: number | null
           name: string
+          next_event_at: string | null
+          next_event_title: string | null
           offer_active: boolean | null
           offer_expiry: string | null
           offer_terms: string | null
           offer_text: string | null
           office_states: string[] | null
           onboarded_at: string | null
+          onboarding_done_at: string | null
           onboarding_step: number | null
           pause_warning_sent_at: string | null
+          pending_tier: string | null
+          pending_tier_effective_at: string | null
           phone: string | null
           photo_url: string | null
+          pii_redacted_at: string | null
           portal_onboarded: boolean | null
           preferred_lead_price_cents: number | null
           profile_complete: boolean | null
+          profile_completion_pct: number
           profile_gate_checked_at: string | null
           profile_gate_step: number | null
           profile_missing_fields: string[] | null
@@ -13058,14 +15531,19 @@ export type Database = {
           profile_score: number | null
           qualifications: Json | null
           rating: number | null
+          referral_credit_cents: number
           registration_number: string | null
           research_offering: string | null
           response_time_hours: number | null
           review_count: number | null
+          role: string | null
+          search_vec: unknown
           service_areas: Json | null
           service_tiers: Json | null
+          session_price_cents: number | null
           slack_webhook_url: string | null
           slug: string
+          specializations: string[]
           specialties: Json | null
           sponsored_boost: number | null
           status: string | null
@@ -13082,24 +15560,32 @@ export type Database = {
           tier_changed_by: string | null
           total_leads: number | null
           total_leads_received: number | null
+          trust_score_overall: number | null
+          trust_score_updated_at: string | null
+          trust_score_version: number
           twitter_url: string | null
           type: string
           unresponded_leads: number | null
           updated_at: string | null
+          verification_doc_url: string | null
           verification_failures: number | null
           verification_method: string | null
           verification_notes: string | null
+          verification_status: string
           verified: boolean | null
           verified_at: string | null
           verified_by: string | null
           website: string | null
+          welcome_email_sent_at: string | null
           year_founded: number | null
           years_experience: number | null
         }
         Insert: {
           abn?: string | null
           accepting_new_clients?: boolean | null
+          accepts_briefs?: boolean
           accepts_international?: boolean | null
+          accepts_international_clients?: boolean | null
           accepts_new_clients?: boolean
           account_type?: string | null
           acn?: string | null
@@ -13109,22 +15595,31 @@ export type Database = {
           advisor_nudge_sent_at?: string | null
           advisor_tier?: string | null
           afsl_number?: string | null
+          ai_generated_summary?: string | null
+          ai_summary_generated_at?: string | null
+          ai_summary_published?: boolean
+          alert_preferences?: Json
           aum_aud_billions?: number | null
           aum_percentage?: number | null
           auth_user_id?: string | null
           auto_pause_reason?: string | null
           auto_paused_at?: string | null
+          availability_status?: string
           available_in_countries?: string[]
           avg_response_minutes?: number | null
+          bid_templates?: Json
           bio?: string | null
           booking_enabled?: boolean | null
           booking_intro?: string | null
           booking_link?: string | null
           content_license_accepted_at?: string | null
           conversion_rate?: number | null
+          country_eligibility?: Json
           created_at?: string | null
           credit_auto_topup?: boolean | null
           credit_balance_cents?: number
+          deleted_at?: string | null
+          digest_opt_out?: boolean
           education?: Json | null
           email?: string | null
           faqs?: Json | null
@@ -13133,10 +15628,12 @@ export type Database = {
           fee_description?: string | null
           fee_model?: string | null
           fee_structure?: string | null
+          firb_specialist?: boolean | null
           firm_id?: number | null
           firm_name?: string | null
           firm_type?: string | null
           flat_fee_cents?: number | null
+          follower_count?: number
           free_leads_used?: number | null
           geog?: unknown
           health_factors?: Json | null
@@ -13147,11 +15644,13 @@ export type Database = {
           id?: number
           ideal_client?: string | null
           initial_consultation_free?: boolean | null
+          international_tax_specialist?: boolean | null
           intro_video_poster_url?: string | null
           intro_video_url?: string | null
           is_firm_admin?: boolean | null
           is_sponsored?: boolean
           languages?: Json | null
+          languages_spoken?: string[]
           last_drip_at?: string | null
           last_lead_at?: string | null
           last_lead_date?: string | null
@@ -13175,23 +15674,33 @@ export type Database = {
           memberships?: Json | null
           meta_description?: string | null
           meta_title?: string | null
+          migration_agent?: boolean | null
+          migration_agent_marn?: string | null
+          min_client_assets_band?: string | null
           min_client_balance_cents?: number | null
           min_investment_cents?: number | null
           minimum_investment_cents?: number | null
           name: string
+          next_event_at?: string | null
+          next_event_title?: string | null
           offer_active?: boolean | null
           offer_expiry?: string | null
           offer_terms?: string | null
           offer_text?: string | null
           office_states?: string[] | null
           onboarded_at?: string | null
+          onboarding_done_at?: string | null
           onboarding_step?: number | null
           pause_warning_sent_at?: string | null
+          pending_tier?: string | null
+          pending_tier_effective_at?: string | null
           phone?: string | null
           photo_url?: string | null
+          pii_redacted_at?: string | null
           portal_onboarded?: boolean | null
           preferred_lead_price_cents?: number | null
           profile_complete?: boolean | null
+          profile_completion_pct?: number
           profile_gate_checked_at?: string | null
           profile_gate_step?: number | null
           profile_missing_fields?: string[] | null
@@ -13199,14 +15708,19 @@ export type Database = {
           profile_score?: number | null
           qualifications?: Json | null
           rating?: number | null
+          referral_credit_cents?: number
           registration_number?: string | null
           research_offering?: string | null
           response_time_hours?: number | null
           review_count?: number | null
+          role?: string | null
+          search_vec?: unknown
           service_areas?: Json | null
           service_tiers?: Json | null
+          session_price_cents?: number | null
           slack_webhook_url?: string | null
           slug: string
+          specializations?: string[]
           specialties?: Json | null
           sponsored_boost?: number | null
           status?: string | null
@@ -13223,24 +15737,32 @@ export type Database = {
           tier_changed_by?: string | null
           total_leads?: number | null
           total_leads_received?: number | null
+          trust_score_overall?: number | null
+          trust_score_updated_at?: string | null
+          trust_score_version?: number
           twitter_url?: string | null
           type: string
           unresponded_leads?: number | null
           updated_at?: string | null
+          verification_doc_url?: string | null
           verification_failures?: number | null
           verification_method?: string | null
           verification_notes?: string | null
+          verification_status?: string
           verified?: boolean | null
           verified_at?: string | null
           verified_by?: string | null
           website?: string | null
+          welcome_email_sent_at?: string | null
           year_founded?: number | null
           years_experience?: number | null
         }
         Update: {
           abn?: string | null
           accepting_new_clients?: boolean | null
+          accepts_briefs?: boolean
           accepts_international?: boolean | null
+          accepts_international_clients?: boolean | null
           accepts_new_clients?: boolean
           account_type?: string | null
           acn?: string | null
@@ -13250,22 +15772,31 @@ export type Database = {
           advisor_nudge_sent_at?: string | null
           advisor_tier?: string | null
           afsl_number?: string | null
+          ai_generated_summary?: string | null
+          ai_summary_generated_at?: string | null
+          ai_summary_published?: boolean
+          alert_preferences?: Json
           aum_aud_billions?: number | null
           aum_percentage?: number | null
           auth_user_id?: string | null
           auto_pause_reason?: string | null
           auto_paused_at?: string | null
+          availability_status?: string
           available_in_countries?: string[]
           avg_response_minutes?: number | null
+          bid_templates?: Json
           bio?: string | null
           booking_enabled?: boolean | null
           booking_intro?: string | null
           booking_link?: string | null
           content_license_accepted_at?: string | null
           conversion_rate?: number | null
+          country_eligibility?: Json
           created_at?: string | null
           credit_auto_topup?: boolean | null
           credit_balance_cents?: number
+          deleted_at?: string | null
+          digest_opt_out?: boolean
           education?: Json | null
           email?: string | null
           faqs?: Json | null
@@ -13274,10 +15805,12 @@ export type Database = {
           fee_description?: string | null
           fee_model?: string | null
           fee_structure?: string | null
+          firb_specialist?: boolean | null
           firm_id?: number | null
           firm_name?: string | null
           firm_type?: string | null
           flat_fee_cents?: number | null
+          follower_count?: number
           free_leads_used?: number | null
           geog?: unknown
           health_factors?: Json | null
@@ -13288,11 +15821,13 @@ export type Database = {
           id?: number
           ideal_client?: string | null
           initial_consultation_free?: boolean | null
+          international_tax_specialist?: boolean | null
           intro_video_poster_url?: string | null
           intro_video_url?: string | null
           is_firm_admin?: boolean | null
           is_sponsored?: boolean
           languages?: Json | null
+          languages_spoken?: string[]
           last_drip_at?: string | null
           last_lead_at?: string | null
           last_lead_date?: string | null
@@ -13316,23 +15851,33 @@ export type Database = {
           memberships?: Json | null
           meta_description?: string | null
           meta_title?: string | null
+          migration_agent?: boolean | null
+          migration_agent_marn?: string | null
+          min_client_assets_band?: string | null
           min_client_balance_cents?: number | null
           min_investment_cents?: number | null
           minimum_investment_cents?: number | null
           name?: string
+          next_event_at?: string | null
+          next_event_title?: string | null
           offer_active?: boolean | null
           offer_expiry?: string | null
           offer_terms?: string | null
           offer_text?: string | null
           office_states?: string[] | null
           onboarded_at?: string | null
+          onboarding_done_at?: string | null
           onboarding_step?: number | null
           pause_warning_sent_at?: string | null
+          pending_tier?: string | null
+          pending_tier_effective_at?: string | null
           phone?: string | null
           photo_url?: string | null
+          pii_redacted_at?: string | null
           portal_onboarded?: boolean | null
           preferred_lead_price_cents?: number | null
           profile_complete?: boolean | null
+          profile_completion_pct?: number
           profile_gate_checked_at?: string | null
           profile_gate_step?: number | null
           profile_missing_fields?: string[] | null
@@ -13340,14 +15885,19 @@ export type Database = {
           profile_score?: number | null
           qualifications?: Json | null
           rating?: number | null
+          referral_credit_cents?: number
           registration_number?: string | null
           research_offering?: string | null
           response_time_hours?: number | null
           review_count?: number | null
+          role?: string | null
+          search_vec?: unknown
           service_areas?: Json | null
           service_tiers?: Json | null
+          session_price_cents?: number | null
           slack_webhook_url?: string | null
           slug?: string
+          specializations?: string[]
           specialties?: Json | null
           sponsored_boost?: number | null
           status?: string | null
@@ -13364,17 +15914,23 @@ export type Database = {
           tier_changed_by?: string | null
           total_leads?: number | null
           total_leads_received?: number | null
+          trust_score_overall?: number | null
+          trust_score_updated_at?: string | null
+          trust_score_version?: number
           twitter_url?: string | null
           type?: string
           unresponded_leads?: number | null
           updated_at?: string | null
+          verification_doc_url?: string | null
           verification_failures?: number | null
           verification_method?: string | null
           verification_notes?: string | null
+          verification_status?: string
           verified?: boolean | null
           verified_at?: string | null
           verified_by?: string | null
           website?: string | null
+          welcome_email_sent_at?: string | null
           year_founded?: number | null
           years_experience?: number | null
         }
@@ -13394,6 +15950,36 @@ export type Database = {
             referencedColumns: ["firm_id"]
           },
         ]
+      }
+      profile_share_tokens: {
+        Row: {
+          consumed_at: string | null
+          created_at: string
+          expires_at: string
+          id: string
+          snapshot_json: Json
+          token: string
+          user_id: string
+        }
+        Insert: {
+          consumed_at?: string | null
+          created_at?: string
+          expires_at: string
+          id?: string
+          snapshot_json?: Json
+          token: string
+          user_id: string
+        }
+        Update: {
+          consumed_at?: string | null
+          created_at?: string
+          expires_at?: string
+          id?: string
+          snapshot_json?: Json
+          token?: string
+          user_id?: string
+        }
+        Relationships: []
       }
       profiles: {
         Row: {
@@ -13908,6 +16494,119 @@ export type Database = {
           },
         ]
       }
+      push_subscriptions: {
+        Row: {
+          created_at: string
+          endpoint: string
+          id: string
+          keys_auth: string
+          keys_p256dh: string
+          topics: string[]
+          updated_at: string
+          user_id: string | null
+        }
+        Insert: {
+          created_at?: string
+          endpoint: string
+          id?: string
+          keys_auth: string
+          keys_p256dh: string
+          topics?: string[]
+          updated_at?: string
+          user_id?: string | null
+        }
+        Update: {
+          created_at?: string
+          endpoint?: string
+          id?: string
+          keys_auth?: string
+          keys_p256dh?: string
+          topics?: string[]
+          updated_at?: string
+          user_id?: string | null
+        }
+        Relationships: []
+      }
+      qa_answers: {
+        Row: {
+          answer_text: string
+          created_at: string
+          id: number
+          published_at: string | null
+          question_id: number
+          source: string
+          status: string
+          updated_at: string
+        }
+        Insert: {
+          answer_text: string
+          created_at?: string
+          id?: number
+          published_at?: string | null
+          question_id: number
+          source?: string
+          status?: string
+          updated_at?: string
+        }
+        Update: {
+          answer_text?: string
+          created_at?: string
+          id?: number
+          published_at?: string | null
+          question_id?: number
+          source?: string
+          status?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "qa_answers_question_id_fkey"
+            columns: ["question_id"]
+            isOneToOne: false
+            referencedRelation: "qa_questions"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      qa_questions: {
+        Row: {
+          category: string
+          created_at: string
+          email: string | null
+          id: number
+          moderation_note: string | null
+          question_text: string
+          slug: string
+          source_ip_hash: string | null
+          status: string
+          updated_at: string
+        }
+        Insert: {
+          category?: string
+          created_at?: string
+          email?: string | null
+          id?: number
+          moderation_note?: string | null
+          question_text: string
+          slug: string
+          source_ip_hash?: string | null
+          status?: string
+          updated_at?: string
+        }
+        Update: {
+          category?: string
+          created_at?: string
+          email?: string | null
+          id?: number
+          moderation_note?: string | null
+          question_text?: string
+          slug?: string
+          source_ip_hash?: string | null
+          status?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
       qa_votes: {
         Row: {
           created_at: string | null
@@ -14390,6 +17089,56 @@ export type Database = {
         }
         Relationships: []
       }
+      rate_change_log: {
+        Row: {
+          broker_id: number
+          broker_name: string
+          broker_slug: string
+          delta_bps: number
+          direction: string
+          id: string
+          logged_at: string
+          new_rate_bps: number
+          old_rate_bps: number | null
+          product_kind: string
+          snapshot_captured_at: string
+        }
+        Insert: {
+          broker_id: number
+          broker_name: string
+          broker_slug: string
+          delta_bps: number
+          direction: string
+          id?: string
+          logged_at?: string
+          new_rate_bps: number
+          old_rate_bps?: number | null
+          product_kind: string
+          snapshot_captured_at: string
+        }
+        Update: {
+          broker_id?: number
+          broker_name?: string
+          broker_slug?: string
+          delta_bps?: number
+          direction?: string
+          id?: string
+          logged_at?: string
+          new_rate_bps?: number
+          old_rate_bps?: number | null
+          product_kind?: string
+          snapshot_captured_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "rate_change_log_broker_id_fkey"
+            columns: ["broker_id"]
+            isOneToOne: false
+            referencedRelation: "brokers"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       rate_limit_buckets: {
         Row: {
           created_at: string
@@ -14438,6 +17187,83 @@ export type Database = {
           id?: number
           key?: string
           window_start?: string | null
+        }
+        Relationships: []
+      }
+      rate_verifications: {
+        Row: {
+          broker_id: number
+          comment: string | null
+          created_at: string
+          id: string
+          product_kind: string
+          status: string
+          term_months: number | null
+          user_id: string
+          verified_rate_bps: number
+        }
+        Insert: {
+          broker_id: number
+          comment?: string | null
+          created_at?: string
+          id?: string
+          product_kind: string
+          status?: string
+          term_months?: number | null
+          user_id: string
+          verified_rate_bps: number
+        }
+        Update: {
+          broker_id?: number
+          comment?: string | null
+          created_at?: string
+          id?: string
+          product_kind?: string
+          status?: string
+          term_months?: number | null
+          user_id?: string
+          verified_rate_bps?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "rate_verifications_broker_id_fkey"
+            columns: ["broker_id"]
+            isOneToOne: false
+            referencedRelation: "brokers"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      rba_polls: {
+        Row: {
+          change_bps: number | null
+          created_at: string
+          decided_at: string | null
+          description: string
+          id: number
+          meeting_date: string
+          outcome: number | null
+          status: string
+        }
+        Insert: {
+          change_bps?: number | null
+          created_at?: string
+          decided_at?: string | null
+          description?: string
+          id?: number
+          meeting_date: string
+          outcome?: number | null
+          status?: string
+        }
+        Update: {
+          change_bps?: number | null
+          created_at?: string
+          decided_at?: string | null
+          description?: string
+          id?: number
+          meeting_date?: string
+          outcome?: number | null
+          status?: string
         }
         Relationships: []
       }
@@ -15096,6 +17922,30 @@ export type Database = {
         }
         Relationships: []
       }
+      seasonal_email_sends: {
+        Row: {
+          email_type: string
+          id: number
+          send_year: number
+          sent_at: string
+          user_id: string
+        }
+        Insert: {
+          email_type: string
+          id?: number
+          send_year: number
+          sent_at?: string
+          user_id: string
+        }
+        Update: {
+          email_type?: string
+          id?: number
+          send_year?: number
+          sent_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
       sector_reports: {
         Row: {
           gated: boolean | null
@@ -15614,315 +18464,6 @@ export type Database = {
         }
         Relationships: []
       }
-      startup_data_room_access: {
-        Row: {
-          file_id: string
-          granted_at: string
-          granted_by_user_id: string
-          granted_to_user_id: string
-          id: string
-          revoked_at: string | null
-        }
-        Insert: {
-          file_id: string
-          granted_at?: string
-          granted_by_user_id: string
-          granted_to_user_id: string
-          id?: string
-          revoked_at?: string | null
-        }
-        Update: {
-          file_id?: string
-          granted_at?: string
-          granted_by_user_id?: string
-          granted_to_user_id?: string
-          id?: string
-          revoked_at?: string | null
-        }
-        Relationships: []
-      }
-      startup_data_room_files: {
-        Row: {
-          category: string
-          filename: string
-          id: string
-          requires_wholesale_cert: boolean
-          round_id: string | null
-          startup_id: string
-          storage_path: string
-          uploaded_at: string
-        }
-        Insert: {
-          category: string
-          filename: string
-          id?: string
-          requires_wholesale_cert?: boolean
-          round_id?: string | null
-          startup_id: string
-          storage_path: string
-          uploaded_at?: string
-        }
-        Update: {
-          category?: string
-          filename?: string
-          id?: string
-          requires_wholesale_cert?: boolean
-          round_id?: string | null
-          startup_id?: string
-          storage_path?: string
-          uploaded_at?: string
-        }
-        Relationships: []
-      }
-      startup_investor_inquiries: {
-        Row: {
-          created_at: string
-          data_room_access_granted_at: string | null
-          id: string
-          inquiry_message: string
-          investor_user_id: string
-          round_id: string
-          status: string
-          wholesale_cert_id: string | null
-        }
-        Insert: {
-          created_at?: string
-          data_room_access_granted_at?: string | null
-          id?: string
-          inquiry_message: string
-          investor_user_id: string
-          round_id: string
-          status?: string
-          wholesale_cert_id?: string | null
-        }
-        Update: {
-          created_at?: string
-          data_room_access_granted_at?: string | null
-          id?: string
-          inquiry_message?: string
-          investor_user_id?: string
-          round_id?: string
-          status?: string
-          wholesale_cert_id?: string | null
-        }
-        Relationships: []
-      }
-      startup_profiles: {
-        Row: {
-          abn: string | null
-          company_name: string
-          created_at: string
-          esic_eligible_self_attested: boolean
-          esic_verified_at: string | null
-          esic_verified_by: string | null
-          founded_at: string | null
-          id: string
-          linkedin_url: string | null
-          owner_user_id: string
-          pitch_deck_url: string | null
-          sector: string[]
-          slug: string
-          stage: string
-          status: string
-          team: Json
-          updated_at: string
-        }
-        Insert: {
-          abn?: string | null
-          company_name: string
-          created_at?: string
-          esic_eligible_self_attested?: boolean
-          esic_verified_at?: string | null
-          esic_verified_by?: string | null
-          founded_at?: string | null
-          id?: string
-          linkedin_url?: string | null
-          owner_user_id: string
-          pitch_deck_url?: string | null
-          sector?: string[]
-          slug: string
-          stage: string
-          status?: string
-          team?: Json
-          updated_at?: string
-        }
-        Update: {
-          abn?: string | null
-          company_name?: string
-          created_at?: string
-          esic_eligible_self_attested?: boolean
-          esic_verified_at?: string | null
-          esic_verified_by?: string | null
-          founded_at?: string | null
-          id?: string
-          linkedin_url?: string | null
-          owner_user_id?: string
-          pitch_deck_url?: string | null
-          sector?: string[]
-          slug?: string
-          stage?: string
-          status?: string
-          team?: Json
-          updated_at?: string
-        }
-        Relationships: []
-      }
-      startup_rounds: {
-        Row: {
-          closes_at: string | null
-          created_at: string
-          discount_pct: number | null
-          id: string
-          instrument: string
-          interest_rate_pct: number | null
-          lead_investor_name: string | null
-          maturity_months: number | null
-          min_ticket_aud_cents: number
-          raised_aud_cents: number
-          startup_id: string
-          status: string
-          target_aud_cents: number
-          updated_at: string
-          valuation_cap_aud_cents: number | null
-          wholesale_only: boolean
-        }
-        Insert: {
-          closes_at?: string | null
-          created_at?: string
-          discount_pct?: number | null
-          id?: string
-          instrument: string
-          interest_rate_pct?: number | null
-          lead_investor_name?: string | null
-          maturity_months?: number | null
-          min_ticket_aud_cents?: number
-          raised_aud_cents?: number
-          startup_id: string
-          status?: string
-          target_aud_cents: number
-          updated_at?: string
-          valuation_cap_aud_cents?: number | null
-          wholesale_only?: boolean
-        }
-        Update: {
-          closes_at?: string | null
-          created_at?: string
-          discount_pct?: number | null
-          id?: string
-          instrument?: string
-          interest_rate_pct?: number | null
-          lead_investor_name?: string | null
-          maturity_months?: number | null
-          min_ticket_aud_cents?: number
-          raised_aud_cents?: number
-          startup_id?: string
-          status?: string
-          target_aud_cents?: number
-          updated_at?: string
-          valuation_cap_aud_cents?: number | null
-          wholesale_only?: boolean
-        }
-        Relationships: []
-      }
-      startup_sessions: {
-        Row: {
-          created_at: string
-          expires_at: string
-          id: string
-          session_token: string
-          startup_id: string
-          user_id: string
-        }
-        Insert: {
-          created_at?: string
-          expires_at: string
-          id?: string
-          session_token?: string
-          startup_id: string
-          user_id: string
-        }
-        Update: {
-          created_at?: string
-          expires_at?: string
-          id?: string
-          session_token?: string
-          startup_id?: string
-          user_id?: string
-        }
-        Relationships: []
-      }
-      esic_verifications: {
-        Row: {
-          ato_register_check: Json | null
-          created_at: string
-          evidence_doc_path: string
-          id: string
-          notes: string | null
-          outcome: string
-          reviewed_at: string | null
-          reviewed_by_user_id: string | null
-          startup_id: string
-        }
-        Insert: {
-          ato_register_check?: Json | null
-          created_at?: string
-          evidence_doc_path: string
-          id?: string
-          notes?: string | null
-          outcome?: string
-          reviewed_at?: string | null
-          reviewed_by_user_id?: string | null
-          startup_id: string
-        }
-        Update: {
-          ato_register_check?: Json | null
-          created_at?: string
-          evidence_doc_path?: string
-          id?: string
-          notes?: string | null
-          outcome?: string
-          reviewed_at?: string | null
-          reviewed_by_user_id?: string | null
-          startup_id?: string
-        }
-        Relationships: []
-      }
-      wholesale_investor_certifications: {
-        Row: {
-          certification_type: string
-          created_at: string
-          evidence_doc_path: string
-          expires_at: string
-          id: string
-          status: string
-          user_id: string
-          verified_at: string | null
-          verified_by: string | null
-        }
-        Insert: {
-          certification_type: string
-          created_at?: string
-          evidence_doc_path: string
-          expires_at: string
-          id?: string
-          status?: string
-          user_id: string
-          verified_at?: string | null
-          verified_by?: string | null
-        }
-        Update: {
-          certification_type?: string
-          created_at?: string
-          evidence_doc_path?: string
-          expires_at?: string
-          id?: string
-          status?: string
-          user_id?: string
-          verified_at?: string | null
-          verified_by?: string | null
-        }
-        Relationships: []
-      }
       stripe_webhook_events: {
         Row: {
           completed_at: string | null
@@ -16032,6 +18573,8 @@ export type Database = {
           postcode: string | null
           rental_yield_house: number | null
           rental_yield_unit: number | null
+          schools_rating: number | null
+          seo_description: string | null
           slug: string | null
           state: string
           suburb: string
@@ -16055,6 +18598,8 @@ export type Database = {
           postcode?: string | null
           rental_yield_house?: number | null
           rental_yield_unit?: number | null
+          schools_rating?: number | null
+          seo_description?: string | null
           slug?: string | null
           state: string
           suburb: string
@@ -16078,6 +18623,8 @@ export type Database = {
           postcode?: string | null
           rental_yield_house?: number | null
           rental_yield_unit?: number | null
+          schools_rating?: number | null
+          seo_description?: string | null
           slug?: string | null
           state?: string
           suburb?: string
@@ -16386,6 +18933,35 @@ export type Database = {
           },
         ]
       }
+      td_reminder_sends: {
+        Row: {
+          days_before: number
+          id: number
+          sent_at: string
+          td_id: number
+        }
+        Insert: {
+          days_before: number
+          id?: number
+          sent_at?: string
+          td_id: number
+        }
+        Update: {
+          days_before?: number
+          id?: number
+          sent_at?: string
+          td_id?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "td_reminder_sends_td_id_fkey"
+            columns: ["td_id"]
+            isOneToOne: false
+            referencedRelation: "user_term_deposits"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       team_brief_assignments: {
         Row: {
           brief_id: number
@@ -16512,36 +19088,45 @@ export type Database = {
       }
       team_brief_referrals: {
         Row: {
+          accept_credits_charged: number | null
           brief_id: number
           created_at: string
           from_professional_id: number | null
           from_team_id: number
           id: number
           note: string | null
+          payout_recorded_at: string | null
+          referrer_credits_awarded: number | null
           responded_at: string | null
           responded_by_professional_id: number | null
           status: string
           to_team_id: number
         }
         Insert: {
+          accept_credits_charged?: number | null
           brief_id: number
           created_at?: string
           from_professional_id?: number | null
           from_team_id: number
           id?: number
           note?: string | null
+          payout_recorded_at?: string | null
+          referrer_credits_awarded?: number | null
           responded_at?: string | null
           responded_by_professional_id?: number | null
           status?: string
           to_team_id: number
         }
         Update: {
+          accept_credits_charged?: number | null
           brief_id?: number
           created_at?: string
           from_professional_id?: number | null
           from_team_id?: number
           id?: number
           note?: string | null
+          payout_recorded_at?: string | null
+          referrer_credits_awarded?: number | null
           responded_at?: string | null
           responded_by_professional_id?: number | null
           status?: string
@@ -16687,6 +19272,7 @@ export type Database = {
       }
       team_members: {
         Row: {
+          advisor_slug: string | null
           avatar_url: string | null
           created_at: string | null
           credentials: Json | null
@@ -16703,6 +19289,7 @@ export type Database = {
           updated_at: string | null
         }
         Insert: {
+          advisor_slug?: string | null
           avatar_url?: string | null
           created_at?: string | null
           credentials?: Json | null
@@ -16719,6 +19306,7 @@ export type Database = {
           updated_at?: string | null
         }
         Update: {
+          advisor_slug?: string | null
           avatar_url?: string | null
           created_at?: string | null
           credentials?: Json | null
@@ -16733,6 +19321,45 @@ export type Database = {
           status?: string | null
           twitter_url?: string | null
           updated_at?: string | null
+        }
+        Relationships: []
+      }
+      telegram_subscriptions: {
+        Row: {
+          active: boolean
+          confirmed: boolean
+          created_at: string
+          email: string
+          fee_alerts: boolean
+          id: string
+          rate_alerts: boolean
+          telegram_chat_id: number
+          updated_at: string
+          user_id: string | null
+        }
+        Insert: {
+          active?: boolean
+          confirmed?: boolean
+          created_at?: string
+          email: string
+          fee_alerts?: boolean
+          id?: string
+          rate_alerts?: boolean
+          telegram_chat_id: number
+          updated_at?: string
+          user_id?: string | null
+        }
+        Update: {
+          active?: boolean
+          confirmed?: boolean
+          created_at?: string
+          email?: string
+          fee_alerts?: boolean
+          id?: string
+          rate_alerts?: boolean
+          telegram_chat_id?: number
+          updated_at?: string
+          user_id?: string | null
         }
         Relationships: []
       }
@@ -17000,6 +19627,270 @@ export type Database = {
         }
         Relationships: []
       }
+      user_current_products: {
+        Row: {
+          broker_id: number | null
+          broker_name: string
+          created_at: string
+          estimated_balance_cents: number | null
+          estimated_trades_pa: number | null
+          fee_text: string | null
+          id: string
+          last_review_reminder_at: string | null
+          product_kind: string
+          started_at: string
+          status: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          broker_id?: number | null
+          broker_name: string
+          created_at?: string
+          estimated_balance_cents?: number | null
+          estimated_trades_pa?: number | null
+          fee_text?: string | null
+          id?: string
+          last_review_reminder_at?: string | null
+          product_kind: string
+          started_at: string
+          status?: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          broker_id?: number | null
+          broker_name?: string
+          created_at?: string
+          estimated_balance_cents?: number | null
+          estimated_trades_pa?: number | null
+          fee_text?: string | null
+          id?: string
+          last_review_reminder_at?: string | null
+          product_kind?: string
+          started_at?: string
+          status?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "user_current_products_broker_id_fkey"
+            columns: ["broker_id"]
+            isOneToOne: false
+            referencedRelation: "brokers"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      user_daily_checkins: {
+        Row: {
+          check_in_date: string
+          created_at: string
+          id: string
+          points: number
+          source: string
+          streak_count: number
+          user_id: string
+        }
+        Insert: {
+          check_in_date: string
+          created_at?: string
+          id?: string
+          points?: number
+          source?: string
+          streak_count?: number
+          user_id: string
+        }
+        Update: {
+          check_in_date?: string
+          created_at?: string
+          id?: string
+          points?: number
+          source?: string
+          streak_count?: number
+          user_id?: string
+        }
+        Relationships: []
+      }
+      user_documents: {
+        Row: {
+          created_at: string
+          description: string | null
+          document_type: string
+          file_name: string
+          file_path: string
+          file_size_bytes: number
+          id: string
+          mime_type: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          description?: string | null
+          document_type: string
+          file_name: string
+          file_path: string
+          file_size_bytes: number
+          id?: string
+          mime_type: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          description?: string | null
+          document_type?: string
+          file_name?: string
+          file_path?: string
+          file_size_bytes?: number
+          id?: string
+          mime_type?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
+      user_health_score_log: {
+        Row: {
+          cost: number
+          diversification: number
+          engagement: number
+          id: string
+          overall: number
+          risk_alignment: number
+          scored_at: string
+          scored_month: string
+          user_id: string
+        }
+        Insert: {
+          cost: number
+          diversification: number
+          engagement: number
+          id?: string
+          overall: number
+          risk_alignment: number
+          scored_at?: string
+          scored_month: string
+          user_id: string
+        }
+        Update: {
+          cost?: number
+          diversification?: number
+          engagement?: number
+          id?: string
+          overall?: number
+          risk_alignment?: number
+          scored_at?: string
+          scored_month?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
+      user_list_follows: {
+        Row: {
+          followed_at: string
+          follower_user_id: string
+          id: number
+          list_id: number
+        }
+        Insert: {
+          followed_at?: string
+          follower_user_id: string
+          id?: number
+          list_id: number
+        }
+        Update: {
+          followed_at?: string
+          follower_user_id?: string
+          id?: number
+          list_id?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "user_list_follows_list_id_fkey"
+            columns: ["list_id"]
+            isOneToOne: false
+            referencedRelation: "user_lists"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      user_list_items: {
+        Row: {
+          added_at: string
+          id: number
+          item_ref: string
+          item_type: string
+          label: string
+          list_id: number
+          notes: string
+        }
+        Insert: {
+          added_at?: string
+          id?: number
+          item_ref: string
+          item_type: string
+          label?: string
+          list_id: number
+          notes?: string
+        }
+        Update: {
+          added_at?: string
+          id?: number
+          item_ref?: string
+          item_type?: string
+          label?: string
+          list_id?: number
+          notes?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "user_list_items_list_id_fkey"
+            columns: ["list_id"]
+            isOneToOne: false
+            referencedRelation: "user_lists"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      user_lists: {
+        Row: {
+          created_at: string
+          description: string
+          follower_count: number
+          id: number
+          is_public: boolean
+          item_count: number
+          owner_user_id: string
+          slug: string
+          title: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          description?: string
+          follower_count?: number
+          id?: number
+          is_public?: boolean
+          item_count?: number
+          owner_user_id: string
+          slug: string
+          title: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          description?: string
+          follower_count?: number
+          id?: number
+          is_public?: boolean
+          item_count?: number
+          owner_user_id?: string
+          slug?: string
+          title?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
       user_notifications: {
         Row: {
           body: string | null
@@ -17131,6 +20022,47 @@ export type Database = {
           user_id?: string | null
         }
         Relationships: []
+      }
+      user_rate_memory: {
+        Row: {
+          broker_id: number
+          id: string
+          last_seen_at: string
+          last_seen_rate_bps: number
+          notified_at: string | null
+          notified_rate_bps: number | null
+          product_kind: string
+          user_id: string
+        }
+        Insert: {
+          broker_id: number
+          id?: string
+          last_seen_at?: string
+          last_seen_rate_bps: number
+          notified_at?: string | null
+          notified_rate_bps?: number | null
+          product_kind: string
+          user_id: string
+        }
+        Update: {
+          broker_id?: number
+          id?: string
+          last_seen_at?: string
+          last_seen_rate_bps?: number
+          notified_at?: string | null
+          notified_rate_bps?: number | null
+          product_kind?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "user_rate_memory_broker_id_fkey"
+            columns: ["broker_id"]
+            isOneToOne: false
+            referencedRelation: "brokers"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       user_reviews: {
         Row: {
@@ -17308,6 +20240,48 @@ export type Database = {
             referencedColumns: ["id"]
           },
         ]
+      }
+      user_term_deposits: {
+        Row: {
+          created_at: string
+          id: number
+          institution_name: string
+          maturity_date: string
+          notes: string
+          principal_cents: number
+          provider_slug: string
+          rate_bps: number
+          term_months: number
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: number
+          institution_name: string
+          maturity_date: string
+          notes?: string
+          principal_cents: number
+          provider_slug?: string
+          rate_bps: number
+          term_months: number
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: number
+          institution_name?: string
+          maturity_date?: string
+          notes?: string
+          principal_cents?: number
+          provider_slug?: string
+          rate_bps?: number
+          term_months?: number
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: []
       }
       user_watchlist_items: {
         Row: {
@@ -17624,6 +20598,60 @@ export type Database = {
         }
         Relationships: []
       }
+      weights: {
+        Row: {
+          broker_slug: string
+          updated_at: string
+          weights: Json
+        }
+        Insert: {
+          broker_slug: string
+          updated_at?: string
+          weights?: Json
+        }
+        Update: {
+          broker_slug?: string
+          updated_at?: string
+          weights?: Json
+        }
+        Relationships: []
+      }
+      widget_licenses: {
+        Row: {
+          allowed_domains: string[]
+          api_key_id: string
+          created_at: string
+          id: string
+          is_active: boolean
+          name: string
+          token_hash: string
+          token_prefix: string
+          updated_at: string
+        }
+        Insert: {
+          allowed_domains?: string[]
+          api_key_id: string
+          created_at?: string
+          id?: string
+          is_active?: boolean
+          name?: string
+          token_hash: string
+          token_prefix: string
+          updated_at?: string
+        }
+        Update: {
+          allowed_domains?: string[]
+          api_key_id?: string
+          created_at?: string
+          id?: string
+          is_active?: boolean
+          name?: string
+          token_hash?: string
+          token_prefix?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
     }
     Views: {
       account_kind_membership: {
@@ -17804,6 +20832,23 @@ export type Database = {
         }
         Relationships: []
       }
+      product_user_verified_counts: {
+        Row: {
+          product_ref: string | null
+          product_type: string | null
+          verified_count: number | null
+        }
+        Relationships: []
+      }
+      rba_poll_accuracy: {
+        Row: {
+          accuracy_pct: number | null
+          correct_predictions: number | null
+          polls_participated: number | null
+          voter_user_id: string | null
+        }
+        Relationships: []
+      }
       slow_query_snapshot: {
         Row: {
           calls: number | null
@@ -17973,6 +21018,10 @@ export type Database = {
       cleanup_expired_data: { Args: never; Returns: undefined }
       cleanup_old_analytics: { Args: never; Returns: undefined }
       cleanup_rate_limits: { Args: never; Returns: undefined }
+      decrement_oh_upvote: {
+        Args: { question_id_arg: number }
+        Returns: undefined
+      }
       disablelongtransactions: { Args: never; Returns: string }
       dropgeometrycolumn:
         | {
@@ -18215,6 +21264,10 @@ export type Database = {
       }
       increment_listing_views: {
         Args: { listing_id: number }
+        Returns: undefined
+      }
+      increment_oh_upvote: {
+        Args: { question_id_arg: number }
         Returns: undefined
       }
       increment_placement_event: {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "audit:stale-dated-stats": "node scripts/check-stale-dated-stats.mjs",
     "audit:dated-stats": "node scripts/check-stale-dated-stats.mjs",
     "audit:rls-migrations": "node scripts/check-rls-migrations.mjs",
+    "audit:migration-filenames": "node scripts/check-migration-filenames.mjs",
+    "audit:ledger-drift": "node scripts/audit/ledger-drift.mjs",
     "audit:drift-types": "node scripts/check-database-types-drift.mjs",
     "audit:schema-refs": "node scripts/check-schema-references.mjs",
     "audit:financial-invariants": "node scripts/check-financial-invariants.mjs",

--- a/scripts/audit/ledger-drift.mjs
+++ b/scripts/audit/ledger-drift.mjs
@@ -26,31 +26,28 @@ import { fileURLToPath } from "node:url";
  *   SUPABASE_MIGRATIONS_JSON=path/to/ledger.json npm run audit:ledger-drift
  *   node scripts/audit/ledger-drift.mjs --ledger path/to/ledger.json --json
  *
- * Exit code is always 0 — this is an audit/observability tool, not a CI gate.
+ * Exit code is 0 on success/divergence — this is an audit/observability tool,
+ * not a CI gate (a CLI usage error, e.g. `--ledger` with no path, exits non-zero).
  * Its purpose during reconciliation is to prove the job is done: after the
  * baseline-squash + `migration repair`, `local_only` and `ledger_only` should
- * both collapse to ~0.
+ * both collapse to ~0 AND `ledger_empty` must be false (an empty dump is treated
+ * as "not reconciled", never as done).
  */
 
 import { promises as fs } from "node:fs";
 import path from "node:path";
 
+import { versionOf } from "../lib/migration-version.mjs";
+
 const MIGRATIONS_DIR = "supabase/migrations";
+
+// Re-export so existing unit tests importing from this module keep working,
+// while the parsing logic lives in one shared place (scripts/lib).
+export { versionOf };
 
 // ---------------------------------------------------------------------------
 // Core logic — exported for unit tests (pure, no I/O)
 // ---------------------------------------------------------------------------
-
-/**
- * CLI-parsed version (leading digits before first `_`) from a filename.
- * @param {string} filename
- * @returns {string}
- */
-export function versionOf(filename) {
-  const base = filename.replace(/^.*\//, "").replace(/\.sql$/i, "");
-  const m = /^(\d+)/.exec(base);
-  return m ? m[1] : "";
-}
 
 /**
  * Parse a ledger dump into the set of versions. Accepts either the raw
@@ -69,7 +66,9 @@ export function parseLedger(doc) {
   const versions = new Set();
   for (const row of arr) {
     if (typeof row === "string") versions.add(row);
-    else if (row && typeof row === "object" && typeof row.version === "string") versions.add(row.version);
+    // Accept numeric `version` too (some dump tooling emits it unquoted) by
+    // coercing to string, so the ledger is never silently undercounted.
+    else if (row && typeof row === "object" && row.version != null) versions.add(String(row.version));
   }
   return versions;
 }
@@ -125,7 +124,16 @@ export function versionToFiles(basenames) {
 
 async function readLedger() {
   const argIdx = process.argv.indexOf("--ledger");
-  const fromArg = argIdx >= 0 ? process.argv[argIdx + 1] : undefined;
+  let fromArg;
+  if (argIdx >= 0) {
+    const next = process.argv[argIdx + 1];
+    // Don't silently swallow the next flag as a filename (e.g. `--ledger --json`).
+    if (!next || next.startsWith("--")) {
+      console.error(`[ledger-drift] --ledger requires a file path argument (got ${next ?? "nothing"}).`);
+      process.exit(2);
+    }
+    fromArg = next;
+  }
   const file = fromArg || process.env.SUPABASE_MIGRATIONS_JSON;
   if (!file) return null;
   const doc = JSON.parse(await fs.readFile(file, "utf8"));
@@ -145,7 +153,10 @@ async function main() {
   }
 
   const v2f = versionToFiles(basenames);
-  const collisions = [...v2f.entries()].filter(([, files]) => files.length > 1);
+  // A real collision is two files sharing a *non-empty* version; non-versioned
+  // helpers (e.g. seed.sql, *_baseline_schema.sql) all map to "" and must not be
+  // reported as colliding with each other.
+  const collisions = [...v2f.entries()].filter(([v, files]) => v && files.length > 1);
   const localVersions = [...v2f.keys()].filter(Boolean);
 
   const ledger = await readLedger();
@@ -167,6 +178,7 @@ async function main() {
       JSON.stringify(
         {
           files: basenames.length,
+          ledgerEmpty: ledger.size === 0,
           collisions: collisions.map(([v, files]) => ({ version: v, files })),
           ...drift,
         },
@@ -186,7 +198,16 @@ async function main() {
   console.log(`- Local only (a \`db push\` would attempt these): **${drift.localOnly.length}**`);
   console.log(`- Ledger only (applied out-of-band, no local file): **${drift.ledgerOnly.length}**`);
   console.log("");
-  if (drift.localOnly.length === 0 && drift.ledgerOnly.length === 0) {
+  if (ledger.size === 0) {
+    // An empty/failed dump must never read as "done" — that would falsely
+    // certify the destructive baseline-squash complete (the runbook's exit gate
+    // is exactly "ledger_only == 0").
+    console.log(
+      "⚠️  Ledger dump parsed to 0 rows — it is empty or the dump failed. " +
+        "Refusing to certify reconciliation; re-run the dump SQL from this " +
+        "script's header and confirm it returns the full schema_migrations set.",
+    );
+  } else if (drift.localOnly.length === 0 && drift.ledgerOnly.length === 0) {
     console.log("✅ Tree and ledger are fully reconciled.");
   } else {
     console.log(

--- a/scripts/audit/ledger-drift.mjs
+++ b/scripts/audit/ledger-drift.mjs
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+// @ts-check
+import { fileURLToPath } from "node:url";
+/**
+ * Migration-ledger drift audit.
+ *
+ * Quantifies the divergence between the local migration tree
+ * (`supabase/migrations/*.sql`, by CLI-parsed version) and the production
+ * `supabase_migrations.schema_migrations` ledger. This is the *history* drift
+ * that the table-level gates (check-database-types-drift / schema-references)
+ * cannot see: prod was built by hundreds of out-of-band `apply_migration`
+ * calls with regenerated timestamps, so the local versions and the prod ledger
+ * are almost completely disjoint and `supabase db push` can no longer be run.
+ *
+ * The prod ledger is NOT exposed via PostgREST (it lives in the
+ * `supabase_migrations` schema, not `public`), so this tool reads a dump rather
+ * than hitting the network. Produce one during reconciliation with:
+ *
+ *   -- as service-role SQL (Supabase MCP execute_sql or psql):
+ *   SELECT json_agg(json_build_object('version', version, 'name', name)
+ *                   ORDER BY version)
+ *   FROM supabase_migrations.schema_migrations;
+ *
+ * and save it to a file, then:
+ *
+ *   SUPABASE_MIGRATIONS_JSON=path/to/ledger.json npm run audit:ledger-drift
+ *   node scripts/audit/ledger-drift.mjs --ledger path/to/ledger.json --json
+ *
+ * Exit code is always 0 — this is an audit/observability tool, not a CI gate.
+ * Its purpose during reconciliation is to prove the job is done: after the
+ * baseline-squash + `migration repair`, `local_only` and `ledger_only` should
+ * both collapse to ~0.
+ */
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+const MIGRATIONS_DIR = "supabase/migrations";
+
+// ---------------------------------------------------------------------------
+// Core logic — exported for unit tests (pure, no I/O)
+// ---------------------------------------------------------------------------
+
+/**
+ * CLI-parsed version (leading digits before first `_`) from a filename.
+ * @param {string} filename
+ * @returns {string}
+ */
+export function versionOf(filename) {
+  const base = filename.replace(/^.*\//, "").replace(/\.sql$/i, "");
+  const m = /^(\d+)/.exec(base);
+  return m ? m[1] : "";
+}
+
+/**
+ * Parse a ledger dump into the set of versions. Accepts either the raw
+ * `json_agg` array (`[{version,name}, …]`), or `{ ledger: [...] }`, or a plain
+ * array of version strings.
+ *
+ * @param {unknown} doc
+ * @returns {Set<string>}
+ */
+export function parseLedger(doc) {
+  const arr = Array.isArray(doc)
+    ? doc
+    : doc && typeof doc === "object" && Array.isArray(/** @type {any} */ (doc).ledger)
+      ? /** @type {any} */ (doc).ledger
+      : [];
+  const versions = new Set();
+  for (const row of arr) {
+    if (typeof row === "string") versions.add(row);
+    else if (row && typeof row === "object" && typeof row.version === "string") versions.add(row.version);
+  }
+  return versions;
+}
+
+/**
+ * Compute the two-way set difference between local file versions and the prod
+ * ledger versions.
+ *
+ * @param {string[]} localVersions   distinct CLI versions from the tree
+ * @param {Set<string>} ledgerVersions
+ */
+export function computeLedgerDrift(localVersions, ledgerVersions) {
+  const local = new Set(localVersions);
+  const both = [];
+  const localOnly = [];
+  for (const v of local) {
+    if (ledgerVersions.has(v)) both.push(v);
+    else localOnly.push(v);
+  }
+  const ledgerOnly = [];
+  for (const v of ledgerVersions) {
+    if (!local.has(v)) ledgerOnly.push(v);
+  }
+  return {
+    localDistinct: local.size,
+    ledgerDistinct: ledgerVersions.size,
+    both: both.sort(),
+    localOnly: localOnly.sort(), // a `db push` would attempt these
+    ledgerOnly: ledgerOnly.sort(), // applied out-of-band; no local file
+  };
+}
+
+/**
+ * Count files-per-version to surface collisions (multiple files → one version).
+ * @param {string[]} basenames
+ * @returns {Map<string, string[]>}
+ */
+export function versionToFiles(basenames) {
+  /** @type {Map<string, string[]>} */
+  const map = new Map();
+  for (const name of basenames) {
+    const v = versionOf(name);
+    const list = map.get(v) ?? [];
+    list.push(name);
+    map.set(v, list);
+  }
+  return map;
+}
+
+// ---------------------------------------------------------------------------
+// Main runner
+// ---------------------------------------------------------------------------
+
+async function readLedger() {
+  const argIdx = process.argv.indexOf("--ledger");
+  const fromArg = argIdx >= 0 ? process.argv[argIdx + 1] : undefined;
+  const file = fromArg || process.env.SUPABASE_MIGRATIONS_JSON;
+  if (!file) return null;
+  const doc = JSON.parse(await fs.readFile(file, "utf8"));
+  return parseLedger(doc);
+}
+
+async function main() {
+  const asJson = process.argv.includes("--json");
+
+  let basenames;
+  try {
+    const entries = await fs.readdir(path.join(process.cwd(), MIGRATIONS_DIR));
+    basenames = entries.filter((f) => f.endsWith(".sql"));
+  } catch (err) {
+    console.error(`[ledger-drift] cannot read ${MIGRATIONS_DIR}: ${/** @type {Error} */ (err).message}`);
+    process.exit(0);
+  }
+
+  const v2f = versionToFiles(basenames);
+  const collisions = [...v2f.entries()].filter(([, files]) => files.length > 1);
+  const localVersions = [...v2f.keys()].filter(Boolean);
+
+  const ledger = await readLedger();
+  if (!ledger) {
+    console.log(
+      `[ledger-drift] no ledger dump supplied — skipping divergence diff.\n` +
+        `  Local tree: ${basenames.length} files, ${localVersions.length} distinct versions, ` +
+        `${collisions.length} colliding version(s).\n` +
+        `  To diff against prod, pass --ledger <file> or set SUPABASE_MIGRATIONS_JSON ` +
+        `(see the header of this script for the SQL to dump it).`,
+    );
+    process.exit(0);
+  }
+
+  const drift = computeLedgerDrift(localVersions, ledger);
+
+  if (asJson) {
+    console.log(
+      JSON.stringify(
+        {
+          files: basenames.length,
+          collisions: collisions.map(([v, files]) => ({ version: v, files })),
+          ...drift,
+        },
+        null,
+        2,
+      ),
+    );
+    process.exit(0);
+  }
+
+  console.log(`# Migration-ledger drift audit\n`);
+  console.log(`- Local migration files: **${basenames.length}**`);
+  console.log(`- Distinct local versions: **${drift.localDistinct}**`);
+  console.log(`- Colliding versions (>1 file → same version): **${collisions.length}**`);
+  console.log(`- Prod ledger rows: **${drift.ledgerDistinct}**`);
+  console.log(`- Local ∩ ledger (tracked): **${drift.both.length}**`);
+  console.log(`- Local only (a \`db push\` would attempt these): **${drift.localOnly.length}**`);
+  console.log(`- Ledger only (applied out-of-band, no local file): **${drift.ledgerOnly.length}**`);
+  console.log("");
+  if (drift.localOnly.length === 0 && drift.ledgerOnly.length === 0) {
+    console.log("✅ Tree and ledger are fully reconciled.");
+  } else {
+    console.log(
+      "⚠️  Tree and ledger have diverged — do NOT run `supabase db push`. " +
+        "See docs/runbooks/MIGRATION_LEDGER_RECONCILIATION.md.",
+    );
+  }
+  if (collisions.length > 0) {
+    console.log(`\n## Colliding versions (first 20)\n`);
+    for (const [v, files] of collisions.slice(0, 20)) {
+      console.log(`- \`${v}\` → ${files.map((f) => `\`${f}\``).join(", ")}`);
+    }
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error("[ledger-drift] unexpected error:", err);
+    process.exit(0);
+  });
+}

--- a/scripts/check-migration-filenames.mjs
+++ b/scripts/check-migration-filenames.mjs
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+// @ts-check
+import { fileURLToPath } from "node:url";
+/**
+ * Migration filename / version-hygiene gate.
+ *
+ * Fails the build if a NEW migration file's name does not begin with a unique
+ * 14-digit timestamp version (`YYYYMMDDHHMMSS_description.sql`), or if its
+ * version collides with one already present in the tree.
+ *
+ * Why this exists: the Supabase CLI derives a migration's *version* (its primary
+ * key in `supabase_migrations.schema_migrations`) from the leading digits of the
+ * filename. The legacy tree accumulated THREE incompatible version formats —
+ * 3-digit (`001_*.sql`), 8-digit date-only (`20260702_*.sql`), and 14-digit
+ * timestamp (`20260603120000_*.sql`) — and **50 distinct date-only prefixes that
+ * map more than one file to the same version**. Colliding/short versions break
+ * `supabase db push` ordering and make `migration repair` ambiguous, which is a
+ * load-bearing reason the local tree can no longer be replayed against prod
+ * (see docs/runbooks/MIGRATION_LEDGER_RECONCILIATION.md).
+ *
+ * This gate stops the rot from growing: every migration added from here on must
+ * carry a unique full timestamp. It is the filename counterpart to the
+ * RLS-migration gate and runs the same PR-scoped diff so it never red-fails on
+ * the pre-existing legacy files (those are retired by the baseline-squash, not
+ * by this gate).
+ *
+ * Usage:
+ *   npm run audit:migration-filenames            # PR-scoped (CI)
+ *   node scripts/check-migration-filenames.mjs --all   # audit the whole tree
+ *
+ * CI sets GITHUB_BASE_REF so only files ADDED in the current PR are checked.
+ */
+
+import { execSync } from "node:child_process";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+const MIGRATIONS_DIR = "supabase/migrations";
+// Only the top-level migrations dir is the active set. Archived legacy files
+// (post-baseline) live under supabase/migrations/archive/** and are NOT checked.
+const MIGRATIONS_GLOB = `${MIGRATIONS_DIR}/*.sql`;
+
+// ---------------------------------------------------------------------------
+// Core logic — exported so unit tests can call directly (pure, no I/O)
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse the CLI-visible version (leading run of digits before the first `_`)
+ * from a migration filename or path.
+ *
+ * @param {string} filename  e.g. "supabase/migrations/20260603120000_x.sql"
+ * @returns {{ base: string, version: string, is14: boolean, hasDigits: boolean }}
+ */
+export function parseMigrationVersion(filename) {
+  const base = filename.replace(/^.*\//, "").replace(/\.sql$/i, "");
+  const m = /^(\d+)/.exec(base);
+  const version = m ? m[1] : "";
+  return {
+    base,
+    version,
+    is14: /^\d{14}$/.test(version),
+    hasDigits: version.length > 0,
+  };
+}
+
+/**
+ * Given the basenames of newly-added migration files and the set of versions
+ * already present in the tree (everything except the added files), return the
+ * list of hygiene violations.
+ *
+ * A violation is one of:
+ *   - "format"            : version is not a 14-digit timestamp
+ *   - "collision-existing": 14-digit version already used by another tree file
+ *   - "collision-added"   : two added files share the same 14-digit version
+ *
+ * @param {string[]} addedBasenames
+ * @param {Set<string>} existingVersions  versions already in the tree
+ * @returns {{ file: string, version: string, kind: "format"|"collision-existing"|"collision-added" }[]}
+ */
+export function computeFilenameViolations(addedBasenames, existingVersions) {
+  /** @type {{ file: string, version: string, kind: "format"|"collision-existing"|"collision-added" }[]} */
+  const violations = [];
+  const seenInAdded = new Set();
+  for (const name of addedBasenames) {
+    const { version, is14, hasDigits } = parseMigrationVersion(name);
+    if (!is14) {
+      violations.push({ file: name, version: hasDigits ? version : "(none)", kind: "format" });
+      continue;
+    }
+    if (existingVersions.has(version)) {
+      violations.push({ file: name, version, kind: "collision-existing" });
+    } else if (seenInAdded.has(version)) {
+      violations.push({ file: name, version, kind: "collision-added" });
+    }
+    seenInAdded.add(version);
+  }
+  return violations;
+}
+
+// ---------------------------------------------------------------------------
+// File / git acquisition
+// ---------------------------------------------------------------------------
+
+/**
+ * Basenames of migration files added in the current PR vs the base branch.
+ * Falls back to [] (no new files) outside a git/CI context.
+ *
+ * @param {string} baseRef
+ * @returns {string[]}
+ */
+export function getAddedMigrationBasenames(baseRef) {
+  try {
+    const raw = execSync(
+      `git diff --name-only --diff-filter=A origin/${baseRef}...HEAD -- ${MIGRATIONS_GLOB}`,
+      { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] },
+    ).trim();
+    if (!raw) return [];
+    return raw
+      .split("\n")
+      .map((f) => f.trim())
+      .filter(Boolean)
+      // Defensive: the glob keeps subdirs out, but double-check we only take the
+      // active top-level dir, never archived files.
+      .filter((f) => path.dirname(f) === MIGRATIONS_DIR)
+      .map((f) => path.basename(f));
+  } catch {
+    return [];
+  }
+}
+
+/** @returns {Promise<string[]>} basenames of every active migration file */
+async function readAllMigrationBasenames() {
+  try {
+    const entries = await fs.readdir(path.join(process.cwd(), MIGRATIONS_DIR));
+    return entries.filter((f) => f.endsWith(".sql"));
+  } catch {
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main runner
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const auditAll = process.argv.includes("--all");
+  const allBasenames = await readAllMigrationBasenames();
+
+  let targets;
+  if (auditAll) {
+    targets = allBasenames;
+  } else {
+    const baseRef = process.env.GITHUB_BASE_REF ?? "main";
+    targets = getAddedMigrationBasenames(baseRef);
+    if (targets.length === 0) {
+      console.log("No new migration files in this PR — migration-filename gate passed.");
+      process.exit(0);
+    }
+  }
+
+  // Existing versions = the tree minus the files we're checking, so an added
+  // file is never compared against itself.
+  const targetSet = new Set(targets);
+  const existingVersions = new Set();
+  for (const name of allBasenames) {
+    if (targetSet.has(name)) continue;
+    const { version, is14 } = parseMigrationVersion(name);
+    if (is14) existingVersions.add(version);
+  }
+
+  const violations = computeFilenameViolations(targets, existingVersions);
+
+  if (auditAll) {
+    // Whole-tree mode is an audit, not a gate: report the legacy-format spread
+    // so the reconciliation can see how much it is collapsing.
+    const fmt = { d3: 0, d8: 0, d14: 0, other: 0 };
+    for (const name of allBasenames) {
+      const { version, is14, hasDigits } = parseMigrationVersion(name);
+      if (is14) fmt.d14++;
+      else if (/^\d{8}$/.test(version)) fmt.d8++;
+      else if (/^\d{3}$/.test(version)) fmt.d3++;
+      else if (!hasDigits) fmt.other++;
+      else fmt.other++;
+    }
+    console.log(
+      `Migration filename audit — ${allBasenames.length} files: ` +
+        `${fmt.d14} timestamped(14), ${fmt.d8} date-only(8), ${fmt.d3} numbered(3), ${fmt.other} other.`,
+    );
+    // --all is an audit, not a gate: report the legacy non-conforming files but
+    // never exit non-zero (the legacy spread is retired by the baseline-squash).
+    const nonConforming = violations.filter((v) => v.kind === "format").length;
+    console.log(
+      `${nonConforming} legacy file(s) do not use a 14-digit timestamp version ` +
+        `(expected pre-reconciliation; collapsed by the baseline-squash).`,
+    );
+    process.exit(0);
+  }
+
+  if (violations.length === 0) {
+    console.log(
+      `Migration-filename gate passed — ${targets.length} file(s) carry a unique 14-digit timestamp version.`,
+    );
+    process.exit(0);
+  }
+
+  console.error(
+    `\n::error::Migration-filename gate failed — ${violations.length} file(s) violate version hygiene:\n`,
+  );
+  for (const v of violations) {
+    if (v.kind === "format") {
+      console.error(`  ✗  ${v.file}`);
+      console.error(`     → version "${v.version}" is not a 14-digit timestamp.`);
+    } else if (v.kind === "collision-existing") {
+      console.error(`  ✗  ${v.file}  — version ${v.version} already used by another migration`);
+    } else {
+      console.error(`  ✗  ${v.file}  — version ${v.version} duplicated by another added migration`);
+    }
+  }
+  console.error(
+    `\nFix: rename to a unique full timestamp, e.g.\n` +
+      `  ${MIGRATIONS_DIR}/${nowStamp()}_<short_description>.sql\n` +
+      `Generate one with: date -u +%Y%m%d%H%M%S\n` +
+      `Background: docs/runbooks/MIGRATION_LEDGER_RECONCILIATION.md\n`,
+  );
+  process.exit(1);
+}
+
+/** @returns {string} a fresh UTC 14-digit stamp, for the fix hint */
+function nowStamp() {
+  return new Date().toISOString().replace(/[-:T]/g, "").slice(0, 14);
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error("check-migration-filenames: unexpected error:", err);
+    process.exit(1);
+  });
+}

--- a/scripts/check-migration-filenames.mjs
+++ b/scripts/check-migration-filenames.mjs
@@ -35,33 +35,17 @@ import { execSync } from "node:child_process";
 import { promises as fs } from "node:fs";
 import path from "node:path";
 
+import { parseMigrationVersion } from "./lib/migration-version.mjs";
+
 const MIGRATIONS_DIR = "supabase/migrations";
-// Only the top-level migrations dir is the active set. Archived legacy files
-// (post-baseline) live under supabase/migrations/archive/** and are NOT checked.
-const MIGRATIONS_GLOB = `${MIGRATIONS_DIR}/*.sql`;
+
+// Re-export so existing unit tests importing from this module keep working,
+// while the parsing logic lives in one shared place (scripts/lib).
+export { parseMigrationVersion };
 
 // ---------------------------------------------------------------------------
 // Core logic — exported so unit tests can call directly (pure, no I/O)
 // ---------------------------------------------------------------------------
-
-/**
- * Parse the CLI-visible version (leading run of digits before the first `_`)
- * from a migration filename or path.
- *
- * @param {string} filename  e.g. "supabase/migrations/20260603120000_x.sql"
- * @returns {{ base: string, version: string, is14: boolean, hasDigits: boolean }}
- */
-export function parseMigrationVersion(filename) {
-  const base = filename.replace(/^.*\//, "").replace(/\.sql$/i, "");
-  const m = /^(\d+)/.exec(base);
-  const version = m ? m[1] : "";
-  return {
-    base,
-    version,
-    is14: /^\d{14}$/.test(version),
-    hasDigits: version.length > 0,
-  };
-}
 
 /**
  * Given the basenames of newly-added migration files and the set of versions
@@ -102,16 +86,58 @@ export function computeFilenameViolations(addedBasenames, existingVersions) {
 // ---------------------------------------------------------------------------
 
 /**
+ * Resolve the base ref to diff against: prefer `origin/<ref>` (CI), fall back to
+ * a local `<ref>` (developer machines without the remote). Returns null when
+ * neither resolves, so the caller can warn loudly instead of false-passing.
+ *
+ * @param {string} baseRef
+ * @returns {string | null}
+ */
+function resolveBaseRef(baseRef) {
+  for (const cand of [`origin/${baseRef}`, baseRef]) {
+    try {
+      execSync(`git rev-parse --verify --quiet ${cand}^{commit}`, {
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      return cand;
+    } catch {
+      /* try next candidate */
+    }
+  }
+  return null;
+}
+
+/**
  * Basenames of migration files added in the current PR vs the base branch.
- * Falls back to [] (no new files) outside a git/CI context.
+ *
+ * Note on scoping: we pass the *directory* pathspec `supabase/migrations` (git
+ * pathspecs match recursively, unlike a shell glob), then filter to direct
+ * children with the `path.dirname` check below — that filter is **load-bearing**:
+ * it is the only thing excluding archived legacy files under
+ * `supabase/migrations/archive/**`. `diff.renames=false` is forced so a
+ * rename-to-a-bad-name is reported as an Add (and thus caught) regardless of the
+ * caller's git config.
+ *
+ * Returns [] when there genuinely are no new files; warns and returns [] when
+ * the base ref can't be resolved (so a misconfigured local run is visible rather
+ * than a silent green).
  *
  * @param {string} baseRef
  * @returns {string[]}
  */
 export function getAddedMigrationBasenames(baseRef) {
+  const ref = resolveBaseRef(baseRef);
+  if (!ref) {
+    console.warn(
+      `[migration-filenames] base ref "${baseRef}" is not resolvable ` +
+        `(no origin/${baseRef} and no local ${baseRef}); skipping the PR-scoped ` +
+        `check. Use --all to audit the whole tree.`,
+    );
+    return [];
+  }
   try {
     const raw = execSync(
-      `git diff --name-only --diff-filter=A origin/${baseRef}...HEAD -- ${MIGRATIONS_GLOB}`,
+      `git -c diff.renames=false diff --name-only --diff-filter=A ${ref}...HEAD -- ${MIGRATIONS_DIR}`,
       { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] },
     ).trim();
     if (!raw) return [];
@@ -119,11 +145,15 @@ export function getAddedMigrationBasenames(baseRef) {
       .split("\n")
       .map((f) => f.trim())
       .filter(Boolean)
-      // Defensive: the glob keeps subdirs out, but double-check we only take the
-      // active top-level dir, never archived files.
+      // Load-bearing: the directory pathspec matches archive/** too, so this is
+      // what keeps archived legacy files out of the active set.
       .filter((f) => path.dirname(f) === MIGRATIONS_DIR)
       .map((f) => path.basename(f));
-  } catch {
+  } catch (err) {
+    console.warn(
+      `[migration-filenames] git diff failed (${/** @type {Error} */ (err).message}); ` +
+        `skipping the PR-scoped check.`,
+    );
     return [];
   }
 }
@@ -175,12 +205,11 @@ async function main() {
     // so the reconciliation can see how much it is collapsing.
     const fmt = { d3: 0, d8: 0, d14: 0, other: 0 };
     for (const name of allBasenames) {
-      const { version, is14, hasDigits } = parseMigrationVersion(name);
+      const { version, is14 } = parseMigrationVersion(name);
       if (is14) fmt.d14++;
       else if (/^\d{8}$/.test(version)) fmt.d8++;
       else if (/^\d{3}$/.test(version)) fmt.d3++;
-      else if (!hasDigits) fmt.other++;
-      else fmt.other++;
+      else fmt.other++; // no digits, or any other non-conforming length
     }
     console.log(
       `Migration filename audit — ${allBasenames.length} files: ` +

--- a/scripts/db/baseline-squash.sh
+++ b/scripts/db/baseline-squash.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# Migration-ledger baseline-squash helper (Path A).
+#
+# Automates the error-prone, NON-destructive local file shuffling of the
+# reconciliation and prints the exact prod-touching commands to run next. It
+# deliberately STOPS before `supabase migration repair` — that is the point of
+# no return and must be run by hand, after a verified snapshot.
+#
+# Full procedure + rationale: docs/runbooks/MIGRATION_LEDGER_RECONCILIATION.md
+# State of record:            docs/audits/DB-STATE-2026-06-07.md
+#
+# Requirements (founder-run): supabase CLI installed and `supabase link`ed to
+# the project; a FRESH prod snapshot taken; a clean git working tree.
+#
+# Usage:
+#   scripts/db/baseline-squash.sh                 # dry-run (default): shows the plan
+#   SNAPSHOT_CONFIRMED=1 scripts/db/baseline-squash.sh --execute
+#
+# --execute performs ONLY the safe, reversible local steps:
+#   1. dump the live public schema to the baseline migration file
+#   2. archive the legacy migration files (git mv → supabase/migrations/archive/)
+# It then prints the prod ledger-repair + types-regen + verify commands.
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+MIGRATIONS_DIR="supabase/migrations"
+ARCHIVE_DIR="${MIGRATIONS_DIR}/archive"
+EXECUTE=0
+[[ "${1:-}" == "--execute" ]] && EXECUTE=1
+
+# CSF / s708 files that must NEVER enter the active set or a bulk apply
+# (REGULATORY-AVOID-LIST.md — founder + legal only).
+CSF_GLOBS=("*sp02_startup_portal*" "*sp03_startup*" "*startup_portal*" "*wholesale*" "*esic*")
+
+say() { printf '%s\n' "$*"; }
+die() { printf '::error:: %s\n' "$*" >&2; exit 1; }
+
+[[ -d "$MIGRATIONS_DIR" ]] || die "run from the repo root ($MIGRATIONS_DIR not found)"
+
+TS="$(date -u +%Y%m%d%H%M%S)"
+BASELINE="${MIGRATIONS_DIR}/${TS}_baseline_schema.sql"
+legacy_count="$(find "$MIGRATIONS_DIR" -maxdepth 1 -name '*.sql' | wc -l | tr -d ' ')"
+
+say "=== Baseline-squash plan ==="
+say "  Baseline file : $BASELINE"
+say "  Legacy files  : $legacy_count → $ARCHIVE_DIR/"
+say "  CSF hold      : files matching ${CSF_GLOBS[*]} are reported, NOT bulk-applied"
+say ""
+
+# Surface the CSF-sensitive files so the operator can fence them explicitly.
+say "--- CSF / s708 files in the tree (handle separately, legal sign-off) ---"
+csf_files="$(for g in "${CSF_GLOBS[@]}"; do find "$MIGRATIONS_DIR" -maxdepth 1 -name "$g" 2>/dev/null; done | sort -u)"
+if [[ -n "$csf_files" ]]; then
+  while IFS= read -r f; do say "  ⚖️  $f"; done <<< "$csf_files"
+else
+  say "  (none found by glob — still verify manually)"
+fi
+say ""
+
+if [[ "$EXECUTE" != 1 ]]; then
+  say "DRY RUN — no changes made. Re-run with: SNAPSHOT_CONFIRMED=1 $0 --execute"
+  exit 0
+fi
+
+# --- guards before any change ---
+[[ "${SNAPSHOT_CONFIRMED:-}" == "1" ]] || die "set SNAPSHOT_CONFIRMED=1 to confirm a fresh prod snapshot exists (step 0)"
+command -v supabase >/dev/null 2>&1 || die "supabase CLI not found — install + 'supabase link' first"
+git diff --quiet && git diff --cached --quiet || die "git working tree is dirty — commit/stash first"
+
+say "1/2 Dumping live public schema → $BASELINE"
+supabase db dump --linked --schema public -f "$BASELINE" \
+  || die "supabase db dump failed — is the project linked?"
+say "    Review $BASELINE: ensure RLS + policies present, CREATEs idempotent, strip owner/grant noise."
+
+say "2/2 Archiving $legacy_count legacy migration(s) → $ARCHIVE_DIR/"
+mkdir -p "$ARCHIVE_DIR"
+# Move every legacy .sql EXCEPT the new baseline we just wrote.
+find "$MIGRATIONS_DIR" -maxdepth 1 -name '*.sql' ! -name "$(basename "$BASELINE")" -print0 \
+  | xargs -0 -I{} git mv {} "$ARCHIVE_DIR/"
+
+say ""
+say "✅ Local steps done. NEXT (prod — run by hand, irreversible):"
+cat <<EOF
+  # 3. Reconcile the ledger so the baseline is the applied floor and nothing is pending:
+  supabase migration list --linked
+  supabase migration repair --status applied "${TS}"
+  #    (mark superseded legacy versions reverted as needed; goal: db push --dry-run shows NOTHING pending)
+
+  # 4. Regenerate types from prod and commit:
+  npm run db:types && git add lib/database.types.ts
+
+  # 5. Verify reproducibility on a throwaway branch:
+  supabase branches create reconcile-verify   # build a staging DB from the tree, smoke-test
+  supabase branches delete reconcile-verify
+
+  # 6. Only AFTER the above: enable auto-apply (add SUPABASE_PROJECT_REF + SUPABASE_DB_PASSWORD
+  #    secrets) with the CSF files fenced in archive/.
+EOF
+say ""
+say "Confirm done: SUPABASE_MIGRATIONS_JSON=<ledger-dump.json> npm run audit:ledger-drift  → local-only/ledger-only == 0"

--- a/scripts/db/baseline-squash.sh
+++ b/scripts/db/baseline-squash.sh
@@ -29,9 +29,12 @@ ARCHIVE_DIR="${MIGRATIONS_DIR}/archive"
 EXECUTE=0
 [[ "${1:-}" == "--execute" ]] && EXECUTE=1
 
-# CSF / s708 files that must NEVER enter the active set or a bulk apply
-# (REGULATORY-AVOID-LIST.md — founder + legal only).
-CSF_GLOBS=("*sp02_startup_portal*" "*sp03_startup*" "*startup_portal*" "*wholesale*" "*esic*")
+# CSF / s708 / wholesale files that must NEVER enter the active set or a bulk
+# apply (REGULATORY-AVOID-LIST.md — founder + legal only). These are advisory
+# *reporting* globs, so they err toward OVER-matching (token-level) rather than
+# the exact current filenames: a future *_s708_*.sql / *_startup_rounds.sql /
+# *_esic_*.sql etc. must still surface here, never be silently archived.
+CSF_GLOBS=("*startup*" "*wholesale*" "*esic*" "*s708*" "*crowdfund*" "*csf*" "*sophisticated*")
 
 say() { printf '%s\n' "$*"; }
 die() { printf '::error:: %s\n' "$*" >&2; exit 1; }
@@ -40,7 +43,8 @@ die() { printf '::error:: %s\n' "$*" >&2; exit 1; }
 
 TS="$(date -u +%Y%m%d%H%M%S)"
 BASELINE="${MIGRATIONS_DIR}/${TS}_baseline_schema.sql"
-legacy_count="$(find "$MIGRATIONS_DIR" -maxdepth 1 -name '*.sql' | wc -l | tr -d ' ')"
+# Count tracked top-level .sql (what will actually be archived); never archive/**.
+legacy_count="$( (git ls-files -- "$MIGRATIONS_DIR/*.sql" ":(exclude)$ARCHIVE_DIR/*" 2>/dev/null || true) | wc -l | tr -d ' ')"
 
 say "=== Baseline-squash plan ==="
 say "  Baseline file : $BASELINE"
@@ -66,7 +70,12 @@ fi
 # --- guards before any change ---
 [[ "${SNAPSHOT_CONFIRMED:-}" == "1" ]] || die "set SNAPSHOT_CONFIRMED=1 to confirm a fresh prod snapshot exists (step 0)"
 command -v supabase >/dev/null 2>&1 || die "supabase CLI not found — install + 'supabase link' first"
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "not inside a git work tree"
 git diff --quiet && git diff --cached --quiet || die "git working tree is dirty — commit/stash first"
+# Untracked .sql under the migrations dir would break the archive half-way
+# (git mv refuses untracked paths), leaving a partially-moved tree — fail first.
+untracked="$(git ls-files --others --exclude-standard -- "$MIGRATIONS_DIR" | grep -E '\.sql$' || true)"
+[[ -z "$untracked" ]] || die "untracked .sql under $MIGRATIONS_DIR — commit or remove before archiving:"$'\n'"$untracked"
 
 say "1/2 Dumping live public schema → $BASELINE"
 supabase db dump --linked --schema public -f "$BASELINE" \
@@ -75,9 +84,19 @@ say "    Review $BASELINE: ensure RLS + policies present, CREATEs idempotent, st
 
 say "2/2 Archiving $legacy_count legacy migration(s) → $ARCHIVE_DIR/"
 mkdir -p "$ARCHIVE_DIR"
-# Move every legacy .sql EXCEPT the new baseline we just wrote.
-find "$MIGRATIONS_DIR" -maxdepth 1 -name '*.sql' ! -name "$(basename "$BASELINE")" -print0 \
-  | xargs -0 -I{} git mv {} "$ARCHIVE_DIR/"
+baseline_base="$(basename "$BASELINE")"
+moved=0
+# Tracked top-level .sql only (git ls-files omits untracked; the exclude pathspec
+# omits archive/**); skip the baseline we just wrote. On any failure, stop with a
+# recovery hint rather than leaving a silently half-archived tree.
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  [[ "$(basename "$f")" == "$baseline_base" ]] && continue
+  git mv "$f" "$ARCHIVE_DIR/" \
+    || die "git mv failed on '$f' — the tree may be PARTIALLY archived. Inspect with 'git status'; 'git reset --hard' undoes the staged moves (nothing is committed yet)."
+  moved=$((moved + 1))
+done < <(git ls-files -- "$MIGRATIONS_DIR/*.sql" ":(exclude)$ARCHIVE_DIR/*")
+say "    archived $moved file(s)."
 
 say ""
 say "✅ Local steps done. NEXT (prod — run by hand, irreversible):"

--- a/scripts/lib/migration-version.mjs
+++ b/scripts/lib/migration-version.mjs
@@ -1,0 +1,42 @@
+// @ts-check
+/**
+ * Canonical migration-version parsing — shared by the filename gate
+ * (`scripts/check-migration-filenames.mjs`) and the ledger-drift audit
+ * (`scripts/audit/ledger-drift.mjs`) so the two can never drift apart.
+ *
+ * The Supabase CLI derives a migration's *version* (its primary key in
+ * `supabase_migrations.schema_migrations`) from the **leading run of digits**
+ * in the basename — everything up to the first non-digit. Only a full 14-digit
+ * timestamp `YYYYMMDDHHMMSS` is a valid steady-state version; legacy 3-digit
+ * (`001_*`), 8-digit date-only (`20260702_*`), zero-padded, or >14-digit forms
+ * are non-conforming and flagged. Directory prefix and the `.sql` / `.up.sql` /
+ * `.down.sql` suffix are ignored for version extraction.
+ */
+
+/**
+ * @param {string} filename  e.g. "supabase/migrations/20260603120000_x.sql"
+ * @returns {{ base: string, version: string, is14: boolean, hasDigits: boolean }}
+ */
+export function parseMigrationVersion(filename) {
+  const base = String(filename)
+    .replace(/^.*\//, "") // drop any directory prefix
+    .replace(/\.sql$/i, "")
+    .replace(/\.(up|down)$/i, ""); // tolerate split up/down migrations
+  const m = /^(\d+)/.exec(base);
+  const version = m ? m[1] : "";
+  return {
+    base,
+    version,
+    is14: /^\d{14}$/.test(version),
+    hasDigits: version.length > 0,
+  };
+}
+
+/**
+ * Thin accessor: just the CLI-parsed version string ("" if none).
+ * @param {string} filename
+ * @returns {string}
+ */
+export function versionOf(filename) {
+  return parseMigrationVersion(filename).version;
+}


### PR DESCRIPTION
## The real problem

The standing "database backlog" is **not** "118 migrations behind main; run `supabase db push`." Measured against live prod (`guggzyqceattncjwvgyc`) on 2026-06-07, the local migration tree and the prod `schema_migrations` **ledger have forked**:

| | |
|---|---|
| Prod ledger rows | **439** (0 duplicates) |
| Distinct local versions | **250** (from 404 files) |
| Local versions **also in prod** | **5** |
| Local versions **not in prod** (a `db push` would attempt) | **245** |
| Prod versions **not in any local file** (out-of-band applies) | **434** |

So `supabase db push` is **destructive here** — it would attempt ~245 migrations, re-creating tables that already exist and **re-running ~35 non-idempotent data backfills**, plus the CSF/Tier-E startup-portal migration. The local tree also mixes 3 version formats (14-/8-/3-digit) with **50 colliding date-only prefixes**.

**Root cause:** `supabase-migrate.yml` silently no-op'd for months (its `PROJECT_REF`/`DB_PASSWORD` secrets were unset → green-but-applied-nothing — confirmed by #1463), so every prod migration was applied out-of-band via MCP with a fresh timestamp and the ledger never matched the files.

**The good news (right-sizes the fix):** schema *content* is ~98% converged (397/412 local tables live) and RLS is comprehensive (414/415; the one exception is benign PostGIS `spatial_ref_sys`). This is **history reconciliation + pipeline repair**, not a schema rebuild.

## What this PR ships (safe, repo-only)

- **`docs/audits/DB-STATE-2026-06-07.md`** — measured source of truth (supersedes the diagnosis in `drift-list.md` / `SCHEMA-DRIFT-2026-06-05.md`).
- **`docs/runbooks/MIGRATION_LEDGER_RECONCILIATION.md`** — the corrected end-to-end procedure: **Path A baseline-squash + `migration repair`**, with snapshot, CSF/legal fences, verification via preview branch, and rollback.
- **`docs/runbooks/MIGRATION_DEPLOY_BACKLOG.md`** — 🛑 SUPERSEDED banner; corrects its dangerous "run `db push`" headline.
- **`scripts/check-migration-filenames.mjs`** + `audit:migration-filenames` + a CI gate — blocks any **new** migration that doesn't carry a **unique 14-digit timestamp** (PR-scoped, so it never red-fails on the legacy files). +10 unit tests.
- **`scripts/audit/ledger-drift.mjs`** + `audit:ledger-drift` — quantifies tree-vs-ledger divergence from a ledger dump; the reconciliation is "done" when local-only/ledger-only → 0. +8 unit tests.
- **`CONTRIBUTING.md`** — migration discipline: 14-digit timestamps, apply via the pipeline (not ad-hoc MCP), never `db push` pre-reconciliation, regenerate types after.
- **`docs/strategy/FIN_NOTEBOOK.md`** — decision record (Path A chosen).

`npm run audit:drift-types` stays green; eslint clean; pre-push type-check + rate-limit audit pass; 18 new tests green.

## Deliberately NOT done here (gated)

- **Tier E (founder-supervised):** the prod baseline-squash + ledger `migration repair`, the zombie-table drops, and **enabling auto-apply** (adding the two secrets) — all must wait until *after* the baseline, else `db push --include-all` replays the backlog.
- **⚖️ Legal-gated:** the startup-portal (CSF) and wholesale-cert (s708) tables stay held per `REGULATORY-AVOID-LIST.md`; the runbook explicitly excludes them.

## Relationship to in-flight work

- Builds on **#1463** (which makes the silent-no-op workflow fail loudly) — this adds the *reconciliation* it points to.
- Unblocks **#1459** (listings consolidation, stuck on "migration applied + types regenerated") once the runbook is executed.

Draft for review — the next step is yours: schedule the Tier-E baseline-squash session.

https://claude.ai/code/session_01G2NPY2nCDNTR3KE5s425tx

---
_Generated by [Claude Code](https://claude.ai/code/session_01G2NPY2nCDNTR3KE5s425tx)_