### PR TITLE
fix(invest): sector count badges now match each sector page

### DIFF
--- a/app/invest/page.tsx
+++ b/app/invest/page.tsx
@@ -17,7 +17,7 @@ import {
 } from "@/lib/compliance";
 import type { InvestmentListing } from "@/lib/types";
 import { logger } from "@/lib/logger";
-import { listingUrl, categoryForListing } from "@/lib/listing-url";
+import { listingUrl, categoryForListing, rawVerticalVariants } from "@/lib/listing-url";
 import { categoryListingsHref } from "@/lib/invest-listing-routes";
 import InvestListingsClient from "@/components/InvestListingsClient";
 import GetMatchedEmbed from "@/components/get-matched/GetMatchedEmbed";
@@ -174,16 +174,21 @@ export default async function InvestMarketplacePage() {
   const categories = getOpportunityCategories();
   const categoryTabs = categories.map((c) => ({ slug: c.slug, label: c.label }));
 
-  // Discovery-card counts must match what the client filter actually shows
-  // when a card is clicked, so we bucket each listing the same way the
-  // client does — via categoryForListing — rather than summing raw
-  // dbVerticals (which misses drifted vertical strings like
-  // "renewable-energy"/"startups" and double-counts fund sub-categories
-  // that belong to other categories).
+  // Discovery-card counts must match what each sector's /listings page
+  // actually shows. That page fetches by the category's vertical(s) and then
+  // the client filters by categoryForListing — so a listing counts for a
+  // sector only if it satisfies BOTH: categoryForListing(l) === slug AND
+  // l.vertical is one of the category's (alias-expanded) verticals.
+  // (categoryForListing alone over-counted "funds": cross-vertical listed
+  // securities — uranium/hydrogen/oil-gas ASX stocks — fall to "funds" via
+  // the categoryForListing fallback but aren't fetched by the funds page's
+  // vertical query, so the badge said 55 while the page showed 11.)
   const categoryCounts: Record<string, number> = {};
-  for (const l of listings) {
-    const slug = categoryForListing(l);
-    categoryCounts[slug] = (categoryCounts[slug] || 0) + 1;
+  for (const cat of categories) {
+    const verts = new Set(cat.dbVerticals.flatMap(rawVerticalVariants));
+    categoryCounts[cat.slug] = listings.filter(
+      (l) => categoryForListing(l) === cat.slug && verts.has(l.vertical as string),
+    ).length;
   }
 
   function getCategoryCount(cat: InvestCategory): number {


### PR DESCRIPTION
## Bot UX pass — sector count badges were misleading

The `/invest` "Browse by sector" grid counted by `categoryForListing` alone, but each sector `/listings` page fetches by vertical and *then* filters by `categoryForListing`. Cross-vertical **listed securities** (uranium/hydrogen/oil-gas ASX stocks, `kind='listed_security'`) fall to "funds" via the `categoryForListing` fallback but aren't fetched by the funds page's vertical query — so the badge read e.g. **"55"** while the page showed **11**. Confusing.

## Fix

Count a listing for a sector only if `categoryForListing(l) === slug` **AND** `l.vertical` is one of the category's alias-expanded verticals — i.e. exactly the set the destination page renders. Display-only change in `app/invest/page.tsx`.

Verified against live DB data (via Supabase): funds badge → 11 (matches page), other sectors unchanged.

## Context (from the same DB review — for awareness, not changed here)
- `royalties` / `sda-housing` sector pages are empty because there are genuinely **0** rows for them — the "check back soon" state is correct, not a bug.
- The 32 **listed securities** (uranium/hydrogen/oil-gas verticals) are filed under "Funds" via the fallback. Giving them a proper home is cross-vertical + `kind`-based categorisation (a taxonomy decision) — flagged for you rather than guessed at.

Rollback: revert this commit.

https://claude.ai/code/session_019aPVcfri9PgMADCrTGTPyT

---
_Generated by [Claude Code](https://claude.ai/code/session_019aPVcfri9PgMADCrTGTPyT)_