### PR TITLE
fix(invest): humanise listing-card text — acronym-aware labels, no raw enum keys

### DIFF
--- a/__tests__/lib/listing-format.test.ts
+++ b/__tests__/lib/listing-format.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import {
+  humanizeTitle,
+  formatMetricValue,
+  listingDisplayMetrics,
+} from "@/lib/listing-format";
+
+describe("humanizeTitle", () => {
+  it("title-cases snake_case and preserves domain acronyms", () => {
+    expect(humanizeTitle("venture_capital")).toBe("Venture Capital");
+    expect(humanizeTitle("sda_housing")).toBe("SDA Housing");
+    expect(humanizeTitle("esvclp")).toBe("ESVCLP");
+    expect(humanizeTitle("nsw_bcs")).toBe("NSW BCS");
+    expect(humanizeTitle("Property")).toBe("Property");
+  });
+
+  it("returns an empty string for nullish/empty input", () => {
+    expect(humanizeTitle(null)).toBe("");
+    expect(humanizeTitle(undefined)).toBe("");
+    expect(humanizeTitle("")).toBe("");
+  });
+});
+
+describe("formatMetricValue", () => {
+  it("formats percentages, snake_case values and booleans", () => {
+    expect(formatMetricValue("ebitda_margin_pct", 18.8)).toBe("18.8%");
+    expect(formatMetricValue("unit_type", "biodiversity_credit")).toBe("Biodiversity Credit");
+    expect(formatMetricValue("structure", "managed_fund")).toBe("Managed Fund");
+    expect(formatMetricValue("siv_complying", true)).toBe("Yes");
+  });
+
+  it("does not add thousands separators to plain numbers (e.g. years)", () => {
+    expect(formatMetricValue("build_year", 2025)).toBe("2025");
+  });
+
+  it("leaves already-presentable values untouched", () => {
+    expect(formatMetricValue("scheme", "NSW BCS")).toBe("NSW BCS");
+    expect(formatMetricValue("sil_provider", "Confidential")).toBe("Confidential");
+  });
+});
+
+describe("listingDisplayMetrics", () => {
+  it("humanises keys + values and applies label overrides", () => {
+    expect(
+      listingDisplayMetrics({ bedrooms: 3, build_year: 2025, sil_provider: "Confidential" }),
+    ).toEqual([
+      { key: "bedrooms", label: "bedrooms", value: "3" },
+      { key: "build_year", label: "build year", value: "2025" },
+      { key: "sil_provider", label: "SIL provider", value: "Confidential" },
+    ]);
+  });
+
+  it("skips price/yield duplicates and noise keys, capping at the limit", () => {
+    const metrics = listingDisplayMetrics({
+      net_yield_pct: 12.5, // shown on the price line — skipped
+      min_investment_aud: 100000, // shown as the price — skipped
+      bedrooms: 4,
+      build_year: 2026,
+      scheme: "NSW BCS",
+    });
+    expect(metrics.map((m) => m.key)).toEqual(["bedrooms", "build_year", "scheme"]);
+  });
+
+  it("returns [] for nullish metrics", () => {
+    expect(listingDisplayMetrics(null)).toEqual([]);
+    expect(listingDisplayMetrics(undefined)).toEqual([]);
+  });
+});

--- a/components/InvestListingCard.tsx
+++ b/components/InvestListingCard.tsx
@@ -9,6 +9,7 @@ import {
   formatListingPrice,
   freshnessSignal,
 } from "@/lib/listing-kind";
+import { humanizeTitle, listingDisplayMetrics } from "@/lib/listing-format";
 import Icon from "@/components/Icon";
 import EnquireButton from "@/components/marketplace/EnquireButton";
 import ListingShortlistButton from "@/components/invest/ListingShortlistButton";
@@ -17,11 +18,6 @@ import ListingClaimLink from "@/components/invest/ListingClaimLink";
 function formatLocation(state?: string, city?: string): string | null {
   if (city && state) return `${city}, ${state}`;
   return state || city || null;
-}
-
-function formatKeyMetricValue(value: string | number | boolean): string {
-  if (typeof value === "boolean") return value ? "Yes" : "No";
-  return String(value);
 }
 
 /**
@@ -120,9 +116,7 @@ export default function InvestListingCard({
   const location = formatLocation(listing.location_state, listing.location_city);
   const stripColor = KIND_STRIP[kind];
 
-  const metricEntries = listing.key_metrics
-    ? Object.entries(listing.key_metrics).slice(0, 3)
-    : [];
+  const displayMetrics = listingDisplayMetrics(listing.key_metrics);
   const dbHeroImage = listing.images?.[0];
   const commodityKey =
     listing.sub_category ??
@@ -147,14 +141,14 @@ export default function InvestListingCard({
     </span>
   );
 
-  // Inline metric line ("$720k EBITDA · 3.6× · 18.8% margin").
-  const metricLine = metricEntries.length > 0 && (
+  // Inline metric line ("3 bedrooms · 2025 build year · SIL provider").
+  const metricLine = displayMetrics.length > 0 && (
     <p className="text-xs leading-relaxed text-slate-600">
-      {metricEntries.map(([k, v], i) => (
-        <span key={k}>
+      {displayMetrics.map((m, i) => (
+        <span key={m.key}>
           {i > 0 && <span className="text-slate-300"> · </span>}
-          <span className="font-bold text-ink-800">{formatKeyMetricValue(v)}</span>{" "}
-          <span className="text-slate-500">{k.replace(/_/g, " ")}</span>
+          <span className="font-bold text-ink-800">{m.value}</span>{" "}
+          <span className="text-slate-500">{m.label}</span>
         </span>
       ))}
     </p>
@@ -359,8 +353,8 @@ export default function InvestListingCard({
         </h3>
 
         {(listing.industry || listing.sub_category) && (
-          <p className="-mt-1 text-xs capitalize text-slate-500">
-            {[listing.industry, listing.sub_category?.replace(/_/g, " ")].filter(Boolean).join(" · ")}
+          <p className="-mt-1 text-xs text-slate-500">
+            {[humanizeTitle(listing.industry), humanizeTitle(listing.sub_category)].filter(Boolean).join(" · ")}
           </p>
         )}
 

--- a/components/invest/ListingDetailView.tsx
+++ b/components/invest/ListingDetailView.tsx
@@ -6,6 +6,7 @@ import ListingCard, { type InvestmentListing } from "@/components/ListingCard";
 import ListingEnquiryForm from "@/components/ListingEnquiryForm";
 import ListingDecisionTools from "@/components/invest/ListingDecisionTools";
 import ListingSchemaScripts from "@/components/ListingSchemaScripts";
+import { humanizeTitle, formatMetricValue } from "@/lib/listing-format";
 
 /**
  * Shared single-listing detail view.
@@ -118,8 +119,8 @@ export default function ListingDetailView({
                   <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
                     {Object.entries(km).map(([key, value]) => (
                       <div key={key} className="bg-slate-50 rounded-lg p-3">
-                        <p className="text-xs text-slate-500 capitalize mb-1">{key.replace(/_/g, " ")}</p>
-                        <p className="text-sm font-bold text-slate-900 capitalize">{String(value)}</p>
+                        <p className="text-xs text-slate-500 mb-1">{humanizeTitle(key)}</p>
+                        <p className="text-sm font-bold text-slate-900">{formatMetricValue(key, value)}</p>
                       </div>
                     ))}
                   </div>

--- a/lib/listing-format.ts
+++ b/lib/listing-format.ts
@@ -1,0 +1,151 @@
+/**
+ * Human-readable formatting for investment-listing text.
+ *
+ * Listing rows carry raw, machine-shaped strings: snake_case verticals/
+ * sub-categories (`venture_capital`, `sda_housing`), free-form `key_metrics`
+ * keyed by column-style names (`net_yield_pct`, `sil_provider`, `build_year`)
+ * and enum-ish values (`biodiversity_credit`). Rendering those directly — or
+ * worse, through CSS `capitalize`, which clobbers acronyms ("Sda Housing",
+ * "Esvclp") — makes the cards read cheap.
+ *
+ * This module humanises them with **acronym awareness**: known domain
+ * abbreviations stay uppercased, the rest get sentence/title case. It's the
+ * single source of truth for listing label/value formatting (card grid +
+ * detail view) — don't hand-roll `.replace(/_/g, " ")` at call sites.
+ */
+
+/**
+ * Domain abbreviations that must stay uppercased when they appear as a
+ * standalone token. Lowercased here; matched case-insensitively. Kept
+ * deliberately to terms that are abbreviations in this marketplace's context
+ * (states, disability-housing, tax/structure, finance, energy units) so we
+ * don't accidentally shout ordinary words.
+ */
+const ACRONYMS = new Set([
+  // Australian states / territories
+  "nsw", "vic", "qld", "wa", "sa", "nt", "act", "tas",
+  // Disability accommodation / NDIS
+  "sda", "sil", "ndis", "ohc",
+  // Schemes / tax / investor structures
+  "bcs", "esvclp", "esic", "siv", "firb", "cgt", "smsf", "fhog", "reit", "spv",
+  // Finance / deal terms
+  "asx", "im", "pds", "irr", "mer", "aum", "ppa", "jorc", "ebitda", "roi",
+  "npv", "etf", "ipo", "nav", "ltv", "icr", "wale", "p2p",
+  // Energy / capacity units
+  "kw", "mw", "gw", "kwh", "mwh", "gwh", "mwp", "co2",
+  // Misc
+  "esg", "ip", "gst", "abn", "acn", "usd", "aud", "gbp", "eur",
+]);
+
+/** Field keys we never surface as a metric chip on a card: shown elsewhere
+ *  (price line), used only for kind derivation, or pure noise. */
+const METRIC_SKIP = new Set([
+  // Yield / return — already shown on the price line for yield-bearing kinds.
+  "net_yield_pct", "gross_yield_pct", "yield_pct", "distribution_yield", "yield",
+  // Price / ticket — shown as the hero price.
+  "min_investment_aud", "min_commit_aud", "min_investment", "asking_price",
+  "asking_price_aud", "price", "price_aud",
+  // Identifiers / derivation inputs / eligibility flags (rendered elsewhere).
+  "asx_ticker", "commodity", "structure", "stage", "royalty_type",
+  "wholesale_only", "s708_required", "accredited_only", "open_to_retail",
+  "retail_eligible",
+]);
+
+/** Field keys with a hand-picked label that reads better than the generic
+ *  humanisation of the column name. */
+const METRIC_LABEL_OVERRIDES: Record<string, string> = {
+  sil_provider: "SIL provider",
+  unit_type: "type",
+  build_year: "build year",
+  case_size_mm: "case size",
+  aum_billions: "AUM (bn)",
+  mer_bps: "MER (bps)",
+};
+
+/** Metric keys whose numeric value should render as a percentage. */
+const PCT_KEY = /(?:_pct|_percent|margin|yield|irr|return|_roi)$/i;
+
+function titleCaseToken(token: string): string {
+  if (!token) return token;
+  if (ACRONYMS.has(token.toLowerCase())) return token.toUpperCase();
+  // Leave tokens that already carry internal capitals (e.g. "McLaren", "iPhone").
+  if (/[A-Z]/.test(token.slice(1))) return token;
+  return token.charAt(0).toUpperCase() + token.slice(1).toLowerCase();
+}
+
+/**
+ * Title Case with acronym preservation — for category / sub-category lines.
+ * `venture_capital` → "Venture Capital", `sda_housing` → "SDA Housing",
+ * `esvclp` → "ESVCLP", `nsw_bcs` → "NSW BCS".
+ */
+export function humanizeTitle(raw: string | null | undefined): string {
+  if (!raw) return "";
+  return raw
+    .replace(/[_-]+/g, " ")
+    .trim()
+    .split(/\s+/)
+    .map((w) => titleCaseToken(w))
+    .join(" ");
+}
+
+/** Lowercase words + acronyms — for the small grey metric labels
+ *  ("bedrooms", "build year", "SIL provider"). */
+function humanizeMetricLabel(key: string): string {
+  if (METRIC_LABEL_OVERRIDES[key]) return METRIC_LABEL_OVERRIDES[key];
+  return key
+    .replace(/[_-]+/g, " ")
+    .trim()
+    .split(/\s+/)
+    .map((w) => (ACRONYMS.has(w.toLowerCase()) ? w.toUpperCase() : w.toLowerCase()))
+    .join(" ");
+}
+
+/** Format a metric value: booleans → Yes/No, pct keys → "12.5%", snake_case
+ *  values → sentence case with acronyms, others left as-is. */
+export function formatMetricValue(key: string, value: unknown): string {
+  if (typeof value === "boolean") return value ? "Yes" : "No";
+  if (typeof value === "number") {
+    return PCT_KEY.test(key) ? `${value}%` : String(value);
+  }
+  const s = String(value).trim();
+  if (!s) return s;
+  // Machine-shaped value (snake/kebab, or all-lowercase) → humanise it.
+  // Mixed-case values ("Confidential", "NSW BCS") are already presentable.
+  if (/[_-]/.test(s) || s === s.toLowerCase()) {
+    return s
+      .replace(/[_-]+/g, " ")
+      .trim()
+      .split(/\s+/)
+      .map((w) => titleCaseToken(w))
+      .join(" ");
+  }
+  return s;
+}
+
+export interface DisplayMetric {
+  key: string;
+  /** Lowercase-with-acronyms label, e.g. "build year", "SIL provider". */
+  label: string;
+  /** Presentable value, e.g. "2025", "Biodiversity credit", "12.5%". */
+  value: string;
+}
+
+/**
+ * Pick and format up to `limit` `key_metrics` entries for a card's inline
+ * metric line — skipping price/yield duplicates, derivation inputs and noise,
+ * and humanising both key and value.
+ */
+export function listingDisplayMetrics(
+  km: Record<string, unknown> | null | undefined,
+  limit = 3,
+): DisplayMetric[] {
+  if (!km) return [];
+  const out: DisplayMetric[] = [];
+  for (const [key, value] of Object.entries(km)) {
+    if (value == null || value === "") continue;
+    if (METRIC_SKIP.has(key)) continue;
+    out.push({ key, label: humanizeMetricLabel(key), value: formatMetricValue(key, value) });
+    if (out.length >= limit) break;
+  }
+  return out;
+}


### PR DESCRIPTION
## Problem
The `/invest` marketplace cards rendered raw, machine-shaped text that looked cheap:

| Before | After |
|---|---|
| `Property · Sda Housing` | `Property · SDA Housing` |
| `Venture_capital · Esvclp` | `Venture Capital · ESVCLP` |
| `Biodiversity · Nsw Bcs` | `Biodiversity · NSW BCS` |
| `Confidential sil provider` | `Confidential SIL provider` |
| `biodiversity_credit unit type` | `Biodiversity Credit type` |
| `12.5 net yield pct` (dupes the price's "Net yield 12.5%") | *(dropped — already on the price line)* |

Causes: CSS `capitalize` clobbered acronyms, `industry` was never de-underscored, `key_metrics` showed column-style keys + snake_case values, and the net-yield metric duplicated the price line.

## Fix
New **`lib/listing-format.ts`** — single source of truth for listing text:
- **`humanizeTitle`** — Title Case with domain-acronym preservation (NSW/VIC/…, SDA, SIL, NDIS, ESVCLP, ESIC, SIV, FIRB, ASX, IRR, EBITDA, …) for the category line.
- **`formatMetricValue`** — booleans → Yes/No, `*_pct` → `12.5%`, snake_case values → Title Case, already-presentable values untouched, **no thousands separators on years**.
- **`listingDisplayMetrics`** — humanises key + value and **skips** price/yield duplicates, kind-derivation inputs, and eligibility-flag noise.

Wired into the card grid (`InvestListingCard`) and the detail view (`ListingDetailView`); both drop the acronym-clobbering `capitalize`.

## Verification
`tsc` clean · `eslint --max-warnings 0` clean · **8 new unit tests** (acronyms, snake values, year-no-separator, skip logic) + existing `listing-kind` (60) and `InvestListingsClient` (renders the card) suites pass.

`/invest` renders 0 listings locally (no Supabase env), so the live visual confirmation is best done on the deploy — I can run `/ai-journey` against it once merged.

https://claude.ai/code/session_012cKsbjxnQ77BH1ACPqyTCj

---
_Generated by [Claude Code](https://claude.ai/code/session_012cKsbjxnQ77BH1ACPqyTCj)_