### PR TITLE
feat(advisors): compact light header + inline Get Matched + density & AI search

### DIFF
--- a/__tests__/components/AdvisorsClient.test.tsx
+++ b/__tests__/components/AdvisorsClient.test.tsx
@@ -124,3 +124,60 @@ describe("AdvisorsClient — filter panel wiring", () => {
     expect(screen.getByRole("button", { name: "Filters (1)" })).toBeInTheDocument();
   });
 });
+
+describe("AdvisorsClient — compact header redesign", () => {
+  beforeEach(() => {
+    mockReplace.mockClear();
+    paramsRef.current = new URLSearchParams();
+  });
+
+  it("renders the light compact header (filter-reactive title, no dark eyebrow pill)", () => {
+    render(<AdvisorsClient professionals={professionals} />);
+    expect(screen.getByRole("heading", { level: 1 }).textContent).toMatch(
+      /Find a Financial Advisor/i,
+    );
+    // The light tone intentionally omits the dark "Verified advisors" eyebrow pill.
+    expect(screen.queryByText("Verified advisors")).not.toBeInTheDocument();
+  });
+
+  it("drops the standalone 'Get matched in 60 seconds' card (folded into the toolbar)", () => {
+    render(<AdvisorsClient professionals={professionals} />);
+    expect(screen.queryByText(/Get matched in 60 seconds/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Not sure which advisor you need/i)).not.toBeInTheDocument();
+  });
+
+  it("exposes the Comfy/Compact density toggle and keeps the concierge link", () => {
+    render(<AdvisorsClient professionals={professionals} />);
+    expect(screen.getByRole("button", { name: /^comfy$/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^compact$/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Ask the AI concierge/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("Enter routes the search phrase through the AI filter, then clears the box on a successful parse", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ params: { type: "smsf_accountant" } }),
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+    try {
+      render(<AdvisorsClient professionals={professionals} />);
+      const input = screen.getByRole("searchbox", {
+        name: /Search advisors/i,
+      }) as HTMLInputElement;
+      fireEvent.change(input, { target: { value: "smsf help in sydney" } });
+      fireEvent.submit(input.closest("form")!);
+      // Enter routes the phrase to /api/smart-filter (the merged AI filter)…
+      await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+      expect(fetchMock.mock.calls[0]?.[0]).toBe("/api/smart-filter");
+      // …and on a successful parse the literal text is cleared so only the
+      // parsed structured filters apply (regression guard: the phrase must not
+      // linger as a substring filter or be re-read back into the box).
+      await waitFor(() => expect(input.value).toBe(""));
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});

--- a/app/advisors/AdvisorsClient.tsx
+++ b/app/advisors/AdvisorsClient.tsx
@@ -28,7 +28,8 @@ import ResultCount from "@/components/directory/ResultCount";
 import EmptyState from "@/components/directory/EmptyState";
 import CompareBar from "@/components/directory/CompareBar";
 import { FilterPill, FilterPopover } from "@/components/directory/FilterPill";
-import SmartFilterBar from "@/components/directory/SmartFilterBar";
+import { useSmartFilter } from "@/lib/hooks/useSmartFilter";
+import { useDensity } from "@/lib/hooks/useDensity";
 
 export interface ExpertTeamCard {
   id: number;
@@ -677,48 +678,65 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
     return [...ordered, ...extra];
   }, [professionals]);
 
+  // ── Comfy/Compact result density (localStorage-backed; reusable hook) ──
+  const [density, setDensity] = useDensity();
+  // AI smart-filter folded into the main search box: pressing Enter routes the
+  // phrase through /api/smart-filter and applies the parsed filters to the
+  // page's local filter state directly (the URL-mirror effect then reflects
+  // them). /advisors derives results from local state, so applying to state —
+  // not just writing the URL — is what makes the filters actually take effect
+  // and avoids the raw phrase being re-read back into the search box.
+  const applySmartFilters = useCallback((updates: Record<string, string>) => {
+    if (
+      updates.provider_type === "individual" ||
+      updates.provider_type === "firm" ||
+      updates.provider_type === "team"
+    ) {
+      setProviderType(updates.provider_type);
+    }
+    if (updates.type) {
+      const types = updates.type
+        .split(",")
+        .filter((v) => TYPE_FILTERS.some((f) => f.key === v)) as ProfessionalType[];
+      if (types.length > 0) setTypeFilters(new Set(types));
+    }
+    if (updates.state && (AU_STATES as readonly string[]).includes(updates.state)) {
+      setStateFilter(updates.state);
+    }
+    if (updates.specialty) setSpecialtyFilters(updates.specialty.split(",").filter(Boolean));
+    if (updates.language) setLanguageFilter(updates.language);
+    if (updates.fee) setFeeFilter(updates.fee);
+    if (updates.min_rating) {
+      const r = Number(updates.min_rating);
+      if (!Number.isNaN(r)) setMinRating(r);
+    }
+    if (updates.verified === "true") setVerifiedOnly(true);
+    if (updates.sort) setSortBy(updates.sort as SortKey);
+  }, []);
+  const smartFilter = useSmartFilter("advisors", applySmartFilters);
+  const resultsGridCls =
+    density === "compact"
+      ? "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 2xl:grid-cols-5 gap-3.5"
+      : "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-5";
+
   return (
     <>
-      {/* Shared full-bleed dark stat-led hero (SC-4) — matches /invest + /compare.
-          Headline + breadcrumb stay filter-reactive; banners render in the
-          canonical slot directly below the hero. */}
+      {/* Compact light directory header (matches the /invest treatment):
+          title + breadcrumb stay filter-reactive, the stats ride as small
+          inline pills, banners render in the canonical slot below. The old
+          standalone "Get matched in 60s" card is folded into the toolbar. */}
       <DirectoryHero
+        tone="light"
         containerClassName="container-custom"
         breadcrumbLabel={activeTypeLabel || "Find an Advisor"}
-        pill={{ label: "Verified advisors", live: true }}
-        headlineLead={
-          activeTypeLabel
-            ? `${providerTypeCounts.all} ${dynamicTitle.replace(/^Find\s+/, "").toLowerCase()}`
-            : `${providerTypeCounts.all} licensed advisors.`
-        }
-        headlineAccent="Three free intros."
+        headlineLead={dynamicTitle}
         subtitle={dynamicDescription}
         stats={advisorHeroStats}
       >
         {banners}
       </DirectoryHero>
-      <div className="py-5 md:py-12">
+      <div className="py-4 md:py-6">
         <div className="container-custom">
-        {/* Advisor matching + concierge — light band below the hero */}
-        <div className="mb-4 md:mb-6">
-          <p className="text-sm font-medium text-slate-600 mb-2 text-center">Not sure which advisor you need? Get matched in 60 seconds.</p>
-          <GetMatchedEmbed context="advisor_directory" />
-          <p className="text-[0.65rem] md:text-xs text-slate-500 mt-3 text-center">
-            Prefer to chat?{" "}
-            <Link
-              href="/concierge?finder=advisor-finder"
-              onClick={() =>
-                trackEvent("concierge_seed_clicked", {
-                  finder: "advisor-finder",
-                  source: "advisors_hero",
-                })
-              }
-              className="font-semibold text-slate-700 hover:text-coral-700 underline-offset-2 hover:underline"
-            >
-              Ask the AI concierge →
-            </Link>
-          </p>
-        </div>
 
         {/* Compare/shortlist bar — canonical primitive (slate/amber). Replaces
             the bespoke violet bar that broke the design system. */}
@@ -751,30 +769,23 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
           />
         )}
 
-        {/* AI filter bar — natural language → URL params */}
-        <div className="mb-3">
-          <SmartFilterBar
-            setParams={(updates) => {
-              const p = new URLSearchParams(searchParams.toString());
-              for (const [k, v] of Object.entries(updates)) {
-                if (v) p.set(k, v); else p.delete(k);
-              }
-              router.replace(`/advisors?${p.toString()}`, { scroll: false });
-            }}
-            surface="advisors"
-          />
-        </div>
-
-        {/* Toolbar: search · all-filters · sort (mirrors /invest) */}
-        <div className="flex gap-2 mb-3 items-center">
+        {/* Toolbar: search (press Enter for AI filtering) · Get Matched ·
+            all-filters · sort. The standalone AI bar is folded into the search
+            via useSmartFilter; the Get-matched card is now this inline CTA. */}
+        <div className="flex flex-wrap gap-2 mb-1.5 items-center">
           <SearchInput
             className="flex-1"
             value={search}
             onChange={setSearch}
-            placeholder="Search name, firm, team, specialty, suburb…"
-            ariaLabel="Search advisors"
+            onSubmit={async (q) => {
+              const applied = await smartFilter.run(q);
+              if (applied) setSearch("");
+            }}
+            placeholder="Search name, firm, specialty, suburb — or try “SMSF advisor in Sydney”"
+            ariaLabel="Search advisors — or press Enter to filter by description"
             id="advisor-search"
           />
+          <GetMatchedEmbed context="advisor_directory" inline />
           <button
             type="button"
             onClick={() => setFiltersOpen(true)}
@@ -788,6 +799,38 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
             value={sortBy}
             onChange={(v) => setSortBy(v as SortKey)}
           />
+        </div>
+
+        {/* AI smart-filter status + concierge fallback (replaces the old
+            standalone "Get matched in 60 seconds" band). */}
+        <div className="mb-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
+          {smartFilter.isLoading && (
+            <span className="font-medium text-amber-600">Parsing your search…</span>
+          )}
+          {!smartFilter.isLoading && smartFilter.status !== "idle" && (
+            <span
+              role="status"
+              aria-live="polite"
+              className={`font-medium ${smartFilter.status === "success" ? "text-emerald-600" : "text-rose-600"}`}
+            >
+              {smartFilter.message}
+            </span>
+          )}
+          <span className="text-slate-500">
+            Prefer to chat?{" "}
+            <Link
+              href="/concierge?finder=advisor-finder"
+              onClick={() =>
+                trackEvent("concierge_seed_clicked", {
+                  finder: "advisor-finder",
+                  source: "advisors_hero",
+                })
+              }
+              className="font-semibold text-slate-700 hover:text-coral-700 underline-offset-2 hover:underline"
+            >
+              Ask the AI concierge →
+            </Link>
+          </span>
         </div>
 
         {/* Primary facet pills — mirrors /invest + /compare (shared FilterPill). */}
@@ -1025,7 +1068,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
         />
 
         {/* Result count — canonical primitive */}
-        <div className="flex items-center justify-between mb-3 md:mb-4">
+        <div className="flex items-center justify-between gap-3 mb-3 md:mb-4">
           {nearbyLoading ? (
             <span className="text-sm text-slate-500">Searching nearby advisors…</span>
           ) : (
@@ -1039,7 +1082,23 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
               })()}
             />
           )}
-          {totalPages > 1 && <p className="text-[0.62rem] md:text-xs text-slate-500">Page {page} of {totalPages}</p>}
+          <div className="flex items-center gap-3 shrink-0">
+            {totalPages > 1 && <p className="text-[0.62rem] md:text-xs text-slate-500">Page {page} of {totalPages}</p>}
+            {/* Comfy/Compact result density — personal view pref (localStorage). */}
+            <div className="hidden sm:inline-flex rounded-lg border border-slate-200 bg-white p-0.5" role="group" aria-label="Result density">
+              {(["comfy", "compact"] as const).map((d) => (
+                <button
+                  key={d}
+                  type="button"
+                  aria-pressed={density === d}
+                  onClick={() => setDensity(d)}
+                  className={`px-2.5 py-1 rounded-md text-xs font-semibold capitalize transition-colors ${density === d ? "bg-slate-100 text-slate-900" : "text-slate-500 hover:bg-slate-50"}`}
+                >
+                  {d}
+                </button>
+              ))}
+            </div>
+          </div>
         </div>
 
         {/* Firm sub-filter — narrows individual results to one firm.
@@ -1078,7 +1137,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
 
         {/* Results */}
         {nearbyLoading ? (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-5">
+          <div className={resultsGridCls}>
             {Array.from({ length: 8 }).map((_, i) => (
               <div key={i} className="bg-white border border-slate-100 rounded-2xl overflow-hidden animate-pulse shadow-sm flex flex-col">
                 <div className="h-44 bg-slate-100" />
@@ -1105,7 +1164,7 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
             ))}
           </div>
         ) : paginatedFeed.length > 0 ? (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-5">
+          <div className={resultsGridCls}>
             {paginatedFeed.map((item, index) => {
               if (item.kind === "firm") {
                 const firm = item.firm;

--- a/components/directory/SmartFilterBar.tsx
+++ b/components/directory/SmartFilterBar.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState, useRef, type FormEvent } from "react";
+import { useState, type FormEvent } from "react";
 import Icon from "@/components/Icon";
+import { useSmartFilter } from "@/lib/hooks/useSmartFilter";
 
 export interface SmartFilterBarProps {
   setParams: (updates: Record<string, string>) => void;
@@ -15,8 +16,11 @@ const PLACEHOLDERS: Record<string, string> = {
   invest: 'Try: "commercial property Brisbane with yield over 7%"',
 };
 
-type Status = "idle" | "loading" | "success" | "error" | "empty";
-
+/**
+ * Standalone natural-language filter bar. The parse/apply engine lives in
+ * `useSmartFilter` so the same behaviour can be folded inline into a search
+ * box on surfaces that prefer one input (see /advisors).
+ */
 export default function SmartFilterBar({
   setParams,
   surface,
@@ -24,56 +28,13 @@ export default function SmartFilterBar({
   className = "",
 }: SmartFilterBarProps) {
   const [query, setQuery] = useState("");
-  const [status, setStatus] = useState<Status>("idle");
-  const [message, setMessage] = useState("");
-  const cooldownRef = useRef(false);
+  const { run, status, message, isLoading } = useSmartFilter(surface, setParams);
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    if (!query.trim() || cooldownRef.current) return;
-
-    setStatus("loading");
-    setMessage("");
-    cooldownRef.current = true;
-    setTimeout(() => { cooldownRef.current = false; }, 1000);
-
-    try {
-      const res = await fetch("/api/smart-filter", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ query: query.trim(), surface }),
-      });
-
-      if (res.status === 429) {
-        setStatus("error");
-        setMessage("Too many requests — wait a moment and try again.");
-        return;
-      }
-      if (!res.ok) {
-        setStatus("error");
-        setMessage("Couldn't parse that — try a shorter phrase.");
-        return;
-      }
-
-      const data = (await res.json()) as { params?: Record<string, string> };
-      if (!data.params || Object.keys(data.params).length === 0) {
-        setStatus("empty");
-        setMessage("No filters found — try being more specific.");
-        return;
-      }
-
-      setParams(data.params);
-      setStatus("success");
-      setMessage(`Applied ${Object.keys(data.params).length} filter${Object.keys(data.params).length !== 1 ? "s" : ""}`);
-      setQuery("");
-      setTimeout(() => setStatus("idle"), 2000);
-    } catch {
-      setStatus("error");
-      setMessage("Couldn't parse that — try a shorter phrase.");
-    }
+    const applied = await run(query);
+    if (applied) setQuery("");
   };
-
-  const isLoading = status === "loading";
 
   return (
     <div className={`w-full ${className}`}>

--- a/components/get-matched/GetMatchedEmbed.tsx
+++ b/components/get-matched/GetMatchedEmbed.tsx
@@ -11,8 +11,10 @@ interface Props {
   listingId?: number;
   /**
    * Render as a single compact CTA button instead of the full card. Used in
-   * the /invest toolbar so the "build an action plan" entry point lives inline
-   * on the search row rather than as a space-eating standalone card.
+   * directory toolbars (/invest, /advisors) so the matching entry point lives
+   * inline on the search row rather than as a space-eating standalone card.
+   * Per-context button copy comes from `inline_cta` in the embed config;
+   * contexts without it fall back to a generic "Get matched" label.
    */
   inline?: boolean;
 }
@@ -34,17 +36,20 @@ export default function GetMatchedEmbed({ context, listingId, inline }: Props) {
   if (listingId) baseQuery.set("listing_id", String(listingId));
 
   // Compact inline CTA — same destination as the full card, sized to sit on a
-  // toolbar row. The "Need help on a deal?" lead-in is hidden on small screens
-  // so the button stays a single tap target.
+  // toolbar row. Copy comes from the per-context config (`inline_cta`) so each
+  // surface reads correctly; the lead-in is hidden on small screens so the
+  // button stays a single tap target.
   if (inline) {
+    const lead = cfg.inline_cta?.lead;
+    const label = cfg.inline_cta?.label ?? "Get matched";
     return (
       <Link
         href={`/get-matched?${baseQuery.toString()}`}
         className="inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-lg border border-coral-300 bg-coral-50 px-3 py-2 text-sm font-semibold text-coral-700 transition-colors hover:border-coral-400 hover:bg-coral-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-coral-400"
       >
         <Icon name="help-circle" size={14} className="shrink-0" />
-        <span className="hidden sm:inline">Need help on a deal?</span>
-        <span>Build an action plan</span>
+        {lead && <span className="hidden sm:inline">{lead}</span>}
+        <span>{label}</span>
         <Icon name="arrow-right" size={13} className="shrink-0" />
       </Link>
     );

--- a/lib/getmatched/embeds.ts
+++ b/lib/getmatched/embeds.ts
@@ -29,6 +29,7 @@ const CONFIGS: Record<EmbedContext, Omit<EmbedConfig, "context">> = {
     intent_prefill: "opportunity_assessment",
     start_step: 3,
     prefill_answers: { intent: "opportunity_assessment" },
+    inline_cta: { lead: "Need help on a deal?", label: "Build an action plan" },
   },
   advisor_directory: {
     headline: "Not sure whether you need an individual, firm or team?",
@@ -37,6 +38,7 @@ const CONFIGS: Record<EmbedContext, Omit<EmbedConfig, "context">> = {
     intent_prefill: "financial_advice",
     start_step: 4,
     prefill_answers: { intent: "financial_advice" },
+    inline_cta: { lead: "Not sure who you need?", label: "Get matched" },
   },
   platform_compare: {
     headline: "Not sure which platform fits your investing style?",

--- a/lib/getmatched/types.ts
+++ b/lib/getmatched/types.ts
@@ -239,4 +239,11 @@ export interface EmbedConfig {
   start_step?: number;
   /** Optional pre-filled answers that feed into `ActionPlanAnswers`. */
   prefill_answers?: ActionPlanAnswers;
+  /**
+   * Short copy for the compact `inline` CTA variant (a single toolbar
+   * button). `lead` is an optional context-setting phrase shown on wider
+   * screens ("Need help on a deal?"); `label` is the always-visible button
+   * text ("Build an action plan"). Falls back to a generic label when unset.
+   */
+  inline_cta?: { lead: string; label: string };
 }

--- a/lib/hooks/useDensity.ts
+++ b/lib/hooks/useDensity.ts
@@ -1,0 +1,44 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+export type Density = "comfy" | "compact";
+
+/**
+ * Result-density preference (Comfy vs Compact) for directory result grids.
+ *
+ * A personal *viewing* preference rather than a shareable filter, so it's
+ * persisted in `localStorage` (not the URL) and shared across directory
+ * surfaces (`/advisors`, `/invest`) via a common storage key. SSR-safe:
+ * renders the default ("comfy") on first paint, then syncs from storage on
+ * mount — avoiding a hydration mismatch at the cost of a one-frame settle.
+ */
+export function useDensity(storageKey = "iv-density"): [Density, (d: Density) => void] {
+  const [density, setDensityState] = useState<Density>("comfy");
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(storageKey);
+      // One-time hydration of a client-only preference after mount; the SSR
+      // render intentionally uses the "comfy" default to avoid a mismatch.
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- see above
+      if (stored === "compact" || stored === "comfy") setDensityState(stored);
+    } catch {
+      /* localStorage unavailable (private mode / SSR) — keep the default */
+    }
+  }, [storageKey]);
+
+  const setDensity = useCallback(
+    (d: Density) => {
+      setDensityState(d);
+      try {
+        localStorage.setItem(storageKey, d);
+      } catch {
+        /* ignore persistence failures */
+      }
+    },
+    [storageKey],
+  );
+
+  return [density, setDensity];
+}

--- a/lib/hooks/useSmartFilter.ts
+++ b/lib/hooks/useSmartFilter.ts
@@ -1,0 +1,86 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+
+export type SmartFilterStatus = "idle" | "loading" | "success" | "error" | "empty";
+
+export interface UseSmartFilterResult {
+  /** Parse `query` into URL params and apply them via `setParams`. Resolves
+   *  to `true` when at least one filter was applied, else `false`. */
+  run: (query: string) => Promise<boolean>;
+  status: SmartFilterStatus;
+  message: string;
+  isLoading: boolean;
+}
+
+/**
+ * Shared natural-language → URL-params filtering engine.
+ *
+ * Extracted from `<SmartFilterBar>` (which now consumes it) so the same
+ * `/api/smart-filter` call + status handling can also power an inline "press
+ * Enter to filter" affordance on a directory's main search box — letting a
+ * surface fold the standalone AI bar into the search input without
+ * duplicating the fetch/cooldown/parse logic.
+ */
+export function useSmartFilter(
+  surface: "advisors" | "invest",
+  setParams: (updates: Record<string, string>) => void,
+): UseSmartFilterResult {
+  const [status, setStatus] = useState<SmartFilterStatus>("idle");
+  const [message, setMessage] = useState("");
+  const cooldownRef = useRef(false);
+
+  const run = useCallback(
+    async (query: string): Promise<boolean> => {
+      const q = query.trim();
+      if (!q || cooldownRef.current) return false;
+
+      setStatus("loading");
+      setMessage("");
+      cooldownRef.current = true;
+      setTimeout(() => {
+        cooldownRef.current = false;
+      }, 1000);
+
+      try {
+        const res = await fetch("/api/smart-filter", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ query: q, surface }),
+        });
+
+        if (res.status === 429) {
+          setStatus("error");
+          setMessage("Too many requests — wait a moment and try again.");
+          return false;
+        }
+        if (!res.ok) {
+          setStatus("error");
+          setMessage("Couldn't parse that — try a shorter phrase.");
+          return false;
+        }
+
+        const data = (await res.json()) as { params?: Record<string, string> };
+        if (!data.params || Object.keys(data.params).length === 0) {
+          setStatus("empty");
+          setMessage("No filters found — try being more specific.");
+          return false;
+        }
+
+        setParams(data.params);
+        setStatus("success");
+        const n = Object.keys(data.params).length;
+        setMessage(`Applied ${n} filter${n !== 1 ? "s" : ""}`);
+        setTimeout(() => setStatus("idle"), 2000);
+        return true;
+      } catch {
+        setStatus("error");
+        setMessage("Couldn't parse that — try a shorter phrase.");
+        return false;
+      }
+    },
+    [surface, setParams],
+  );
+
+  return { run, status, message, isLoading: status === "loading" };
+}


### PR DESCRIPTION
## What

Applies the `/invest` "reclaim the fold" treatment to **`/advisors`**, plus the density + AI-search polish that was deferred on `/invest` (Phase 1 + 2). Built so `/invest` can adopt the new primitives later.

### Phase 1 — reclaim the fold
- `/advisors` `DirectoryHero` → **`tone="light"`** (the variant shipped with `/invest`): stats become small inline pills beside a filter-reactive title; the dark gradient box is gone.
- The standalone **"Get matched in 60 seconds" card** is removed; the entry point is folded into the toolbar as `<GetMatchedEmbed context="advisor_directory" inline />`, with the concierge link kept as a compact secondary. Inline CTA copy now comes from a per-context **`inline_cta`** on the embed config (SSoT) — `/invest` keeps "Build an action plan", `/advisors` reads "Get matched".

### Phase 2 — density + AI search (reusable primitives)
- **`useDensity`** (Comfy/Compact, localStorage-backed) + a toggle in the result-count row; compact tightens the grid (more columns, smaller gap).
- **`useSmartFilter`** extracts the NL→filter engine from `SmartFilterBar` (which now consumes it — unchanged for `/invest`). The standalone AI bar on `/advisors` is folded into the main search: **Enter** routes the phrase through `/api/smart-filter`.

## Correctness (from the `/code-review` pass)
`/advisors` derives results from **local** filter state (URL is a mount-hydration source + debounced mirror), so the parsed filters are applied **directly to the local setters** rather than written to the URL. Writing the URL (the naive approach, and what the old standalone bar did) wouldn't take effect here and would re-read the raw phrase back into the search box as a literal substring filter → empty results. The box is cleared only on a *successful* parse.

## Verification
- `tsc --noEmit` clean · `eslint --max-warnings 0` clean · 22 component tests pass (incl. new: light header / card removed / density toggle / **Enter→AI→apply→clear** regression guard).
- `SmartFilterBar` refactor verified non-breaking for `/invest` (`InvestListingsClient` tests pass).
- Reviewed via fan-out subagents (correctness ×3 + cleanup + altitude); load-bearing finding fixed, rest triaged below.

## Notes / follow-ups (non-blocking)
- **Density vs `DIRECTORY_UX_UNIFICATION.md`:** density is an orthogonal axis from the planned URL-backed `view` (grid/list/table). It's localStorage-backed (a personal pref); worth reconciling when Session 7 lands the URL `view` model on `/advisors`.
- The single aggregate "N licensed advisors" headline is now expressed across per-type stat pills (Advisors / Firms / Expert teams).
- `/invest` still uses the standalone AI bar; `useSmartFilter`/`useDensity` make unifying it cheap later.

I'll run the **`/ai-journey` bots** against the deployed `/advisors` to QA the interactive search/density flow once it's live.

https://claude.ai/code/session_012cKsbjxnQ77BH1ACPqyTCj

---
_Generated by [Claude Code](https://claude.ai/code/session_012cKsbjxnQ77BH1ACPqyTCj)_