### PR TITLE
fix(advisor-credit): remove duplicate NegativeBalanceError + align allowNegative fields

### DIFF
--- a/__tests__/api/stripe-webhook.test.ts
+++ b/__tests__/api/stripe-webhook.test.ts
@@ -73,6 +73,10 @@ const mockFrom = vi.fn((table: string) => createChainableBuilder(table));
 vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: () => ({
     from: mockFrom,
+    // recordLedgerEntry now calls supabase.rpc("apply_credit_ledger_balance").
+    // Return { data: null, error: null } so the typeof-number guard skips all
+    // branches — finalBalance stays as newBalance, no extra from() calls needed.
+    rpc: vi.fn().mockResolvedValue({ data: null, error: null }),
   }),
 }));
 

--- a/__tests__/lib/stripe-webhook/checkout-session-completed.test.ts
+++ b/__tests__/lib/stripe-webhook/checkout-session-completed.test.ts
@@ -799,10 +799,9 @@ describe("handleCheckoutSessionCompleted", () => {
         if (profCalls === 1) {
           return thenable({ credit_balance_cents: 500, lifetime_credit_cents: 2000 });
         }
-        if (profCalls === 2) {
-          return thenable(); // update — succeeds via then()
-        }
-        // Third call: select email/name inside try block — throws
+        // Second call: select email/name inside try block — throws.
+        // (The optimistic-lock UPDATE is now replaced by the atomic RPC, so
+        // professionals is only called once by recordLedgerEntry before this.)
         return {
           ...thenable(),
           maybeSingle: vi.fn().mockRejectedValue(new Error("Connection lost")),

--- a/__tests__/lib/team-brief-referrals.test.ts
+++ b/__tests__/lib/team-brief-referrals.test.ts
@@ -266,7 +266,16 @@ const mockFrom = vi.fn((table: string) => ({
 }));
 
 vi.mock("@/lib/supabase/admin", () => ({
-  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+  createAdminClient: vi.fn(() => ({
+    from: mockFrom,
+    // recordLedgerEntry calls supabase.rpc("apply_credit_ledger_balance").
+    // Return PGRST202 "missing" so the optimistic-lock fallback path runs —
+    // the existing mockFrom chain already satisfies that fallback.
+    rpc: vi.fn().mockResolvedValue({
+      data: null,
+      error: { code: "PGRST202", message: "function not found" },
+    }),
+  })),
 }));
 
 // ─── Subject under test (imported AFTER mocks register) ──────────────

--- a/lib/advisor-credit-ledger.ts
+++ b/lib/advisor-credit-ledger.ts
@@ -136,25 +136,6 @@ export interface RecordLedgerEntryInput {
 }
 
 /**
- * Thrown when a prepaid-credit spend would drive the cached balance below
- * zero. Mirrors `lib/marketplace/wallet.ts`'s "Adjustment would result in
- * negative balance" guard so no caller can silently over-spend.
- */
-export class NegativeBalanceError extends Error {
-  constructor(
-    public readonly professionalId: number,
-    public readonly currentBalanceCents: number,
-    public readonly amountCents: number,
-  ) {
-    super(
-      `recordLedgerEntry: spend would drive advisor ${professionalId} below zero ` +
-        `(balance ${currentBalanceCents}c, amount ${amountCents}c)`,
-    );
-    this.name = "NegativeBalanceError";
-  }
-}
-
-/**
  * Spend kinds whose balance must not be driven below zero unless the caller
  * explicitly opts out via `allowNegativeBalance`. These are the prepaid-credit
  * accept-time charges; clawbacks / expiry of already-spent credits are
@@ -250,13 +231,10 @@ export async function recordLedgerEntry(
     input.amountCents < 0 &&
     newBalance < 0 &&
     !input.allowNegativeBalance &&
+    !input.allowNegative &&
     FLOORED_SPEND_KINDS.has(input.kind)
   ) {
-    throw new NegativeBalanceError(
-      input.professionalId,
-      currentBalance,
-      input.amountCents,
-    );
+    throw new NegativeBalanceError(input.professionalId, input.amountCents);
   }
 
   // ── 3. Insert the ledger row ───────────────────────────────────────
@@ -322,7 +300,11 @@ export async function recordLedgerEntry(
     lifetimeSpendDelta = Math.abs(input.amountCents);
   }
 
-  const allowNegative = input.allowNegative ?? defaultAllowNegative(input.kind);
+  // `allowNegative` is the canonical field for the RPC / fallback paths.
+  // `allowNegativeBalance` is the legacy name kept for callers that passed it
+  // before the rename. Either one opting in should disable the guard.
+  const allowNegative =
+    input.allowNegative ?? input.allowNegativeBalance ?? defaultAllowNegative(input.kind);
 
   // Preferred path: a single atomic SQL statement under a row lock. This
   // eliminates the read-modify-write race entirely — concurrent writers to


### PR DESCRIPTION
## Summary

Two PRs (#1377 and the pre-existing main) both touched lib/advisor-credit-ledger.ts and produced a duplicate NegativeBalanceError class export, causing TS2300 and TS2554 on every CI build since the merge.

Changes: Remove the 3-arg duplicate class (lines 138-155). Update the pre-insert FLOORED_SPEND_KINDS guard to also respect allowNegative. Map allowNegativeBalance through to allowNegative for the RPC param.

## Test plan

- CI passes (no TS2300/TS2554 errors)
- advisor-credit-ledger tests all pass

🤖 Generated with Claude Code