### PR TITLE
test: repair pre-existing test drift breaking CI on main

### DIFF
--- a/__tests__/api/health-score-detail-page.test.ts
+++ b/__tests__/api/health-score-detail-page.test.ts
@@ -18,6 +18,7 @@ vi.mock("@/lib/seo", () => ({
     items,
   })),
   SITE_URL: "https://invest.com.au",
+  SITE_NAME: "Invest.com.au",
   CURRENT_YEAR: 2026,
 }));
 

--- a/__tests__/app/broker-changelog-page.test.tsx
+++ b/__tests__/app/broker-changelog-page.test.tsx
@@ -23,6 +23,8 @@ vi.mock("@/lib/request-cache", () => ({
 vi.mock("@/lib/seo", () => ({
   absoluteUrl: (p: string) => `https://invest.com.au${p}`,
   breadcrumbJsonLd: () => ({}),
+  SITE_NAME: "Invest.com.au",
+  SITE_URL: "https://invest.com.au",
   CURRENT_YEAR: "2026",
 }));
 

--- a/__tests__/app/methodology-page.test.tsx
+++ b/__tests__/app/methodology-page.test.tsx
@@ -12,6 +12,7 @@ vi.mock("@/lib/seo", () => ({
   absoluteUrl: (path: string) => `https://invest.com.au${path}`,
   breadcrumbJsonLd: () => ({}),
   SITE_NAME: "Invest.com.au",
+  SITE_URL: "https://invest.com.au",
 }));
 
 vi.mock("@/lib/sponsorship", () => ({

--- a/__tests__/app/office-hours-detail-page.test.tsx
+++ b/__tests__/app/office-hours-detail-page.test.tsx
@@ -28,6 +28,7 @@ vi.mock("@/lib/seo", () => ({
   absoluteUrl: (p: string) => `https://invest.com.au${p}`,
   breadcrumbJsonLd: () => ({}),
   SITE_URL: "https://invest.com.au",
+  SITE_NAME: "Invest.com.au",
 }));
 
 vi.mock("@/lib/compliance", () => ({

--- a/__tests__/app/startup-grants-page.test.tsx
+++ b/__tests__/app/startup-grants-page.test.tsx
@@ -86,9 +86,9 @@ describe("StartupGrantsHubPage", () => {
     expect(names).toContain("Grants");
   });
 
-  it("does NOT render FAQPage JSON-LD because grantsHubConfig has no faqs", async () => {
+  it("renders FAQPage JSON-LD because grantsHubConfig now has faqs", async () => {
     render(await StartupGrantsHubPage());
-    expect(screen.queryByTestId("hub-page-faq-ld")).not.toBeInTheDocument();
+    expect(screen.getByTestId("hub-page-faq-ld")).toBeInTheDocument();
   });
 
   it("renders compliance block", async () => {

--- a/__tests__/app/visa-investment-page.test.tsx
+++ b/__tests__/app/visa-investment-page.test.tsx
@@ -60,9 +60,9 @@ describe("VisaInvestmentHubPage", () => {
     expect(names).toContain("Visa Investment");
   });
 
-  it("does NOT render FAQPage JSON-LD because visaInvestmentHubConfig has no faqs", () => {
+  it("renders FAQPage JSON-LD because visaInvestmentHubConfig now has faqs", () => {
     render(<VisaInvestmentHubPage />);
-    expect(screen.queryByTestId("hub-page-faq-ld")).not.toBeInTheDocument();
+    expect(screen.getByTestId("hub-page-faq-ld")).toBeInTheDocument();
   });
 
   it("renders the compliance block", () => {

--- a/__tests__/components/GlossarySearch.test.tsx
+++ b/__tests__/components/GlossarySearch.test.tsx
@@ -28,7 +28,7 @@ describe("GlossarySearch", () => {
   it("does NOT render results until query is > 1 character", async () => {
     const user = userEvent.setup();
     render(<GlossarySearch entries={ENTRIES} />);
-    const input = screen.getByRole("textbox");
+    const input = screen.getByRole("searchbox");
     await user.type(input, "A");
     expect(screen.queryByText(/result/)).not.toBeInTheDocument();
   });
@@ -36,7 +36,7 @@ describe("GlossarySearch", () => {
   it("filters by term substring (case-insensitive)", async () => {
     const user = userEvent.setup();
     render(<GlossarySearch entries={ENTRIES} />);
-    await user.type(screen.getByRole("textbox"), "asx");
+    await user.type(screen.getByRole("searchbox"), "asx");
     expect(screen.getByText("ASX")).toBeInTheDocument();
     expect(screen.getByText(/1 result/)).toBeInTheDocument();
   });
@@ -44,14 +44,14 @@ describe("GlossarySearch", () => {
   it("filters by definition substring (case-insensitive)", async () => {
     const user = userEvent.setup();
     render(<GlossarySearch entries={ENTRIES} />);
-    await user.type(screen.getByRole("textbox"), "fund");
+    await user.type(screen.getByRole("searchbox"), "fund");
     expect(screen.getByText("ETF")).toBeInTheDocument();
   });
 
   it("shows 'No terms match' empty state for unmatched queries", async () => {
     const user = userEvent.setup();
     render(<GlossarySearch entries={ENTRIES} />);
-    await user.type(screen.getByRole("textbox"), "zzzzzzzzz");
+    await user.type(screen.getByRole("searchbox"), "zzzzzzzzz");
     expect(screen.getByText(/No terms match/)).toBeInTheDocument();
   });
 
@@ -59,21 +59,21 @@ describe("GlossarySearch", () => {
     const user = userEvent.setup();
     render(<GlossarySearch entries={ENTRIES} />);
     // "ex" matches "Exchange" in ASX definition + "Exchange Traded Fund" in ETF definition
-    await user.type(screen.getByRole("textbox"), "exchange");
+    await user.type(screen.getByRole("searchbox"), "exchange");
     expect(screen.getByText(/2 results/)).toBeInTheDocument();
   });
 
   it("renders the category pill for entries that have a category", async () => {
     const user = userEvent.setup();
     render(<GlossarySearch entries={ENTRIES} />);
-    await user.type(screen.getByRole("textbox"), "asx");
+    await user.type(screen.getByRole("searchbox"), "asx");
     expect(screen.getByText("Markets")).toBeInTheDocument();
   });
 
   it("omits the category pill for entries without one", async () => {
     const user = userEvent.setup();
     render(<GlossarySearch entries={ENTRIES} />);
-    await user.type(screen.getByRole("textbox"), "etf");
+    await user.type(screen.getByRole("searchbox"), "etf");
     // ETF entry has no category — Markets / Custody should not appear
     expect(screen.queryByText("Markets")).not.toBeInTheDocument();
     expect(screen.queryByText("Custody")).not.toBeInTheDocument();

--- a/__tests__/components/GrantsHub.test.tsx
+++ b/__tests__/components/GrantsHub.test.tsx
@@ -154,10 +154,8 @@ describe("GrantsHub migration — <HubPage> with grantsHubConfig", () => {
     expect(screen.getByTestId("rd-calculator")).toBeInTheDocument();
   });
 
-  it("does not render FAQPage JSON-LD (grants config has empty faqs)", () => {
+  it("renders FAQPage JSON-LD (grants config now has faqs)", () => {
     render(<HubPage config={grantsHubConfig} />);
-    expect(
-      screen.queryByTestId("hub-page-faq-ld")
-    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("hub-page-faq-ld")).toBeInTheDocument();
   });
 });

--- a/__tests__/components/RelatedContentGrid.test.tsx
+++ b/__tests__/components/RelatedContentGrid.test.tsx
@@ -26,9 +26,16 @@ const ITEMS = [
 ];
 
 describe("RelatedContentGrid", () => {
-  it("renders nothing when items is empty", () => {
-    const { container } = render(<RelatedContentGrid items={[]} />);
-    expect(container).toBeEmptyDOMElement();
+  it("renders the curated fallback when items is empty (ADV-116: never returns null)", () => {
+    render(<RelatedContentGrid items={[]} />);
+    // Empty items → curated static articles, so users always have a next step.
+    expect(screen.getByText("You might also like")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /How to start investing in Australia/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Discover more investing guides/ }),
+    ).toBeInTheDocument();
   });
 
   it("uses the default 'Related Content' heading", () => {

--- a/scripts/check-ai-factual-filter.mjs
+++ b/scripts/check-ai-factual-filter.mjs
@@ -60,6 +60,10 @@ const EXEMPT = new Map(
       "app/api/account/holdings/ai-analysis/route.ts",
       "delegates LLM orchestration to lib/holdings/ai-analysis.ts which itself imports + calls filterFactualOutput before returning result.rawText; route only forwards the already-filtered text",
     ],
+    [
+      "app/api/smart-filter/route.ts",
+      "structured-extraction route — LLM output is JSON-parsed then whitelisted to a fixed set of URL filter-param keys (INVEST_PARAMS/ADVISOR_PARAMS, string/number only); no model prose is ever returned to the user, only known filter keys",
+    ],
   ]),
 );
 


### PR DESCRIPTION
## What

Repairs the **9 failing test files / 11 failing tests** that are red on `main` right now (the full `vitest` suite fails). None are production bugs — the code is correct; the tests/mocks drifted. This is the standalone "make main's CI green again" PR.

It also **unblocks #1480** (the `/invest` compact-header PR), whose `Lint · Type-check · Test · Build` job inherits these same pre-existing failures.

## Fixes, by category

| Category | Files | Fix |
|---|---|---|
| Stale `@/lib/seo` mocks | `health-score-detail`, `broker-changelog`, `methodology`, `office-hours` page tests | `lib/schema-markup.ts` reads `SITE_NAME` + `SITE_URL` at import time; the mocks omitted one/both → "No SITE_NAME export" on collection. Added the missing exports. |
| Stale FAQ-LD assertions | `GrantsHub`, `startup-grants-page`, `visa-investment-page` | Their configs gained `faqs`, so `<HubPage>` now correctly emits `FAQPage` JSON-LD. Flipped the "does NOT render" assertions. |
| Stale empty-state test | `RelatedContentGrid` | Component was changed (ADV-116) to never return null — it renders a curated fallback. Updated the test. |
| ARIA role drift | `GlossarySearch` | `<input type="search">` resolves to role `searchbox`, not `textbox`, under the current `aria-query`. Updated the 7 queries. |

Also adds `app/api/smart-filter/route.ts` to the **V-NEW-02 EXEMPT** allowlist (same rationale as #1480 — output is whitelisted to fixed filter-param keys, never model prose) so this branch's gate is green.

## Verification

- The 9 files: **87 tests pass** locally.
- V-NEW-02 gate: ✅ (5 exempt, 0 offenders).
- `eslint --max-warnings 0` clean on all changed files; pre-push `tsc` + rate-limit audit passed.

All changes are test/CI-only — zero production behaviour change.

https://claude.ai/code/session_012cKsbjxnQ77BH1ACPqyTCj

---
_Generated by [Claude Code](https://claude.ai/code/session_012cKsbjxnQ77BH1ACPqyTCj)_