### PR TITLE
fix(invest): buy-business listings were invisible (vertical drift)

### DIFF
--- a/lib/investment-listings-query.ts
+++ b/lib/investment-listings-query.ts
@@ -212,7 +212,10 @@ export async function fetchListingBySlug(
     const { data, error } = await supabase
       .from("investment_listings")
       .select("*")
-      .eq("vertical", vertical)
+      // Alias-aware: match drifted vertical strings (e.g. "buy-business"
+      // for "business") so bespoke detail pages resolve them, consistent
+      // with fetchListingsByVertical.
+      .in("vertical", rawVerticalVariants(vertical))
       .eq("slug", slug)
       .maybeSingle();
 

--- a/lib/listing-url.ts
+++ b/lib/listing-url.ts
@@ -48,6 +48,7 @@ export const VERTICAL_ALIASES: Record<string, string> = {
   funds: "fund",
   startups: "startup",
   "renewable-energy": "energy",
+  "buy-business": "business",
 };
 
 /** Canonical vertical for a (possibly drifted) raw vertical string. */


### PR DESCRIPTION
## Bot UX pass — buy-business listings were invisible

The sector-count-badge audit (#1468) surfaced that **buy-business showed 0** in the grid despite **10 active buy-business listings** in the DB.

**Cause:** those listings are stored with `vertical="buy-business"`, but the canonical vertical key is `"business"` (`VERTICAL_TO_CATEGORY`). That drift wasn't in the alias map, so they fell to the `?? "funds"` fallback — the **buy-business sector page showed an empty state**, the badge read 0, and they were mis-bucketed as funds in the marketplace. (Detail pages happened to work only via the funds fallback URL.) Verified on the mirror: `/invest/buy-business/listings` → empty state.

**Fix** (same drift-alias pattern as the existing fund/funds, energy/renewable-energy aliases):
- Add `"buy-business" → "business"` to `VERTICAL_ALIASES`.
- Make `fetchListingBySlug` alias-aware (`.in(rawVerticalVariants(...))`) so the bespoke buy-business detail page resolves the drifted vertical, consistent with `fetchListingsByVertical`.

Result: `/invest/buy-business/listings` shows its 10 listings, the badge reads 10, details render at `/invest/buy-business/listings/<slug>`, and they're categorised as buy-business (not funds). `type-check` + the listing-url / query unit tests (45) pass.

Rollback: revert this commit. Registry alias + query-helper only.

https://claude.ai/code/session_019aPVcfri9PgMADCrTGTPyT

---
_Generated by [Claude Code](https://claude.ai/code/session_019aPVcfri9PgMADCrTGTPyT)_