### PR TITLE
refactor(advisors): make Get-quotes a compact toolbar option, drop the bottom band

### DIFF
--- a/__tests__/components/AdvisorsClient.test.tsx
+++ b/__tests__/components/AdvisorsClient.test.tsx
@@ -158,12 +158,14 @@ describe("AdvisorsClient — compact header redesign", () => {
     expect(screen.queryByRole("button", { name: /^compact$/i })).not.toBeInTheDocument();
   });
 
-  it("renders the 'Get quotes from verified pros' CTA linking to the brief flow", () => {
+  it("exposes a compact 'Get quotes' option in the toolbar linking to the brief flow", () => {
     render(<AdvisorsClient professionals={professionals} />);
-    expect(
-      screen.getByRole("heading", { name: /Get quotes from verified pros/i }),
-    ).toBeInTheDocument();
+    // Compact top-bar option (not the big bottom band) → /briefs/new.
     const cta = screen.getByRole("link", { name: /^Get quotes$/i });
     expect(cta).toHaveAttribute("href", "/briefs/new");
+    // The big bottom-band heading is gone.
+    expect(
+      screen.queryByRole("heading", { name: /Get quotes from verified pros/i }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/app/advisors/AdvisorsClient.tsx
+++ b/app/advisors/AdvisorsClient.tsx
@@ -770,6 +770,16 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
             id="advisor-search"
           />
           <GetMatchedEmbed context="advisor_directory" inline />
+          <Link
+            href="/briefs/new"
+            onClick={() =>
+              trackEvent("get_quotes_cta_clicked", { source: "advisors_toolbar" })
+            }
+            className="inline-flex shrink-0 items-center gap-1.5 rounded-lg border border-slate-300 bg-white px-3 md:px-4 py-2 text-sm font-semibold text-slate-700 whitespace-nowrap transition-colors hover:border-slate-400 hover:text-slate-900"
+          >
+            <Icon name="file-text" size={14} />
+            Get quotes
+          </Link>
           <button
             type="button"
             onClick={() => setFiltersOpen(true)}
@@ -1466,39 +1476,6 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
             <button onClick={() => setPage(p => Math.min(totalPages, p + 1))} disabled={page === totalPages} className="px-3 py-2 text-xs font-semibold border border-slate-200 rounded-lg hover:bg-slate-50 disabled:opacity-40 disabled:cursor-not-allowed">Next {"\u2192"}</button>
           </div>
         )}
-
-        {/* Reverse-marketplace CTA \u2014 post a brief to get competing quotes from
-            verified individuals, firms or Pro Squads. Mirrors the /briefs/new
-            hero branding (dark + amber) so the destination feels connected. */}
-        <section className="mt-8 md:mt-12">
-          <div className="relative overflow-hidden rounded-2xl bg-gradient-to-br from-slate-900 via-slate-900 to-slate-800 px-6 py-8 shadow-sm md:px-10 md:py-10">
-            <div className="flex flex-col gap-5 md:flex-row md:items-center md:justify-between md:gap-8">
-              <div className="max-w-2xl">
-                <p className="mb-2 text-[0.7rem] font-semibold uppercase tracking-widest text-amber-400">
-                  Match Request \u00b7 Australia
-                </p>
-                <h2 className="text-xl font-extrabold text-white md:text-2xl">
-                  Get quotes from verified pros
-                </h2>
-                <p className="mt-2 text-sm leading-relaxed text-slate-300">
-                  Tell verified Australian professionals, firms or Pro Squads what you
-                  need help with. They&apos;ll see a masked preview and respond only if
-                  it&apos;s a fit \u2014 you stay in control of who sees your contact details.
-                </p>
-              </div>
-              <Link
-                href="/briefs/new"
-                onClick={() =>
-                  trackEvent("get_quotes_cta_clicked", { source: "advisors_directory" })
-                }
-                className="inline-flex shrink-0 items-center justify-center gap-1.5 rounded-xl bg-amber-500 px-5 py-3 text-sm font-bold text-slate-900 transition-colors hover:bg-amber-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
-              >
-                Get quotes
-                <Icon name="arrow-right" size={15} />
-              </Link>
-            </div>
-          </div>
-        </section>
 
         {/* Editorial content */}
         {editorial && (


### PR DESCRIPTION
Per your feedback — the "Get quotes" entry point should be a **small option in the top toolbar**, not the big band at the bottom.

- ❌ Removed the bottom dark "Get quotes from verified pros" band.
- ✅ Added a compact **"Get quotes"** button to the toolbar row (alongside Get Matched / All filters / Sort), still linking to `/briefs/new`.

Net: **+16 / −37** (mostly removal). `tsc` clean · `eslint --max-warnings 0` clean · 11 `/advisors` tests pass (the test now asserts the compact toolbar link and that the big-band heading is gone).

https://claude.ai/code/session_012cKsbjxnQ77BH1ACPqyTCj

---
_Generated by [Claude Code](https://claude.ai/code/session_012cKsbjxnQ77BH1ACPqyTCj)_