### PR TITLE
feat(advisors): add "Get quotes from verified pros" CTA to the directory

### DIFF
--- a/__tests__/components/AdvisorsClient.test.tsx
+++ b/__tests__/components/AdvisorsClient.test.tsx
@@ -157,4 +157,13 @@ describe("AdvisorsClient — compact header redesign", () => {
     expect(screen.queryByRole("button", { name: /^comfy$/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /^compact$/i })).not.toBeInTheDocument();
   });
+
+  it("renders the 'Get quotes from verified pros' CTA linking to the brief flow", () => {
+    render(<AdvisorsClient professionals={professionals} />);
+    expect(
+      screen.getByRole("heading", { name: /Get quotes from verified pros/i }),
+    ).toBeInTheDocument();
+    const cta = screen.getByRole("link", { name: /^Get quotes$/i });
+    expect(cta).toHaveAttribute("href", "/briefs/new");
+  });
 });

--- a/app/advisors/AdvisorsClient.tsx
+++ b/app/advisors/AdvisorsClient.tsx
@@ -1467,6 +1467,39 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
           </div>
         )}
 
+        {/* Reverse-marketplace CTA \u2014 post a brief to get competing quotes from
+            verified individuals, firms or Pro Squads. Mirrors the /briefs/new
+            hero branding (dark + amber) so the destination feels connected. */}
+        <section className="mt-8 md:mt-12">
+          <div className="relative overflow-hidden rounded-2xl bg-gradient-to-br from-slate-900 via-slate-900 to-slate-800 px-6 py-8 shadow-sm md:px-10 md:py-10">
+            <div className="flex flex-col gap-5 md:flex-row md:items-center md:justify-between md:gap-8">
+              <div className="max-w-2xl">
+                <p className="mb-2 text-[0.7rem] font-semibold uppercase tracking-widest text-amber-400">
+                  Match Request \u00b7 Australia
+                </p>
+                <h2 className="text-xl font-extrabold text-white md:text-2xl">
+                  Get quotes from verified pros
+                </h2>
+                <p className="mt-2 text-sm leading-relaxed text-slate-300">
+                  Tell verified Australian professionals, firms or Pro Squads what you
+                  need help with. They&apos;ll see a masked preview and respond only if
+                  it&apos;s a fit \u2014 you stay in control of who sees your contact details.
+                </p>
+              </div>
+              <Link
+                href="/briefs/new"
+                onClick={() =>
+                  trackEvent("get_quotes_cta_clicked", { source: "advisors_directory" })
+                }
+                className="inline-flex shrink-0 items-center justify-center gap-1.5 rounded-xl bg-amber-500 px-5 py-3 text-sm font-bold text-slate-900 transition-colors hover:bg-amber-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
+              >
+                Get quotes
+                <Icon name="arrow-right" size={15} />
+              </Link>
+            </div>
+          </div>
+        </section>
+
         {/* Editorial content */}
         {editorial && (
           <section className="mt-8 md:mt-12 space-y-4">


### PR DESCRIPTION
## What
Adds the requested **"Get quotes from verified pros"** element to the `/advisors` directory — a reverse-marketplace CTA band that routes to the brief flow (`/briefs/new`): post once, and verified individuals, firms or **Pro Squads** respond with quotes.

- **Copy + branding** mirror the `/briefs/new` hero — heading "Get quotes from verified pros", subtext "Tell verified Australian professionals, firms or Pro Squads what you need help with…", and the dark-slate + amber treatment — so the CTA and its destination feel like one system.
- **Placement:** below the results/pagination (not the header), so it doesn't eat the compact-header fold we just reclaimed. Click tracked via `trackEvent("get_quotes_cta_clicked", { source: "advisors_directory" })`.
- Links to the canonical `/briefs/new` flow (the existing "post a brief → masked preview → pros respond" board), so no new backend.

## Verification
`tsc` clean · `eslint --max-warnings 0` clean · 11 `/advisors` tests pass, including a new one asserting the CTA heading renders and the button links to `/briefs/new`.

https://claude.ai/code/session_012cKsbjxnQ77BH1ACPqyTCj

---
_Generated by [Claude Code](https://claude.ai/code/session_012cKsbjxnQ77BH1ACPqyTCj)_