### PR TITLE
feat(invest): add factual "Listed Securities (ASX)" category

### DIFF
--- a/__tests__/lib/invest-categories.test.ts
+++ b/__tests__/lib/invest-categories.test.ts
@@ -21,11 +21,12 @@ describe("invest-categories data integrity", () => {
     for (const cat of cats) {
       expect(cat.slug).toBeTruthy();
       expect(cat.label).toBeTruthy();
-      // income-assets is a placeholder sector with no distinct DB vertical
-      // seeded yet — it intentionally carries an empty dbVerticals (the old
-      // ["business"] value collided with buy-business). Its listings page
-      // renders a graceful empty state until a vertical/sub_category exists.
-      if (cat.slug !== "income-assets") {
+      // Two categories intentionally carry empty dbVerticals:
+      //  - income-assets: placeholder with no distinct vertical seeded yet
+      //    (the old ["business"] value collided with buy-business).
+      //  - listed-securities: grouped by listing_kind, not vertical (its
+      //    /listings page fetches by kind across many verticals).
+      if (!["income-assets", "listed-securities"].includes(cat.slug)) {
         expect(cat.dbVerticals.length).toBeGreaterThan(0);
       }
       expect(cat.color).toBeDefined();
@@ -163,6 +164,8 @@ describe("IA intent (2026-05-07 refactor)", () => {
         "carbon-credits",
         "sda-housing",
         "water-rights",
+        // 2026-06 — ASX-listed securities (instrument-class category)
+        "listed-securities",
       ].sort(),
     );
   });

--- a/__tests__/lib/listing-url.test.ts
+++ b/__tests__/lib/listing-url.test.ts
@@ -68,6 +68,34 @@ describe("categoryForListing", () => {
     ).toBe("mining");
   });
 
+  it("routes listed securities to 'listed-securities' by kind, across verticals", () => {
+    // ASX-listed securities span many (often unmapped) verticals; the
+    // listing_kind takes precedence so they don't fall to the funds fallback.
+    for (const vertical of ["uranium", "hydrogen", "oil-gas", "digital-infrastructure"]) {
+      expect(
+        categoryForListing({
+          vertical: vertical as InvestListingVertical,
+          sub_category: undefined,
+          listing_kind: "listed_security",
+        }),
+      ).toBe("listed-securities");
+    }
+  });
+
+  it("only applies the kind override for listed_security (other kinds use vertical)", () => {
+    expect(
+      categoryForListing({
+        vertical: "mining" as InvestListingVertical,
+        sub_category: undefined,
+        listing_kind: "project_equity",
+      }),
+    ).toBe("mining");
+    // Missing listing_kind keeps the vertical-based behaviour (e.g. state rollups).
+    expect(
+      categoryForListing({ vertical: "mining" as InvestListingVertical, sub_category: undefined }),
+    ).toBe("mining");
+  });
+
   it("normalises drifted vertical strings to the right category", () => {
     // These non-canonical vertical values exist in the DB from earlier
     // seed waves and must not silently fall through to "funds".

--- a/app/invest/listed-securities/listings/page.tsx
+++ b/app/invest/listed-securities/listings/page.tsx
@@ -1,0 +1,77 @@
+import type { Metadata } from "next";
+import { Suspense } from "react";
+import Link from "next/link";
+import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
+import { getAllInvestCategories, getInvestCategoryBySlug } from "@/lib/invest-categories";
+import { fetchListingsByKind, countListingsByKind } from "@/lib/investment-listings-query";
+import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
+import InvestListingsClient from "@/components/InvestListingsClient";
+import Icon from "@/components/Icon";
+
+export const revalidate = 300;
+
+// Grouped by instrument kind, not vertical — ASX-listed securities span
+// uranium / hydrogen / oil-gas / … verticals. categoryForListing routes
+// listing_kind="listed_security" to the "listed-securities" category.
+const KIND = "listed_security";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const cat = getInvestCategoryBySlug("listed-securities");
+  const count = await countListingsByKind(KIND);
+  const countLabel = count > 0 ? `${count} ` : "";
+  return {
+    title: cat?.title ?? `ASX-Listed Securities (${CURRENT_YEAR})`,
+    description: cat?.metaDescription,
+    alternates: { canonical: `${SITE_URL}/invest/listed-securities/listings` },
+    openGraph: {
+      title: `ASX-Listed Securities by Theme — ${countLabel}Listings`,
+      description: cat?.metaDescription,
+      url: `${SITE_URL}/invest/listed-securities/listings`,
+    },
+  };
+}
+
+export default async function ListedSecuritiesPage() {
+  const listings = await fetchListingsByKind(KIND);
+  const categoryTabs = getAllInvestCategories().map((c) => ({ slug: c.slug, label: c.label }));
+  const cat = getInvestCategoryBySlug("listed-securities");
+
+  const breadcrumb = breadcrumbJsonLd([
+    { name: "Home", url: `${SITE_URL}/` },
+    { name: "Invest", url: `${SITE_URL}/invest` },
+    { name: "Listed Securities" },
+  ]);
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
+      />
+
+      {/* Factual / general-information notice — these are public securities,
+          not an offer or recommendation (lean lane per REGULATORY-AVOID-LIST). */}
+      <div className="container-custom pt-6">
+        <div className="flex gap-2.5 rounded-xl border border-blue-200 bg-blue-50 px-4 py-3 text-xs leading-relaxed text-blue-800">
+          <Icon name="shield-check" size={15} className="mt-0.5 shrink-0 text-blue-600" />
+          <p>
+            <strong className="font-semibold">General information only.</strong> These are publicly traded
+            ASX-listed securities you buy through your own broker — we don&apos;t issue, sell, arrange or
+            recommend them, and nothing here is an offer or a recommendation. {GENERAL_ADVICE_WARNING}{" "}
+            <Link href="/how-we-earn" className="underline hover:no-underline">How we earn</Link>.
+          </p>
+        </div>
+      </div>
+
+      <Suspense fallback={<div className="py-12 text-center text-slate-400">Loading listings...</div>}>
+        <InvestListingsClient
+          listings={listings}
+          categories={categoryTabs}
+          lockedCategory="listed-securities"
+          pageTitle={cat?.h1 ?? "ASX-Listed Securities"}
+          pageSubtitle={cat?.intro}
+        />
+      </Suspense>
+    </>
+  );
+}

--- a/app/invest/page.tsx
+++ b/app/invest/page.tsx
@@ -186,8 +186,12 @@ export default async function InvestMarketplacePage() {
   const categoryCounts: Record<string, number> = {};
   for (const cat of categories) {
     const verts = new Set(cat.dbVerticals.flatMap(rawVerticalVariants));
+    // Kind-based categories (no dbVerticals — e.g. listed-securities) are
+    // bucketed purely by categoryForListing; vertical-based ones additionally
+    // require the listing's vertical to be one the sector page fetches.
+    const kindBased = verts.size === 0;
     categoryCounts[cat.slug] = listings.filter(
-      (l) => categoryForListing(l) === cat.slug && verts.has(l.vertical as string),
+      (l) => categoryForListing(l) === cat.slug && (kindBased || verts.has(l.vertical as string)),
     ).length;
   }
 

--- a/docs/strategy/FIN_NOTEBOOK.md
+++ b/docs/strategy/FIN_NOTEBOOK.md
@@ -14,6 +14,25 @@
 
 ## Active strategic decisions log
 
+### 2026-06-07 — Sign-off: factual "Listed Securities (ASX)" category
+
+Founder signed off on adding a **Listed Securities (ASX)** browse category to
+the /invest marketplace. ~32 ASX-listed securities (uranium / hydrogen /
+oil-gas / digital-infrastructure themes) were previously mis-bucketed into
+"Funds" via the `categoryForListing` fallback; `categoryForListing` is now
+keyed on `listing_kind="listed_security"` so they group correctly, with a
+dedicated `/invest/listed-securities/listings` page.
+
+**Regulatory posture (lean lane, per `REGULATORY-AVOID-LIST.md`):** this is a
+**factual listing of already-public securities + referral** ("buy via your own
+broker"), explicitly the sanctioned lean alternative — *not* an escalator. It
+does **not** issue, sell, arrange, facilitate an offer, run a market, or give
+personal advice. `GENERAL_ADVICE_WARNING` + a "general information only, not an
+offer/recommendation" notice are wired onto the page. If legal wants to review
+the securities framing, the category can be flag-gated. (Sign-off recorded here
+per the avoid-list's "founder + legal sign-off recorded in this repo" rule;
+legal review still open if desired.)
+
 ### 2026-06-03 — Bot-QA system: ranked roadmap for the next big projects
 
 Context: the AI-Journey bot found a real P1 in one run (`/api/versus/vote` 500s

--- a/lib/invest-categories.ts
+++ b/lib/invest-categories.ts
@@ -97,6 +97,12 @@ const INTENT_BY_SLUG: Record<string, InvestCategoryIntent> = {
   "carbon-credits": "opportunity",
   "sda-housing": "opportunity",
 
+  // ASX-listed securities — instrument-class category (grouped by
+  // listing_kind, not vertical) so ASX equities/ETFs across themes stop
+  // falling to the "funds" fallback. Factual listing only (founder
+  // sign-off 2026-06-07; lean lane per docs/strategy/REGULATORY-AVOID-LIST.md).
+  "listed-securities": "opportunity",
+
   // Compare (4) — 301-redirected to canonical Compare/duplicate. The
   // entries are kept in categories[] for back-compat with iterators
   // that key off the array; redirects in next.config.ts intercept the
@@ -2197,6 +2203,36 @@ const categoriesRaw: Omit<InvestCategory, "intent">[] = [
     h1: "SDA Housing — 10-13% Yield, Government-Backed NDIS Rent",
     metaDescription: `Specialist Disability Accommodation (SDA) — Fully-Accessible, High-Physical-Support, Robust and Improved-Livability NDIS-registered dwellings. Net yields 10-13%, LRBA-compatible, SMSF-eligible. ${upd}.`,
     intro: `Specialist Disability Accommodation — purpose-built dwellings for NDIS participants with extreme functional impairment. The NDIA pays Reasonable Rent Contribution directly to the owner (typically $80,000-$130,000 per qualifying tenant per year depending on design category), producing net yields of 10-13% on $650k-$1.1M contract prices. Four design categories: Improved-Livability, Robust, Fully-Accessible, and High-Physical-Support. LRBA-compatible bare-trust structures available for SMSF investors. Vacancy risk is real — choose locations near disability services and reputable SIL (Supported Independent Living) operators.`,
+    sections: [],
+    faqs: [],
+    subcategories: [],
+  },
+
+  // ─── Listed securities (ASX) ───
+  // Instrument-class category (NOT vertical-based): groups ASX-listed
+  // equities/ETFs that span sectors (uranium, hydrogen, oil & gas, …).
+  // categoryForListing routes listing_kind="listed_security" here so they
+  // stop falling to the "funds" fallback. Factual listing only — public
+  // securities bought via the user's own broker; no issuing, arranging,
+  // offer facilitation or advice (founder sign-off 2026-06-07; lean lane
+  // per docs/strategy/REGULATORY-AVOID-LIST.md). dbVerticals is intentionally
+  // empty: the /listings page fetches by listing_kind, not vertical.
+  {
+    slug: "listed-securities",
+    label: "Listed Securities (ASX)",
+    dbVerticals: [],
+    color: {
+      bg: "bg-blue-50",
+      border: "border-blue-200",
+      text: "text-blue-700",
+      accent: "bg-blue-600",
+      gradient: "from-blue-50 to-white",
+    },
+    icon: "trending-up",
+    title: `ASX-Listed Securities by Theme — Uranium, Hydrogen, Oil & Gas (${yr})`,
+    h1: "ASX-Listed Securities",
+    metaDescription: `A factual directory of ASX-listed companies grouped by theme — uranium, hydrogen, oil & gas and more. Publicly traded securities you buy through your own broker. General information only, not a recommendation or an offer. ${upd}.`,
+    intro: `A factual directory of ASX-listed companies grouped by investment theme — uranium, hydrogen, oil & gas, critical minerals and more. These are publicly traded securities: you buy and sell them yourself through your own broker. We don't issue, sell, arrange or recommend them, and nothing here is a recommendation or an offer. General information only — do your own research and consider seeking licensed advice before investing.`,
     sections: [],
     faqs: [],
     subcategories: [],

--- a/lib/invest-listing-routes.ts
+++ b/lib/invest-listing-routes.ts
@@ -39,6 +39,7 @@ export const STATIC_LISTING_SLUGS = [
   "pre-ipo",
   "private-equity",
   "royalties",
+  "listed-securities",
 ] as const;
 
 /**

--- a/lib/investment-listings-query.ts
+++ b/lib/investment-listings-query.ts
@@ -128,6 +128,63 @@ export async function countListingsByVertical(
 }
 
 /**
+ * Fetches active listings of a given `listing_kind` across all verticals.
+ * Used by the "listed-securities" category page, which is grouped by
+ * instrument kind (ASX-listed securities span uranium/hydrogen/oil-gas/…
+ * verticals) rather than by a single vertical. Never throws — returns [].
+ */
+export async function fetchListingsByKind(
+  kind: string,
+  limit: number = DEFAULT_LIMIT,
+): Promise<InvestmentListing[]> {
+  try {
+    const supabase = await createClient();
+    const { data, error } = await supabase
+      .from("investment_listings")
+      .select("*")
+      .eq("listing_kind", kind)
+      .eq("status", "active")
+      .order("listing_type", { ascending: false })
+      .order("created_at", { ascending: false })
+      .limit(limit);
+    if (error) {
+      log.warn("investment_listings kind query failed", { kind, error: error.message, code: error.code });
+      return [];
+    }
+    return (data ?? []) as InvestmentListing[];
+  } catch (err) {
+    log.error("investment_listings kind fetch threw", {
+      kind,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return [];
+  }
+}
+
+/** Count of active listings of a given `listing_kind` (for generateMetadata). */
+export async function countListingsByKind(kind: string): Promise<number> {
+  try {
+    const supabase = await createClient();
+    const { count, error } = await supabase
+      .from("investment_listings")
+      .select("id", { count: "exact", head: true })
+      .eq("listing_kind", kind)
+      .eq("status", "active");
+    if (error) {
+      log.warn("investment_listings kind count failed", { kind, error: error.message });
+      return 0;
+    }
+    return count ?? 0;
+  } catch (err) {
+    log.warn("investment_listings kind count threw", {
+      kind,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return 0;
+  }
+}
+
+/**
  * Sub-categories that belong to the "alternatives" URL category.
  * Source of truth: lib/listing-url.ts FUND_SUB_TO_CATEGORY.
  * Duplicated here to avoid a server/client module boundary issue

--- a/lib/listing-url.ts
+++ b/lib/listing-url.ts
@@ -1,4 +1,4 @@
-import type { InvestmentListing, InvestListingVertical } from "@/lib/types";
+import type { InvestmentListing, InvestListingVertical, ListingKind } from "@/lib/types";
 
 /**
  * Maps each `vertical` value from the database to its corresponding
@@ -116,7 +116,18 @@ export const FUND_SUB_TO_CATEGORY: Record<string, string> = {
  * Returns the canonical category slug for an investment listing.
  * Used to construct correct URLs for listing detail pages.
  */
-export function categoryForListing(listing: Pick<InvestmentListing, "vertical" | "sub_category">): string {
+export function categoryForListing(
+  listing: Pick<InvestmentListing, "vertical" | "sub_category"> & {
+    listing_kind?: ListingKind | null;
+  },
+): string {
+  // ASX-listed securities are an instrument class that spans many sectors
+  // (uranium, hydrogen, oil & gas, …). Group them into one factual
+  // "listed-securities" category instead of scattering them by vertical —
+  // where the unmapped energy verticals previously fell to the "funds"
+  // fallback. (listing_kind is optional: callers passing only vertical/
+  // sub_category — e.g. state rollups — keep the vertical-based behaviour.)
+  if (listing.listing_kind === "listed_security") return "listed-securities";
   const vertical = normaliseVertical(listing.vertical as string);
   if (vertical === "fund" && listing.sub_category) {
     const override = FUND_SUB_TO_CATEGORY[listing.sub_category];
@@ -132,6 +143,10 @@ export function categoryForListing(listing: Pick<InvestmentListing, "vertical" |
  * Use this everywhere instead of hardcoded URL templates to ensure links
  * always go to the correct category-specific route.
  */
-export function listingUrl(listing: Pick<InvestmentListing, "vertical" | "sub_category" | "slug">): string {
+export function listingUrl(
+  listing: Pick<InvestmentListing, "vertical" | "sub_category" | "slug"> & {
+    listing_kind?: ListingKind | null;
+  },
+): string {
   return `/invest/${categoryForListing(listing)}/listings/${listing.slug}`;
 }


### PR DESCRIPTION
## Founder-signed-off: a factual "Listed Securities (ASX)" category

The bot audit found ~32 ASX-listed securities (`kind="listed_security"` — uranium / hydrogen / oil-gas / digital-infra themes) mis-bucketed into **"Funds"** because their verticals are unmapped and fell to the `categoryForListing` fallback. They're an *instrument class* spanning sectors, so this groups them into one dedicated category.

**Changes**
- `categoryForListing` is now keyed on `listing_kind="listed_security"` first (the `listing_kind` param is **optional** — vertical-only callers like state rollups keep prior behaviour).
- New **`listed-securities`** opportunity category (`dbVerticals` empty — it's kind-based) + a bespoke **`/invest/listed-securities/listings`** page that fetches by `listing_kind` across verticals (`fetchListingsByKind` / `countListingsByKind`).
- Registered in `lib/invest-listing-routes.ts` (grid link + `?category=` redirect); the grid **count** logic handles kind-based categories (no vertical gate).
- Tests: kind-aware `categoryForListing` cases; opportunity-slug list + dbVerticals-invariant updated for the new kind-based category.

**Regulatory (lean lane, per `REGULATORY-AVOID-LIST.md`)**
This is a **factual listing of already-public securities + "buy via your own broker" referral** — the explicitly-sanctioned lean alternative, **not** an escalator. No issuing / arranging / offer facilitation / personal advice. The page carries a "general information only — not an offer or recommendation" notice + `GENERAL_ADVICE_WARNING`. **Founder sign-off recorded** in `docs/strategy/FIN_NOTEBOOK.md` (2026-06-07); legal review remains open if desired (the category can be flag-gated).

Verified: `type-check`, full build (2801 pages), and unit tests (listing-url / invest-categories / invest-listing-routes / query / InvestListingsClient) all green. Will confirm the page renders the ~32 securities on the mirror after deploy.

Rollback: revert this commit (additive category + a kind-aware branch in `categoryForListing`).

https://claude.ai/code/session_019aPVcfri9PgMADCrTGTPyT

---
_Generated by [Claude Code](https://claude.ai/code/session_019aPVcfri9PgMADCrTGTPyT)_