### PR TITLE
feat(briefs): Brief Studio — gold-standard /briefs/new creation flow

### DIFF
--- a/__tests__/components/briefs/BriefStrengthMeter.test.tsx
+++ b/__tests__/components/briefs/BriefStrengthMeter.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "../setup";
+
+import BriefStrengthMeter from "@/components/briefs/BriefStrengthMeter";
+import type { BriefStrength } from "@/lib/briefs/brief-strength";
+
+const weak: BriefStrength = {
+  score: 20,
+  tier: "weak",
+  label: "Needs more detail",
+  tips: [
+    { id: "description", text: "Add a sentence or two about your situation." },
+    { id: "budget", text: "Set a budget band." },
+  ],
+};
+
+const great: BriefStrength = {
+  score: 95,
+  tier: "great",
+  label: "Excellent — pros love this",
+  tips: [],
+};
+
+describe("BriefStrengthMeter", () => {
+  it("renders the tier label and an accessible meter value", () => {
+    render(<BriefStrengthMeter strength={weak} />);
+    expect(screen.getByText("Needs more detail")).toBeInTheDocument();
+    const meter = screen.getByRole("meter");
+    expect(meter).toHaveAttribute("aria-valuenow", "20");
+    expect(meter).toHaveAttribute("aria-valuemax", "100");
+  });
+
+  it("surfaces coaching tips for a weak brief", () => {
+    render(<BriefStrengthMeter strength={weak} />);
+    expect(screen.getByText(/add a sentence or two/i)).toBeInTheDocument();
+  });
+
+  it("shows a celebratory message (and no tips) when great", () => {
+    render(<BriefStrengthMeter strength={great} />);
+    expect(screen.getByText(/this brief gives pros what they need/i)).toBeInTheDocument();
+    expect(screen.queryByText(/set a budget band/i)).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/components/briefs/IntentPicker.test.tsx
+++ b/__tests__/components/briefs/IntentPicker.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, userEvent } from "../setup";
+
+import IntentPicker from "@/components/briefs/IntentPicker";
+
+function setup(overrides: Partial<React.ComponentProps<typeof IntentPicker>> = {}) {
+  const onSelect = vi.fn();
+  const onFreeform = vi.fn();
+  render(
+    <IntentPicker
+      selectedIntentId={null}
+      onSelect={onSelect}
+      onFreeform={onFreeform}
+      aiEnabled={false}
+      {...overrides}
+    />,
+  );
+  return { onSelect, onFreeform };
+}
+
+describe("IntentPicker", () => {
+  it("renders the freeform hero and a grouped gallery", () => {
+    setup();
+    expect(
+      screen.getByRole("button", { name: /describe it in your own words/i }),
+    ).toBeInTheDocument();
+    // A canonical intent card is present.
+    expect(
+      screen.getByRole("button", { name: /home loan or refinance/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows an AI badge in the hero when aiEnabled", () => {
+    setup({ aiEnabled: true });
+    const hero = screen.getByRole("button", { name: /describe it in your own words/i });
+    expect(hero).toHaveTextContent(/AI/);
+  });
+
+  it("calls onFreeform when the hero is clicked", async () => {
+    const user = userEvent.setup();
+    const { onFreeform } = setup();
+    await user.click(
+      screen.getByRole("button", { name: /describe it in your own words/i }),
+    );
+    expect(onFreeform).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onSelect with the chosen intent", async () => {
+    const user = userEvent.setup();
+    const { onSelect } = setup();
+    await user.click(screen.getByRole("button", { name: /home loan or refinance/i }));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0]?.[0]?.template).toBe("mortgage");
+  });
+
+  it("filters intents by search query (quiz vocabulary)", async () => {
+    const user = userEvent.setup();
+    setup();
+    await user.type(screen.getByRole("searchbox"), "refinance");
+    // The mortgage card surfaces…
+    expect(
+      screen.getByRole("button", { name: /home loan or refinance/i }),
+    ).toBeInTheDocument();
+    // …and an unrelated card drops out of the results.
+    expect(
+      screen.queryByRole("button", { name: /buying a business/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("offers the freeform escape hatch when nothing matches", async () => {
+    const user = userEvent.setup();
+    const { onFreeform } = setup();
+    await user.type(screen.getByRole("searchbox"), "zzzqqxnomatch");
+    expect(screen.getByText(/no exact match/i)).toBeInTheDocument();
+    // Both the hero and the empty-state link share wording; the inline link is last.
+    const buttons = screen.getAllByRole("button", {
+      name: /describe it in your own words/i,
+    });
+    await user.click(buttons[buttons.length - 1]!);
+    expect(onFreeform).toHaveBeenCalled();
+  });
+});

--- a/__tests__/lib/briefs/brief-strength.test.ts
+++ b/__tests__/lib/briefs/brief-strength.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  scoreBriefStrength,
+  type BriefStrengthInput,
+} from "@/lib/briefs/brief-strength";
+
+const EMPTY: BriefStrengthInput = {
+  title: "",
+  description: "",
+  budgetBand: "",
+  locationState: "",
+  payload: {},
+  fields: [],
+};
+
+function withDefaults(over: Partial<BriefStrengthInput>): BriefStrengthInput {
+  return { ...EMPTY, ...over };
+}
+
+describe("scoreBriefStrength — bounds & tiers", () => {
+  it("an empty brief scores low and is 'weak'", () => {
+    const r = scoreBriefStrength(EMPTY);
+    expect(r.score).toBeLessThan(40);
+    expect(r.tier).toBe("weak");
+    expect(r.label).toBe("Needs more detail");
+  });
+
+  it("a complete, detailed brief scores high and is 'great'", () => {
+    const r = scoreBriefStrength({
+      title: "SMSF property strategy in QLD with $200k super",
+      description:
+        "I'm 38, based in NSW, with about $200k in super. I want to set up an SMSF to buy an investment property in Brisbane, budget around $2,000 for advice, and I'd like to move in the next 3 months. I need lending and a buyer's agent.",
+      budgetBand: "2k_5k",
+      locationState: "NSW",
+      payload: { timeline: "1_3_months", smsf_status: "considering_smsf", property_budget: "500k_700k", help_needed: ["lending"] },
+      fields: [
+        { key: "smsf_status", required: true },
+        { key: "property_budget", required: true },
+        { key: "timeline", required: true },
+        { key: "help_needed", required: true },
+      ],
+    });
+    expect(r.score).toBeGreaterThanOrEqual(85);
+    expect(r.tier).toBe("great");
+    expect(r.tips).toHaveLength(0);
+  });
+
+  it("never exceeds 100 or drops below 0", () => {
+    const r = scoreBriefStrength({
+      title: "A very specific title with 12345 numbers and detail",
+      description: "x".repeat(5000),
+      budgetBand: "5k_10k",
+      locationState: "VIC",
+      payload: { timeline: "asap" },
+      fields: [{ key: "timeline", required: true }],
+    });
+    expect(r.score).toBeLessThanOrEqual(100);
+    expect(r.score).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe("scoreBriefStrength — coaching tips", () => {
+  it("surfaces the highest-impact missing dimension first", () => {
+    // Title + budget + location present, but description empty → description
+    // (max 40) is the biggest gap and should lead the tips.
+    const r = scoreBriefStrength(
+      withDefaults({
+        title: "Refinance my $600k investment loan in NSW",
+        budgetBand: "2k_5k",
+        locationState: "NSW",
+      }),
+    );
+    expect(r.tips[0]?.id).toBe("description");
+  });
+
+  it("recommends setting a budget when it's missing", () => {
+    const r = scoreBriefStrength(
+      withDefaults({
+        title: "Tax help after selling a property",
+        description:
+          "I sold an investment property this financial year and want to minimise capital gains tax. Looking for a proactive accountant in the next month.",
+        locationState: "QLD",
+      }),
+    );
+    expect(r.tips.some((t) => t.id === "budget")).toBe(true);
+  });
+
+  it("returns at most three tips", () => {
+    expect(scoreBriefStrength(EMPTY).tips.length).toBeLessThanOrEqual(3);
+  });
+
+  it("treats 'not_sure' budget as weaker than a real band", () => {
+    const base = withDefaults({
+      title: "Financial planning for retirement",
+      description:
+        "I'm 50 and want a long-term retirement plan covering super, shares and insurance over the next 6 months.",
+      locationState: "WA",
+    });
+    const notSure = scoreBriefStrength({ ...base, budgetBand: "not_sure" });
+    const real = scoreBriefStrength({ ...base, budgetBand: "5k_10k" });
+    expect(real.score).toBeGreaterThan(notSure.score);
+  });
+});
+
+describe("scoreBriefStrength — timeline relevance", () => {
+  it("does not penalise templates that have no timeline field", () => {
+    const notesOnly = scoreBriefStrength(
+      withDefaults({
+        title: "Independent review of my Statement of Advice",
+        description:
+          "My adviser recommended switching super funds. I'd like an independent professional to review the Statement of Advice before I act.",
+        budgetBand: "500_2k",
+        locationState: "NSW",
+        fields: [{ key: "notes" }],
+      }),
+    );
+    // No timeline tip should appear for a template without a timeline field.
+    expect(notesOnly.tips.some((t) => t.id === "timeline")).toBe(false);
+  });
+
+  it("asks for a timeline when the template has the field but it's unset", () => {
+    const r = scoreBriefStrength(
+      withDefaults({
+        title: "SMSF property purchase help in QLD",
+        description:
+          "I have an established SMSF and want to buy an investment property. I need lending and a buyer's agent to help me through it.",
+        budgetBand: "2k_5k",
+        locationState: "QLD",
+        payload: { smsf_status: "smsf_established" },
+        fields: [
+          { key: "smsf_status", required: true },
+          { key: "timeline", required: true },
+        ],
+      }),
+    );
+    expect(r.tips.some((t) => t.id === "timeline")).toBe(true);
+  });
+});

--- a/__tests__/lib/briefs/intent-catalog.test.ts
+++ b/__tests__/lib/briefs/intent-catalog.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  INTENT_CATALOG,
+  INTENT_GROUPS,
+  getIntentById,
+  intentForTemplate,
+  popularIntents,
+  intentsForGroup,
+  searchIntents,
+} from "@/lib/briefs/intent-catalog";
+import { BRIEF_TEMPLATES } from "@/lib/briefs/templates";
+
+describe("intent catalog — integrity", () => {
+  it("every intent maps to a real brief_template", () => {
+    for (const intent of INTENT_CATALOG) {
+      expect(BRIEF_TEMPLATES).toContain(intent.template);
+    }
+  });
+
+  it("covers all 14 brief templates at least once", () => {
+    const covered = new Set(INTENT_CATALOG.map((i) => i.template));
+    for (const t of BRIEF_TEMPLATES) {
+      expect(covered.has(t)).toBe(true);
+    }
+  });
+
+  it("has unique intent ids", () => {
+    const ids = INTENT_CATALOG.map((i) => i.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("every intent belongs to a declared group", () => {
+    const groupIds = new Set(INTENT_GROUPS.map((g) => g.id));
+    for (const intent of INTENT_CATALOG) {
+      expect(groupIds.has(intent.group)).toBe(true);
+    }
+  });
+
+  it("every intent has at least one keyword and one example", () => {
+    for (const intent of INTENT_CATALOG) {
+      expect(intent.keywords.length).toBeGreaterThan(0);
+      expect(intent.examples.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("intent catalog — lookups", () => {
+  it("getIntentById resolves a known id and returns undefined otherwise", () => {
+    expect(getIntentById("mortgage")?.template).toBe("mortgage");
+    expect(getIntentById("does-not-exist")).toBeUndefined();
+    expect(getIntentById(null)).toBeUndefined();
+  });
+
+  it("intentForTemplate returns a canonical intent for each template", () => {
+    expect(intentForTemplate("financial_adviser")?.id).toBeDefined();
+    expect(intentForTemplate(null)).toBeUndefined();
+  });
+
+  it("popularIntents returns only popular entries", () => {
+    const pop = popularIntents();
+    expect(pop.length).toBeGreaterThan(0);
+    expect(pop.every((i) => i.popular)).toBe(true);
+  });
+
+  it("intentsForGroup filters by group", () => {
+    const advice = intentsForGroup("advice");
+    expect(advice.every((i) => i.group === "advice")).toBe(true);
+    expect(advice.length).toBeGreaterThan(0);
+  });
+});
+
+describe("intent catalog — search", () => {
+  it("returns the full catalog for an empty query", () => {
+    expect(searchIntents("").length).toBe(INTENT_CATALOG.length);
+    expect(searchIntents("   ").length).toBe(INTENT_CATALOG.length);
+  });
+
+  it("matches quiz-style vocabulary to the right template", () => {
+    expect(searchIntents("refinance")[0]?.template).toBe("mortgage");
+    expect(searchIntents("FIRB")[0]?.template).toBe("foreign_investor");
+    expect(searchIntents("CGT")[0]?.template).toBe("tax");
+    expect(searchIntents("sell my business")[0]?.template).toBe("listing");
+    expect(searchIntents("second opinion")[0]?.template).toBe("second_opinion");
+  });
+
+  it("ranks a label match above a loose keyword match", () => {
+    const results = searchIntents("tax");
+    expect(results[0]?.template).toBe("tax");
+  });
+
+  it("is case-insensitive", () => {
+    expect(searchIntents("MORTGAGE")[0]?.template).toBe("mortgage");
+  });
+
+  it("returns an empty array when nothing matches", () => {
+    expect(searchIntents("zzzqqxnomatch")).toEqual([]);
+  });
+});

--- a/app/briefs/new/BriefForm.tsx
+++ b/app/briefs/new/BriefForm.tsx
@@ -1,21 +1,44 @@
 "use client";
 
-import { useEffect, useId, useMemo, useState } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 
 import Icon from "@/components/Icon";
+import { Button } from "@/components/ui/Button";
+import { Input } from "@/components/ui/Input";
+import { Select } from "@/components/ui/Select";
+import { Badge } from "@/components/ui/Badge";
+import FormStepper from "@/components/FormStepper";
 import {
   BRIEF_TEMPLATES,
   BRIEF_TEMPLATE_LABELS,
-  BRIEF_TEMPLATE_BLURBS,
   BRIEF_TEMPLATE_FIELDS,
   type FieldHint,
 } from "@/lib/briefs/templates";
 import type { BriefTemplate } from "@/lib/briefs/types";
+import {
+  getIntentById,
+  intentForTemplate,
+  type IntentDef,
+} from "@/lib/briefs/intent-catalog";
+import { scoreBriefStrength } from "@/lib/briefs/brief-strength";
+import IntentPicker from "@/components/briefs/IntentPicker";
+import BriefPreviewCard from "@/components/briefs/BriefPreviewCard";
+import BriefStrengthMeter from "@/components/briefs/BriefStrengthMeter";
+import MatchModeChooser, { type MatchPatch } from "@/components/briefs/MatchModeChooser";
+import BriefSuccess from "@/components/briefs/BriefSuccess";
 import ListingCompanionServices from "./ListingCompanionServices";
 
-type Step = "template" | "details" | "preference" | "contact" | "success";
+type Step = "intent" | "details" | "match" | "contact" | "success";
+
+const STEP_ORDER: Step[] = ["intent", "details", "match", "contact"];
+const STEPPER: { label: string }[] = [
+  { label: "What you need" },
+  { label: "Details" },
+  { label: "Matching" },
+  { label: "Contact" },
+];
 
 const STATES = ["NSW", "VIC", "QLD", "WA", "SA", "TAS", "ACT", "NT"];
 const BUDGETS = [
@@ -27,31 +50,15 @@ const BUDGETS = [
   { value: "not_sure", label: "Budget TBD" },
 ];
 
-const PROVIDER_PREFERENCES = [
-  { value: "any", label: "No preference" },
-  { value: "individual", label: "Individual expert" },
-  { value: "firm", label: "Firm / brokerage" },
-  { value: "expert_team", label: "Expert team" },
-  { value: "multiple", label: "Multiple professional responses" },
-];
+const PROVIDER_PREF_LABELS: Record<string, string> = {
+  any: "Any verified pro",
+  individual: "An individual expert",
+  firm: "A firm / brokerage",
+  expert_team: "An expert team",
+  multiple: "Multiple verified pros",
+};
 
-const ROUTING_MODES = [
-  {
-    value: "smart_match",
-    label: "Smart Match",
-    blurb: "We route to the most relevant verified providers.",
-  },
-  {
-    value: "direct",
-    label: "Send to a specific provider",
-    blurb: "Use a team/firm/individual slug from their profile page.",
-  },
-  {
-    value: "multi_response",
-    label: "Receive multiple responses",
-    blurb: "Open the brief up to several providers in parallel.",
-  },
-];
+const DRAFT_KEY = "brief-studio-draft:v1";
 
 interface FormState {
   brief_template: BriefTemplate | "";
@@ -84,7 +91,7 @@ const INITIAL: FormState = {
   location_state: "",
   payload: {},
   provider_preference: "any",
-  routing_mode: "smart_match",
+  routing_mode: "multi_response",
   target_team_slug: "",
   contact_name: "",
   contact_email: "",
@@ -109,24 +116,25 @@ export interface WorkspaceContext {
 
 interface BriefFormProps {
   /**
-   * Whether the AI co-pilot toggle should render. Resolved server-side
-   * via `isFlagEnabled('ai_match_request_copilot', ...)` in the parent
-   * server page. When false the toggle never renders, so the freeform
-   * textarea + Submit button path is never reachable client-side either.
+   * Whether the AI co-pilot drafting path is enabled. Resolved server-side
+   * via `isFlagEnabled('ai_match_request_copilot', ...)`. The freeform
+   * "describe it in your own words" entry always exists; when this is false
+   * it seeds a general brief from the text instead of calling the AI.
    */
   aiCopilotEnabled?: boolean;
-  /** Server-resolved active workspace — drives the "Filing as <kind>" chip
-   * and prefills contact fields. Null = not signed in or no active kind. */
+  /** Server-resolved active workspace — drives the "Filing as" chip and prefills contact. */
   workspace?: WorkspaceContext | null;
-  /** Server-resolved Investor Pro subscription state — unlocks the
-   * direct-route shortcut that skips the 24h smart-match window. */
+  /** Server-resolved Investor Pro subscription state — unlocks the direct-route perk. */
   proSubscriber?: boolean;
+  /** Honest count of active verified pros, for social proof. Null hides the number. */
+  proSupply?: number | null;
 }
 
 export default function BriefForm({
   aiCopilotEnabled = false,
   workspace = null,
   proSubscriber = false,
+  proSupply = null,
 }: BriefFormProps) {
   const searchParams = useSearchParams();
   const presetTeam = searchParams?.get("team") ?? "";
@@ -134,31 +142,26 @@ export default function BriefForm({
   const presetProviderPreference = searchParams?.get("provider_preference") ?? "";
   const presetRoutingMode = searchParams?.get("routing_mode") ?? "";
   const planId = searchParams?.get("plan_id") ?? "";
+  const hasPreset = !!(presetTeam || presetTemplate || planId);
 
-  // ── AI co-pilot state ───────────────────────────────────────────────
-  // The toggle only renders when the parent server page passed
-  // aiCopilotEnabled=true (feature flag on). When toggled ON, we replace
-  // the multi-step form with a single textarea. On submit the textarea
-  // POSTs to /api/briefs/ai-copilot; if confidence is high enough we
-  // pre-fill the form and drop the user back into step "details" to
-  // review. Otherwise we fall back to the manual flow with a toast.
-  const [copilotMode, setCopilotMode] = useState(false);
-  const [copilotText, setCopilotText] = useState("");
-  const [copilotLoading, setCopilotLoading] = useState(false);
-  const [copilotInfo, setCopilotInfo] = useState<string | null>(null);
+  // ── Freeform / AI co-pilot state ────────────────────────────────────
+  const [freeformMode, setFreeformMode] = useState(false);
+  const [freeformText, setFreeformText] = useState("");
+  const [freeformLoading, setFreeformLoading] = useState(false);
+  const [info, setInfo] = useState<string | null>(null);
 
-  const [step, setStep] = useState<Step>("template");
+  const [step, setStep] = useState<Step>("intent");
+  const [selectedIntentId, setSelectedIntentId] = useState<string | null>(
+    presetTemplate ? intentForTemplate(presetTemplate as BriefTemplate)?.id ?? null : null,
+  );
   const [form, setForm] = useState<FormState>(() => ({
     ...INITIAL,
     target_team_slug: presetTeam || "",
-    routing_mode: presetRoutingMode || (presetTeam ? "direct" : "smart_match"),
+    routing_mode: presetRoutingMode || (presetTeam ? "direct" : "multi_response"),
     provider_preference: presetProviderPreference || "any",
     brief_template: (BRIEF_TEMPLATES.includes(presetTemplate as BriefTemplate)
       ? (presetTemplate as BriefTemplate)
       : "") as BriefTemplate | "",
-    // Workspace-aware prefill: pulls contact name/email/phone from the
-    // signed-in user's active account-kind row so business + listing
-    // owners don't retype their own details.
     contact_name: workspace?.prefillName ?? INITIAL.contact_name,
     contact_email: workspace?.prefillEmail ?? INITIAL.contact_email,
     contact_phone: workspace?.prefillPhone ?? INITIAL.contact_phone,
@@ -171,8 +174,56 @@ export default function BriefForm({
     risk_review_status: string;
   } | null>(null);
   const [planPrefilled, setPlanPrefilled] = useState(false);
+  const [restoredDraft, setRestoredDraft] = useState(false);
+  const draftLoaded = useRef(false);
 
-  // Pre-fill from Get Matched action plan if plan_id present.
+  // ── Draft restore (once, only for clean anonymous starts) ───────────
+  useEffect(() => {
+    if (draftLoaded.current) return;
+    draftLoaded.current = true;
+    if (hasPreset || typeof window === "undefined") return;
+    try {
+      const raw = window.localStorage.getItem(DRAFT_KEY);
+      if (!raw) return;
+      const saved = JSON.parse(raw) as { form?: FormState; step?: Step; intentId?: string | null };
+      const f = saved.form;
+      if (!f || typeof f !== "object") return;
+      // Only restore if there's meaningful content and a valid template.
+      const validTemplate = f.brief_template && BRIEF_TEMPLATES.includes(f.brief_template);
+      if (!validTemplate && !f.job_title && !f.job_description) return;
+      setForm((prev) => ({ ...prev, ...f }));
+      setSelectedIntentId(saved.intentId ?? null);
+      const restoredStep = saved.step && STEP_ORDER.includes(saved.step) ? saved.step : "details";
+      setStep(restoredStep);
+      setRestoredDraft(true);
+    } catch {
+      /* ignore malformed draft */
+    }
+  }, [hasPreset]);
+
+  // ── Draft autosave ──────────────────────────────────────────────────
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (planId || step === "intent" || step === "success") return;
+    try {
+      window.localStorage.setItem(
+        DRAFT_KEY,
+        JSON.stringify({ form, step, intentId: selectedIntentId }),
+      );
+    } catch {
+      /* storage full / disabled — non-fatal */
+    }
+  }, [form, step, selectedIntentId, planId]);
+
+  function clearDraft() {
+    try {
+      if (typeof window !== "undefined") window.localStorage.removeItem(DRAFT_KEY);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  // ── Pre-fill from Get Matched action plan ───────────────────────────
   useEffect(() => {
     if (!planId) return;
     let cancelled = false;
@@ -195,14 +246,12 @@ export default function BriefForm({
           job_description: data.description ?? "Investment brief from action plan.",
           budget_band: plan?.budget_band ?? "not_sure",
           location_state: plan?.location_state ?? "NSW",
-          provider_preference:
-            presetProviderPreference || providerPrefForRoute(plan?.route),
-          routing_mode: presetRoutingMode || "smart_match",
+          provider_preference: presetProviderPreference || providerPrefForRoute(plan?.route),
+          routing_mode: presetRoutingMode || "multi_response",
           payload: plan?.answers ?? {},
         }));
+        setSelectedIntentId(intentForTemplate(template)?.id ?? null);
         setPlanPrefilled(true);
-        // Skip ahead to contact step since template + details + preference
-        // are now known.
         setStep("contact");
       } catch {
         /* ignore */
@@ -219,6 +268,25 @@ export default function BriefForm({
     return BRIEF_TEMPLATE_FIELDS[form.brief_template] ?? [];
   }, [form.brief_template]);
 
+  const strength = useMemo(
+    () =>
+      scoreBriefStrength({
+        title: form.job_title,
+        description: form.job_description,
+        budgetBand: form.budget_band,
+        locationState: form.location_state,
+        payload: form.payload,
+        fields,
+      }),
+    [form.job_title, form.job_description, form.budget_band, form.location_state, form.payload, fields],
+  );
+
+  const activeIntent = getIntentById(selectedIntentId);
+  const intentLabel =
+    activeIntent?.label ??
+    (form.brief_template ? BRIEF_TEMPLATE_LABELS[form.brief_template] : null);
+  const budgetLabel = BUDGETS.find((b) => b.value === form.budget_band)?.label ?? null;
+
   function setField<K extends keyof FormState>(key: K, value: FormState[K]) {
     setForm((p) => ({ ...p, [key]: value }));
   }
@@ -227,55 +295,88 @@ export default function BriefForm({
     setForm((p) => ({ ...p, payload: { ...p.payload, [key]: value } }));
   }
 
-  const canTemplate = !!form.brief_template;
   const canDetails =
     form.job_title.trim().length >= 8 &&
     form.job_description.trim().length >= 30 &&
-    form.budget_band &&
-    form.location_state &&
+    !!form.budget_band &&
+    !!form.location_state &&
     fields
       .filter((f) => f.required)
       .every((f) => {
         const v = form.payload[f.key];
-        if (f.kind === "multiselect") {
-          return Array.isArray(v) && v.length > 0;
-        }
+        if (f.kind === "multiselect") return Array.isArray(v) && v.length > 0;
         return typeof v === "string" && v.length > 0;
       });
-  const canPreference = !!form.provider_preference && !!form.routing_mode;
   const canContact =
     form.contact_name.trim().length > 0 &&
     /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.contact_email) &&
     form.consent;
 
-  async function runCopilot() {
-    if (copilotText.trim().length < 10) {
-      setCopilotInfo("Tell us a bit more — at least 10 characters.");
+  function selectIntent(intent: IntentDef) {
+    setSelectedIntentId(intent.id);
+    setForm((p) => ({
+      ...p,
+      brief_template: intent.template,
+      provider_preference: presetProviderPreference || intent.providerPreference || "any",
+      routing_mode: p.routing_mode || "multi_response",
+    }));
+    setInfo(null);
+    setStep("details");
+  }
+
+  function openFreeform() {
+    setFreeformMode(true);
+    setInfo(null);
+  }
+
+  async function submitFreeform() {
+    const text = freeformText.trim();
+    if (text.length < 10) {
+      setInfo("Tell us a bit more — at least 10 characters.");
       return;
     }
-    setCopilotLoading(true);
-    setCopilotInfo(null);
+    // No AI: seed a general brief from the text and let the user refine.
+    if (!aiCopilotEnabled) {
+      setForm((p) => ({
+        ...p,
+        brief_template: p.brief_template || "general",
+        job_description: p.job_description || text,
+      }));
+      setSelectedIntentId((id) => id ?? "general");
+      setFreeformMode(false);
+      setStep("details");
+      setInfo("We've started your brief — add a title and a few details below.");
+      return;
+    }
+    // AI co-pilot drafting path.
+    setFreeformLoading(true);
+    setInfo(null);
     try {
       const res = await fetch("/api/briefs/ai-copilot", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ description: copilotText }),
+        body: JSON.stringify({ description: text }),
       });
       if (res.status === 404) {
-        // Feature flag flipped off between server render and submit —
-        // bail back to the manual form silently.
-        setCopilotMode(false);
-        setCopilotInfo(null);
+        // Flag flipped off — fall back to seeding a general brief.
+        setForm((p) => ({
+          ...p,
+          brief_template: p.brief_template || "general",
+          job_description: p.job_description || text,
+        }));
+        setSelectedIntentId((id) => id ?? "general");
+        setFreeformMode(false);
+        setStep("details");
         return;
       }
       if (!res.ok) {
-        setCopilotInfo("We couldn't draft your brief. Use the form below instead.");
-        setCopilotMode(false);
+        setInfo("We couldn't draft your brief. Pick an option below instead.");
+        setFreeformMode(false);
         return;
       }
       const data = (await res.json()) as {
         ok: boolean;
-        payload: Partial<FormState> & {
+        payload: {
           brief_template?: BriefTemplate;
           job_title?: string;
           job_description?: string;
@@ -287,40 +388,33 @@ export default function BriefForm({
         confidence: number;
         missing_fields: string[];
       };
-      const ok =
-        data.ok &&
-        data.confidence >= 0.6 &&
-        (data.missing_fields?.length ?? 0) === 0;
-
-      // Pre-fill what we can regardless — even a low-confidence draft
-      // beats an empty form for the user.
+      const good = data.ok && data.confidence >= 0.6 && (data.missing_fields?.length ?? 0) === 0;
       const p = data.payload || {};
       const template = BRIEF_TEMPLATES.includes(p.brief_template as BriefTemplate)
         ? (p.brief_template as BriefTemplate)
-        : form.brief_template;
+        : form.brief_template || "general";
       setForm((prev) => ({
         ...prev,
         brief_template: template || "general",
         job_title: p.job_title ?? prev.job_title,
-        job_description: p.job_description ?? prev.job_description,
+        job_description: p.job_description ?? text,
         budget_band: p.budget_band ?? prev.budget_band,
         location_state: p.location_state ?? prev.location_state,
         payload: { ...prev.payload, ...(p.brief_payload ?? {}) },
       }));
-
-      // Always drop the user into the manual form so they can review.
-      setCopilotMode(false);
+      setSelectedIntentId(intentForTemplate(template as BriefTemplate)?.id ?? "general");
+      setFreeformMode(false);
       setStep("details");
-      if (ok) {
-        setCopilotInfo("We've drafted your brief — review and submit.");
-      } else {
-        setCopilotInfo("We need a bit more info — please fill in the highlighted fields.");
-      }
+      setInfo(
+        good
+          ? "We've drafted your brief — review and refine it below."
+          : "We've made a start — please fill in the highlighted details below.",
+      );
     } catch {
-      setCopilotInfo("We couldn't draft your brief. Use the form below instead.");
-      setCopilotMode(false);
+      setInfo("We couldn't draft your brief. Pick an option below instead.");
+      setFreeformMode(false);
     } finally {
-      setCopilotLoading(false);
+      setFreeformLoading(false);
     }
   }
 
@@ -328,12 +422,8 @@ export default function BriefForm({
     setLoading(true);
     setError(null);
     try {
-      // If we have a plan_id, use the plan→brief endpoint so the brief is
-      // linked back to the action plan.
       const fromPlan = !!planId && planPrefilled;
-      const url = fromPlan
-        ? `/api/get-matched/plans/${planId}/to-brief`
-        : "/api/briefs";
+      const url = fromPlan ? `/api/get-matched/plans/${planId}/to-brief` : "/api/briefs";
       const body = fromPlan
         ? {
             contact_name: form.contact_name,
@@ -366,6 +456,7 @@ export default function BriefForm({
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data?.error || "Failed to create brief.");
+      clearDraft();
       setResult({
         slug: fromPlan ? (data.brief_slug as string) : (data.slug as string),
         accept_credits_cost: data.accept_credits_cost ?? null,
@@ -379,635 +470,449 @@ export default function BriefForm({
     }
   }
 
+  // ── Success ─────────────────────────────────────────────────────────
   if (step === "success" && result) {
-    const heldForReview = result.risk_review_status === "pending_review";
     return (
-      <div className="bg-white border border-emerald-200 rounded-2xl p-8 text-center max-w-2xl mx-auto">
-        <div className="w-14 h-14 bg-emerald-100 rounded-full flex items-center justify-center mx-auto mb-4">
-          <Icon name="check-circle" size={28} className="text-emerald-600" />
-        </div>
-        <h2 className="text-2xl font-extrabold text-slate-900 mb-2">
-          Match Request sent
-        </h2>
-        <p className="text-slate-600 text-sm leading-relaxed mb-6 max-w-md mx-auto">
-          {heldForReview
-            ? "Your brief mentions topics that need a quick compliance review before verified providers can see it. We'll email you once it's cleared."
-            : `Verified providers can now see a masked preview of your brief. ${
-                result.accept_credits_cost
-                  ? `Accept cost: ~${result.accept_credits_cost} credits.`
-                  : ""
-              } We'll email you when a provider accepts.`}
-        </p>
-        <div className="flex flex-col sm:flex-row gap-3 justify-center">
-          <Link
-            href={`/briefs/${result.slug}?email=${encodeURIComponent(
-              form.contact_email,
-            )}`}
-            className="inline-flex items-center justify-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold px-6 py-3 rounded-xl transition-colors"
-          >
-            View your Quote Status
-            <Icon name="arrow-right" size={16} />
-          </Link>
-          <Link
-            href="/advisors"
-            className="inline-flex items-center justify-center gap-2 bg-white border border-slate-200 text-slate-700 font-semibold px-6 py-3 rounded-xl hover:border-slate-300 transition-colors"
-          >
-            Browse verified providers
-          </Link>
-        </div>
-      </div>
+      <BriefSuccess
+        slug={result.slug}
+        contactEmail={form.contact_email}
+        riskReviewStatus={result.risk_review_status}
+      />
     );
   }
 
-  // ── AI co-pilot mode — single textarea replaces the multi-step form
-  if (copilotMode && aiCopilotEnabled) {
+  // ── Freeform / AI drafting view ─────────────────────────────────────
+  if (freeformMode) {
     return (
-      <div className="bg-white border border-slate-200 rounded-2xl p-6 sm:p-8 shadow-sm">
-        <div className="flex items-center justify-between mb-4">
+      <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+        <div className="mb-4 flex items-start justify-between gap-3">
           <div>
-            <span className="inline-flex items-center gap-1 bg-amber-100 text-amber-900 text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full">
-              Beta
-            </span>
-            <h2 className="text-xl font-bold text-slate-900 mt-2">
+            {aiCopilotEnabled && (
+              <Badge variant="warning" size="sm">
+                <Icon name="zap" size={11} /> AI co-pilot · beta
+              </Badge>
+            )}
+            <h2 className="mt-2 text-xl font-bold text-slate-900">
               Tell us what you&apos;re trying to do
             </h2>
-            <p className="text-sm text-slate-500 mt-1">
-              Describe your situation in your own words. We&apos;ll draft a brief for you to review.
+            <p className="mt-1 text-sm text-slate-500">
+              Describe your situation in your own words.{" "}
+              {aiCopilotEnabled
+                ? "We'll draft a structured brief for you to review."
+                : "We'll set up the right brief for you to refine."}
             </p>
           </div>
           <button
             type="button"
             onClick={() => {
-              setCopilotMode(false);
-              setCopilotInfo(null);
+              setFreeformMode(false);
+              setInfo(null);
             }}
-            className="text-xs font-semibold text-slate-500 hover:text-slate-700 underline"
+            className="shrink-0 text-xs font-semibold text-slate-500 underline hover:text-slate-700"
           >
-            Use the regular form
+            Pick from a list
           </button>
         </div>
         <textarea
           rows={8}
           maxLength={3000}
-          value={copilotText}
-          onChange={(e) => setCopilotText(e.target.value)}
+          value={freeformText}
+          onChange={(e) => setFreeformText(e.target.value)}
           placeholder="e.g. I'm a 38-year-old in NSW with a $200k super balance and I'm thinking about setting up an SMSF to buy an investment property in QLD. Budget around $2,000 for advice. Need help in the next 3 months."
-          className="w-full border border-slate-300 rounded-lg px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400 resize-y"
+          className="w-full resize-y rounded-xl border border-slate-300 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
         />
-        <p className="text-xs text-slate-400 mt-1">
-          {copilotText.length} / 3000
-        </p>
-        {copilotInfo && (
-          <div className="bg-amber-50 border border-amber-200 rounded-xl p-3 text-sm text-amber-900 mt-3">
-            {copilotInfo}
+        <p className="mt-1 text-xs text-slate-400">{freeformText.length} / 3000</p>
+        {info && (
+          <div className="mt-3 rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
+            {info}
           </div>
         )}
-        <div className="flex justify-end mt-5">
-          <button
-            type="button"
-            disabled={copilotLoading || copilotText.trim().length < 10}
-            onClick={runCopilot}
-            className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 disabled:bg-slate-200 disabled:text-slate-400 disabled:cursor-not-allowed text-slate-900 font-bold px-7 py-3 rounded-xl"
+        <div className="mt-5 flex justify-end">
+          <Button
+            onClick={submitFreeform}
+            loading={freeformLoading}
+            disabled={freeformText.trim().length < 10}
+            icon={<Icon name="arrow-right" size={16} />}
           >
-            {copilotLoading ? (
-              <>
-                <div aria-hidden="true" className="w-4 h-4 border-2 border-slate-900 border-t-transparent rounded-full animate-spin" />
-                Drafting…
-              </>
-            ) : (
-              <>
-                Draft my brief <Icon name="arrow-right" size={16} />
-              </>
-            )}
-          </button>
+            {aiCopilotEnabled ? "Draft my brief" : "Continue"}
+          </Button>
         </div>
-        <p className="text-xs text-slate-400 mt-4 leading-relaxed">
-          AI assists with structuring only — verified providers deliver the actual service under their own licence. We never give personal advice.
+        <p className="mt-4 text-xs leading-relaxed text-slate-400">
+          AI assists with structuring only — verified pros deliver the service
+          under their own licence. We never give personal advice.
         </p>
       </div>
     );
   }
 
+  const currentStepIndex = STEP_ORDER.indexOf(step);
+  const showRail = step === "details" || step === "match" || step === "contact";
+
   return (
-    <div className="bg-white border border-slate-200 rounded-2xl p-6 sm:p-8 shadow-sm">
-      {/* Workspace chip — tells the user which account-kind context the
-          brief will be filed under (a business owner's contact details
-          differ from their investor profile's). Swappable via
-          /account/select-workspace. Only shown when an active kind
-          resolved (not anonymous). */}
+    <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm sm:p-7">
+      {/* Workspace chip */}
       {workspace && (
-        <div className="bg-slate-50 border border-slate-200 rounded-xl px-3 py-2 mb-6 flex items-center gap-2 text-xs text-slate-600">
-          <span className="font-semibold uppercase tracking-wide text-slate-500">
-            Filing as
-          </span>
-          <span className="font-bold text-slate-900 truncate">
-            {workspace.label}
-          </span>
-          <span className="text-slate-400">·</span>
-          <span className="text-slate-500 truncate">
-            {workspace.kind === "business_owner" && "Business workspace"}
-            {workspace.kind === "investor" && "Investor workspace"}
-            {workspace.kind === "listing_owner" && "Listing-owner workspace"}
-            {workspace.kind === "advisor" && "Advisor workspace"}
-            {workspace.kind === "broker_partner" && "Broker-partner workspace"}
-          </span>
+        <div className="mb-5 flex items-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-600">
+          <span className="font-semibold uppercase tracking-wide text-slate-500">Filing as</span>
+          <span className="truncate font-bold text-slate-900">{workspace.label}</span>
           <Link
             href="/account/select-workspace"
-            className="ml-auto text-amber-700 font-semibold hover:underline shrink-0"
+            className="ml-auto shrink-0 font-semibold text-amber-700 hover:underline"
           >
             Switch
           </Link>
         </div>
       )}
-      {aiCopilotEnabled && (
-        <div className="bg-slate-50 border border-slate-200 rounded-xl p-3 mb-6 flex items-center justify-between gap-3">
-          <div className="flex items-start gap-2 min-w-0">
-            <Icon name="lightbulb" size={16} className="text-amber-500 mt-0.5 shrink-0" />
-            <p className="text-xs text-slate-600 leading-relaxed">
-              <strong className="text-slate-900">Try AI co-pilot (beta).</strong>{" "}
-              Describe your situation in plain English and we&apos;ll draft the brief for you.
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={() => {
-              setCopilotMode(true);
-              setCopilotInfo(null);
-            }}
-            className="text-xs font-bold text-amber-700 hover:text-amber-900 underline shrink-0"
-          >
-            Try it
-          </button>
+
+      {/* Restored-draft banner */}
+      {restoredDraft && step !== "intent" && (
+        <div className="mb-5 flex items-start gap-2 rounded-xl border border-blue-200 bg-blue-50 p-3 text-xs text-blue-900">
+          <Icon name="rotate-ccw" size={14} className="mt-0.5 shrink-0 text-blue-500" />
+          <p className="leading-relaxed">
+            <strong>We saved your progress.</strong> Picked up right where you left off.{" "}
+            <button
+              type="button"
+              onClick={() => {
+                clearDraft();
+                setForm({
+                  ...INITIAL,
+                  contact_name: workspace?.prefillName ?? "",
+                  contact_email: workspace?.prefillEmail ?? "",
+                  contact_phone: workspace?.prefillPhone ?? "",
+                });
+                setSelectedIntentId(null);
+                setRestoredDraft(false);
+                setStep("intent");
+              }}
+              className="font-semibold underline hover:text-blue-700"
+            >
+              Start over
+            </button>
+          </p>
         </div>
       )}
-      {copilotInfo && !copilotMode && (
-        <div className="bg-amber-50 border border-amber-200 rounded-xl p-3 text-sm text-amber-900 mb-4">
-          {copilotInfo}
-        </div>
-      )}
-      {/* Progress */}
-      <div className="flex items-center gap-2 mb-8">
-        {(["template", "details", "preference", "contact"] as Step[]).map(
-          (s, i) => {
-            const order: Step[] = ["template", "details", "preference", "contact"];
-            const cur = order.indexOf(step);
-            const idx = order.indexOf(s);
-            const done = cur > idx;
-            const active = step === s;
-            const labels: Record<string, string> = {
-              template: "Template",
-              details: "Details",
-              preference: "Match",
-              contact: "Contact",
-            };
-            return (
-              <div key={s} className="flex items-center gap-2 flex-1">
-                {i > 0 && (
-                  <div
-                    className={`flex-1 h-px ${done ? "bg-amber-500" : "bg-slate-200"}`}
-                  />
-                )}
-                <div className="flex items-center gap-2">
-                  <div
-                    className={`w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold ${
-                      done
-                        ? "bg-amber-500 text-slate-900"
-                        : active
-                          ? "bg-slate-900 text-white"
-                          : "bg-slate-200 text-slate-500"
-                    }`}
-                  >
-                    {done ? <Icon name="check" size={13} /> : i + 1}
-                  </div>
-                  <span
-                    className={`text-xs hidden sm:block ${active ? "text-slate-900 font-semibold" : "text-slate-400"}`}
-                  >
-                    {labels[s]}
-                  </span>
-                </div>
-              </div>
-            );
-          },
-        )}
+
+      <div className="mb-7">
+        <FormStepper steps={STEPPER} currentStepIndex={currentStepIndex} />
       </div>
 
-      {step === "template" && (
-        <div className="space-y-6">
-          <div>
-            <h2 className="text-xl font-bold text-slate-900 mb-1">
-              What kind of help do you need?
-            </h2>
-            <p className="text-sm text-slate-500">
-              Pick the closest match. We ask a few structured questions so verified pros can quote you well.
-            </p>
-          </div>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            {BRIEF_TEMPLATES.filter(
-              (t) => t !== "listing" && t !== "listing_readiness",
-            ).map((t) => (
-              <button
-                type="button"
-                key={t}
-                onClick={() => setField("brief_template", t)}
-                className={`text-left rounded-xl p-4 border transition-colors ${
-                  form.brief_template === t
-                    ? "border-amber-500 ring-2 ring-amber-300 bg-amber-50"
-                    : "border-slate-200 hover:border-slate-300"
-                }`}
-              >
-                <p className="font-bold text-sm text-slate-900">
-                  {BRIEF_TEMPLATE_LABELS[t]}
-                </p>
-                <p className="text-xs text-slate-500 mt-0.5 leading-snug">
-                  {BRIEF_TEMPLATE_BLURBS[t]}
-                </p>
-              </button>
-            ))}
-          </div>
-          <div className="flex justify-end">
-            <button
-              type="button"
-              disabled={!canTemplate}
-              onClick={() => setStep("details")}
-              className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 disabled:bg-slate-200 disabled:text-slate-400 disabled:cursor-not-allowed text-slate-900 font-bold px-7 py-3 rounded-xl"
-            >
-              Continue <Icon name="arrow-right" size={16} />
-            </button>
-          </div>
+      {info && (
+        <div className="mb-5 rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
+          {info}
         </div>
       )}
 
-      {step === "details" && form.brief_template && (
-        <div className="space-y-6">
-          <div>
-            <h2 className="text-xl font-bold text-slate-900 mb-1">
-              {BRIEF_TEMPLATE_LABELS[form.brief_template]}
-            </h2>
-            <p className="text-sm text-slate-500">
-              Be specific — verified providers respond better when the brief is clear.
-            </p>
-          </div>
-
-          <div>
-            <label htmlFor="brief-title" className="block text-sm font-semibold text-slate-700 mb-1.5">
-              Title <span className="text-red-500">*</span>
-            </label>
-            <input
-              id="brief-title"
-              type="text"
-              maxLength={120}
-              value={form.job_title}
-              onChange={(e) => setField("job_title", e.target.value)}
-              placeholder="e.g. SMSF property strategy in QLD"
-              className="w-full border border-slate-300 rounded-lg px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
-            />
-          </div>
-
-          <div>
-            <label htmlFor="brief-description" className="block text-sm font-semibold text-slate-700 mb-1.5">
-              Describe the situation <span className="text-red-500">*</span>
-            </label>
-            <textarea
-              id="brief-description"
-              rows={5}
-              maxLength={3000}
-              value={form.job_description}
-              onChange={(e) => setField("job_description", e.target.value)}
-              placeholder="What's the situation, what outcome you want, any deadlines."
-              className="w-full border border-slate-300 rounded-lg px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400 resize-y"
-            />
-            <p className="text-xs text-slate-400 mt-1">
-              {form.job_description.length} / 3000
-            </p>
-          </div>
-
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <div>
-              <label htmlFor="brief-state" className="block text-sm font-semibold text-slate-700 mb-1.5">
-                State <span className="text-red-500">*</span>
-              </label>
-              <select
-                id="brief-state"
-                value={form.location_state}
-                onChange={(e) => setField("location_state", e.target.value)}
-                className="w-full border border-slate-300 rounded-lg px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
-              >
-                <option value="">Select state</option>
-                {STATES.map((s) => (
-                  <option key={s} value={s}>
-                    {s}
-                  </option>
-                ))}
-              </select>
-            </div>
-            <div>
-              <label htmlFor="brief-budget" className="block text-sm font-semibold text-slate-700 mb-1.5">
-                Budget band <span className="text-red-500">*</span>
-              </label>
-              <select
-                id="brief-budget"
-                value={form.budget_band}
-                onChange={(e) => setField("budget_band", e.target.value)}
-                className="w-full border border-slate-300 rounded-lg px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
-              >
-                <option value="">Select budget</option>
-                {BUDGETS.map((b) => (
-                  <option key={b.value} value={b.value}>
-                    {b.label}
-                  </option>
-                ))}
-              </select>
-            </div>
-          </div>
-
-          {fields.length > 0 && (
-            <div className="border-t border-slate-100 pt-6 space-y-4">
-              <p className="text-xs font-semibold uppercase tracking-wider text-slate-500">
-                Template-specific details
-              </p>
-              {fields.map((field) => (
-                <DynamicField
-                  key={field.key}
-                  field={field}
-                  value={form.payload[field.key]}
-                  onChange={(v) => setPayload(field.key, v)}
-                />
-              ))}
+      <div
+        className={
+          showRail
+            ? "grid items-start gap-6 lg:grid-cols-[1fr_320px] lg:gap-8"
+            : ""
+        }
+      >
+        {/* Main column */}
+        <div key={step} style={{ animation: "slideInRight 0.3s ease-out" }}>
+          {step === "intent" && (
+            <div className="space-y-5">
+              <div>
+                <h2 className="text-xl font-bold text-slate-900">
+                  What do you need help with?
+                </h2>
+                <p className="mt-1 text-sm text-slate-500">
+                  Post once. Verified pros respond. You compare and choose — your
+                  details stay private until you do.
+                </p>
+              </div>
+              <IntentPicker
+                selectedIntentId={selectedIntentId}
+                onSelect={selectIntent}
+                onFreeform={openFreeform}
+                aiEnabled={aiCopilotEnabled}
+              />
             </div>
           )}
 
-          <div className="flex justify-between">
-            <button
-              type="button"
-              onClick={() => setStep("template")}
-              className="inline-flex items-center gap-2 text-slate-600 hover:text-slate-900 font-semibold text-sm px-4 py-2.5"
-            >
-              <Icon name="arrow-left" size={14} /> Back
-            </button>
-            <button
-              type="button"
-              disabled={!canDetails}
-              onClick={() => setStep("preference")}
-              className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 disabled:bg-slate-200 disabled:text-slate-400 disabled:cursor-not-allowed text-slate-900 font-bold px-7 py-3 rounded-xl"
-            >
-              Continue <Icon name="arrow-right" size={16} />
-            </button>
-          </div>
+          {step === "details" && form.brief_template && (
+            <div className="space-y-5">
+              <div>
+                <h2 className="text-xl font-bold text-slate-900">
+                  {intentLabel ?? "Tell pros about it"}
+                </h2>
+                <p className="mt-1 text-sm text-slate-500">
+                  Be specific — clear briefs get more, better responses.
+                </p>
+              </div>
 
-          {(form.brief_template === "listing" ||
-            form.brief_template === "listing_readiness") && (
-            <ListingCompanionServices />
-          )}
-        </div>
-      )}
+              <Input
+                id="brief-title"
+                label="Title"
+                required
+                maxLength={120}
+                value={form.job_title}
+                onChange={(e) => setField("job_title", e.target.value)}
+                placeholder="e.g. SMSF property strategy in QLD"
+                hint={
+                  form.job_title.trim().length > 0 && form.job_title.trim().length < 8
+                    ? undefined
+                    : "A specific one-liner helps pros decide fast."
+                }
+                error={
+                  form.job_title.trim().length > 0 && form.job_title.trim().length < 8
+                    ? "Add a little more — at least 8 characters."
+                    : undefined
+                }
+              />
 
-      {step === "preference" && (
-        <div className="space-y-6">
-          <div>
-            <h2 className="text-xl font-bold text-slate-900 mb-1">
-              Who do you want to hear from?
-            </h2>
-            <p className="text-sm text-slate-500">
-              Pick the provider type and the routing mode. You stay in control.
-            </p>
-          </div>
-
-          {/* Investor Pro perk — skips the smart-match window and sends
-              directly to a chosen verified expert team. Only shown when
-              the parent server page resolves an active subscription. */}
-          {proSubscriber && (
-            <div className="rounded-xl border border-violet-300 bg-violet-50 p-4">
-              <label className="flex items-start gap-3 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={
-                    form.routing_mode === "direct" &&
-                    form.provider_preference === "expert_team"
+              <div>
+                <label
+                  htmlFor="brief-description"
+                  className="mb-1.5 block text-sm font-semibold text-slate-700"
+                >
+                  Describe the situation <span className="text-red-500">*</span>
+                </label>
+                <textarea
+                  id="brief-description"
+                  rows={5}
+                  maxLength={3000}
+                  value={form.job_description}
+                  onChange={(e) => setField("job_description", e.target.value)}
+                  placeholder={
+                    activeIntent?.examples[0] ??
+                    "What's the situation, what outcome you want, and any deadlines."
                   }
-                  onChange={(e) => {
-                    if (e.target.checked) {
-                      setField("routing_mode", "direct");
-                      setField("provider_preference", "expert_team");
-                    } else {
-                      setField("routing_mode", "smart_match");
-                    }
-                  }}
-                  className="mt-0.5 h-4 w-4 rounded border-violet-400 text-violet-600 focus:ring-violet-500"
+                  className="w-full resize-y rounded-xl border border-slate-200 px-4 py-3 text-sm transition-all duration-150 hover:border-slate-300 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400"
                 />
-                <div>
-                  <p className="text-sm font-bold text-violet-900">
-                    Skip the smart-match queue · Investor Pro
+                <div className="mt-1 flex items-center justify-between">
+                  <span className="text-xs text-slate-400">
+                    {form.job_description.trim().length < 30
+                      ? `${30 - form.job_description.trim().length} more characters for a complete brief`
+                      : "Looking good"}
+                  </span>
+                  <span className="text-xs text-slate-400">{form.job_description.length} / 3000</span>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <Select
+                  id="brief-state"
+                  label="State"
+                  required
+                  value={form.location_state}
+                  onChange={(e) => setField("location_state", e.target.value)}
+                  options={[
+                    { value: "", label: "Select state" },
+                    ...STATES.map((s) => ({ value: s, label: s })),
+                  ]}
+                />
+                <Select
+                  id="brief-budget"
+                  label="Budget band"
+                  required
+                  value={form.budget_band}
+                  onChange={(e) => setField("budget_band", e.target.value)}
+                  options={[{ value: "", label: "Select budget" }, ...BUDGETS]}
+                />
+              </div>
+
+              {fields.length > 0 && (
+                <div className="space-y-4 border-t border-slate-100 pt-5">
+                  <p className="text-xs font-semibold uppercase tracking-wider text-slate-500">
+                    A few specifics
                   </p>
-                  <p className="text-xs text-violet-800 mt-0.5">
-                    Route directly to a verified Expert Team of your choice.
-                    Bypasses the 24-hour smart-match window so they see your
-                    brief in their inbox immediately.
+                  {fields.map((field) => (
+                    <DynamicField
+                      key={field.key}
+                      field={field}
+                      value={form.payload[field.key]}
+                      onChange={(v) => setPayload(field.key, v)}
+                    />
+                  ))}
+                </div>
+              )}
+
+              {(form.brief_template === "listing" ||
+                form.brief_template === "listing_readiness") && <ListingCompanionServices />}
+
+              <StepNav
+                onBack={() => setStep("intent")}
+                onNext={() => setStep("match")}
+                nextDisabled={!canDetails}
+                nextLabel="Continue"
+              />
+            </div>
+          )}
+
+          {step === "match" && (
+            <div className="space-y-5">
+              <div>
+                <h2 className="text-xl font-bold text-slate-900">How do you want to be matched?</h2>
+                <p className="mt-1 text-sm text-slate-500">You stay in control the whole way.</p>
+              </div>
+              <MatchModeChooser
+                routingMode={form.routing_mode}
+                providerPreference={form.provider_preference}
+                targetSlug={form.target_team_slug}
+                proSubscriber={proSubscriber}
+                proSupply={proSupply}
+                onChange={(patch: MatchPatch) => setForm((p) => ({ ...p, ...patch }))}
+              />
+              <StepNav
+                onBack={() => setStep("details")}
+                onNext={() => setStep("contact")}
+                nextDisabled={false}
+                nextLabel="Continue"
+              />
+            </div>
+          )}
+
+          {step === "contact" && (
+            <div className="space-y-5">
+              {planPrefilled && (
+                <div className="flex items-start gap-2 rounded-xl border border-amber-200 bg-amber-50 p-3">
+                  <Icon name="check-circle" size={14} className="mt-0.5 shrink-0 text-amber-600" />
+                  <p className="text-xs leading-relaxed text-amber-900">
+                    <strong>Pre-filled from your Action Plan.</strong> Edit anything below.
                   </p>
                 </div>
-              </label>
-            </div>
-          )}
-
-          <div>
-            <p className="block text-sm font-semibold text-slate-700 mb-2">
-              Provider preference
-            </p>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-              {PROVIDER_PREFERENCES.map((p) => (
-                <button
-                  type="button"
-                  key={p.value}
-                  onClick={() => setField("provider_preference", p.value)}
-                  className={`text-left rounded-lg p-3 border text-sm transition-colors ${
-                    form.provider_preference === p.value
-                      ? "border-amber-500 ring-2 ring-amber-300 bg-amber-50"
-                      : "border-slate-200 hover:border-slate-300"
-                  }`}
-                >
-                  {p.label}
-                </button>
-              ))}
-            </div>
-          </div>
-
-          <div>
-            <p className="block text-sm font-semibold text-slate-700 mb-2">
-              Routing mode
-            </p>
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
-              {ROUTING_MODES.map((m) => (
-                <button
-                  type="button"
-                  key={m.value}
-                  onClick={() => setField("routing_mode", m.value)}
-                  className={`text-left rounded-lg p-3 border text-sm transition-colors ${
-                    form.routing_mode === m.value
-                      ? "border-amber-500 ring-2 ring-amber-300 bg-amber-50"
-                      : "border-slate-200 hover:border-slate-300"
-                  }`}
-                >
-                  <p className="font-semibold text-slate-900">{m.label}</p>
-                  <p className="text-xs text-slate-500 mt-0.5">{m.blurb}</p>
-                </button>
-              ))}
-            </div>
-          </div>
-
-          {form.routing_mode === "direct" && (
-            <div>
-              <label htmlFor="brief-target-slug" className="block text-sm font-semibold text-slate-700 mb-1.5">
-                Target team / firm / individual slug
-              </label>
-              <input
-                id="brief-target-slug"
-                type="text"
-                value={form.target_team_slug}
-                onChange={(e) => setField("target_team_slug", e.target.value)}
-                placeholder="e.g. sydney-smsf-property-team"
-                className="w-full border border-slate-300 rounded-lg px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
-              />
-              <p className="text-xs text-slate-400 mt-1">
-                Use the slug from a verified team, firm or individual profile URL.
-              </p>
-            </div>
-          )}
-
-          <div className="flex justify-between">
-            <button
-              type="button"
-              onClick={() => setStep("details")}
-              className="inline-flex items-center gap-2 text-slate-600 hover:text-slate-900 font-semibold text-sm px-4 py-2.5"
-            >
-              <Icon name="arrow-left" size={14} /> Back
-            </button>
-            <button
-              type="button"
-              disabled={!canPreference}
-              onClick={() => setStep("contact")}
-              className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 disabled:bg-slate-200 disabled:text-slate-400 disabled:cursor-not-allowed text-slate-900 font-bold px-7 py-3 rounded-xl"
-            >
-              Continue <Icon name="arrow-right" size={16} />
-            </button>
-          </div>
-        </div>
-      )}
-
-      {step === "contact" && (
-        <div className="space-y-6">
-          {planPrefilled && (
-            <div className="bg-amber-50 border border-amber-200 rounded-xl p-3 flex items-start gap-2">
-              <Icon name="check-circle" size={14} className="text-amber-600 mt-0.5 shrink-0" />
-              <p className="text-xs text-amber-900 leading-relaxed">
-                <strong>Pre-filled from your Action Plan.</strong> We&apos;ll send this brief with the goal, budget, timeline and route you already picked. Edit anything you need below.
-              </p>
-            </div>
-          )}
-          <div>
-            <h2 className="text-xl font-bold text-slate-900 mb-1">
-              Your details
-            </h2>
-            <p className="text-sm text-slate-500">
-              Hidden from providers until one accepts your brief.
-            </p>
-          </div>
-
-          <div>
-            <label htmlFor="brief-contact-name" className="block text-sm font-semibold text-slate-700 mb-1.5">
-              Name <span className="text-red-500">*</span>
-            </label>
-            <input
-              id="brief-contact-name"
-              type="text"
-              value={form.contact_name}
-              onChange={(e) => setField("contact_name", e.target.value)}
-              className="w-full border border-slate-300 rounded-lg px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
-            />
-          </div>
-
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <div>
-              <label htmlFor="brief-contact-email" className="block text-sm font-semibold text-slate-700 mb-1.5">
-                Email <span className="text-red-500">*</span>
-              </label>
-              <input
-                id="brief-contact-email"
-                type="email" autoCapitalize="off" autoCorrect="off" spellCheck={false}
-                value={form.contact_email}
-                onChange={(e) => setField("contact_email", e.target.value)}
-                placeholder="you@example.com"
-                className="w-full border border-slate-300 rounded-lg px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
-              />
-            </div>
-            <div>
-              <label htmlFor="brief-contact-phone" className="block text-sm font-semibold text-slate-700 mb-1.5">
-                Phone
-              </label>
-              <input
-                id="brief-contact-phone"
-                type="tel"
-                autoComplete="tel"
-                value={form.contact_phone}
-                onChange={(e) => setField("contact_phone", e.target.value)}
-                placeholder="+61 4XX XXX XXX"
-                className="w-full border border-slate-300 rounded-lg px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
-              />
-            </div>
-          </div>
-
-          <label className="flex items-start gap-3 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={form.consent}
-              onChange={(e) => setField("consent", e.target.checked)}
-              className="mt-0.5 w-4 h-4 accent-amber-500 shrink-0"
-            />
-            <span className="text-xs text-slate-600 leading-relaxed">
-              I&apos;m happy for my brief details (without contact information) to be shown to relevant verified providers. My contact details are only shared after a provider accepts. I&apos;ve read the{" "}
-              <Link href="/privacy" className="underline hover:text-slate-700">
-                privacy policy
-              </Link>
-              {" "}and{" "}
-              <Link href="/terms" className="underline hover:text-slate-700">
-                terms
-              </Link>
-              . I understand Invest.com.au provides general information only — the professional, firm or team I engage delivers the service under their own licence.
-            </span>
-          </label>
-
-          {error && (
-            <div role="alert" className="bg-red-50 border border-red-200 rounded-xl p-3 text-sm text-red-700">
-              {error}
-            </div>
-          )}
-
-          <div className="flex justify-between">
-            <button
-              type="button"
-              onClick={() => setStep("preference")}
-              className="inline-flex items-center gap-2 text-slate-600 hover:text-slate-900 font-semibold text-sm px-4 py-2.5"
-            >
-              <Icon name="arrow-left" size={14} /> Back
-            </button>
-            <button
-              type="button"
-              disabled={!canContact || loading}
-              onClick={submit}
-              className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 disabled:bg-amber-300 text-slate-900 font-bold px-8 py-3 rounded-xl"
-            >
-              {loading ? (
-                <>
-                  <div aria-hidden="true" className="w-4 h-4 border-2 border-slate-900 border-t-transparent rounded-full animate-spin" />
-                  Creating…
-                </>
-              ) : (
-                <>
-                  Send Match Request <Icon name="check" size={16} />
-                </>
               )}
-            </button>
-          </div>
+              <div>
+                <h2 className="text-xl font-bold text-slate-900">Where should responses go?</h2>
+                <p className="mt-1 text-sm text-slate-500">
+                  Hidden from pros until one responds and you choose to share.
+                </p>
+              </div>
+
+              <Input
+                id="brief-contact-name"
+                label="Name"
+                required
+                value={form.contact_name}
+                onChange={(e) => setField("contact_name", e.target.value)}
+                placeholder="Your name"
+              />
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <Input
+                  id="brief-contact-email"
+                  label="Email"
+                  required
+                  type="email"
+                  autoCapitalize="off"
+                  autoCorrect="off"
+                  spellCheck={false}
+                  value={form.contact_email}
+                  onChange={(e) => setField("contact_email", e.target.value)}
+                  placeholder="you@example.com"
+                />
+                <Input
+                  id="brief-contact-phone"
+                  label="Phone (optional)"
+                  type="tel"
+                  autoComplete="tel"
+                  value={form.contact_phone}
+                  onChange={(e) => setField("contact_phone", e.target.value)}
+                  placeholder="+61 4XX XXX XXX"
+                />
+              </div>
+
+              <label className="flex cursor-pointer items-start gap-3">
+                <input
+                  type="checkbox"
+                  checked={form.consent}
+                  onChange={(e) => setField("consent", e.target.checked)}
+                  className="mt-0.5 h-4 w-4 shrink-0 accent-amber-500"
+                />
+                <span className="text-xs leading-relaxed text-slate-600">
+                  I&apos;m happy for my brief details (without contact information) to be
+                  shown to relevant verified pros. My contact details are only shared
+                  after a pro responds and I choose to share them. I&apos;ve read the{" "}
+                  <Link href="/privacy" className="underline hover:text-slate-700">
+                    privacy policy
+                  </Link>{" "}
+                  and{" "}
+                  <Link href="/terms" className="underline hover:text-slate-700">
+                    terms
+                  </Link>
+                  . I understand Invest.com.au provides general information only — the
+                  professional, firm or team I engage delivers the service under their
+                  own licence.
+                </span>
+              </label>
+
+              {error && (
+                <div role="alert" className="rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+                  {error}
+                </div>
+              )}
+
+              <StepNav
+                onBack={() => setStep("match")}
+                onNext={submit}
+                nextDisabled={!canContact}
+                nextLoading={loading}
+                nextLabel="Post my brief"
+                nextIcon={<Icon name="check" size={16} />}
+              />
+            </div>
+          )}
         </div>
-      )}
+
+        {/* Live rail */}
+        {showRail && (
+          <aside className="space-y-4 lg:sticky lg:top-20">
+            <BriefPreviewCard
+              intentLabel={intentLabel}
+              title={form.job_title}
+              description={form.job_description}
+              budgetLabel={budgetLabel}
+              locationState={form.location_state || null}
+              providerPreferenceLabel={
+                step === "match" || step === "contact"
+                  ? PROVIDER_PREF_LABELS[form.provider_preference] ?? null
+                  : null
+              }
+            />
+            <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+              <BriefStrengthMeter strength={strength} />
+            </div>
+          </aside>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StepNav({
+  onBack,
+  onNext,
+  nextDisabled,
+  nextLoading,
+  nextLabel,
+  nextIcon,
+}: {
+  onBack: () => void;
+  onNext: () => void;
+  nextDisabled: boolean;
+  nextLoading?: boolean;
+  nextLabel: string;
+  nextIcon?: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3 border-t border-slate-100 pt-5">
+      <button
+        type="button"
+        onClick={onBack}
+        className="inline-flex items-center gap-1.5 px-2 py-2 text-sm font-semibold text-slate-600 hover:text-slate-900"
+      >
+        <Icon name="arrow-left" size={14} /> Back
+      </button>
+      <Button
+        onClick={onNext}
+        disabled={nextDisabled}
+        loading={nextLoading}
+        icon={nextIcon ?? <Icon name="arrow-right" size={16} />}
+        className="min-w-[9rem]"
+      >
+        {nextLabel}
+      </Button>
     </div>
   );
 }
@@ -1024,27 +929,21 @@ function DynamicField({
   const id = useId();
   if (field.kind === "text") {
     return (
-      <div>
-        <label htmlFor={id} className="block text-sm font-semibold text-slate-700 mb-1.5">
-          {field.label}
-          {field.required && <span className="text-red-500"> *</span>}
-        </label>
-        <input
-          id={id}
-          type="text"
-          maxLength={field.maxLength}
-          placeholder={field.placeholder}
-          value={typeof value === "string" ? value : ""}
-          onChange={(e) => onChange(e.target.value)}
-          className="w-full border border-slate-300 rounded-lg px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
-        />
-      </div>
+      <Input
+        id={id}
+        label={field.label}
+        required={field.required}
+        maxLength={field.maxLength}
+        placeholder={field.placeholder}
+        value={typeof value === "string" ? value : ""}
+        onChange={(e) => onChange(e.target.value)}
+      />
     );
   }
   if (field.kind === "textarea") {
     return (
       <div>
-        <label htmlFor={id} className="block text-sm font-semibold text-slate-700 mb-1.5">
+        <label htmlFor={id} className="mb-1.5 block text-sm font-semibold text-slate-700">
           {field.label}
           {field.required && <span className="text-red-500"> *</span>}
         </label>
@@ -1055,52 +954,39 @@ function DynamicField({
           placeholder={field.placeholder}
           value={typeof value === "string" ? value : ""}
           onChange={(e) => onChange(e.target.value)}
-          className="w-full border border-slate-300 rounded-lg px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400 resize-y"
+          className="w-full resize-y rounded-xl border border-slate-200 px-4 py-3 text-sm transition-all duration-150 hover:border-slate-300 focus:border-amber-400 focus:outline-none focus:ring-2 focus:ring-amber-400"
         />
       </div>
     );
   }
   if (field.kind === "select") {
     return (
-      <div>
-        <label htmlFor={id} className="block text-sm font-semibold text-slate-700 mb-1.5">
-          {field.label}
-          {field.required && <span className="text-red-500"> *</span>}
-        </label>
-        <select
-          id={id}
-          value={typeof value === "string" ? value : ""}
-          onChange={(e) => onChange(e.target.value)}
-          className="w-full border border-slate-300 rounded-lg px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
-        >
-          <option value="">Select…</option>
-          {field.options?.map((o) => (
-            <option key={o.value} value={o.value}>
-              {o.label}
-            </option>
-          ))}
-        </select>
-      </div>
+      <Select
+        id={id}
+        label={field.label}
+        required={field.required}
+        value={typeof value === "string" ? value : ""}
+        onChange={(e) => onChange(e.target.value)}
+        options={[{ value: "", label: "Select…" }, ...(field.options ?? [])]}
+      />
     );
   }
   // multiselect
   const arr = Array.isArray(value) ? (value as string[]) : [];
   return (
     <div>
-      <p className="block text-sm font-semibold text-slate-700 mb-1.5">
+      <p className="mb-1.5 block text-sm font-semibold text-slate-700">
         {field.label}
         {field.required && <span className="text-red-500"> *</span>}
       </p>
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
         {field.options?.map((o) => {
           const checked = arr.includes(o.value);
           return (
             <label
               key={o.value}
-              className={`flex items-center gap-2 rounded-lg border px-3 py-2 text-sm cursor-pointer transition-colors ${
-                checked
-                  ? "border-amber-500 bg-amber-50"
-                  : "border-slate-200 hover:border-slate-300"
+              className={`flex cursor-pointer items-center gap-2 rounded-lg border px-3 py-2 text-sm transition-colors ${
+                checked ? "border-amber-500 bg-amber-50" : "border-slate-200 hover:border-slate-300"
               }`}
             >
               <input
@@ -1108,9 +994,7 @@ function DynamicField({
                 className="accent-amber-500"
                 checked={checked}
                 onChange={() => {
-                  const next = checked
-                    ? arr.filter((x) => x !== o.value)
-                    : [...arr, o.value];
+                  const next = checked ? arr.filter((x) => x !== o.value) : [...arr, o.value];
                   onChange(next);
                 }}
               />

--- a/app/briefs/new/page.tsx
+++ b/app/briefs/new/page.tsx
@@ -72,8 +72,6 @@ async function loadWorkspaceContext(): Promise<WorkspaceContext | null> {
         prefillPhone: null,
       };
     }
-    // advisor / broker_partner — generic label, no prefill (those kinds
-    // don't typically file briefs).
     return {
       kind: active,
       label: active.replace(/_/g, " "),
@@ -106,40 +104,74 @@ async function isProSubscriber(): Promise<boolean> {
   }
 }
 
-// Flag-gated AI co-pilot toggle reads from feature_flags on every request.
-// We can't ISR-cache when the response branches on a feature flag — the
-// flag's 30-second in-process cache (see lib/feature-flags.ts) already
-// absorbs the read cost.
+/**
+ * Honest social proof: count active, publicly-listable verified pros via the
+ * anon client so RLS scopes us to exactly the rows a visitor could see in the
+ * directory. Returns null on any error — the form then shows qualitative copy
+ * rather than a fabricated number.
+ */
+async function loadProviderSupply(): Promise<number | null> {
+  try {
+    const supabase = await createClient();
+    const { count, error } = await supabase
+      .from("professionals")
+      .select("id", { count: "exact", head: true })
+      .eq("status", "active");
+    if (error) return null;
+    return typeof count === "number" ? count : null;
+  } catch {
+    return null;
+  }
+}
+
 export const dynamic = "force-dynamic";
 
 export const metadata: Metadata = {
-  title: `Get Quotes from Verified Australian Pros (${CURRENT_YEAR}) — Invest.com.au`,
+  title: `Post a Brief — Get Responses from Verified Australian Pros (${CURRENT_YEAR}) — Invest.com.au`,
   description:
-    "Match Request: verified professionals see a masked brief and respond only if it's a fit. You control who sees your contact details.",
+    "Post one brief and verified Australian professionals, firms and expert teams respond. Compare them and choose — your contact details stay private until you do.",
   alternates: { canonical: `${SITE_URL}/briefs/new` },
   robots: { index: true, follow: true },
 };
 
 const TRUST_BLOCKS = [
   {
-    icon: "shield-check",
-    title: "Verified providers only",
-    desc: "Every professional, firm and team is verified before they can receive briefs.",
+    icon: "users",
+    title: "Pros come to you",
+    desc: "Post once — verified pros respond. No cold-calling a dozen firms yourself.",
   },
   {
     icon: "lock",
-    title: "Your contact details stay private",
-    desc: "Providers see a masked preview. Contact details only unlock after a provider accepts.",
+    title: "Your details stay private",
+    desc: "Pros see a masked brief. Your contact details unlock only when you choose.",
   },
   {
-    icon: "users",
-    title: "You stay in control",
-    desc: "Route to an individual, a firm, or an expert team. Pick the response that fits.",
+    icon: "shield-check",
+    title: "Verified pros only",
+    desc: "Every professional, firm and team is verified before they can respond.",
   },
   {
-    icon: "info",
-    title: "General information",
-    desc: "We are a marketplace, not an adviser. Services are delivered by the provider you engage.",
+    icon: "thumbs-up",
+    title: "You choose",
+    desc: "Compare responses side by side and pick the pro that fits. No obligation.",
+  },
+];
+
+const HOW_IT_WORKS = [
+  {
+    n: 1,
+    title: "Tell us what you need",
+    desc: "Pick what you're after or describe it in your own words. A few smart questions, that's it.",
+  },
+  {
+    n: 2,
+    title: "Verified pros respond",
+    desc: "Matching individuals, firms and expert teams see your masked brief and respond if it's a fit.",
+  },
+  {
+    n: 3,
+    title: "Compare & choose",
+    desc: "Line up the responses, message your favourites, and choose. The service sits with the pro under their licence.",
   },
 ];
 
@@ -150,9 +182,6 @@ export default async function NewBriefPage({
 }) {
   void searchParams;
 
-  // Stable per-visitor key for the feature flag's percentage rollout —
-  // IP from the proxy headers. We don't have a user session at this
-  // point (anonymous brief flow), so IP is the best stable signal.
   const h = await headers();
   const visitorIp =
     h.get("x-forwarded-for")?.split(",")[0]?.trim() ||
@@ -162,16 +191,19 @@ export default async function NewBriefPage({
     userKey: visitorIp,
   });
 
-  const [workspace, proSubscriber] = await Promise.all([
+  const [workspace, proSubscriber, proSupply] = await Promise.all([
     loadWorkspaceContext(),
     isProSubscriber(),
+    loadProviderSupply(),
   ]);
 
   const breadcrumb = breadcrumbJsonLd([
     { name: "Home", url: `${SITE_URL}/` },
-    { name: "Match Requests", url: `${SITE_URL}/briefs` },
+    { name: "Briefs", url: `${SITE_URL}/briefs` },
     { name: "New" },
   ]);
+
+  const showSupply = proSupply != null && proSupply >= 12;
 
   return (
     <>
@@ -181,31 +213,34 @@ export default async function NewBriefPage({
       />
 
       <section className="bg-gradient-to-b from-slate-900 via-slate-900 to-slate-800 text-white">
-        <div className="max-w-5xl mx-auto px-4 py-16 sm:py-20">
+        <div className="mx-auto max-w-5xl px-4 py-14 sm:py-20">
           <div className="text-center">
-            <p className="text-amber-400 text-xs font-semibold uppercase tracking-widest mb-3">
-              Match Request · Australia
+            <p className="mb-3 text-xs font-semibold uppercase tracking-widest text-amber-400">
+              Briefs · Australia
             </p>
-            <h1 className="text-3xl sm:text-5xl font-extrabold mb-4">
-              Get quotes from verified pros
+            <h1 className="mb-4 text-3xl font-extrabold sm:text-5xl">
+              Post a brief.
+              <br className="hidden sm:block" /> Get responses. Choose your pro.
             </h1>
-            <p className="text-slate-300 max-w-2xl mx-auto leading-relaxed">
-              Tell verified Australian professionals, firms or Pro Squads what
-              you need help with. They&apos;ll see a masked preview and respond
-              only if it&apos;s a fit. You stay in control of who sees your
-              contact details.
+            <p className="mx-auto max-w-2xl leading-relaxed text-slate-300">
+              Tell verified Australian professionals, firms and expert teams what you
+              need. They respond to you — you compare and pick the right fit. Your
+              contact details stay private until you choose to share them.
             </p>
+            {showSupply && (
+              <p className="mt-5 inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-1.5 text-sm font-semibold text-emerald-300">
+                <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-400" aria-hidden />
+                {proSupply} verified pros ready to respond
+              </p>
+            )}
           </div>
 
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 sm:gap-6 max-w-4xl mx-auto mt-12">
+          <div className="mx-auto mt-12 grid max-w-4xl grid-cols-2 gap-3 sm:grid-cols-4 sm:gap-6">
             {TRUST_BLOCKS.map((t) => (
-              <div
-                key={t.title}
-                className="bg-white/5 rounded-xl p-4 border border-white/10"
-              >
-                <Icon name={t.icon} size={20} className="text-amber-400 mb-2" />
-                <p className="text-sm font-bold text-white mb-1">{t.title}</p>
-                <p className="text-xs text-slate-400 leading-snug">{t.desc}</p>
+              <div key={t.title} className="rounded-xl border border-white/10 bg-white/5 p-4">
+                <Icon name={t.icon} size={20} className="mb-2 text-amber-400" />
+                <p className="mb-1 text-sm font-bold text-white">{t.title}</p>
+                <p className="text-xs leading-snug text-slate-400">{t.desc}</p>
               </div>
             ))}
           </div>
@@ -213,50 +248,35 @@ export default async function NewBriefPage({
       </section>
 
       <section className="bg-slate-50 py-12 sm:py-16">
-        <div className="max-w-3xl mx-auto px-4">
+        <div className="mx-auto max-w-5xl px-4">
           <BriefForm
             aiCopilotEnabled={aiCopilotEnabled}
             workspace={workspace}
             proSubscriber={proSubscriber}
+            proSupply={proSupply}
           />
         </div>
       </section>
 
       <section className="bg-white py-12 sm:py-16">
-        <div className="max-w-4xl mx-auto px-4">
-          <h2 className="text-2xl sm:text-3xl font-extrabold text-slate-900 mb-2 text-center">
-            How Match Requests work
+        <div className="mx-auto max-w-4xl px-4">
+          <h2 className="mb-2 text-center text-2xl font-extrabold text-slate-900 sm:text-3xl">
+            How it works
           </h2>
-          <p className="text-sm text-slate-500 mb-10 text-center max-w-2xl mx-auto">
-            A structured way to bring verified providers into your decision.
-            Invest.com.au never gives personal advice — the professional or
-            firm you engage delivers the service under their own licence.
+          <p className="mx-auto mb-10 max-w-2xl text-center text-sm text-slate-500">
+            A simpler way to bring verified pros into your decision. Invest.com.au never
+            gives personal advice — the professional, firm or team you engage delivers the
+            service under their own licence.
           </p>
 
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
-            {[
-              {
-                n: 1,
-                title: "Tell us what you need",
-                desc: "Pick a template, answer a few structured questions, and set how you want to be matched.",
-              },
-              {
-                n: 2,
-                title: "Verified pros may respond",
-                desc: "Eligible individuals, firms or Pro Squads see a masked preview and can accept with credits to unlock your details.",
-              },
-              {
-                n: 3,
-                title: "Track your quotes in one place",
-                desc: "Status, next step, and accepted pro — all visible to you. The service itself sits with the professional under their licence.",
-              },
-            ].map((s) => (
+          <div className="grid grid-cols-1 gap-6 sm:grid-cols-3">
+            {HOW_IT_WORKS.map((s) => (
               <div key={s.n} className="text-center">
-                <div className="w-12 h-12 bg-amber-500 text-slate-900 rounded-full font-extrabold flex items-center justify-center mx-auto mb-3 text-lg">
+                <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-amber-500 text-lg font-extrabold text-slate-900">
                   {s.n}
                 </div>
-                <p className="font-bold text-slate-900 mb-1">{s.title}</p>
-                <p className="text-sm text-slate-600 leading-relaxed">{s.desc}</p>
+                <p className="mb-1 font-bold text-slate-900">{s.title}</p>
+                <p className="text-sm leading-relaxed text-slate-600">{s.desc}</p>
               </div>
             ))}
           </div>

--- a/components/briefs/BriefPreviewCard.tsx
+++ b/components/briefs/BriefPreviewCard.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import Icon from "@/components/Icon";
+import { Badge } from "@/components/ui/Badge";
+import { cn } from "@/lib/utils";
+
+/**
+ * Live "this is exactly what pros will see" preview. Mirrors
+ * `maskBriefForProvider` (lib/briefs/mask.ts): the masked inbox card shows
+ * the title, template, budget, location and a 280-char description preview —
+ * never the contact details. Updates as the user types so they can see their
+ * brief take shape from the provider's side.
+ */
+
+const PREVIEW_MAX = 280;
+
+export interface BriefPreviewCardProps {
+  intentLabel?: string | null;
+  title: string;
+  description: string;
+  budgetLabel?: string | null;
+  locationState?: string | null;
+  providerPreferenceLabel?: string | null;
+  className?: string;
+}
+
+export default function BriefPreviewCard({
+  intentLabel,
+  title,
+  description,
+  budgetLabel,
+  locationState,
+  providerPreferenceLabel,
+  className = "",
+}: BriefPreviewCardProps) {
+  const preview = description.trim();
+  const truncated =
+    preview.length > PREVIEW_MAX ? `${preview.slice(0, PREVIEW_MAX)}…` : preview;
+
+  return (
+    <div
+      className={cn(
+        "rounded-2xl border border-slate-200 bg-white shadow-sm overflow-hidden",
+        className,
+      )}
+    >
+      <div className="flex items-center justify-between gap-2 border-b border-slate-100 bg-slate-50 px-4 py-2.5">
+        <span className="flex items-center gap-1.5 text-xs font-semibold text-slate-600">
+          <Icon name="eye" size={13} className="text-slate-400" />
+          What pros will see
+        </span>
+        <Badge variant="success" size="sm">
+          <Icon name="shield-check" size={11} /> Masked preview
+        </Badge>
+      </div>
+
+      <div className="p-4 space-y-3">
+        <div className="flex flex-wrap items-center gap-1.5">
+          {intentLabel && (
+            <Badge variant="gold" size="sm">
+              {intentLabel}
+            </Badge>
+          )}
+          {locationState && (
+            <Badge variant="default" size="sm">
+              <Icon name="map-pin" size={10} /> {locationState}
+            </Badge>
+          )}
+          {budgetLabel && (
+            <Badge variant="default" size="sm">
+              <Icon name="dollar-sign" size={10} /> {budgetLabel}
+            </Badge>
+          )}
+        </div>
+
+        <p
+          className={cn(
+            "text-sm font-bold leading-snug",
+            title.trim() ? "text-slate-900" : "text-slate-300",
+          )}
+        >
+          {title.trim() || "Your title will appear here…"}
+        </p>
+
+        <p
+          className={cn(
+            "text-xs leading-relaxed whitespace-pre-wrap",
+            truncated ? "text-slate-600" : "text-slate-300",
+          )}
+        >
+          {truncated ||
+            "As you describe your situation, pros will see a clear summary here — enough to decide they're a fit, without your contact details."}
+        </p>
+
+        {providerPreferenceLabel && (
+          <p className="text-[0.7rem] text-slate-400">
+            Routed to: <span className="font-semibold text-slate-500">{providerPreferenceLabel}</span>
+          </p>
+        )}
+
+        <div className="flex items-start gap-2 rounded-xl bg-slate-50 px-3 py-2 text-[0.7rem] leading-relaxed text-slate-500">
+          <Icon name="lock" size={13} className="mt-0.5 shrink-0 text-slate-400" />
+          <span>
+            Your name, email and phone stay hidden until a verified pro responds
+            and you choose to share them.
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/briefs/BriefStrengthMeter.tsx
+++ b/components/briefs/BriefStrengthMeter.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import Icon from "@/components/Icon";
+import { cn } from "@/lib/utils";
+import type { BriefStrength, StrengthTier } from "@/lib/briefs/brief-strength";
+
+/**
+ * Live brief-strength meter. Pure display — the parent computes the
+ * {@link BriefStrength} with `scoreBriefStrength` and passes it in, so the
+ * bar updates as the user types. Coaches the user toward the single
+ * highest-impact improvement.
+ */
+
+const BAR: Record<StrengthTier, string> = {
+  weak: "bg-rose-400",
+  fair: "bg-amber-400",
+  good: "bg-emerald-400",
+  great: "bg-emerald-500",
+};
+
+const LABEL_TEXT: Record<StrengthTier, string> = {
+  weak: "text-rose-600",
+  fair: "text-amber-600",
+  good: "text-emerald-600",
+  great: "text-emerald-700",
+};
+
+export default function BriefStrengthMeter({
+  strength,
+  className = "",
+}: {
+  strength: BriefStrength;
+  className?: string;
+}) {
+  const { score, tier, label, tips } = strength;
+  return (
+    <div className={cn("space-y-2", className)}>
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-xs font-semibold uppercase tracking-wider text-slate-500">
+          Brief strength
+        </span>
+        <span className={cn("text-xs font-bold tnum", LABEL_TEXT[tier])}>
+          {label}
+        </span>
+      </div>
+      <div
+        className="h-2 w-full rounded-full bg-slate-100 overflow-hidden"
+        role="meter"
+        aria-valuenow={score}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={`Brief strength: ${label}, ${score} out of 100`}
+      >
+        <div
+          className={cn("h-full rounded-full transition-all duration-500 ease-out", BAR[tier])}
+          style={{ width: `${Math.max(6, score)}%` }}
+        />
+      </div>
+      {tier === "great" ? (
+        <p className="flex items-center gap-1.5 text-xs text-emerald-700">
+          <Icon name="check-circle" size={13} className="shrink-0" />
+          Looking great — this brief gives pros what they need to respond well.
+        </p>
+      ) : tips.length > 0 ? (
+        <ul className="space-y-1">
+          {tips.slice(0, 2).map((tip) => (
+            <li key={tip.id} className="flex items-start gap-1.5 text-xs text-slate-500">
+              <Icon name="lightbulb" size={13} className="mt-0.5 shrink-0 text-amber-500" />
+              <span>{tip.text}</span>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}

--- a/components/briefs/BriefSuccess.tsx
+++ b/components/briefs/BriefSuccess.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import Icon from "@/components/Icon";
+import { Button } from "@/components/ui/Button";
+
+/**
+ * Brief Studio success state. Celebratory, and — crucially — orients the user
+ * to the next action: responses are coming, compare them and choose. Handles
+ * the compliance-review hold path too.
+ */
+
+export interface BriefSuccessProps {
+  slug: string;
+  contactEmail: string;
+  riskReviewStatus: string;
+}
+
+const NEXT_STEPS = [
+  {
+    icon: "eye",
+    title: "Pros review your brief",
+    desc: "Matching verified pros are notified now and see your masked brief.",
+  },
+  {
+    icon: "bell",
+    title: "Responses come to you",
+    desc: "We email you the moment a pro responds — usually within hours.",
+  },
+  {
+    icon: "user-check",
+    title: "Compare & choose",
+    desc: "Line up the responses, pick the pro that fits. Your details stay private until you do.",
+  },
+];
+
+export default function BriefSuccess({
+  slug,
+  contactEmail,
+  riskReviewStatus,
+}: BriefSuccessProps) {
+  const heldForReview = riskReviewStatus === "pending_review";
+
+  return (
+    <div
+      className="mx-auto max-w-2xl rounded-2xl border border-emerald-200 bg-white p-8 text-center shadow-sm"
+      style={{ animation: "resultCardIn 0.5s cubic-bezier(0.34, 1.56, 0.64, 1)" }}
+    >
+      <div
+        className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-emerald-100 celebrate-emoji"
+        aria-hidden="true"
+      >
+        <Icon
+          name={heldForReview ? "clock" : "party-popper"}
+          size={32}
+          className="text-emerald-600"
+        />
+      </div>
+
+      <h2 className="mb-2 text-2xl font-extrabold text-slate-900">
+        {heldForReview ? "Brief received — quick review first" : "Your brief is live 🎉"}
+      </h2>
+      <p className="mx-auto mb-6 max-w-md text-sm leading-relaxed text-slate-600">
+        {heldForReview
+          ? "Your brief mentions topics that need a quick compliance review before verified pros can see it. We'll email you the moment it's cleared."
+          : "We're notifying matching verified pros now. The responses come to you — compare them and choose who to work with."}
+      </p>
+
+      {!heldForReview && (
+        <ol className="mb-7 space-y-3 text-left">
+          {NEXT_STEPS.map((step, i) => (
+            <li key={step.title} className="flex items-start gap-3">
+              <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-slate-900 text-xs font-bold text-white">
+                {i + 1}
+              </span>
+              <span className="min-w-0">
+                <span className="flex items-center gap-1.5 text-sm font-bold text-slate-900">
+                  <Icon name={step.icon} size={14} className="text-amber-500" />
+                  {step.title}
+                </span>
+                <span className="mt-0.5 block text-xs leading-relaxed text-slate-500">
+                  {step.desc}
+                </span>
+              </span>
+            </li>
+          ))}
+        </ol>
+      )}
+
+      <div className="flex flex-col justify-center gap-3 sm:flex-row">
+        <Button
+          href={`/briefs/${slug}?email=${encodeURIComponent(contactEmail)}`}
+          variant="primary"
+          icon={<Icon name="arrow-right" size={16} />}
+        >
+          {heldForReview ? "View your brief status" : "Track responses"}
+        </Button>
+        <Button href="/advisors" variant="secondary">
+          Browse verified pros
+        </Button>
+      </div>
+
+      <p className="mt-5 text-xs leading-relaxed text-slate-400">
+        Invest.com.au provides general information only — the professional, firm
+        or team you engage delivers the service under their own licence.
+      </p>
+    </div>
+  );
+}

--- a/components/briefs/IntentPicker.tsx
+++ b/components/briefs/IntentPicker.tsx
@@ -1,0 +1,275 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import Icon from "@/components/Icon";
+import { Badge } from "@/components/ui/Badge";
+import SearchInput from "@/components/directory/SearchInput";
+import { cn } from "@/lib/utils";
+import {
+  INTENT_GROUPS,
+  intentsForGroup,
+  searchIntents,
+  type IntentDef,
+  type IntentGroup,
+} from "@/lib/briefs/intent-catalog";
+
+/**
+ * The Brief Studio intent gallery. A warm, searchable entry point that maps
+ * every consumer journey (the quiz goals, "find a mortgage broker", "FIRB
+ * help", "second opinion") onto a canonical brief_template. The freeform
+ * hero is a first-class path — it drives the AI co-pilot when enabled and
+ * gracefully seeds a general brief when not.
+ */
+
+type GroupFilter = "all" | IntentGroup;
+
+export interface IntentPickerProps {
+  selectedIntentId: string | null;
+  onSelect: (intent: IntentDef) => void;
+  onFreeform: () => void;
+  aiEnabled: boolean;
+  className?: string;
+}
+
+function IntentCard({
+  intent,
+  selected,
+  onSelect,
+}: {
+  intent: IntentDef;
+  selected: boolean;
+  onSelect: (intent: IntentDef) => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(intent)}
+      aria-pressed={selected}
+      className={cn(
+        "group relative flex w-full items-start gap-3 rounded-xl border p-4 text-left transition-all duration-150 hover:-translate-y-0.5 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400",
+        selected
+          ? "border-amber-500 ring-2 ring-amber-300 bg-amber-50"
+          : "border-slate-200 hover:border-slate-300 bg-white",
+      )}
+    >
+      <span
+        className={cn(
+          "flex h-10 w-10 shrink-0 items-center justify-center rounded-lg transition-colors",
+          selected
+            ? "bg-amber-500 text-slate-900"
+            : "bg-slate-100 text-slate-500 group-hover:bg-amber-100 group-hover:text-amber-700",
+        )}
+        aria-hidden="true"
+      >
+        <Icon name={intent.icon} size={20} />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="flex items-center gap-1.5">
+          <span className="text-sm font-bold text-slate-900">{intent.label}</span>
+          {intent.popular && (
+            <Badge variant="gold" size="sm" className="shrink-0">
+              Popular
+            </Badge>
+          )}
+        </span>
+        <span className="mt-0.5 block text-xs leading-snug text-slate-500">
+          {intent.tagline}
+        </span>
+      </span>
+      {selected && (
+        <Icon
+          name="check-circle"
+          size={18}
+          className="absolute right-3 top-3 text-amber-600"
+        />
+      )}
+    </button>
+  );
+}
+
+export default function IntentPicker({
+  selectedIntentId,
+  onSelect,
+  onFreeform,
+  aiEnabled,
+  className = "",
+}: IntentPickerProps) {
+  const [query, setQuery] = useState("");
+  const [group, setGroup] = useState<GroupFilter>("all");
+
+  const searching = query.trim().length > 0;
+  const results = useMemo(() => (searching ? searchIntents(query) : []), [query, searching]);
+
+  return (
+    <div className={cn("space-y-5", className)}>
+      {/* Freeform hero — the first-class "describe it in your words" path */}
+      <button
+        type="button"
+        onClick={onFreeform}
+        className="group flex w-full items-center gap-4 rounded-2xl border border-slate-900 bg-slate-900 p-4 text-left text-white transition-all duration-150 hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400 sm:p-5"
+      >
+        <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-amber-500 text-slate-900">
+          <Icon name={aiEnabled ? "zap" : "edit-3"} size={22} />
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="flex items-center gap-2">
+            <span className="text-sm font-bold sm:text-base">
+              Describe it in your own words
+            </span>
+            {aiEnabled && (
+              <span className="rounded-full bg-amber-400 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-slate-900">
+                AI
+              </span>
+            )}
+          </span>
+          <span className="mt-0.5 block text-xs leading-snug text-slate-300">
+            {aiEnabled
+              ? "Tell us your situation in plain English — our co-pilot drafts a structured brief you can review."
+              : "Tell us your situation in plain English and we'll set up the right brief for you."}
+          </span>
+        </span>
+        <Icon
+          name="arrow-right"
+          size={18}
+          className="shrink-0 text-amber-400 transition-transform group-hover:translate-x-1"
+        />
+      </button>
+
+      <div className="flex items-center gap-2">
+        <div className="h-px flex-1 bg-slate-200" />
+        <span className="text-xs font-medium text-slate-400">or pick what you need</span>
+        <div className="h-px flex-1 bg-slate-200" />
+      </div>
+
+      {/* Search */}
+      <SearchInput
+        id="intent-search"
+        value={query}
+        onChange={setQuery}
+        placeholder="Search — try 'refinance', 'SMSF', 'FIRB', 'sell my business'…"
+        ariaLabel="Search for what you need help with"
+        className="!flex-none"
+      />
+
+      {/* Group filter chips (hidden while searching — search spans all groups) */}
+      {!searching && (
+        <div className="flex flex-wrap gap-2" role="group" aria-label="Filter by category">
+          <GroupChip
+            label="All"
+            icon="grid"
+            active={group === "all"}
+            onClick={() => setGroup("all")}
+          />
+          {INTENT_GROUPS.map((g) => (
+            <GroupChip
+              key={g.id}
+              label={g.label}
+              icon={g.icon}
+              active={group === g.id}
+              onClick={() => setGroup(g.id)}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Results */}
+      {searching ? (
+        results.length > 0 ? (
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            {results.map((intent) => (
+              <IntentCard
+                key={intent.id}
+                intent={intent}
+                selected={selectedIntentId === intent.id}
+                onSelect={onSelect}
+              />
+            ))}
+          </div>
+        ) : (
+          <div className="rounded-xl border border-dashed border-slate-300 bg-slate-50 p-6 text-center">
+            <p className="text-sm font-semibold text-slate-700">
+              No exact match for “{query.trim()}”
+            </p>
+            <p className="mt-1 text-xs text-slate-500">
+              No problem — use{" "}
+              <button
+                type="button"
+                onClick={onFreeform}
+                className="font-semibold text-amber-700 underline hover:text-amber-900"
+              >
+                describe it in your own words
+              </button>{" "}
+              and we&apos;ll route it to the right pros.
+            </p>
+          </div>
+        )
+      ) : group === "all" ? (
+        <div className="space-y-6">
+          {INTENT_GROUPS.map((g) => {
+            const intents = intentsForGroup(g.id);
+            if (intents.length === 0) return null;
+            return (
+              <section key={g.id} aria-label={g.label}>
+                <h3 className="mb-2 flex items-center gap-1.5 text-xs font-bold uppercase tracking-wider text-slate-500">
+                  <Icon name={g.icon} size={13} className="text-slate-400" />
+                  {g.label}
+                </h3>
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                  {intents.map((intent) => (
+                    <IntentCard
+                      key={intent.id}
+                      intent={intent}
+                      selected={selectedIntentId === intent.id}
+                      onSelect={onSelect}
+                    />
+                  ))}
+                </div>
+              </section>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          {intentsForGroup(group).map((intent) => (
+            <IntentCard
+              key={intent.id}
+              intent={intent}
+              selected={selectedIntentId === intent.id}
+              onSelect={onSelect}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function GroupChip({
+  label,
+  icon,
+  active,
+  onClick,
+}: {
+  label: string;
+  icon: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      onClick={onClick}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400",
+        active
+          ? "border-slate-900 bg-slate-900 text-white"
+          : "border-slate-200 bg-white text-slate-600 hover:border-slate-300 hover:bg-slate-50",
+      )}
+    >
+      <Icon name={icon} size={12} className={active ? "text-amber-400" : "text-slate-400"} />
+      {label}
+    </button>
+  );
+}

--- a/components/briefs/MatchModeChooser.tsx
+++ b/components/briefs/MatchModeChooser.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import Icon from "@/components/Icon";
+import { Badge } from "@/components/ui/Badge";
+import { Input } from "@/components/ui/Input";
+import { Select } from "@/components/ui/Select";
+import ResultCount from "@/components/directory/ResultCount";
+import { cn } from "@/lib/utils";
+
+/**
+ * "How do you want to be matched?" — reframed around the marketplace promise:
+ * post once, get responses from multiple verified pros, and choose. The
+ * multi-response mode leads as the recommended default.
+ *
+ * Honest social proof only: the live pro-supply count is passed from the
+ * server (a real `professionals` count) and rendered solely above a floor, so
+ * we never advertise an empty marketplace.
+ */
+
+const SUPPLY_FLOOR = 12;
+
+interface ModeDef {
+  value: string;
+  title: string;
+  blurb: string;
+  icon: string;
+  recommended?: boolean;
+}
+
+const MODES: ModeDef[] = [
+  {
+    value: "multi_response",
+    title: "Open to multiple pros",
+    blurb: "Several verified pros can respond. Compare them side by side and choose the best fit — like getting quotes.",
+    icon: "users",
+    recommended: true,
+  },
+  {
+    value: "smart_match",
+    title: "Smart match",
+    blurb: "We route your brief to the best-fit verified pros and notify them for you.",
+    icon: "target",
+  },
+  {
+    value: "direct",
+    title: "Send to one specific pro",
+    blurb: "Have someone in mind? Enter the slug from their profile URL.",
+    icon: "user-check",
+  },
+];
+
+const PROVIDER_TYPES = [
+  { value: "any", label: "No preference — widest response" },
+  { value: "individual", label: "Individual expert" },
+  { value: "firm", label: "Firm / brokerage" },
+  { value: "expert_team", label: "Expert team (multi-discipline)" },
+];
+
+export interface MatchPatch {
+  routing_mode?: string;
+  provider_preference?: string;
+  target_team_slug?: string;
+}
+
+export interface MatchModeChooserProps {
+  routingMode: string;
+  providerPreference: string;
+  targetSlug: string;
+  proSubscriber: boolean;
+  proSupply: number | null;
+  onChange: (patch: MatchPatch) => void;
+  className?: string;
+}
+
+export default function MatchModeChooser({
+  routingMode,
+  providerPreference,
+  targetSlug,
+  proSubscriber,
+  proSupply,
+  onChange,
+  className = "",
+}: MatchModeChooserProps) {
+  const showSupply = proSupply != null && proSupply >= SUPPLY_FLOOR;
+  const proPerkActive =
+    routingMode === "direct" && providerPreference === "expert_team";
+
+  return (
+    <div className={cn("space-y-6", className)}>
+      {/* Honest live social proof */}
+      <div className="rounded-xl border border-emerald-200 bg-emerald-50/60 p-4">
+        {showSupply ? (
+          <ResultCount
+            total={proSupply ?? 0}
+            pills={[
+              {
+                tone: "live",
+                count: proSupply ?? 0,
+                label: "verified pros ready to respond",
+              },
+            ]}
+          />
+        ) : (
+          <p className="flex items-center gap-2 text-sm font-semibold text-emerald-800">
+            <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-500" aria-hidden />
+            Verified pros across Australia
+          </p>
+        )}
+        <p className="mt-1.5 text-xs leading-relaxed text-emerald-800/80">
+          Matching pros are notified the moment you post. You&apos;ll get an email
+          as soon as one responds — then you compare and choose. Your contact
+          details stay private until then.
+        </p>
+      </div>
+
+      {/* Investor Pro perk */}
+      {proSubscriber && (
+        <div className="rounded-xl border border-violet-300 bg-violet-50 p-4">
+          <label className="flex cursor-pointer items-start gap-3">
+            <input
+              type="checkbox"
+              checked={proPerkActive}
+              onChange={(e) => {
+                if (e.target.checked) {
+                  onChange({ routing_mode: "direct", provider_preference: "expert_team" });
+                } else {
+                  onChange({ routing_mode: "multi_response" });
+                }
+              }}
+              className="mt-0.5 h-4 w-4 rounded border-violet-400 text-violet-600 focus:ring-violet-500"
+            />
+            <span>
+              <span className="flex items-center gap-1.5 text-sm font-bold text-violet-900">
+                <Icon name="crown" size={14} /> Skip the queue · Investor Pro
+              </span>
+              <span className="mt-0.5 block text-xs text-violet-800">
+                Route directly to a verified Expert Team of your choice — they see
+                your brief in their inbox immediately, bypassing the smart-match
+                window.
+              </span>
+            </span>
+          </label>
+        </div>
+      )}
+
+      <fieldset>
+        <legend className="mb-2 text-sm font-semibold text-slate-700">
+          How would you like to hear back?
+        </legend>
+        <div className="grid grid-cols-1 gap-3">
+          {MODES.map((mode) => {
+            const active = routingMode === mode.value;
+            return (
+              <button
+                key={mode.value}
+                type="button"
+                aria-pressed={active}
+                onClick={() => onChange({ routing_mode: mode.value })}
+                className={cn(
+                  "flex items-start gap-3 rounded-xl border p-4 text-left transition-all duration-150 hover:border-slate-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400",
+                  active
+                    ? "border-amber-500 ring-2 ring-amber-300 bg-amber-50"
+                    : "border-slate-200 bg-white",
+                )}
+              >
+                <span
+                  className={cn(
+                    "flex h-9 w-9 shrink-0 items-center justify-center rounded-lg",
+                    active ? "bg-amber-500 text-slate-900" : "bg-slate-100 text-slate-500",
+                  )}
+                  aria-hidden
+                >
+                  <Icon name={mode.icon} size={18} />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="flex items-center gap-2">
+                    <span className="text-sm font-bold text-slate-900">{mode.title}</span>
+                    {mode.recommended && (
+                      <Badge variant="success" size="sm">
+                        Recommended
+                      </Badge>
+                    )}
+                  </span>
+                  <span className="mt-0.5 block text-xs leading-snug text-slate-500">
+                    {mode.blurb}
+                  </span>
+                </span>
+                {active && <Icon name="check-circle" size={18} className="shrink-0 text-amber-600" />}
+              </button>
+            );
+          })}
+        </div>
+      </fieldset>
+
+      {routingMode === "direct" && (
+        <Input
+          id="brief-target-slug"
+          label="Pro / team / firm profile slug"
+          hint="Use the slug from a verified profile URL, e.g. sydney-smsf-property-team."
+          value={targetSlug}
+          onChange={(e) => onChange({ target_team_slug: e.target.value })}
+          placeholder="e.g. sydney-smsf-property-team"
+          maxLength={120}
+        />
+      )}
+
+      <div className="border-t border-slate-100 pt-5">
+        <Select
+          id="brief-provider-type"
+          label="Provider type (optional)"
+          hint="Leave it open for the widest response, or narrow it if you have a preference."
+          value={providerPreference === "multiple" ? "any" : providerPreference}
+          onChange={(e) => onChange({ provider_preference: e.target.value })}
+          options={PROVIDER_TYPES}
+        />
+      </div>
+    </div>
+  );
+}

--- a/docs/plans/BRIEF_STUDIO.md
+++ b/docs/plans/BRIEF_STUDIO.md
@@ -1,0 +1,107 @@
+# Brief Studio — gold-standard `/briefs/new`
+
+> Status: **Phase 1 shipping** (creation experience). Phase 2 (offers board on the
+> brief detail page) is scoped at the bottom but not built here.
+
+## Why
+
+`/briefs/new` is the front door to the provider marketplace. Today it's a competent
+4-step template form. The bar we're aiming for is the category gold standard — the
+"post a task, get offers, pick a pro" experience people associate with Airtasker —
+re-cast for Australian financial services and **bounded by our lean-lane compliance
+posture** (general information only, no personal advice, no client money, masked PII,
+flat B2B credits).
+
+The single most important reframe: the marketplace's _mechanic_ is "verified pros
+respond to your brief", but the creation flow never **sold that promise** or made it
+feel alive. Brief Studio does.
+
+## What changes (Phase 1)
+
+A ground-up rebuild of the creation experience. **No backend, schema, or API-contract
+changes** — the form still POSTs the exact same body to `/api/briefs` (and the
+`plan_id` → `/api/get-matched/plans/{id}/to-brief` path is preserved). That keeps this
+a page-UI change (Tier A/B), shippable without touching webhooks, cron, auth,
+compliance semantics, or migrations.
+
+### Five pillars
+
+1. **Intent-first entry that covers every journey.**
+   `lib/briefs/intent-catalog.ts` is a new single source of truth that maps a warm,
+   consumer-facing intent gallery onto the 14 existing `brief_template`s. Every intent
+   carries rich search keywords (so quiz-language like "refinance", "FIRB", "negative
+   gearing", "CGT", "due diligence", "sell my business" all resolve), example prompts,
+   an icon, a group, and sensible provider/routing defaults. A hero **"Describe it in
+   your own words"** card is a first-class path: it drives the AI co-pilot when the
+   `ai_match_request_copilot` flag is on, and gracefully seeds a `general` brief from
+   the free text when it's off — so _everyone_ gets the freeform door, not just the
+   flagged cohort.
+
+2. **Live brief preview + strength meter.**
+   A sticky "**This is exactly what pros will see**" card (`BriefPreviewCard`) mirrors
+   `maskBriefForProvider` and fills in as the user types — including a visible reminder
+   of what stays private until a pro responds. A deterministic **strength meter**
+   (`lib/briefs/brief-strength.ts`, mirroring the 1–5 AI quality rubric in
+   `lib/ai/brief-quality.ts`) scores the brief Weak → Excellent and surfaces the single
+   highest-impact next improvement. It coaches better briefs without an API call.
+
+3. **The bids promise, made tangible.**
+   The matching step leads with **"Open to multiple pros — compare & choose"**
+   (`routing_mode='multi_response'`) as the recommended default, with "Smart match" and
+   "Send to one specific pro" as alternates. Honest social proof (a real
+   active-professional count, shown only above a floor so we never advertise an empty
+   marketplace) and a mechanic-based "you're notified the moment a pro responds" framing
+   replace vague claims. The success screen orients the user to the next action:
+   _compare responses and pick your pro_.
+
+4. **Polished, accessible, mobile-first craft.**
+   Step transitions use the existing CSS keyframes (`slideInRight`, `resultCardIn`) and
+   inherit the global `prefers-reduced-motion` guard. Drafts autosave to `localStorage`
+   and offer a restore banner. A sticky bottom action bar (with iOS safe-area inset)
+   drives the flow on mobile. Validation is encouraging and inline; counters, ARIA, and
+   keyboard support are first-class.
+
+5. **Trust & compliance woven in, not bolted on.**
+   Disclaimers come from the canonical `lib/compliance.ts` helpers (never hardcoded).
+   The consent copy, masked-preview explainer, and "we provide general information only —
+   the pro you engage delivers the service under their own licence" framing are all
+   preserved and given prominence.
+
+## Files
+
+| File | Change |
+|---|---|
+| `lib/briefs/intent-catalog.ts` | **new** — intent registry + search, mapped to the 14 templates |
+| `lib/briefs/brief-strength.ts` | **new** — deterministic brief-strength scorer + coaching tips |
+| `components/briefs/IntentPicker.tsx` | **new** — searchable, grouped intent gallery + freeform hero |
+| `components/briefs/BriefStrengthMeter.tsx` | **new** — strength bar + next-best tip |
+| `components/briefs/BriefPreviewCard.tsx` | **new** — live "what pros see" masked preview |
+| `components/briefs/MatchModeChooser.tsx` | **new** — the reframed "how do you want responses" step |
+| `components/briefs/BriefSuccess.tsx` | **new** — vivid, next-action success state |
+| `app/briefs/new/BriefForm.tsx` | **rewrite** — orchestrator; same submit contract + autosave + rail |
+| `app/briefs/new/page.tsx` | **rewrite hero** — Airtasker-grade hero, honest supply, reframed how-it-works |
+| `__tests__/lib/briefs/intent-catalog.test.ts` | **new** |
+| `__tests__/lib/briefs/brief-strength.test.ts` | **new** |
+| `__tests__/components/briefs/*.test.tsx` | **new** — smoke tests for the picker + meter |
+
+## Compliance guardrails honored
+
+- **No new `brief_payload` keys.** Notes-only templates use a `.strict()` Zod schema —
+  adding keys would 400. The structured fields rendered remain exactly
+  `BRIEF_TEMPLATE_FIELDS[template]`.
+- **No personal-advice framing.** Copy stays "verified pros respond / you choose", never
+  "we recommend pro X for you".
+- **No client money / escrow.** The flow sets up responses; money never moves through
+  the platform between consumer and pro. Nothing here charges the consumer.
+- **PII masking preserved.** The preview card mirrors `maskBriefForProvider`; contact
+  details still only unlock after a pro accepts.
+- **Honest numbers only.** Social proof uses a real `professionals` count and is hidden
+  below a floor; no fabricated "avg response time".
+
+## Phase 2 (scoped, not built here)
+
+The Airtasker-style **offers board** on `app/briefs/[slug]` — multiple pro responses
+rendered as comparable cards (pitch, verified credentials, outcome score, shortlist,
+message) with a consumer "choose this pro" action — building on the existing
+`brief_shortlist`, `brief_messages`, and outcome-scoring tables. This is a Tier-B/C
+change (touches the accepted-flow) and warrants its own PR.

--- a/lib/briefs/brief-strength.ts
+++ b/lib/briefs/brief-strength.ts
@@ -1,0 +1,216 @@
+/**
+ * Deterministic brief-strength scoring for the Brief Studio creation flow.
+ *
+ * Mirrors the 1..5 rubric the AI quality scorer uses (`lib/ai/brief-quality.ts`)
+ * — clarity, specificity, genuine intent — but runs client-side with no API
+ * call, so the strength meter updates live as the user types and coaches them
+ * toward the single highest-impact improvement.
+ *
+ * The score is a 0..100 sum across six dimensions. Tips are emitted for the
+ * dimensions with the biggest remaining gap so the meter always points at the
+ * next best thing to add.
+ */
+
+export interface BriefStrengthFieldHint {
+  key: string;
+  required?: boolean;
+}
+
+export interface BriefStrengthInput {
+  title: string;
+  description: string;
+  /** "" | budget band | "not_sure" */
+  budgetBand: string;
+  /** "" | AU state code */
+  locationState: string;
+  /** Structured template answers. */
+  payload: Record<string, unknown>;
+  /** The template's field hints, used for structured completeness + timeline relevance. */
+  fields: readonly BriefStrengthFieldHint[];
+}
+
+export type StrengthTier = "weak" | "fair" | "good" | "great";
+
+export interface StrengthTip {
+  id: string;
+  text: string;
+}
+
+export interface BriefStrength {
+  /** 0..100 */
+  score: number;
+  tier: StrengthTier;
+  label: string;
+  /** Up to 3 coaching tips, highest-impact first. */
+  tips: StrengthTip[];
+}
+
+const MONEY_OR_TIME =
+  /(\$|\d|asap|urgent|deadline|week|month|year|quarter|by\s|before\s)/i;
+
+function isFilled(value: unknown): boolean {
+  if (typeof value === "string") return value.trim().length > 0;
+  if (Array.isArray(value)) return value.length > 0;
+  return value != null && value !== "";
+}
+
+interface Dimension {
+  earned: number;
+  max: number;
+  tip?: StrengthTip;
+}
+
+function scoreTitle(title: string): Dimension {
+  const len = title.trim().length;
+  let earned: number;
+  if (len === 0) earned = 0;
+  else if (len < 8) earned = 4;
+  else if (len < 20) earned = 12;
+  else earned = 18;
+  if (len >= 8 && /\d/.test(title)) earned = Math.min(20, earned + 2);
+  return {
+    earned,
+    max: 20,
+    tip:
+      earned < 14
+        ? {
+            id: "title",
+            text: "Make your title specific — add a location, amount or timeframe.",
+          }
+        : undefined,
+  };
+}
+
+function scoreDescription(description: string): Dimension {
+  const text = description.trim();
+  const len = text.length;
+  let earned: number;
+  if (len < 30) earned = 0;
+  else if (len < 80) earned = 14;
+  else if (len < 160) earned = 24;
+  else if (len < 300) earned = 32;
+  else earned = 36;
+  if (len >= 30 && MONEY_OR_TIME.test(text)) earned = Math.min(40, earned + 4);
+  return {
+    earned,
+    max: 40,
+    tip:
+      earned < 28
+        ? {
+            id: "description",
+            text: "Add a sentence or two: your situation, the outcome you want, and any deadline.",
+          }
+        : undefined,
+  };
+}
+
+function scoreBudget(budgetBand: string): Dimension {
+  let earned: number;
+  if (!budgetBand) earned = 0;
+  else if (budgetBand === "not_sure") earned = 4;
+  else earned = 12;
+  return {
+    earned,
+    max: 12,
+    tip:
+      earned < 12
+        ? {
+            id: "budget",
+            text: "Set a budget band so pros can pitch the right scope.",
+          }
+        : undefined,
+  };
+}
+
+function scoreLocation(locationState: string): Dimension {
+  const earned = locationState ? 8 : 0;
+  return {
+    earned,
+    max: 8,
+    tip:
+      earned === 0
+        ? {
+            id: "location",
+            text: "Add your state so we match pros licensed where you are.",
+          }
+        : undefined,
+  };
+}
+
+function scoreTimeline(
+  payload: Record<string, unknown>,
+  fields: readonly BriefStrengthFieldHint[],
+): Dimension {
+  const relevant = fields.some((f) => f.key === "timeline");
+  if (!relevant) {
+    // Template has no timeline field — treat as satisfied so notes-only
+    // templates aren't penalised for a question we never asked.
+    return { earned: 10, max: 10 };
+  }
+  const value = payload.timeline;
+  let earned: number;
+  if (!isFilled(value)) earned = 0;
+  else if (value === "not_sure") earned = 3;
+  else earned = 10;
+  return {
+    earned,
+    max: 10,
+    tip:
+      earned < 10
+        ? { id: "timeline", text: "Add a timeline so pros know how urgent this is." }
+        : undefined,
+  };
+}
+
+function scoreStructured(
+  payload: Record<string, unknown>,
+  fields: readonly BriefStrengthFieldHint[],
+): Dimension {
+  const structural = fields.filter((f) => f.key !== "timeline");
+  if (structural.length === 0) return { earned: 10, max: 10 };
+  const filled = structural.filter((f) => isFilled(payload[f.key])).length;
+  const earned = Math.round((10 * filled) / structural.length);
+  return {
+    earned,
+    max: 10,
+    tip:
+      earned < 7
+        ? {
+            id: "structured",
+            text: "Answer the remaining detail questions — they help pros quote accurately.",
+          }
+        : undefined,
+  };
+}
+
+function tierFor(score: number): { tier: StrengthTier; label: string } {
+  if (score < 40) return { tier: "weak", label: "Needs more detail" };
+  if (score < 65) return { tier: "fair", label: "Getting there" };
+  if (score < 85) return { tier: "good", label: "Strong brief" };
+  return { tier: "great", label: "Excellent — pros love this" };
+}
+
+export function scoreBriefStrength(input: BriefStrengthInput): BriefStrength {
+  const dims: Dimension[] = [
+    scoreTitle(input.title),
+    scoreDescription(input.description),
+    scoreBudget(input.budgetBand),
+    scoreLocation(input.locationState),
+    scoreTimeline(input.payload, input.fields),
+    scoreStructured(input.payload, input.fields),
+  ];
+
+  const score = Math.max(
+    0,
+    Math.min(100, dims.reduce((sum, d) => sum + d.earned, 0)),
+  );
+  const { tier, label } = tierFor(score);
+
+  const tips = dims
+    .filter((d): d is Dimension & { tip: StrengthTip } => d.tip != null)
+    .sort((a, b) => b.max - b.earned - (a.max - a.earned))
+    .slice(0, 3)
+    .map((d) => d.tip);
+
+  return { score, tier, label, tips };
+}

--- a/lib/briefs/intent-catalog.ts
+++ b/lib/briefs/intent-catalog.ts
@@ -1,0 +1,420 @@
+/**
+ * Brief Studio intent catalog.
+ *
+ * A consumer-facing presentation layer over the 14 `brief_template`s. The
+ * goal is that *every* user intent the site captures elsewhere (the quiz
+ * goals, the get-matched flow, the verticals, the advisor directory) has a
+ * warm, human entry point here that resolves to exactly one canonical
+ * `brief_template` — so the picker can serve "find a mortgage broker",
+ * "FIRB help", "second opinion on my SOA", or "sell my business" without
+ * the user ever needing to know the word "template".
+ *
+ * This is the single source of truth for the intent gallery + search. The
+ * brief form maps a chosen intent → `brief_template` + sensible
+ * provider/routing defaults; the API contract is unchanged.
+ *
+ * Search keywords are deliberately broad and overlap the quiz's vocabulary
+ * (refinance, negative gearing, FIRB, CGT, BAS, due diligence, pre-IPO…) so
+ * typing what you actually want surfaces the right card.
+ */
+
+import type { BriefTemplate, ProviderPreference } from "./types";
+
+export type IntentGroup =
+  | "advice"
+  | "property"
+  | "tax"
+  | "cross_border"
+  | "business"
+  | "selling";
+
+export interface IntentGroupDef {
+  id: IntentGroup;
+  label: string;
+  icon: string;
+}
+
+export interface IntentDef {
+  /** Stable id. Canonical intents share their id with the template. */
+  id: string;
+  /** The brief_template this intent resolves to on submit. */
+  template: BriefTemplate;
+  /** Consumer-facing label shown on the card. */
+  label: string;
+  /** One-line tagline under the label. */
+  tagline: string;
+  /** Icon name (must exist in components/Icon.tsx). */
+  icon: string;
+  /** Group used for the filter tabs. */
+  group: IntentGroup;
+  /** Lowercase search keywords — broad on purpose. */
+  keywords: string[];
+  /** Rotating example prompts shown as freeform placeholders / nudges. */
+  examples: string[];
+  /** Whether to surface in the "Popular" quick row. */
+  popular?: boolean;
+  /** Sensible default provider preference once this intent is picked. */
+  providerPreference?: ProviderPreference;
+  /** Advisor-type hints passed through for routing context. */
+  advisorTypes?: string[];
+}
+
+export const INTENT_GROUPS: readonly IntentGroupDef[] = [
+  { id: "advice", label: "Advice & planning", icon: "trending-up" },
+  { id: "property", label: "Property & lending", icon: "home" },
+  { id: "tax", label: "Tax & accounting", icon: "landmark" },
+  { id: "cross_border", label: "Cross-border", icon: "globe" },
+  { id: "business", label: "Business & deals", icon: "briefcase" },
+  { id: "selling", label: "Selling & listing", icon: "tag" },
+];
+
+export const INTENT_CATALOG: readonly IntentDef[] = [
+  // ── Advice & planning ──────────────────────────────────────────────
+  {
+    id: "financial_adviser",
+    template: "financial_adviser",
+    label: "Financial advice & planning",
+    tagline: "Build wealth, plan retirement, structure your investments.",
+    icon: "trending-up",
+    group: "advice",
+    popular: true,
+    providerPreference: "any",
+    advisorTypes: ["financial_planner"],
+    keywords: [
+      "financial adviser", "financial advisor", "financial planner", "planning",
+      "wealth", "grow my wealth", "start investing", "investing", "portfolio",
+      "retirement", "retire", "super strategy", "shares", "etf", "managed fund",
+      "income", "dividends", "estate planning", "insurance", "smsf advice",
+    ],
+    examples: [
+      "I'm 40, earning $150k, and want a long-term plan to build wealth and retire by 60.",
+      "I have $250k to invest and want help building a diversified portfolio.",
+      "I want a retirement plan that makes my super and investments work together.",
+    ],
+  },
+  {
+    id: "second_opinion",
+    template: "second_opinion",
+    label: "Second opinion on advice",
+    tagline: "Have an independent pro sanity-check advice you've received.",
+    icon: "scale",
+    group: "advice",
+    providerPreference: "any",
+    keywords: [
+      "second opinion", "independent review", "review my advice", "soa",
+      "statement of advice", "sanity check", "is this advice good",
+      "review my plan", "fee review", "conflicted advice", "switch adviser",
+    ],
+    examples: [
+      "My adviser recommended switching my super — I'd like an independent review before I sign.",
+      "I got a Statement of Advice and want a second opinion on whether it's right for me.",
+    ],
+  },
+  {
+    id: "general",
+    template: "general",
+    label: "Something else / not sure",
+    tagline: "Describe your situation and we'll route it to the right pros.",
+    icon: "message-circle",
+    group: "advice",
+    providerPreference: "any",
+    keywords: [
+      "not sure", "other", "general", "help", "question", "advice", "guidance",
+      "where do i start", "don't know", "anything else",
+    ],
+    examples: [
+      "I've come into some money and I'm not sure what kind of professional I need.",
+      "I have a complex situation and want to talk it through with the right expert.",
+    ],
+  },
+
+  // ── Property & lending ─────────────────────────────────────────────
+  {
+    id: "mortgage",
+    template: "mortgage",
+    label: "Home loan or refinance",
+    tagline: "Buy, refinance or restructure — find a mortgage broker.",
+    icon: "home",
+    group: "property",
+    popular: true,
+    providerPreference: "any",
+    advisorTypes: ["mortgage_broker"],
+    keywords: [
+      "mortgage", "home loan", "refinance", "refinancing", "broker",
+      "mortgage broker", "first home", "first home buyer", "pre-approval",
+      "borrowing capacity", "investment loan", "offset", "fixed rate",
+      "variable rate", "lmi", "construction loan", "deposit", "buy a home",
+      "buy a house",
+    ],
+    examples: [
+      "First-home buyer in VIC with a 10% deposit — what can I borrow and who can help?",
+      "I want to refinance a $600k investment loan to a better rate.",
+    ],
+  },
+  {
+    id: "smsf_property",
+    template: "smsf_property",
+    label: "Buy property with your SMSF",
+    tagline: "SMSF property strategy and the team to make it happen.",
+    icon: "building",
+    group: "property",
+    popular: true,
+    providerPreference: "expert_team",
+    advisorTypes: ["smsf_accountant", "buyers_agent", "mortgage_broker"],
+    keywords: [
+      "smsf property", "smsf", "self managed super", "buy property in super",
+      "limited recourse", "lrba", "property in smsf", "super property",
+      "commercial property smsf", "smsf loan", "negative gearing",
+    ],
+    examples: [
+      "I have $200k in super and want to set up an SMSF to buy an investment property in QLD.",
+      "My SMSF is established — I need lending and a buyer's agent to purchase a property.",
+    ],
+  },
+  {
+    id: "commercial_property",
+    template: "commercial_property",
+    label: "Commercial property",
+    tagline: "Purchase, lease or invest in commercial real estate.",
+    icon: "factory",
+    group: "property",
+    providerPreference: "expert_team",
+    keywords: [
+      "commercial property", "commercial real estate", "office", "warehouse",
+      "retail lease", "industrial", "commercial loan", "commercial finance",
+      "lease review", "fit out", "cap rate", "net lease",
+    ],
+    examples: [
+      "I'm buying a $1.2m warehouse for my business and need finance plus a lease review.",
+      "Looking at a retail premises as an investment — need help assessing the lease and yield.",
+    ],
+  },
+
+  // ── Tax & accounting ───────────────────────────────────────────────
+  {
+    id: "tax",
+    template: "tax",
+    label: "Tax & accounting",
+    tagline: "Tax planning, returns, CGT and structuring.",
+    icon: "landmark",
+    group: "tax",
+    popular: true,
+    providerPreference: "any",
+    advisorTypes: ["tax_agent", "accountant"],
+    keywords: [
+      "tax", "accountant", "tax agent", "tax return", "cgt", "capital gains",
+      "bas", "gst", "tax planning", "deductions", "negative gearing tax",
+      "company tax", "trust", "structuring", "depreciation", "ato",
+      "tax debt", "crypto tax",
+    ],
+    examples: [
+      "I sold an investment property this year and need help minimising CGT.",
+      "I run a small business and want a proactive accountant for tax planning, not just returns.",
+    ],
+  },
+  {
+    id: "smsf_accountant",
+    template: "smsf_accountant",
+    label: "SMSF setup & administration",
+    tagline: "Establish, run or wind up a self-managed super fund.",
+    icon: "calculator",
+    group: "tax",
+    providerPreference: "any",
+    advisorTypes: ["smsf_accountant", "accountant"],
+    keywords: [
+      "smsf", "self managed super fund", "smsf setup", "smsf accountant",
+      "smsf administration", "smsf audit", "smsf compliance", "smsf tax",
+      "wind up smsf", "establish smsf", "super fund accountant",
+    ],
+    examples: [
+      "I want to set up an SMSF and need an accountant to handle establishment and ongoing admin.",
+      "My existing SMSF needs a new accountant for compliance and the annual audit.",
+    ],
+  },
+
+  // ── Cross-border ───────────────────────────────────────────────────
+  {
+    id: "foreign_investor",
+    template: "foreign_investor",
+    label: "Investing into Australia from overseas",
+    tagline: "Non-resident? FIRB, tax, structuring and lending.",
+    icon: "globe",
+    group: "cross_border",
+    popular: true,
+    providerPreference: "expert_team",
+    keywords: [
+      "foreign investor", "non-resident", "overseas", "firb",
+      "foreign investment review board", "buy property in australia",
+      "foreign buyer", "stamp duty surcharge", "tax residency",
+      "non resident tax", "offshore", "expatriate investing", "structuring",
+    ],
+    examples: [
+      "I live in Singapore and want to buy a A$1.5m property in Sydney — I need FIRB and tax help.",
+      "Non-resident wanting to invest in Australian managed funds — what structure and tax applies?",
+    ],
+  },
+  {
+    id: "expat",
+    template: "expat",
+    label: "Australian expat abroad",
+    tagline: "Tax residency, super and investing while overseas.",
+    icon: "map",
+    group: "cross_border",
+    providerPreference: "any",
+    keywords: [
+      "expat", "australian expat", "living overseas", "moving abroad",
+      "tax residency", "super while overseas", "non-resident for tax",
+      "repatriation", "returning to australia", "double tax", "dta",
+      "foreign income",
+    ],
+    examples: [
+      "I'm an Aussie working in the UK — I need help with tax residency and what to do with my super.",
+      "Moving back to Australia next year and want to get my investments and tax in order first.",
+    ],
+  },
+
+  // ── Business & deals ───────────────────────────────────────────────
+  {
+    id: "business_acquisition",
+    template: "business_acquisition",
+    label: "Buying a business",
+    tagline: "Due diligence, lending and legal for an acquisition.",
+    icon: "briefcase",
+    group: "business",
+    popular: true,
+    providerPreference: "expert_team",
+    keywords: [
+      "buy a business", "business acquisition", "acquisition", "buy out",
+      "due diligence", "business valuation", "business finance",
+      "business loan", "franchise", "share purchase", "asset purchase",
+      "earnout", "mna", "m&a", "buying a franchise",
+    ],
+    examples: [
+      "I'm buying a $900k business and need due diligence, finance and a lawyer to review the contract.",
+      "Considering a franchise — I want a team to assess the numbers before I commit.",
+    ],
+  },
+  {
+    id: "opportunity_assessment",
+    template: "opportunity_assessment",
+    label: "Assess an opportunity or deal",
+    tagline: "Get experts to vet a specific listing or investment.",
+    icon: "search",
+    group: "business",
+    providerPreference: "expert_team",
+    keywords: [
+      "opportunity", "assess a deal", "due diligence", "review a listing",
+      "investment opportunity", "is this a good investment", "vet a deal",
+      "pre-ipo", "wholesale", "private credit", "syndicate", "second look",
+      "feasibility",
+    ],
+    examples: [
+      "I found a pre-IPO opportunity and want an independent specialist to assess it before I invest.",
+      "There's a property syndicate I'm considering — can a pro review the numbers and risks?",
+    ],
+  },
+
+  // ── Selling & listing ──────────────────────────────────────────────
+  {
+    id: "listing",
+    template: "listing",
+    label: "List an opportunity for sale",
+    tagline: "Find buyers for a business, property or asset.",
+    icon: "tag",
+    group: "selling",
+    providerPreference: "any",
+    keywords: [
+      "sell my business", "list", "listing", "find buyers", "sell",
+      "business broker", "sell a property", "divest", "exit", "sell an asset",
+      "marketplace listing", "advertise opportunity",
+    ],
+    examples: [
+      "I want to sell my business and reach qualified buyers, compliantly.",
+      "Listing a commercial property for sale — I need it packaged and in front of investors.",
+    ],
+  },
+  {
+    id: "listing_readiness",
+    template: "listing_readiness",
+    label: "Get ready to sell / list",
+    tagline: "Legal, financial and copy prep before you go to market.",
+    icon: "clipboard-list",
+    group: "selling",
+    providerPreference: "any",
+    keywords: [
+      "listing readiness", "get ready to sell", "exit ready", "data room",
+      "due diligence pack", "valuation", "information memorandum", "im",
+      "pitch deck", "prepare to sell", "vendor due diligence",
+    ],
+    examples: [
+      "I want my business sale-ready: clean financials, a data room and a valuation.",
+      "Preparing to list — I need help building an information memorandum and getting a defensible price.",
+    ],
+  },
+];
+
+/** Map of template → its canonical intent (first catalog entry for that template). */
+const INTENT_BY_TEMPLATE = new Map<BriefTemplate, IntentDef>();
+for (const intent of INTENT_CATALOG) {
+  if (!INTENT_BY_TEMPLATE.has(intent.template)) {
+    INTENT_BY_TEMPLATE.set(intent.template, intent);
+  }
+}
+
+const INTENT_BY_ID = new Map<string, IntentDef>(
+  INTENT_CATALOG.map((i) => [i.id, i]),
+);
+
+export function getIntentById(id: string | null | undefined): IntentDef | undefined {
+  if (!id) return undefined;
+  return INTENT_BY_ID.get(id);
+}
+
+export function intentForTemplate(
+  template: BriefTemplate | null | undefined,
+): IntentDef | undefined {
+  if (!template) return undefined;
+  return INTENT_BY_TEMPLATE.get(template);
+}
+
+export function popularIntents(): IntentDef[] {
+  return INTENT_CATALOG.filter((i) => i.popular);
+}
+
+export function intentsForGroup(group: IntentGroup): IntentDef[] {
+  return INTENT_CATALOG.filter((i) => i.group === group);
+}
+
+/**
+ * Rank intents against a free-text query. Returns the full catalog
+ * (unranked, original order) for an empty query, or a relevance-ordered
+ * subset otherwise. Scoring favours, in order: label prefix, label
+ * substring, tagline substring, keyword exact, keyword substring.
+ */
+export function searchIntents(query: string): IntentDef[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return [...INTENT_CATALOG];
+
+  const scored: { intent: IntentDef; score: number }[] = [];
+  for (const intent of INTENT_CATALOG) {
+    const label = intent.label.toLowerCase();
+    const tagline = intent.tagline.toLowerCase();
+    let score = 0;
+
+    if (label.startsWith(q)) score = Math.max(score, 100);
+    else if (label.includes(q)) score = Math.max(score, 80);
+    if (tagline.includes(q)) score = Math.max(score, 50);
+
+    for (const kw of intent.keywords) {
+      if (kw === q) score = Math.max(score, 70);
+      else if (kw.startsWith(q)) score = Math.max(score, 55);
+      else if (kw.includes(q) || q.includes(kw)) score = Math.max(score, 40);
+    }
+
+    if (score > 0) scored.push({ intent, score });
+  }
+
+  return scored
+    .sort((a, b) => b.score - a.score)
+    .map((s) => s.intent);
+}


### PR DESCRIPTION
## Brief Studio — rebuilding `/briefs/new` to the category gold standard

`/briefs/new` is the front door to the provider marketplace, but it never **sold the core promise**: post once, verified pros respond, *you* compare and choose. This rebuilds the creation experience into an intent-first, "post a brief → get responses → pick your pro" flow — Airtasker-grade, re-cast for Australian financial services and bounded by our lean-lane compliance posture.

**No backend, schema, or API-contract changes.** The form still POSTs the exact same body to `/api/briefs` (and preserves the `plan_id` → `/api/get-matched/plans/{id}/to-brief` path), all 14 templates, payload schemas, workspace prefill, the Investor Pro perk, and the AI co-pilot endpoint. That keeps this a page-UI change.

### What's new
- **Intent-first entry** (`lib/briefs/intent-catalog.ts`) — a searchable, grouped gallery that maps every consumer journey onto the 14 canonical `brief_template`s, with quiz-grade keywords so "refinance", "FIRB", "CGT", "second opinion", and "sell my business" all resolve. A **first-class freeform / AI-co-pilot path** drives the `ai_match_request_copilot` flag when on and gracefully seeds a general brief when off — so everyone gets the freeform door.
- **Live "what pros will see" masked preview** (`BriefPreviewCard`, mirrors `maskBriefForProvider`) + a deterministic **brief-strength meter** (`lib/briefs/brief-strength.ts`, mirroring the AI quality rubric) that coaches better briefs with zero API calls.
- **Matching step reframed** around "Open to multiple pros — compare & choose" as the recommended default, with **honest live social proof** (a real active-pro count, shown only above a floor so we never advertise an empty marketplace).
- **Craft**: draft autosave + restore, CSS step animations (reduced-motion aware via the global guard), reused house primitives (`Button`/`Input`/`Select`/`Badge`/`FormStepper`/`SearchInput`/`ResultCount`), and a vivid success state that orients the user to compare-and-pick.

### Compliance guardrails honored
- No new `brief_payload` keys (notes-only templates use `.strict()` schemas — adding keys would 400).
- No personal-advice framing ("verified pros respond / you choose", never "we recommend pro X for you").
- No client money / escrow; nothing here charges the consumer. PII masking preserved.
- Honest numbers only — real `professionals` count (anon client, RLS-scoped), hidden below a floor; no fabricated metrics.
- Disclaimers stay in the canonical `lib/compliance.ts` framing.

### Verification
- `tsc --noEmit` clean · `eslint --max-warnings 0` clean · 237 tests pass (new: intent-catalog + brief-strength unit tests, IntentPicker + BriefStrengthMeter component tests).
- Production `next build` compiles the changed code cleanly and every icon used resolves. The critical get-matched → brief e2e is intact (it keys off the preserved "Pre-filled from your Action Plan" banner).

### Phase 2 (scoped in `docs/plans/BRIEF_STUDIO.md`, not in this PR)
The Airtasker-style **offers board** on `app/briefs/[slug]` — multiple pro responses as comparable cards (pitch, verified credentials, outcome score, shortlist, message) with a "choose this pro" action — building on the existing `brief_shortlist`, `brief_messages`, and outcome-scoring tables. That touches the accepted flow and warrants its own PR.

https://claude.ai/code/session_01FdSEBPnPofJaBPhWy1dggf

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdSEBPnPofJaBPhWy1dggf)_