### PR TITLE
feat(community): master plan + Phase 0 safety layer (publish gate, mod queue, expert answers)

### DIFF
--- a/__tests__/api/advisor-auth-posts.test.ts
+++ b/__tests__/api/advisor-auth-posts.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+// classifyText runs REAL — it's pure and the publish gate is the unit under test.
+
+const { mockRequireAdvisorSession, mockNotifyUser } = vi.hoisted(() => ({
+  mockRequireAdvisorSession: vi.fn(),
+  mockNotifyUser: vi.fn(),
+}));
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: mockRequireAdvisorSession,
+}));
+
+const mockAdminFrom = vi.fn();
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({ from: mockAdminFrom }),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: vi.fn(() => Promise.resolve(false)),
+}));
+
+vi.mock("@/lib/notifications", () => ({
+  notifyUser: (...args: unknown[]) => mockNotifyUser(...args),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+}));
+
+import { POST } from "@/app/api/advisor-auth/posts/route";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function makePost(body: Record<string, unknown>): NextRequest {
+  return new NextRequest("http://localhost/api/advisor-auth/posts", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-forwarded-for": "1.2.3.4" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeChain(result: unknown) {
+  const c: Record<string, unknown> = {};
+  for (const m of ["select", "insert", "update", "eq", "limit", "order"]) {
+    c[m] = vi.fn(() => c);
+  }
+  c.single = vi.fn(() => Promise.resolve(result));
+  c.maybeSingle = vi.fn(() => Promise.resolve(result));
+  c.then = (cb: (v: unknown) => void) => {
+    cb(result);
+    return Promise.resolve(result);
+  };
+  return c;
+}
+
+const CLEAN_BODY = {
+  body: "Sharing a quick explainer I wrote for clients comparing ETF management fee tiers and what the difference compounds to over a decade.",
+  post_type: "insight",
+};
+
+const CREATED_POST = { id: 42, professional_id: 7, body: CLEAN_BODY.body, status: "published" };
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("POST /api/advisor-auth/posts — publish gate + follower notifications", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdvisorSession.mockResolvedValue(7);
+    mockNotifyUser.mockResolvedValue(true);
+    // Default success sequence: insert post → follows lookup (none).
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) return makeChain({ data: CREATED_POST, error: null }); // insert
+      return makeChain({ data: [], error: null }); // follows
+    });
+  });
+
+  it("returns 401 when there is no advisor session", async () => {
+    mockRequireAdvisorSession.mockResolvedValue(null);
+    const res = await POST(makePost(CLEAN_BODY));
+    expect(res.status).toBe(401);
+  });
+
+  it("publishes a clean post (201)", async () => {
+    const res = await POST(makePost(CLEAN_BODY));
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.post).toMatchObject({ id: 42, status: "published" });
+  });
+
+  it("blocks forward-looking return promises with an RG 170 message, persisting nothing", async () => {
+    const res = await POST(
+      makePost({
+        body: "My model portfolio is guaranteed to return 15% next year — get in before it doubles your money.",
+        post_type: "insight",
+      }),
+    );
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/forward-looking/i);
+    expect(mockAdminFrom).not.toHaveBeenCalled();
+  });
+
+  it("blocks sub-floor throwaway posts with the generic guideline message", async () => {
+    const res = await POST(makePost({ body: "hi mate", post_type: "update" }));
+    expect(res.status).toBe(400);
+    expect(mockAdminFrom).not.toHaveBeenCalled();
+  });
+
+  it("notifies each follower once with a dedup key when the post publishes", async () => {
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) return makeChain({ data: CREATED_POST, error: null }); // insert
+      if (call === 2)
+        return makeChain({
+          data: [{ follower_user_id: "user-a" }, { follower_user_id: "user-b" }],
+          error: null,
+        }); // follows
+      return makeChain({ data: { name: "Jane Adviser" }, error: null }); // professional
+    });
+
+    const res = await POST(makePost(CLEAN_BODY));
+    expect(res.status).toBe(201);
+    expect(mockNotifyUser).toHaveBeenCalledTimes(2);
+    expect(mockNotifyUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user-a",
+        type: "announcement",
+        title: expect.stringContaining("Jane Adviser"),
+        emailDeliveryKey: "advisor_post_42",
+      }),
+    );
+  });
+
+  it("does not notify when the advisor has no followers", async () => {
+    const res = await POST(makePost(CLEAN_BODY));
+    expect(res.status).toBe(201);
+    expect(mockNotifyUser).not.toHaveBeenCalled();
+  });
+
+  it("still returns 201 when notification fan-out fails", async () => {
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) return makeChain({ data: CREATED_POST, error: null });
+      if (call === 2)
+        return makeChain({ data: [{ follower_user_id: "user-a" }], error: null });
+      return makeChain({ data: { name: "Jane Adviser" }, error: null });
+    });
+    mockNotifyUser.mockRejectedValue(new Error("inbox down"));
+
+    const res = await POST(makePost(CLEAN_BODY));
+    expect(res.status).toBe(201);
+  });
+});

--- a/__tests__/api/community-moderate.test.ts
+++ b/__tests__/api/community-moderate.test.ts
@@ -31,6 +31,15 @@ vi.mock("@/lib/logger", () => ({
   logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() })),
 }));
 
+const { mockRecountThread, mockRecountCategory } = vi.hoisted(() => ({
+  mockRecountThread: vi.fn((..._args: unknown[]) => Promise.resolve()),
+  mockRecountCategory: vi.fn((..._args: unknown[]) => Promise.resolve()),
+}));
+vi.mock("@/lib/community/recount", () => ({
+  recountThread: (...args: unknown[]) => mockRecountThread(...args),
+  recountCategory: (...args: unknown[]) => mockRecountCategory(...args),
+}));
+
 import { POST } from "@/app/api/community/moderate/route";
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
@@ -210,6 +219,104 @@ describe("POST /api/community/moderate", () => {
       mockAdminFrom.mockImplementation(makeReportAdminFrom({ target: null }));
       const res = await POST(makeRequest({ action: "report", target_type: "post", target_id: 999 }));
       expect(res.status).toBe(404);
+    });
+  });
+
+  // ── Approve / dismiss_report (Phase 0 moderation queue) ──
+  describe("approve and dismiss_report actions", () => {
+    // Dispatches admin .from() by table: content tables get an update
+    // builder, forum_reports gets a thenable update→eq chain we can assert.
+    function makeVisibilityAdminFrom(contentData: Record<string, unknown>) {
+      const reportsUpdate = vi.fn();
+      const reportsChain = {
+        update: reportsUpdate.mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        then: (cb: (v: unknown) => void) => {
+          cb({ error: null });
+          return Promise.resolve({ error: null });
+        },
+      };
+      const dispatch = (table: string) => {
+        if (table === "forum_reports") return reportsChain;
+        return makeUpdateBuilder(contentData);
+      };
+      return { dispatch, reportsUpdate };
+    }
+
+    it("approve thread: un-removes, closes reports as reviewed, recounts category (200)", async () => {
+      mockGetUser.mockResolvedValue({ data: { user: ADMIN_USER }, error: null });
+      const { dispatch, reportsUpdate } = makeVisibilityAdminFrom({
+        id: 1,
+        title: "Held thread",
+        category_id: "cat-1",
+        is_removed: false,
+        updated_at: "now",
+      });
+      mockAdminFrom.mockImplementation(dispatch);
+
+      const res = await POST(makeRequest({ action: "approve", thread_id: 1 }));
+      expect(res.status).toBe(200);
+      expect(reportsUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "reviewed", resolved_by: ADMIN_USER.id }),
+      );
+      expect(mockRecountCategory).toHaveBeenCalledWith("cat-1");
+    });
+
+    it("approve post: un-removes, recounts thread + parent category (200)", async () => {
+      mockGetUser.mockResolvedValue({ data: { user: ADMIN_USER }, error: null });
+      const { dispatch } = makeVisibilityAdminFrom({
+        id: 7,
+        thread_id: 3,
+        category_id: "cat-2",
+        is_removed: false,
+        updated_at: "now",
+      });
+      mockAdminFrom.mockImplementation(dispatch);
+
+      const res = await POST(makeRequest({ action: "approve", post_id: 7 }));
+      expect(res.status).toBe(200);
+      expect(mockRecountThread).toHaveBeenCalledWith(3);
+    });
+
+    it("remove thread closes open reports as action_taken", async () => {
+      mockGetUser.mockResolvedValue({ data: { user: ADMIN_USER }, error: null });
+      const { dispatch, reportsUpdate } = makeVisibilityAdminFrom({
+        id: 1,
+        title: "Bad thread",
+        category_id: "cat-1",
+        is_removed: true,
+        updated_at: "now",
+      });
+      mockAdminFrom.mockImplementation(dispatch);
+
+      const res = await POST(makeRequest({ action: "remove", thread_id: 1 }));
+      expect(res.status).toBe(200);
+      expect(reportsUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "action_taken" }),
+      );
+    });
+
+    it("dismiss_report closes reports without touching content (200)", async () => {
+      mockGetUser.mockResolvedValue({ data: { user: ADMIN_USER }, error: null });
+      const { dispatch, reportsUpdate } = makeVisibilityAdminFrom({ id: 1 });
+      mockAdminFrom.mockImplementation(dispatch);
+
+      const res = await POST(
+        makeRequest({ action: "dismiss_report", target_type: "thread", target_id: 1 }),
+      );
+      expect(res.status).toBe(200);
+      expect(reportsUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "dismissed" }),
+      );
+      // Content tables untouched.
+      expect(mockAdminFrom).not.toHaveBeenCalledWith("forum_threads");
+    });
+
+    it("approve requires moderator (403 for regular users)", async () => {
+      mockGetUser.mockResolvedValue({ data: { user: REGULAR_USER }, error: null });
+      mockAdminFrom.mockReturnValue(makeModeratorBuilder(false));
+      const res = await POST(makeRequest({ action: "approve", thread_id: 1 }));
+      expect(res.status).toBe(403);
     });
   });
 });

--- a/__tests__/api/community-posts.test.ts
+++ b/__tests__/api/community-posts.test.ts
@@ -22,6 +22,26 @@ vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
 }));
 
+const { mockGateForumContent, mockIsCommunityPostingDisabled, mockNotifyUser } = vi.hoisted(
+  () => ({
+    mockGateForumContent: vi.fn(),
+    mockIsCommunityPostingDisabled: vi.fn(),
+    mockNotifyUser: vi.fn(),
+  }),
+);
+vi.mock("@/lib/community/moderation", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/community/moderation")>();
+  return {
+    ...actual,
+    gateForumContent: (...args: unknown[]) => mockGateForumContent(...args),
+    isCommunityPostingDisabled: () => mockIsCommunityPostingDisabled(),
+  };
+});
+vi.mock("@/lib/posthog/server", () => ({ captureServerEvent: vi.fn() }));
+vi.mock("@/lib/notifications", () => ({
+  notifyUser: (...args: unknown[]) => mockNotifyUser(...args),
+}));
+
 import { POST } from "@/app/api/community/posts/route";
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
@@ -106,6 +126,9 @@ describe("POST /api/community/posts", () => {
     vi.clearAllMocks();
     mockAuth.getUser.mockResolvedValue({ data: { user: TEST_USER }, error: null });
     mockIsRateLimited.mockResolvedValue(false);
+    mockIsCommunityPostingDisabled.mockResolvedValue(false);
+    mockGateForumContent.mockResolvedValue({ action: "publish", riskScore: 0, reasons: ["clean"] });
+    mockNotifyUser.mockResolvedValue(true);
     setupSuccessPath();
   });
 
@@ -235,5 +258,111 @@ describe("POST /api/community/posts", () => {
     setupSuccessPath(true);
     const res = await POST(makePost({ ...VALID_BODY, parent_id: 2 }));
     expect(res.status).toBe(201);
+  });
+
+  // ── Publish gate (Phase 0 moderation) ────────────────────────────────────────
+
+  it("returns 503 when the community_posting kill switch is on", async () => {
+    mockIsCommunityPostingDisabled.mockResolvedValue(true);
+    const res = await POST(makePost(VALID_BODY));
+    expect(res.status).toBe(503);
+    expect(mockAdminFrom).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 and persists nothing when the gate rejects", async () => {
+    mockGateForumContent.mockResolvedValue({
+      action: "reject",
+      riskScore: 90,
+      reasons: ["link_spam_5plus"],
+    });
+    const res = await POST(makePost(VALID_BODY));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/guidelines/i);
+    // Only the thread lookup ran — no insert.
+    expect(mockAdminFrom).toHaveBeenCalledTimes(1);
+  });
+
+  it("holds escalated replies: hidden insert + queue row + 202, no counter bumps", async () => {
+    mockGateForumContent.mockResolvedValue({
+      action: "hold",
+      riskScore: 35,
+      reasons: ["guaranteed_returns_language"],
+    });
+    mockAdminFrom.mockReset();
+    mockAdminFrom
+      .mockImplementationOnce(() => makeChain({ data: OPEN_THREAD, error: null })) // thread
+      .mockImplementationOnce(() => makeChain({ data: CREATED_POST, error: null })) // insert
+      .mockImplementationOnce(() => makeChain({ error: null })); // forum_reports upsert
+
+    const res = await POST(makePost(VALID_BODY));
+    expect(res.status).toBe(202);
+    const json = await res.json();
+    expect(json.pending_review).toBe(true);
+    expect(json.post).toBeNull();
+
+    const insertChain = mockAdminFrom.mock.results[1].value as { insert: ReturnType<typeof vi.fn> };
+    expect(insertChain.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ is_removed: true }),
+    );
+    const reportChain = mockAdminFrom.mock.results[2].value as { upsert: ReturnType<typeof vi.fn> };
+    expect(reportChain.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target_type: "post",
+        status: "open",
+        reason: expect.stringMatching(/^auto_moderation:/),
+      }),
+      expect.anything(),
+    );
+    expect(mockNotifyUser).not.toHaveBeenCalled();
+    expect(mockAdminFrom).toHaveBeenCalledTimes(3);
+  });
+
+  // ── Reply notifications ──────────────────────────────────────────────────────
+
+  it("notifies the thread author on a published reply from another user", async () => {
+    const ownedThread = {
+      ...OPEN_THREAD,
+      author_id: "thread-owner",
+      title: "Best ETF platform?",
+    };
+    mockAdminFrom.mockReset();
+    let callIndex = 0;
+    mockAdminFrom.mockImplementation(() => {
+      callIndex++;
+      if (callIndex === 1) return makeChain({ data: ownedThread, error: null }); // thread
+      if (callIndex === 2) return makeChain({ data: CREATED_POST, error: null }); // insert
+      if (callIndex === 3) return makeChain({ data: { slug: "etfs-index-funds" }, error: null }); // category slug
+      if (callIndex === 4) return makeChain({ data: { reply_count: 0 }, error: null });
+      return makeChain({ data: { post_count: 0 }, error: null });
+    });
+
+    const res = await POST(makePost(VALID_BODY));
+    expect(res.status).toBe(201);
+    expect(mockNotifyUser).toHaveBeenCalledTimes(1);
+    expect(mockNotifyUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "thread-owner",
+        type: "reply",
+        linkUrl: expect.stringContaining("/community/etfs-index-funds/1"),
+      }),
+    );
+  });
+
+  it("does not notify when replying to your own thread", async () => {
+    const selfThread = { ...OPEN_THREAD, author_id: TEST_USER.id, title: "My thread" };
+    mockAdminFrom.mockReset();
+    let callIndex = 0;
+    mockAdminFrom.mockImplementation(() => {
+      callIndex++;
+      if (callIndex === 1) return makeChain({ data: selfThread, error: null });
+      if (callIndex === 2) return makeChain({ data: CREATED_POST, error: null });
+      if (callIndex === 3) return makeChain({ data: { reply_count: 0 }, error: null });
+      return makeChain({ data: { post_count: 0 }, error: null });
+    });
+
+    const res = await POST(makePost(VALID_BODY));
+    expect(res.status).toBe(201);
+    expect(mockNotifyUser).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/api/community-threads.test.ts
+++ b/__tests__/api/community-threads.test.ts
@@ -22,6 +22,21 @@ vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
 }));
 
+const { mockGateForumContent, mockIsCommunityPostingDisabled } = vi.hoisted(() => ({
+  mockGateForumContent: vi.fn(),
+  mockIsCommunityPostingDisabled: vi.fn(),
+}));
+vi.mock("@/lib/community/moderation", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/community/moderation")>();
+  return {
+    ...actual,
+    gateForumContent: (...args: unknown[]) => mockGateForumContent(...args),
+    isCommunityPostingDisabled: () => mockIsCommunityPostingDisabled(),
+  };
+});
+
+vi.mock("@/lib/posthog/server", () => ({ captureServerEvent: vi.fn() }));
+
 import { GET, POST } from "@/app/api/community/threads/route";
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
@@ -250,6 +265,8 @@ describe("POST /api/community/threads", () => {
     vi.clearAllMocks();
     mockAuth.getUser.mockResolvedValue({ data: { user: TEST_USER }, error: null });
     mockIsRateLimited.mockResolvedValue(false);
+    mockIsCommunityPostingDisabled.mockResolvedValue(false);
+    mockGateForumContent.mockResolvedValue({ action: "publish", riskScore: 0, reasons: ["clean"] });
     setupSuccessPath();
   });
 
@@ -343,5 +360,75 @@ describe("POST /api/community/threads", () => {
     expect(insertChain.insert).toHaveBeenCalledWith(
       expect.objectContaining({ author_name: "Anonymous" }),
     );
+  });
+
+  // ── Publish gate (Phase 0 moderation) ────────────────────────────────────────
+
+  it("returns 503 when the community_posting kill switch is on", async () => {
+    mockIsCommunityPostingDisabled.mockResolvedValue(true);
+    const res = await POST(makePostReq(VALID_POST_BODY));
+    expect(res.status).toBe(503);
+    const json = await res.json();
+    expect(json.error).toMatch(/paused/i);
+    // Nothing persisted — not even the category lookup runs.
+    expect(mockAdminFrom).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 and persists nothing when the gate rejects", async () => {
+    mockGateForumContent.mockResolvedValue({
+      action: "reject",
+      riskScore: 80,
+      reasons: ["scam_terminology"],
+    });
+    const res = await POST(makePostReq(VALID_POST_BODY));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/guidelines/i);
+    // Only the category lookup ran — no insert.
+    expect(mockAdminFrom).toHaveBeenCalledTimes(1);
+  });
+
+  it("publishes visible content with is_removed=false", async () => {
+    const res = await POST(makePostReq(VALID_POST_BODY));
+    expect(res.status).toBe(201);
+    const insertChain = mockAdminFrom.mock.results[1].value as { insert: ReturnType<typeof vi.fn> };
+    expect(insertChain.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ is_removed: false }),
+    );
+  });
+
+  it("holds escalated content: hidden insert + forum_reports queue row + 202, no counter bumps", async () => {
+    mockGateForumContent.mockResolvedValue({
+      action: "hold",
+      riskScore: 40,
+      reasons: ["forward_looking_price_target"],
+    });
+    mockAdminFrom.mockReset();
+    mockAdminFrom
+      .mockImplementationOnce(() => makeChain({ data: CATEGORY, error: null })) // category
+      .mockImplementationOnce(() => makeChain({ data: CREATED_THREAD, error: null })) // insert
+      .mockImplementationOnce(() => makeChain({ error: null })); // forum_reports upsert
+
+    const res = await POST(makePostReq(VALID_POST_BODY));
+    expect(res.status).toBe(202);
+    const json = await res.json();
+    expect(json.pending_review).toBe(true);
+    expect(json.thread).toBeNull();
+
+    const insertChain = mockAdminFrom.mock.results[1].value as { insert: ReturnType<typeof vi.fn> };
+    expect(insertChain.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ is_removed: true }),
+    );
+    const reportChain = mockAdminFrom.mock.results[2].value as { upsert: ReturnType<typeof vi.fn> };
+    expect(reportChain.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        target_type: "thread",
+        status: "open",
+        reason: expect.stringMatching(/^auto_moderation:/),
+      }),
+      expect.anything(),
+    );
+    // Category counter + profile bumps must be skipped for held content.
+    expect(mockAdminFrom).toHaveBeenCalledTimes(3);
   });
 });

--- a/__tests__/lib/community-moderation.test.ts
+++ b/__tests__/lib/community-moderation.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// classifier-config hits Supabase — stub both helpers. getThreshold returns
+// the caller's default unless a test overrides mockHoldAll.
+const { mockHoldAll, mockFeatureDisabled } = vi.hoisted(() => ({
+  mockHoldAll: vi.fn<() => number | undefined>(() => undefined),
+  mockFeatureDisabled: vi.fn(() => Promise.resolve(false)),
+}));
+vi.mock("@/lib/admin/classifier-config", () => ({
+  getThreshold: vi.fn((_classifier: string, _name: string, fallback: number) =>
+    Promise.resolve(mockHoldAll() ?? fallback),
+  ),
+  isFeatureDisabled: () => mockFeatureDisabled(),
+}));
+
+import {
+  autoModerationReason,
+  gateForumContent,
+  isAutoModerationReason,
+  isCommunityPostingDisabled,
+} from "@/lib/community/moderation";
+
+const CLEAN_BODY =
+  "I have been comparing a few brokerage platforms for ASX shares and wanted to hear what fees others are actually paying. My current platform charges flat brokerage but the FX spread on US trades seems high.";
+
+describe("gateForumContent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockHoldAll.mockReturnValue(undefined);
+  });
+
+  it("publishes clean discussion content", async () => {
+    const result = await gateForumContent({
+      kind: "thread",
+      title: "What brokerage fees are you actually paying?",
+      body: CLEAN_BODY,
+    });
+    expect(result.action).toBe("publish");
+  });
+
+  it("publishes short conversational forum replies", async () => {
+    const result = await gateForumContent({ kind: "post", body: "Thanks, that helped a lot!" });
+    expect(result.action).toBe("publish");
+  });
+
+  it("holds forward-looking return promises (ASIC escalation)", async () => {
+    const result = await gateForumContent({
+      kind: "post",
+      body: "Just buy in now — this strategy is guaranteed to return 15% a year, can't lose.",
+    });
+    expect(result.action).toBe("hold");
+    expect(result.reasons.join(",")).toMatch(/forward_looking|guaranteed/);
+  });
+
+  it("holds defamation-risk accusations for human review", async () => {
+    const result = await gateForumContent({
+      kind: "post",
+      body: "This platform scammed me out of my deposit and the directors are criminals who stole my money.",
+    });
+    expect(result.action).toBe("hold");
+  });
+
+  it("rejects explicit scam terminology outright", async () => {
+    const result = await gateForumContent({
+      kind: "thread",
+      title: "Great opportunity",
+      body: "Join my pyramid scheme group, it works like a ponzi but legal, message me for the link.",
+    });
+    expect(result.action).toBe("reject");
+  });
+
+  it("holds everything when forum_moderation.hold_all is set (raid mode)", async () => {
+    mockHoldAll.mockReturnValue(1);
+    const result = await gateForumContent({
+      kind: "thread",
+      title: "What brokerage fees are you actually paying?",
+      body: CLEAN_BODY,
+    });
+    expect(result.action).toBe("hold");
+    expect(result.reasons).toContain("hold_all_active");
+  });
+});
+
+describe("kill switch + queue-reason helpers", () => {
+  it("isCommunityPostingDisabled proxies the automation kill switch", async () => {
+    mockFeatureDisabled.mockResolvedValueOnce(true);
+    expect(await isCommunityPostingDisabled()).toBe(true);
+    expect(await isCommunityPostingDisabled()).toBe(false);
+  });
+
+  it("autoModerationReason prefixes and caps at the column limit (500)", () => {
+    const reason = autoModerationReason(["a".repeat(600)]);
+    expect(reason.startsWith("auto_moderation:")).toBe(true);
+    expect(reason.length).toBeLessThanOrEqual(500);
+  });
+
+  it("isAutoModerationReason distinguishes system holds from user reports", () => {
+    expect(isAutoModerationReason("auto_moderation:spam")).toBe(true);
+    expect(isAutoModerationReason("this post is offensive")).toBe(false);
+    expect(isAutoModerationReason(null)).toBe(false);
+  });
+});

--- a/__tests__/lib/text-moderation.test.ts
+++ b/__tests__/lib/text-moderation.test.ts
@@ -220,3 +220,33 @@ describe("classifyText — forward-looking escalation", () => {
     expect(r.verdict).toBe("escalate");
   });
 });
+
+describe("classifyText — forum surfaces", () => {
+  it("auto-publishes short conversational forum replies (no 50-char floor)", () => {
+    const r = classifyText({ text: "Thanks, great answer!", surface: "forum_post" });
+    expect(r.verdict).toBe("auto_publish");
+  });
+
+  it("auto-publishes a short-but-real forum thread body (20-char floor)", () => {
+    const r = classifyText({
+      text: "Which broker is cheapest for monthly ETF buys?",
+      title: "Cheapest broker for ETF investing",
+      surface: "forum_thread",
+    });
+    expect(r.verdict).toBe("auto_publish");
+  });
+
+  it("escalates sub-floor forum thread bodies", () => {
+    const r = classifyText({ text: "buy now", title: "Hot tip", surface: "forum_thread" });
+    expect(r.verdict).toBe("escalate");
+  });
+
+  it("still escalates forward-looking hype on forum posts", () => {
+    const r = classifyText({
+      text: "Mate trust me, this is the next bitcoin and it will hit $50 by December.",
+      surface: "forum_post",
+    });
+    expect(r.verdict).toBe("escalate");
+    expect(r.reasons.some((x) => x.includes("forward_looking") || x.includes("hype"))).toBe(true);
+  });
+});

--- a/app/admin/community/page.tsx
+++ b/app/admin/community/page.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import AdminShell from "@/components/AdminShell";
+import { logger } from "@/lib/logger";
+
+const log = logger("admin-community-page");
+
+type QueueItem = {
+  report_id: number;
+  target_type: "thread" | "post";
+  target_id: number;
+  reason: string | null;
+  is_auto_hold: boolean;
+  reported_at: string;
+  title: string | null;
+  body_excerpt: string | null;
+  author_name: string | null;
+  is_removed: boolean | null;
+  thread_id: number | null;
+  category_slug: string | null;
+};
+
+type RowState = { busy: boolean; done: string | null; error: string | null };
+
+export default function AdminCommunityPage() {
+  const [items, setItems] = useState<QueueItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [states, setStates] = useState<Record<number, RowState>>({});
+
+  const loadQueue = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const res = await fetch("/api/admin/community");
+      if (!res.ok) throw new Error(`${res.status}`);
+      const json = (await res.json()) as { items: QueueItem[] };
+      setItems(json.items);
+      const initial: Record<number, RowState> = {};
+      for (const item of json.items) {
+        initial[item.report_id] = { busy: false, done: null, error: null };
+      }
+      setStates(initial);
+    } catch (err) {
+      log.error("queue load failed", { err: err instanceof Error ? err.message : String(err) });
+      setLoadError("Failed to load the moderation queue.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadQueue();
+  }, [loadQueue]);
+
+  const act = useCallback(
+    async (
+      item: QueueItem,
+      action: "approve" | "remove" | "dismiss_report",
+    ) => {
+      setStates((prev) => ({
+        ...prev,
+        [item.report_id]: { busy: true, done: null, error: null },
+      }));
+      try {
+        const payload: Record<string, unknown> = { action };
+        if (action === "dismiss_report") {
+          payload.target_type = item.target_type;
+          payload.target_id = item.target_id;
+        } else if (item.target_type === "thread") {
+          payload.thread_id = item.target_id;
+        } else {
+          payload.post_id = item.target_id;
+        }
+        const res = await fetch("/api/community/moderate", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+        if (!res.ok) {
+          const json = (await res.json().catch(() => null)) as { error?: string } | null;
+          throw new Error(json?.error ?? `${res.status}`);
+        }
+        const label =
+          action === "approve" ? "Approved" : action === "remove" ? "Removed" : "Dismissed";
+        setStates((prev) => ({
+          ...prev,
+          [item.report_id]: { busy: false, done: label, error: null },
+        }));
+      } catch (err) {
+        setStates((prev) => ({
+          ...prev,
+          [item.report_id]: {
+            busy: false,
+            done: null,
+            error: err instanceof Error ? err.message : "Action failed",
+          },
+        }));
+      }
+    },
+    [],
+  );
+
+  const pending = items.filter((i) => !states[i.report_id]?.done);
+
+  return (
+    <AdminShell title="Community moderation">
+      <div className="mb-6 flex items-center justify-between gap-4 flex-wrap">
+        <p className="text-sm text-slate-600 max-w-2xl">
+          Open queue items: classifier holds (content hidden until approved) and
+          user reports (content still live unless removed). Approve restores
+          visibility, Remove hides it, Dismiss closes the report without
+          touching the content. Counters recount automatically.
+        </p>
+        <button
+          onClick={() => void loadQueue()}
+          className="text-sm font-semibold text-slate-600 hover:text-slate-900 border border-slate-200 rounded-lg px-3 py-1.5 transition-colors"
+        >
+          Refresh
+        </button>
+      </div>
+
+      {loading && <p className="text-sm text-slate-500">Loading queue…</p>}
+      {loadError && <p className="text-sm text-red-600">{loadError}</p>}
+      {!loading && !loadError && pending.length === 0 && (
+        <div className="bg-white border border-slate-200 rounded-xl p-8 text-center">
+          <p className="text-slate-900 font-semibold mb-1">Queue is clear</p>
+          <p className="text-sm text-slate-500">
+            No open holds or reports. New items appear here automatically.
+          </p>
+        </div>
+      )}
+
+      <div className="space-y-4">
+        {items.map((item) => {
+          const state = states[item.report_id] ?? { busy: false, done: null, error: null };
+          const threadHref =
+            item.category_slug && item.thread_id
+              ? `/community/${item.category_slug}/${item.thread_id}`
+              : null;
+          return (
+            <div
+              key={item.report_id}
+              className={`bg-white border rounded-xl p-5 ${
+                state.done ? "border-slate-100 opacity-60" : "border-slate-200"
+              }`}
+            >
+              <div className="flex items-center gap-2 flex-wrap mb-2">
+                <span
+                  className={`text-xs font-semibold px-2 py-0.5 rounded-full ${
+                    item.is_auto_hold
+                      ? "bg-amber-100 text-amber-700"
+                      : "bg-red-100 text-red-700"
+                  }`}
+                >
+                  {item.is_auto_hold ? "Held by classifier" : "User report"}
+                </span>
+                <span className="text-xs font-medium bg-slate-100 text-slate-600 px-2 py-0.5 rounded-full">
+                  {item.target_type}
+                </span>
+                {item.is_removed ? (
+                  <span className="text-xs font-medium bg-slate-100 text-slate-600 px-2 py-0.5 rounded-full">
+                    Hidden
+                  </span>
+                ) : (
+                  <span className="text-xs font-medium bg-emerald-100 text-emerald-700 px-2 py-0.5 rounded-full">
+                    Live
+                  </span>
+                )}
+                <span className="text-xs text-slate-400">
+                  {new Date(item.reported_at).toLocaleString("en-AU")}
+                </span>
+              </div>
+
+              {item.title && (
+                <p className="font-bold text-slate-900 text-sm mb-1">{item.title}</p>
+              )}
+              <p className="text-sm text-slate-600 mb-2 whitespace-pre-line">
+                {item.body_excerpt ?? "(content unavailable)"}
+              </p>
+              <p className="text-xs text-slate-400 mb-3">
+                By {item.author_name ?? "unknown"}
+                {item.reason && (
+                  <>
+                    {" · "}
+                    <span className="font-mono">{item.reason}</span>
+                  </>
+                )}
+                {threadHref && (
+                  <>
+                    {" · "}
+                    <Link href={threadHref} className="text-emerald-700 hover:underline" target="_blank">
+                      View thread
+                    </Link>
+                  </>
+                )}
+              </p>
+
+              {state.done ? (
+                <p className="text-sm font-semibold text-slate-500">{state.done}</p>
+              ) : (
+                <div className="flex items-center gap-2 flex-wrap">
+                  <button
+                    disabled={state.busy}
+                    onClick={() => void act(item, "approve")}
+                    className="text-sm font-semibold bg-emerald-700 hover:bg-emerald-800 text-white rounded-lg px-3 py-1.5 transition-colors disabled:opacity-50"
+                  >
+                    Approve
+                  </button>
+                  <button
+                    disabled={state.busy}
+                    onClick={() => void act(item, "remove")}
+                    className="text-sm font-semibold bg-red-600 hover:bg-red-700 text-white rounded-lg px-3 py-1.5 transition-colors disabled:opacity-50"
+                  >
+                    Remove
+                  </button>
+                  <button
+                    disabled={state.busy}
+                    onClick={() => void act(item, "dismiss_report")}
+                    className="text-sm font-semibold text-slate-600 hover:text-slate-900 border border-slate-200 rounded-lg px-3 py-1.5 transition-colors disabled:opacity-50"
+                  >
+                    Dismiss report
+                  </button>
+                  {state.error && <span className="text-xs text-red-600">{state.error}</span>}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </AdminShell>
+  );
+}

--- a/app/api/admin/community/route.ts
+++ b/app/api/admin/community/route.ts
@@ -1,0 +1,146 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { ADMIN_EMAILS } from "@/lib/admin";
+import { logger } from "@/lib/logger";
+import { isAutoModerationReason } from "@/lib/community/moderation";
+
+const log = logger("admin-community-queue");
+
+interface QueueItem {
+  report_id: number;
+  target_type: "thread" | "post";
+  target_id: number;
+  reason: string | null;
+  is_auto_hold: boolean;
+  reported_at: string;
+  // Target content (null when the row has been hard-deleted underneath us)
+  title: string | null;
+  body_excerpt: string | null;
+  author_name: string | null;
+  is_removed: boolean | null;
+  thread_id: number | null; // for posts: parent thread for linking
+  category_slug: string | null;
+}
+
+export async function GET(_req: NextRequest) {
+  const supabaseAuth = await createClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabaseAuth.auth.getUser();
+  if (authError || !user || !ADMIN_EMAILS.includes(user.email?.toLowerCase() ?? "")) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const admin = createAdminClient();
+
+  const { data: reports, error } = await admin
+    .from("forum_reports")
+    .select("id, target_type, target_id, reason, status, created_at")
+    .eq("status", "open")
+    .order("created_at", { ascending: false })
+    .limit(100);
+
+  if (error) {
+    log.error("forum_reports fetch failed", { error: error.message });
+    return NextResponse.json({ error: "Failed to fetch queue" }, { status: 500 });
+  }
+
+  const threadIds = new Set<number>();
+  const postIds = new Set<number>();
+  for (const r of reports ?? []) {
+    if (r.target_type === "thread") threadIds.add(r.target_id);
+    else postIds.add(r.target_id);
+  }
+
+  const threadMap = new Map<
+    number,
+    { title: string; body: string; author_name: string; is_removed: boolean; category_id: string }
+  >();
+  if (threadIds.size > 0) {
+    const { data: threads } = await admin
+      .from("forum_threads")
+      .select("id, title, body, author_name, is_removed, category_id")
+      .in("id", Array.from(threadIds));
+    for (const t of threads ?? []) threadMap.set(t.id, t);
+  }
+
+  const postMap = new Map<
+    number,
+    { body: string; author_name: string; is_removed: boolean; thread_id: number }
+  >();
+  if (postIds.size > 0) {
+    const { data: posts } = await admin
+      .from("forum_posts")
+      .select("id, body, author_name, is_removed, thread_id")
+      .in("id", Array.from(postIds));
+    for (const p of posts ?? []) postMap.set(p.id, p);
+  }
+
+  // Resolve category slugs for queue links (threads directly; posts via parent thread)
+  const categoryIds = new Set<string>();
+  for (const t of threadMap.values()) categoryIds.add(t.category_id);
+  const postThreadIds = new Set<number>();
+  for (const p of postMap.values()) postThreadIds.add(p.thread_id);
+  const postThreadMap = new Map<number, { category_id: string }>();
+  if (postThreadIds.size > 0) {
+    const { data: parentThreads } = await admin
+      .from("forum_threads")
+      .select("id, category_id")
+      .in("id", Array.from(postThreadIds));
+    for (const t of parentThreads ?? []) {
+      postThreadMap.set(t.id, t);
+      categoryIds.add(t.category_id);
+    }
+  }
+  const categorySlugMap = new Map<string, string>();
+  if (categoryIds.size > 0) {
+    const { data: cats } = await admin
+      .from("forum_categories")
+      .select("id, slug")
+      .in("id", Array.from(categoryIds));
+    for (const c of cats ?? []) categorySlugMap.set(c.id, c.slug);
+  }
+
+  const excerpt = (s: string | null | undefined) =>
+    s ? (s.length > 280 ? `${s.slice(0, 277)}...` : s) : null;
+
+  const items: QueueItem[] = (reports ?? []).map((r) => {
+    if (r.target_type === "thread") {
+      const t = threadMap.get(r.target_id);
+      return {
+        report_id: r.id,
+        target_type: "thread",
+        target_id: r.target_id,
+        reason: r.reason,
+        is_auto_hold: isAutoModerationReason(r.reason),
+        reported_at: r.created_at,
+        title: t?.title ?? null,
+        body_excerpt: excerpt(t?.body),
+        author_name: t?.author_name ?? null,
+        is_removed: t?.is_removed ?? null,
+        thread_id: r.target_id,
+        category_slug: t ? (categorySlugMap.get(t.category_id) ?? null) : null,
+      };
+    }
+    const p = postMap.get(r.target_id);
+    const parent = p ? postThreadMap.get(p.thread_id) : undefined;
+    return {
+      report_id: r.id,
+      target_type: "post",
+      target_id: r.target_id,
+      reason: r.reason,
+      is_auto_hold: isAutoModerationReason(r.reason),
+      reported_at: r.created_at,
+      title: null,
+      body_excerpt: excerpt(p?.body),
+      author_name: p?.author_name ?? null,
+      is_removed: p?.is_removed ?? null,
+      thread_id: p?.thread_id ?? null,
+      category_slug: parent ? (categorySlugMap.get(parent.category_id) ?? null) : null,
+    };
+  });
+
+  return NextResponse.json({ items });
+}

--- a/app/api/advisor-auth/posts/route.ts
+++ b/app/api/advisor-auth/posts/route.ts
@@ -5,8 +5,71 @@ import { requireAdvisorSession } from "@/lib/require-advisor-session";
 import { isRateLimited } from "@/lib/rate-limit";
 import { logger } from "@/lib/logger";
 import { withValidatedBody } from "@/lib/validation/withValidatedBody";
+import { classifyText } from "@/lib/text-moderation";
+import { notifyUser } from "@/lib/notifications";
 
 const log = logger("advisor-auth:posts");
+
+/** Advisor-facing message for a gated post. Advisors are professionals —
+ *  tell them which rule tripped so they can rephrase, unlike the generic
+ *  consumer-forum message. */
+function gateMessage(reasons: string[]): string {
+  const joined = reasons.join(",");
+  if (/forward_looking|guaranteed|multiplier|hype/.test(joined)) {
+    return "Posts with forward-looking price targets or return promises can't be published under our general-advice posture (ASIC RG 170). Rephrase to past performance or general information and try again.";
+  }
+  if (/legal|defamation|accusation/.test(joined)) {
+    return "Posts containing allegations about identifiable parties need review before publishing. Rephrase or contact the team.";
+  }
+  return "This post can't be published because it appears to breach our content guidelines. Edit it and try again.";
+}
+
+/** Followers are notified when an advisor publishes. Capped so one post by
+ *  a large account can't fan out into an unbounded insert loop. */
+const FOLLOWER_NOTIFY_CAP = 500;
+
+async function notifyFollowers(
+  admin: ReturnType<typeof createAdminClient>,
+  professionalId: number,
+  postId: number,
+  postType: string,
+  bodyText: string,
+): Promise<void> {
+  try {
+    const { data: followers } = await admin
+      .from("advisor_follows")
+      .select("follower_user_id")
+      .eq("following_professional_id", professionalId)
+      .limit(FOLLOWER_NOTIFY_CAP);
+    if (!followers || followers.length === 0) return;
+
+    const { data: pro } = await admin
+      .from("professionals")
+      .select("name")
+      .eq("id", professionalId)
+      .single();
+    const advisorName = pro?.name ?? "An adviser you follow";
+    const excerpt = bodyText.length > 140 ? `${bodyText.slice(0, 137)}...` : bodyText;
+
+    for (const follower of followers) {
+      await notifyUser({
+        userId: follower.follower_user_id,
+        type: "announcement",
+        title: `${advisorName} posted a new ${postType}`,
+        body: excerpt,
+        linkUrl: "/feed",
+        emailDeliveryKey: `advisor_post_${postId}`,
+      });
+    }
+  } catch (err) {
+    // Notification fan-out must never fail the post itself.
+    log.warn("Follower notification fan-out failed", {
+      professionalId,
+      postId,
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
 
 const PostSchema = z.object({
   body: z.string().min(1).max(2000),
@@ -55,6 +118,25 @@ export const POST = withValidatedBody(PostSchema, async (request, body) => {
   const professionalId = await requireAdvisorSession(request);
   if (!professionalId) return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
 
+  // Publish gate — advisor posts render on the public /feed and on profile
+  // pages with the platform's authority behind them, so they run the same
+  // classifyText pipeline as every other UGC surface. Anything short of
+  // auto_publish bounces with the specific reason so the advisor can
+  // rephrase (no hidden-hold queue for professional accounts).
+  const verdict = classifyText({
+    text: body.body,
+    title: body.link_title ?? null,
+    surface: "advisor_post",
+  });
+  if (verdict.verdict !== "auto_publish") {
+    log.warn("Advisor post blocked by publish gate", {
+      professionalId,
+      verdict: verdict.verdict,
+      reasons: verdict.reasons,
+    });
+    return NextResponse.json({ error: gateMessage(verdict.reasons) }, { status: 400 });
+  }
+
   const admin = createAdminClient();
   const { data: post, error } = await admin
     .from("advisor_posts")
@@ -74,6 +156,8 @@ export const POST = withValidatedBody(PostSchema, async (request, body) => {
     log.error("Failed to create advisor post", { error: error?.message, professionalId });
     return NextResponse.json({ error: "Failed to create post" }, { status: 500 });
   }
+
+  await notifyFollowers(admin, professionalId, post.id, body.post_type, body.body);
 
   return NextResponse.json({ post }, { status: 201 });
 });

--- a/app/api/community/moderate/route.ts
+++ b/app/api/community/moderate/route.ts
@@ -5,22 +5,52 @@ import { z } from "zod";
 import { logger } from "@/lib/logger";
 import { ADMIN_EMAILS } from "@/lib/admin";
 import { isAllowed } from "@/lib/rate-limit-db";
+import { recountCategory, recountThread } from "@/lib/community/recount";
 
 const log = logger("community:moderate");
 
-const VALID_ACTIONS = ["pin", "unpin", "lock", "unlock", "remove", "report"] as const;
+const VALID_ACTIONS = [
+  "pin",
+  "unpin",
+  "lock",
+  "unlock",
+  "remove",
+  "approve",
+  "dismiss_report",
+  "report",
+] as const;
 // Moderator-only actions (everything except "report", which any signed-in user may do).
 type ModAction = Exclude<(typeof VALID_ACTIONS)[number], "report">;
 
 const ModerateBody = z.object({
-  action: z.enum(["pin", "unpin", "lock", "unlock", "remove", "report"]),
+  action: z.enum(["pin", "unpin", "lock", "unlock", "remove", "approve", "dismiss_report", "report"]),
   thread_id: z.number().int().positive().optional(),
   post_id: z.number().int().positive().optional(),
-  // "report" payload (any authenticated, non-author user):
+  // "report" / "dismiss_report" payload:
   target_type: z.enum(["thread", "post"]).optional(),
   target_id: z.number().int().positive().optional(),
   reason: z.string().max(500).optional(),
 });
+
+/** Resolve every open report on a target (covers user reports AND the
+ *  auto_moderation hold row). Status records how the queue item ended. */
+async function closeOpenReports(
+  admin: ReturnType<typeof createAdminClient>,
+  targetType: "thread" | "post",
+  targetId: number,
+  status: "reviewed" | "dismissed" | "action_taken",
+  resolvedBy: string,
+): Promise<void> {
+  const { error } = await admin
+    .from("forum_reports")
+    .update({ status, resolved_by: resolvedBy, resolved_at: new Date().toISOString() })
+    .eq("target_type", targetType)
+    .eq("target_id", targetId)
+    .eq("status", "open");
+  if (error) {
+    log.warn("Failed to close reports", { targetType, targetId, error: error.message });
+  }
+}
 
 async function isModerator(userId: string, userEmail: string | undefined): Promise<boolean> {
   if (userEmail && ADMIN_EMAILS.includes(userEmail.toLowerCase())) return true;
@@ -159,20 +189,27 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ thread: updated });
     }
 
-    // Remove action: can target either thread or post
-    if (action === "remove") {
+    // Remove / approve: flip visibility on a thread or post, resolve any
+    // open queue rows, then recount counters from live rows (counters must
+    // only ever reflect visible content).
+    if (action === "remove" || action === "approve") {
+      const makeVisible = action === "approve";
+
       if (thread_id) {
         const { data: updated, error: updateError } = await admin
           .from("forum_threads")
-          .update({ is_removed: true, updated_at: now })
+          .update({ is_removed: !makeVisible, updated_at: now })
           .eq("id", thread_id)
-          .select("id, title, is_removed, updated_at")
+          .select("id, title, category_id, is_removed, updated_at")
           .single();
 
         if (updateError || !updated) {
-          log.error("Failed to remove thread", { thread_id, error: updateError?.message });
-          return NextResponse.json({ error: "Thread not found or removal failed" }, { status: 404 });
+          log.error("Failed to moderate thread visibility", { action, thread_id, error: updateError?.message });
+          return NextResponse.json({ error: "Thread not found or update failed" }, { status: 404 });
         }
+
+        await closeOpenReports(admin, "thread", thread_id, makeVisible ? "reviewed" : "action_taken", user.id);
+        await recountCategory(updated.category_id);
 
         return NextResponse.json({ thread: updated });
       }
@@ -180,20 +217,43 @@ export async function POST(req: NextRequest) {
       if (post_id) {
         const { data: updated, error: updateError } = await admin
           .from("forum_posts")
-          .update({ is_removed: true, updated_at: now })
+          .update({ is_removed: !makeVisible, updated_at: now })
           .eq("id", post_id)
-          .select("id, is_removed, updated_at")
+          .select("id, thread_id, is_removed, updated_at")
           .single();
 
         if (updateError || !updated) {
-          log.error("Failed to remove post", { post_id, error: updateError?.message });
-          return NextResponse.json({ error: "Post not found or removal failed" }, { status: 404 });
+          log.error("Failed to moderate post visibility", { action, post_id, error: updateError?.message });
+          return NextResponse.json({ error: "Post not found or update failed" }, { status: 404 });
+        }
+
+        await closeOpenReports(admin, "post", post_id, makeVisible ? "reviewed" : "action_taken", user.id);
+        await recountThread(updated.thread_id);
+        const { data: parentThread } = await admin
+          .from("forum_threads")
+          .select("category_id")
+          .eq("id", updated.thread_id)
+          .single();
+        if (parentThread) {
+          await recountCategory(parentThread.category_id);
         }
 
         return NextResponse.json({ post: updated });
       }
 
-      return NextResponse.json({ error: "thread_id or post_id is required for remove action" }, { status: 400 });
+      return NextResponse.json({ error: `thread_id or post_id is required for ${action} action` }, { status: 400 });
+    }
+
+    // Dismiss report(s) on a target without touching the content.
+    if (action === "dismiss_report") {
+      if (!target_type || !target_id) {
+        return NextResponse.json(
+          { error: "target_type and target_id are required to dismiss reports" },
+          { status: 400 },
+        );
+      }
+      await closeOpenReports(admin, target_type, target_id, "dismissed", user.id);
+      return NextResponse.json({ ok: true });
     }
 
     return NextResponse.json({ error: "Unhandled action" }, { status: 400 });

--- a/app/api/community/posts/route.ts
+++ b/app/api/community/posts/route.ts
@@ -4,6 +4,16 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { logger } from "@/lib/logger";
 import { isRateLimited } from "@/lib/rate-limit";
+import {
+  autoModerationReason,
+  FORUM_DISABLED_MESSAGE,
+  FORUM_HOLD_MESSAGE,
+  FORUM_REJECT_MESSAGE,
+  gateForumContent,
+  isCommunityPostingDisabled,
+} from "@/lib/community/moderation";
+import { captureServerEvent } from "@/lib/posthog/server";
+import { notifyUser } from "@/lib/notifications";
 
 const PostBody = z.object({
   thread_id: z.number().int().positive(),
@@ -24,6 +34,12 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Authentication required" }, { status: 401 });
     }
 
+    // Kill switch (automation_kill_switches: community_posting) — shared
+    // with thread creation so one row pauses the whole surface.
+    if (await isCommunityPostingDisabled()) {
+      return NextResponse.json({ error: FORUM_DISABLED_MESSAGE }, { status: 503 });
+    }
+
     // Rate limit — 20 posts per hour per user. Prevents a compromised
     // account or impatient bot from flooding threads.
     if (await isRateLimited(`community_post:${user.id}`, 20, 60)) {
@@ -41,10 +57,11 @@ export async function POST(req: NextRequest) {
 
     const admin = createAdminClient();
 
-    // Fetch thread to check it exists and isn't locked
+    // Fetch thread to check it exists and isn't locked. author_id/title
+    // stay server-side — used only for the reply notification below.
     const { data: thread, error: threadError } = await admin
       .from("forum_threads")
-      .select("id, category_id, is_locked, is_removed")
+      .select("id, category_id, author_id, title, is_locked, is_removed")
       .eq("id", thread_id)
       .single();
 
@@ -58,11 +75,13 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Thread is locked" }, { status: 403 });
     }
 
-    // If parent_id is provided, verify it exists in the same thread
+    // If parent_id is provided, verify it exists in the same thread.
+    // author_id is kept server-side for the nested-reply notification.
+    let parentAuthorId: string | null = null;
     if (parent_id) {
       const { data: parentPost, error: parentError } = await admin
         .from("forum_posts")
-        .select("id")
+        .select("id, author_id")
         .eq("id", parent_id)
         .eq("thread_id", thread_id)
         .eq("is_removed", false)
@@ -71,6 +90,22 @@ export async function POST(req: NextRequest) {
       if (parentError || !parentPost) {
         return NextResponse.json({ error: "Parent post not found" }, { status: 404 });
       }
+      parentAuthorId = parentPost.author_id;
+    }
+
+    // Publish gate — same classifyText pipeline as every other UGC surface.
+    const gate = await gateForumContent({ kind: "post", body: postBody.trim() });
+    captureServerEvent(user.id, "community_post_submitted", {
+      thread_id,
+      gate_action: gate.action,
+      risk_score: gate.riskScore,
+      gate_reasons: gate.reasons.join(","),
+      is_nested_reply: !!parent_id,
+    });
+
+    if (gate.action === "reject") {
+      log.warn("Post rejected by publish gate", { userId: user.id, reasons: gate.reasons });
+      return NextResponse.json({ error: FORUM_REJECT_MESSAGE }, { status: 400 });
     }
 
     // Get or derive display name; anonymous posts redact the real name
@@ -81,7 +116,8 @@ export async function POST(req: NextRequest) {
       "Anonymous";
     const displayName = is_anonymous ? "Anonymous Investor" : realDisplayName;
 
-    // Insert post
+    // Insert post — held submissions land hidden (is_removed=true) until
+    // a moderator approves them from /admin/community.
     const { data: post, error: insertError } = await admin
       .from("forum_posts")
       .insert({
@@ -93,6 +129,7 @@ export async function POST(req: NextRequest) {
         is_anonymous: is_anonymous ?? false,
         post_type: debate_position ? "debate" : "reply",
         debate_position: debate_position ?? null,
+        is_removed: gate.action === "hold",
       })
       .select("id, thread_id, author_name, body, parent_id, created_at")
       .single();
@@ -100,6 +137,61 @@ export async function POST(req: NextRequest) {
     if (insertError) {
       log.error("Failed to create post", { error: insertError.message });
       return NextResponse.json({ error: "Failed to create post" }, { status: 500 });
+    }
+
+    if (gate.action === "hold") {
+      // Queue for review; counters skipped (approve recounts from rows).
+      const { error: reportError } = await admin.from("forum_reports").upsert(
+        {
+          target_type: "post",
+          target_id: post.id,
+          reporter_user_id: user.id,
+          reason: autoModerationReason(gate.reasons),
+          status: "open",
+        },
+        { onConflict: "target_type,target_id,reporter_user_id" },
+      );
+      if (reportError) {
+        log.error("Failed to queue held post for review", {
+          postId: post.id,
+          error: reportError.message,
+        });
+      }
+      return NextResponse.json(
+        { post: null, pending_review: true, message: FORUM_HOLD_MESSAGE },
+        { status: 202 },
+      );
+    }
+
+    // Reply notifications — thread author always, parent-post author on
+    // nested replies. Self-replies and author==parent overlaps are skipped.
+    // displayName is already anonymity-masked, so nothing leaks.
+    const notifyTargets = new Set<string>();
+    if (thread.author_id && thread.author_id !== user.id) {
+      notifyTargets.add(thread.author_id);
+    }
+    if (parentAuthorId && parentAuthorId !== user.id) {
+      notifyTargets.add(parentAuthorId);
+    }
+    if (notifyTargets.size > 0) {
+      const { data: threadCategory } = await admin
+        .from("forum_categories")
+        .select("slug")
+        .eq("id", thread.category_id)
+        .single();
+      const threadTitle =
+        (thread.title ?? "your thread").length > 80
+          ? `${(thread.title ?? "").slice(0, 77)}...`
+          : (thread.title ?? "your thread");
+      for (const targetUserId of notifyTargets) {
+        await notifyUser({
+          userId: targetUserId,
+          type: "reply",
+          title: `New reply on "${threadTitle}"`,
+          body: `${displayName} replied in the community forum.`,
+          linkUrl: `/community/${threadCategory?.slug ?? ""}/${thread_id}`,
+        });
+      }
     }
 
     // Update thread counters: reply_count, last_reply_at, last_reply_by

--- a/app/api/community/threads/route.ts
+++ b/app/api/community/threads/route.ts
@@ -4,6 +4,15 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { NextRequest, NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import { isRateLimited } from "@/lib/rate-limit";
+import {
+  autoModerationReason,
+  FORUM_DISABLED_MESSAGE,
+  FORUM_HOLD_MESSAGE,
+  FORUM_REJECT_MESSAGE,
+  gateForumContent,
+  isCommunityPostingDisabled,
+} from "@/lib/community/moderation";
+import { captureServerEvent } from "@/lib/posthog/server";
 
 // All fields optional so Zod v4 doesn't emit an invalid_type error for missing
 // required fields (v4 removed the required_error constructor param). Required
@@ -115,6 +124,12 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Authentication required" }, { status: 401 });
     }
 
+    // Kill switch (automation_kill_switches: community_posting) — lets ops
+    // pause all forum writes during an attack without a deploy.
+    if (await isCommunityPostingDisabled()) {
+      return NextResponse.json({ error: FORUM_DISABLED_MESSAGE }, { status: 503 });
+    }
+
     // Rate limit — 5 new threads per hour per user. Thread creation is
     // costlier than post replies (each spawns a moderation surface and a
     // category bump), so the cap is tighter than for posts.
@@ -163,6 +178,27 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Category not found" }, { status: 404 });
     }
 
+    // Publish gate — same classifyText pipeline every other UGC surface
+    // runs. reject → nothing persisted; hold → inserted hidden + queued
+    // for moderator review; publish → the normal path below.
+    const gate = await gateForumContent({
+      kind: "thread",
+      title: title.trim(),
+      body: threadBody.trim(),
+    });
+    captureServerEvent(user.id, "community_thread_submitted", {
+      category_slug,
+      thread_type: thread_type ?? "discussion",
+      gate_action: gate.action,
+      risk_score: gate.riskScore,
+      gate_reasons: gate.reasons.join(","),
+    });
+
+    if (gate.action === "reject") {
+      log.warn("Thread rejected by publish gate", { userId: user.id, reasons: gate.reasons });
+      return NextResponse.json({ error: FORUM_REJECT_MESSAGE }, { status: 400 });
+    }
+
     // Get or derive display name; confessions always show as "Anonymous Investor"
     const realDisplayName =
       user.user_metadata?.display_name ||
@@ -173,7 +209,8 @@ export async function POST(req: NextRequest) {
 
     const slug = generateSlug(title.trim());
 
-    // Insert thread
+    // Insert thread — held submissions land hidden (is_removed=true) until
+    // a moderator approves them from /admin/community.
     const { data: thread, error: insertError } = await admin
       .from("forum_threads")
       .insert({
@@ -185,6 +222,7 @@ export async function POST(req: NextRequest) {
         body: threadBody.trim(),
         thread_type: thread_type ?? "discussion",
         is_anonymous: is_anonymous ?? false,
+        is_removed: gate.action === "hold",
       })
       .select("id, slug, title, created_at")
       .single();
@@ -192,6 +230,32 @@ export async function POST(req: NextRequest) {
     if (insertError) {
       log.error("Failed to create thread", { error: insertError.message });
       return NextResponse.json({ error: "Failed to create thread" }, { status: 500 });
+    }
+
+    if (gate.action === "hold") {
+      // Queue for review. Reporter is the author (NOT NULL FK) — the
+      // auto_moderation: reason prefix is what marks it as a system hold.
+      const { error: reportError } = await admin.from("forum_reports").upsert(
+        {
+          target_type: "thread",
+          target_id: thread.id,
+          reporter_user_id: user.id,
+          reason: autoModerationReason(gate.reasons),
+          status: "open",
+        },
+        { onConflict: "target_type,target_id,reporter_user_id" },
+      );
+      if (reportError) {
+        log.error("Failed to queue held thread for review", {
+          threadId: thread.id,
+          error: reportError.message,
+        });
+      }
+      // Counters are skipped on hold; the approve action recounts from rows.
+      return NextResponse.json(
+        { thread: null, pending_review: true, message: FORUM_HOLD_MESSAGE },
+        { status: 202 },
+      );
     }
 
     // Update category thread_count and last_thread_id

--- a/app/community/[category]/[threadId]/page.tsx
+++ b/app/community/[category]/[threadId]/page.tsx
@@ -1,6 +1,7 @@
 import { createClient } from "@/lib/supabase/server";
 import { absoluteUrl, breadcrumbJsonLd } from "@/lib/seo";
 import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
+import { SHOW_MATCH_LANGUAGE } from "@/lib/compliance-config";
 import { resolveAdvisorBadges } from "@/lib/forum-author-badges";
 import { notFound } from "next/navigation";
 import Link from "next/link";
@@ -124,12 +125,31 @@ export async function generateMetadata({
 
   const { data: thread } = await supabase
     .from("forum_threads")
-    .select("title, author_name")
+    .select("title, author_name, is_pinned, vote_score")
     .eq("id", threadId)
     .eq("is_removed", false)
     .single();
 
   if (!thread) return { title: "Thread Not Found" };
+
+  // UGC indexing quality bar: hub + category pages always index, but an
+  // individual thread earns its index entry — moderator-pinned, community-
+  // validated (votes), or carrying a verified-adviser reply. Everything
+  // else stays crawlable-but-noindex so thin/unreviewed UGC never dilutes
+  // the domain (critical through the Oct–Dec 2026 migration window).
+  let indexable = thread.is_pinned === true || (thread.vote_score ?? 0) >= 5;
+  if (!indexable) {
+    const { data: replyAuthors } = await supabase
+      .from("forum_posts")
+      .select("author_id")
+      .eq("thread_id", threadId)
+      .eq("is_removed", false);
+    const authorIds = Array.from(new Set((replyAuthors ?? []).map((p) => p.author_id)));
+    if (authorIds.length > 0) {
+      const advisorBadges = await resolveAdvisorBadges(authorIds);
+      indexable = advisorBadges.size > 0;
+    }
+  }
 
   const title = `${thread.title} - Community Forum`;
   const description = `Discussion started by ${thread.author_name} in the Invest.com.au community forum.`;
@@ -139,6 +159,7 @@ export async function generateMetadata({
   return {
     title,
     description,
+    robots: indexable ? { index: true, follow: true } : { index: false, follow: true },
     alternates: { canonical: absoluteUrl(canonicalPath) },
     openGraph: {
       title,
@@ -270,6 +291,9 @@ export default async function ThreadPage({
   const isViewerModerator =
     viewerId != null && profileMap[viewerId]?.is_moderator === true;
 
+  // First verified-adviser reply gets elevated above the fold.
+  const expertPost = posts.find((p) => p.author_profile?.verified_advisor) ?? null;
+
   // Increment view count (fire-and-forget)
   supabase
     .from("forum_threads")
@@ -397,6 +421,67 @@ export default async function ThreadPage({
           </div>
         </div>
       </div>
+
+      {/* Expert answer — the first verified-adviser reply is elevated above
+          the fold; threads without one get the adviser hand-off CTA. */}
+      {expertPost ? (
+        <div className="container-custom max-w-4xl mb-6">
+          <div className="bg-emerald-50 border border-emerald-200 rounded-xl p-6">
+            <div className="flex items-center gap-2 flex-wrap mb-3">
+              <span className="inline-flex items-center gap-1 text-xs font-bold uppercase tracking-wide text-emerald-800">
+                <Icon name="check-circle" size={14} />
+                Verified adviser reply
+              </span>
+            </div>
+            <div className="flex items-center gap-2 flex-wrap mb-3">
+              <span className="text-sm font-semibold text-slate-900">
+                {expertPost.author_name}
+              </span>
+              {expertPost.author_profile?.verified_advisor && (
+                <VerifiedAdvisorBadge
+                  advisorSlug={expertPost.author_profile.verified_advisor.slug}
+                  advisorType={expertPost.author_profile.verified_advisor.type}
+                />
+              )}
+              <span className="text-xs text-slate-400">
+                {timeAgo(expertPost.created_at)}
+              </span>
+            </div>
+            <div className="prose prose-sm max-w-none text-slate-700">
+              {expertPost.body.split("\n").map((paragraph, i) => (
+                <p key={i}>{paragraph}</p>
+              ))}
+            </div>
+            <p className="text-xs text-slate-500 mt-3">
+              General information only — not personal financial advice.
+            </p>
+          </div>
+        </div>
+      ) : (
+        !thread.is_locked && (
+          <div className="container-custom max-w-4xl mb-6">
+            <div className="bg-white border border-slate-200 rounded-xl p-5 flex items-center justify-between gap-4 flex-wrap">
+              <div>
+                <p className="text-sm font-bold text-slate-900">
+                  No verified adviser has answered yet
+                </p>
+                <p className="text-xs text-slate-500 mt-0.5">
+                  Want a professional&apos;s take on questions like this? It&apos;s free
+                  to connect.
+                </p>
+              </div>
+              <Link
+                href={SHOW_MATCH_LANGUAGE ? "/get-matched" : "/advisors"}
+                className="shrink-0 bg-emerald-700 hover:bg-emerald-800 text-white text-sm font-semibold px-4 py-2 rounded-xl transition-colors"
+              >
+                {SHOW_MATCH_LANGUAGE
+                  ? "Get matched with an adviser"
+                  : "Browse verified advisers"}
+              </Link>
+            </div>
+          </div>
+        )
+      )}
 
       {/* Interactive Client Component */}
       <Suspense

--- a/app/community/guidelines/page.tsx
+++ b/app/community/guidelines/page.tsx
@@ -1,0 +1,108 @@
+import Link from "next/link";
+import { absoluteUrl, breadcrumbJsonLd } from "@/lib/seo";
+import { GENERAL_ADVICE_WARNING, REGULATORY_NOTE } from "@/lib/compliance";
+
+export const metadata = {
+  title: "Community Guidelines",
+  description:
+    "The rules of the Invest.com.au community forum: keep discussion general, no personal financial advice, no promotions, how moderation and reporting work.",
+  alternates: { canonical: "/community/guidelines" },
+};
+
+const RULES: Array<{ heading: string; body: string[] }> = [
+  {
+    heading: "1. Keep it general — never personal advice",
+    body: [
+      "Nobody here — including verified advisers — can tell you what YOU should do with YOUR money through a forum post. Frame questions generally: \"How do people compare ETF fees?\" works; \"Should I buy VAS with my $50k?\" doesn't and may be removed.",
+      "Verified advisers who reply are sharing general information only. If you want advice about your situation, book a consultation through their profile or use the adviser directory.",
+    ],
+  },
+  {
+    heading: "2. No buy/sell calls, price predictions, or guaranteed returns",
+    body: [
+      "Posts that tip specific securities (\"XYZ will hit $40\", \"get in before the run\"), promise returns, or use \"guaranteed / risk-free / can't lose\" language are removed automatically. This isn't bureaucracy — ramping and return promises are how people get hurt, and Australian law treats them seriously.",
+    ],
+  },
+  {
+    heading: "3. No promotions, referral codes, or affiliate links",
+    body: [
+      "The forum is for discussion, not distribution. Referral codes, sign-up links, Telegram/WhatsApp group invitations, and promotion dressed up as a question are removed and repeat offenders lose posting access.",
+    ],
+  },
+  {
+    heading: "4. Anonymity is for honesty, not mischief",
+    body: [
+      "Investment Confessions and anonymous posts hide your name from other readers — moderators can still see who posted, and the rules above apply unchanged.",
+    ],
+  },
+  {
+    heading: "5. Be straight with each other",
+    body: [
+      "Share real experience, disclose conflicts (e.g. you work for a platform you're praising), disagree with the idea rather than the person, and don't present opinion as fact.",
+    ],
+  },
+  {
+    heading: "How moderation works",
+    body: [
+      "Every thread and reply passes an automated screen before publishing. Clean posts go live immediately; borderline posts are held for a human moderator (usually a few hours); clear violations are declined at submission.",
+      "Anyone can report a thread or reply — reports go straight to the moderation queue. Moderators can remove content, lock threads, and restrict accounts that repeatedly break the rules.",
+    ],
+  },
+];
+
+export default function CommunityGuidelinesPage() {
+  const breadcrumbLd = breadcrumbJsonLd([
+    { name: "Home", url: absoluteUrl("/") },
+    { name: "Community", url: absoluteUrl("/community") },
+    { name: "Guidelines" },
+  ]);
+
+  return (
+    <div>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+      />
+
+      <section className="bg-gradient-to-br from-slate-900 to-slate-800 text-white py-12">
+        <div className="container-custom max-w-3xl text-center">
+          <h1 className="text-3xl font-extrabold mb-3">Community Guidelines</h1>
+          <p className="text-slate-300 text-sm max-w-xl mx-auto">
+            Short version: keep it general, keep it honest, and remember nobody
+            on a forum knows your full situation.
+          </p>
+        </div>
+      </section>
+
+      <div className="container-custom max-w-3xl py-10">
+        <nav aria-label="Breadcrumb" className="text-sm text-slate-500 mb-8">
+          <Link href="/community" className="hover:text-slate-700">
+            ← Back to Community
+          </Link>
+        </nav>
+
+        <div className="space-y-8">
+          {RULES.map((rule) => (
+            <section key={rule.heading}>
+              <h2 className="text-lg font-extrabold text-slate-900 mb-2">
+                {rule.heading}
+              </h2>
+              {rule.body.map((paragraph, i) => (
+                <p key={i} className="text-sm text-slate-600 leading-relaxed mb-2">
+                  {paragraph}
+                </p>
+              ))}
+            </section>
+          ))}
+        </div>
+
+        <div className="mt-10 border-t border-slate-200 pt-6 space-y-3">
+          <p className="text-xs text-slate-500 leading-relaxed">
+            <strong>General advice warning:</strong> {GENERAL_ADVICE_WARNING}
+          </p>
+          <p className="text-xs text-slate-500 leading-relaxed">{REGULATORY_NOTE}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/community/new/NewThreadClient.tsx
+++ b/app/community/new/NewThreadClient.tsx
@@ -28,7 +28,16 @@ export default function NewThreadClient() {
   const [body, setBody] = useState("");
   const [showPreview, setShowPreview] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  const [heldForReview, setHeldForReview] = useState<string | null>(null);
   const [errors, setErrors] = useState<Record<string, string>>({});
+
+  // Friendly pre-submit nudge (non-blocking): personal-advice phrasing is the
+  // top reason threads get removed — steer toward general framing before the
+  // server-side gate has to.
+  const adviceNudge =
+    /\bshould\s+i\s+(buy|sell|invest)\b|\bwhat\s+should\s+i\s+(buy|invest)\b|\btell\s+me\s+what\s+to\s+(buy|invest)\b/i.test(
+      `${title} ${body}`,
+    );
 
   // Auth redirect
   useEffect(() => {
@@ -103,6 +112,15 @@ export default function NewThreadClient() {
       }
 
       const data = await res.json();
+      if (data.pending_review) {
+        // Held by the publish gate — show the review notice instead of
+        // redirecting to a thread the author can't see yet.
+        setHeldForReview(
+          data.message ||
+            "Your thread is awaiting a quick moderator review before it goes live.",
+        );
+        return;
+      }
       router.push(`/community/${categorySlug}/${data.thread.id}`);
     } catch {
       setErrors({ submit: "Something went wrong. Please try again." });
@@ -126,6 +144,26 @@ export default function NewThreadClient() {
   }
 
   if (!user) return null;
+
+  if (heldForReview) {
+    return (
+      <div className="container-custom max-w-4xl py-12">
+        <div className="bg-white border border-slate-200 rounded-xl p-8 text-center">
+          <Icon name="check-circle" size={40} className="text-emerald-600 mx-auto mb-4" />
+          <h1 className="text-xl font-extrabold text-slate-900 mb-2">
+            Thread submitted for review
+          </h1>
+          <p className="text-sm text-slate-600 max-w-md mx-auto mb-6">{heldForReview}</p>
+          <Link
+            href="/community"
+            className="inline-block bg-emerald-700 hover:bg-emerald-800 text-white font-semibold px-6 py-2.5 rounded-xl transition-colors text-sm"
+          >
+            Back to Community
+          </Link>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="container-custom max-w-4xl py-8">
@@ -315,8 +353,18 @@ export default function NewThreadClient() {
           </div>
         </div>
 
+        {/* Pre-submit compliance nudge — non-blocking */}
+        {adviceNudge && (
+          <div className="bg-amber-50 border border-amber-200 text-amber-800 text-sm rounded-xl px-4 py-3 mb-5">
+            <strong>Keep it general:</strong> asking &quot;should I buy X?&quot; reads as a
+            request for personal financial advice, which no one here can give.
+            Try &quot;how do people evaluate X?&quot; instead — those threads stay up and
+            get better answers.
+          </div>
+        )}
+
         {/* Submit */}
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-3 flex-wrap">
           <button
             onClick={handleSubmit}
             disabled={submitting}
@@ -329,6 +377,12 @@ export default function NewThreadClient() {
             className="text-sm text-slate-500 hover:text-slate-700 transition-colors"
           >
             Cancel
+          </Link>
+          <Link
+            href="/community/guidelines"
+            className="text-sm text-slate-400 hover:text-slate-600 transition-colors ml-auto"
+          >
+            Community guidelines
           </Link>
         </div>
       </div>

--- a/app/community/new/NewThreadClient.tsx
+++ b/app/community/new/NewThreadClient.tsx
@@ -19,6 +19,11 @@ export default function NewThreadClient() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const preselectedCategory = searchParams.get("category") ?? "";
+  // The confessions CTA links /community/new?thread_type=confessions — the
+  // param was previously ignored, silently creating a normal public thread.
+  const rawType = searchParams.get("thread_type");
+  const threadType: "discussion" | "confessions" | "debate" =
+    rawType === "confessions" || rawType === "debate" ? rawType : "discussion";
 
   const [categories, setCategories] = useState<ForumCategory[]>([]);
   const [loadingCats, setLoadingCats] = useState(true);
@@ -26,6 +31,7 @@ export default function NewThreadClient() {
   const [categorySlug, setCategorySlug] = useState(preselectedCategory);
   const [title, setTitle] = useState("");
   const [body, setBody] = useState("");
+  const [isAnonymous, setIsAnonymous] = useState(threadType === "confessions");
   const [showPreview, setShowPreview] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [heldForReview, setHeldForReview] = useState<string | null>(null);
@@ -102,6 +108,8 @@ export default function NewThreadClient() {
           category_slug: categorySlug,
           title: title.trim(),
           body: body.trim(),
+          thread_type: threadType,
+          is_anonymous: isAnonymous,
         }),
       });
 
@@ -192,8 +200,18 @@ export default function NewThreadClient() {
 
       <div className="bg-white border border-slate-200 rounded-xl p-6 md:p-8">
         <h1 className="text-2xl text-slate-900 font-extrabold mb-6">
-          Start a New Thread
+          {threadType === "confessions" ? "Post an Investment Confession" : "Start a New Thread"}
         </h1>
+
+        {threadType === "confessions" && (
+          <div className="bg-slate-800 text-white text-sm rounded-xl px-4 py-3 mb-6 flex items-center gap-2">
+            <span aria-hidden="true">🤫</span>
+            <span>
+              Confessions are anonymous by default — readers see &quot;Anonymous
+              Investor&quot;. Moderators can still see who posted.
+            </span>
+          </div>
+        )}
 
         {errors.submit && (
           <div className="bg-red-50 border border-red-200 text-red-700 text-sm rounded-xl px-4 py-3 mb-6">
@@ -351,6 +369,19 @@ export default function NewThreadClient() {
               {body.length.toLocaleString()}/10,000
             </span>
           </div>
+        </div>
+
+        {/* Anonymity toggle */}
+        <div className="mb-5">
+          <label className="flex items-center gap-2 text-sm text-slate-700 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={isAnonymous}
+              onChange={(e) => setIsAnonymous(e.target.checked)}
+              className="w-4 h-4 rounded border-slate-300 text-emerald-700 focus:ring-emerald-500"
+            />
+            Post anonymously (shown as &quot;Anonymous Investor&quot;)
+          </label>
         </div>
 
         {/* Pre-submit compliance nudge — non-blocking */}

--- a/app/community/page.tsx
+++ b/app/community/page.tsx
@@ -114,6 +114,14 @@ export default async function CommunityPage() {
             <Icon name="plus" size={18} />
             New Thread
           </Link>
+          <p className="mt-4">
+            <Link
+              href="/community/guidelines"
+              className="text-xs text-slate-400 hover:text-slate-200 underline transition-colors"
+            >
+              Community guidelines
+            </Link>
+          </p>
         </div>
       </section>
 

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -203,6 +203,7 @@ export default function Footer() {
               <ul className="space-y-1.5 md:space-y-2 text-xs md:text-sm mb-4 md:mb-5">
                 <li><Link href="/learn" className="hover:text-white transition-colors inline-block py-0.5">Learn to Invest</Link></li>
                 <li><Link href="/articles" className="hover:text-white transition-colors inline-block py-0.5">Articles &amp; Guides</Link></li>
+                <li><Link href="/community" className="hover:text-white transition-colors inline-block py-0.5">Community Forum</Link></li>
                 <li><Link href="/grants" className="hover:text-white transition-colors inline-block py-0.5">Grants Hub</Link></li>
                 <li><Link href="/tax" className="hover:text-white transition-colors inline-block py-0.5">Tax Strategy Hub</Link></li>
                 <li><Link href="/global-investing/tax" className="hover:text-white transition-colors inline-block py-0.5">Global Investing Tax</Link></li>

--- a/docs/plans/COMMUNITY_MASTER_PLAN.md
+++ b/docs/plans/COMMUNITY_MASTER_PLAN.md
@@ -1,0 +1,218 @@
+# Community Master Plan — invest.com.au
+
+**Status:** proposed (founder decisions pending — see §11) · **Author:** strategy session 2026-06-10 with Claude
+**Inputs:** full code audit 2026-06-10 (§2), `FIN_NOTEBOOK.md` 2026-06-10 news/community entry, `DAILY_ENGAGEMENT_IDEAS.md`, `REGULATORY-AVOID-LIST.md`, `COMPANY.md`
+**Companion:** the news verdict (no newsroom; data-news yes) lives in the notebook entry. This doc is community only.
+
+---
+
+## 1. Goal & positioning
+
+**One-liner:** the expert-anchored community for Australia's "boring money" decisions — super, SMSF, property, ETFs, savings, tax, cross-border — where every serious question gets a quality answer within 24 hours, and the best threads become permanent, citable reference pages.
+
+**Anti-positioning (what we are NOT):**
+- Not HotCopper — no stock-tip culture, no ticker pumping. Specific-security "should I buy X" is our compliance hot zone, not our product.
+- Not r/AusFinance — they have volume but zero verification and "go see an adviser" dead-ends. Our verified-advisor directory is the asset they can't copy: the dead-end is our front door.
+- Not a social network — no DMs, no follower-farming for retail users. The graph is users → experts, not users → users (until Phase 4).
+
+**Why community is the strategic prize (vs news):** UGC is the one content type AI engines can't commoditise and must cite; it attacks the core retention problem ("research destination — people come, decide, leave"); the question corpus compounds into GEO authority and the market-intel product (FIN_NOTEBOOK #11); and the advisor side is commercially self-incentivised to supply quality answers (answers → profile links → leads), which is what solves cold start.
+
+**The flywheel:**
+questions → expert answers (≤24h) → best threads promoted to indexed Q&A reference pages → GEO/SEO citations + long-tail traffic → more questioners + more advisor leads → more advisors answering → more questions. Side-products at every turn: newsletter digest content, quiz/lead hand-offs, anonymised trend data.
+
+---
+
+## 2. Current state (code audit, 2026-06-10)
+
+### Already built and live
+| Capability | Where | Notes |
+|---|---|---|
+| Forum: 9 categories, threads, nested replies, votes | `app/community/*`, `forum_categories/threads/posts/votes` | Auth-gated posting, rate-limited (5 threads/hr, 20 posts/hr) |
+| Anonymous confessions + bull/bear debates | `thread_type` + `is_anonymous` + `debate_votes` | `/community/confessions` live |
+| 24 seeded threads (3/category) | `20260802000000_seed_forum_threads.sql` | Attributed "Invest.com.au Community" (good — not fake users) |
+| User forum profiles: reputation, badge, counts | `forum_user_profiles` | Badge/reputation are **static admin fields** — no accrual rules |
+| Verified-adviser badge on threads | `lib/forum-author-badges.ts` | Cross-checks `professionals` (active + verified) |
+| Solid RLS | `20260429_o_iter6_rls_forum.sql` | `author_id` never serialized; users can't self-pin/unlock/unremove |
+| Advisor feed + posting schema | `app/feed`, `advisor_posts` (RLS: advisors can write) | **No posting UI exists** — feed is effectively admin/seeded |
+| Follow schema | `advisor_follows` table | **No UI anywhere** |
+| Adjacent infra ready to wire | `lib/notifications.ts` (has `reply` type), `lib/rate-limit.ts`, `lib/admin/classifier-config.ts` (thresholds + kill switches), `feed_events` (includes `community_thread`), PostHog, `lib/embeddings.ts` | All unused by community routes today |
+
+### Hard gaps (ranked by risk)
+1. **P0 — zero text moderation.** Community POSTs run no classifier, no queue: everything auto-publishes instantly. On a financial site operating pre-AFSL under the factual carve-out, with `/community` indexed, this is the single most exposed surface in the product. (Article comments and Q&A have moderation; the forum does not.)
+2. **P0 — integrity: seeded counters overstate activity.** Seed migration initialises `reply_count` 0–7 and `vote_score` 4–16, but actual seeded replies are 1–2 and votes 0. Same ACL s18 family as the fabricated "X investors compared today" counter removed in #1489. Reconcile counters to real rows.
+3. **P0 — no `GENERAL_ADVICE_WARNING` / house-rules surface** verified on thread pages; the hub FAQ promises moderation + an "Ask an Advisor" category with verified advisers — **neither exists yet** (no mod UI, no such category). The copy over-promises.
+4. No admin moderation UI, no report button, no flag queue.
+5. No reply notifications (infra exists, unwired). No thread subscribe/bookmark (bookmark enum excludes threads — needs a migration, see §4 constraint).
+6. No PostHog events, no feature flag / kill switch on the surface.
+7. Invisible: not in header, footer, or mobile bottom nav (4 tabs, no slot).
+8. Two parallel social systems (forum + advisor feed) with no integration decision.
+
+### Planning constraint that shapes everything
+**The migration ledger is frozen until the baseline-squash** (FIN_NOTEBOOK 2026-06-07 — the #1 infrastructure blocker). Therefore **Phases 0–1 are deliberately schema-free**: every item below either reuses existing tables/columns/config rows or is pure code. Items needing DDL (bookmark enum value, `is_accepted` on posts, reputation-events table, thread embeddings) are explicitly parked in Phase 3+ behind the squash.
+
+---
+
+## 3. Strategy — five pillars
+
+1. **Expert-anchored, not peer-anchored.** The differentiator is a verified professional in the thread. Every mechanic (badges, ranking, programmes) elevates expert participation first. Retail users get great answers; advisors get qualified exposure; the platform gets citable content and warm leads.
+2. **Answer-guaranteed.** "Every question answered within 24h" is a promise no AU competitor makes — and the 19-agent fleet makes it cheap: a compliance-gated **Research Team** baseline answer (clearly bylined per the editorial Tier-2 standard, factual/general-only) backstops any thread no human reaches. This converts the empty-restaurant problem into a service guarantee.
+3. **Outcome-structured.** A thread is not the end state. Good threads get curated into permanent `/questions/`-style reference pages (answer-first, QAPage/Speakable schema, glossary auto-links) — the GEO converter. The forum is the intake; the reference library is the asset.
+4. **Compliance-native, visibly.** Moderation, hot-zone handling and general-advice framing are product features users can see (trust), not a back-office tax. Pre-AFSL: strictly factual/general framing, hot-zone throttles on specific-security threads. Post-AFSL (Nov 2026): general-advice posture relaxes the ceiling, never the floor.
+5. **Honest by construction.** No fake users, no inflated counters, no agent posts masquerading as humans — seeds and AI answers always attributed (Research Team / Community byline). One fabricated number costs more trust than an empty forum ever will.
+
+---
+
+## 4. Phased roadmap
+
+Timeline anchors: AFSL ~Nov 2026 · domain cutover Oct–Dec 2026 · migration freeze applies to *structural* changes, not content cadence.
+
+### Phase 0 — Make it safe & honest (now → mid-July, ~2 wks effort, schema-free)
+*Nothing grows until this ships. All items reuse existing infra.*
+
+| # | Item | How (existing infra) | Tier |
+|---|---|---|---|
+| 0.1 | Text-moderation gate on thread/post POST | Run classifier (same pipeline as article comments) before insert; flagged → `is_removed=true` + queue; thresholds via `classifier_config`; kill switch row in `automation_kill_switches` | B |
+| 0.2 | Hot-zone detection | Ticker/security-name + advice-phrase patterns ("should I buy/sell") → auto-flag for review + stricter banner; never auto-publish | B |
+| 0.3 | Admin moderation queue | `/admin/community`: flagged list, approve/remove/lock/pin, author history. Mirrors `/admin/qa` patterns | B |
+| 0.4 | Report button + house-rules page | `/community/guidelines`; report → flag in queue. Fixes the FAQ over-promise | A |
+| 0.5 | Counter reconciliation | Migration-free script/route to set seeded `reply_count`/`vote_score` to actual row counts (UPDATE on existing columns is DML, not DDL) | A |
+| 0.6 | `GENERAL_ADVICE_WARNING` + "posts are opinions, not advice" banner on every thread page | `lib/compliance.ts` (never hardcode) | A |
+| 0.7 | UGC indexing policy | Hub + category pages stay indexed; **individual threads `noindex` until they pass a quality bar** (mod-approved or expert-answered). Confessions listing → noindex until 0.1–0.3 live | A |
+| 0.8 | PostHog events (`community_thread_created`, `_reply`, `_vote`, `_report`) + feature-flag wrap of the whole surface | `lib/posthog`, `classifier-config` kill switch | A |
+| 0.9 | Reply notifications | `notifyUser()` already has `reply` type + email dedup — wire it on post insert | B |
+
+### Phase 1 — Seed the supply side (mid-July → Sept, schema-free)
+*Solve cold start with experts and rituals, not growth hacks.*
+
+| # | Item | Notes | Effort |
+|---|---|---|---|
+| 1.1 | **Founding Experts programme** | Recruit 10–20 verified advisors (Co-Founder BD + Ops/Email agents automate outreach + weekly "questions waiting for you" digests). Incentive: "Founding Expert" badge (static badge field exists), homepage experts-strip eligibility, free Pro-tier window (founder call, §11). Target SLA: expert reply on every non-trivial thread <48h | BD-heavy, ~3 dev-days |
+| 1.2 | **Advisor quick-post UI** | `/advisor-portal` composer → `advisor_posts` (table + RLS ready). 500-char limit, link, moderation flag on first 3 posts | ~1 wk |
+| 1.3 | **Follow mechanic** | Follow button on advisor profiles/cards → `advisor_follows` (table ready); `/feed` gets Following/Discover tabs; follow count on profiles | ~1 wk |
+| 1.4 | **Question of the Day ritual** | Editorial agent posts daily prompt thread (attributed); advisors answer; best answer featured in newsletter community block. 7 prompts/wk ≈ 350+ threads/yr of structured content | ~3 days + ongoing agent cadence |
+| 1.5 | **24h Research-Team answer SLA** | Agent drafts factual/general answer for any thread unanswered at 24h → compliance scorecard → human-tier publish per escalation rules; always bylined "invest.com.au Research Team", never a persona | ~1 wk |
+| 1.6 | **Ask-an-Advisor category** | Create the promised category; route unanswered/complex threads to `/get-matched` CTA (lead funnel); advisor answers carry profile links | ~2 days |
+| 1.7 | **Cross-linking loops** | Article footers: "Discuss this"; broker/product pages: "Community threads about X"; quiz results: "What people like you asked"; weekly newsletter digest block | ~1 wk total |
+| 1.8 | **AMA / office-hours pilot (lite)** | No new infra: scheduled, pinned, time-boxed thread format with a named advisor; transcript curated to a reference page after | ~3 days |
+| 1.9 | **Density rule** | Concentrate: actively seed/promote only 3 categories first (super-retirement, property, beginners+ETFs). A category "opens" for promotion at ≥10 organic posts/wk; merge/hide laggards (`off-topic` → hide) | policy |
+
+### Phase 2 — Freeze & harvest (Oct → Dec, migration window)
+- **No structural/nav/schema changes.** Rituals (QotD, SLA, digest) continue on cadence — content accumulation is migration-safe.
+- Curate the best 50–100 threads into reference pages; build the launch backlog.
+- Community URLs go into the cutover redirect map (pairs with CO-01); verify canonicals + sitemap parity for `/community/*`.
+- Measure Phase-1 cohorts; make the Phase-3 go/no-go call on data (§9).
+
+### Phase 3 — Open the doors (Q1 2027, post-AFSL + post-cutover + post-baseline-squash)
+- **Nav promotion:** one consolidated top-level entry ("Learn & Community" or "Insights") folding articles/guides/glossary/Q&A/community — not a standalone Community tab; mobile bottom-nav slot decision (§11).
+- **Homepage module:** "From the community" (expert answers + trending), slotting into the 13-module budget — swap-in, not add-on.
+- **Gamification, real accrual:** reputation events (post=1, helpful vote=2, expert-marked answer=10…), earned badges, weekly contributor digest. Needs the post-squash schema window; until then reputation derives from existing counts.
+- **Accepted answers** (`is_accepted` column), **thread bookmarks** (enum extension), **duplicate-question detector** (embeddings similarity at compose time — `lib/embeddings.ts` exists; storage post-squash).
+- **RBA-day megathreads** wired to the market-events calendar (the data-news layer from the notebook entry) — 8 guaranteed engagement spikes/yr.
+- **General-advice posture upgrade** post-AFSL: editorial/Research-Team answers can carry general-advice framing with the licence disclosure set from `lib/compliance.ts`.
+
+### Phase 4 — Compound (2027+)
+- Question-corpus → anonymised trend reports (market-intel #11) and "State of Australian Investing" survey tie-in (#25).
+- Investment clubs / private group watchlists (DAILY_ENGAGEMENT #16) once the public surface is liquid.
+- Unified personalized feed (`feed_events` already includes `community_thread`) as the logged-in home (DAILY_ENGAGEMENT #17).
+- Community embeds/API as B2B surface area (#8).
+
+---
+
+## 5. UX/UI specification notes
+
+**Information architecture**
+- `/community` evolves from "category directory" to **digest**: Today's Question → latest expert answers strip → trending threads → categories. Categories mirror site verticals so cross-links feel native.
+- Thread page goes **answer-first** (same GEO logic as articles): verified-expert reply pinned above the fold with `VerifiedAdvisorBadge`; OP collapses after lead paragraph on long threads; reference-page promotion banner when curated.
+
+**Composer (the make-or-break surface)**
+- Single screen, ≤3 required fields (category auto-suggested from text, title, body). Anonymous toggle stays.
+- **Inline compliance nudge, friendly not legal:** "Keep it general — 'how do people evaluate X?' works; 'should I buy X?' gets removed." Shown on hot-zone pattern match *before* submit (saves the user a removal, saves us a queue item).
+- Similar-threads suggestion before posting (Phase 3, embeddings) to concentrate liquidity.
+- Post-submit: clear state — "Live now. Expert answer expected within 24h" (the SLA as UX copy).
+
+**Trust surfaces**
+- Badge system consistent everywhere (advisor badge component reused on comments/Q&A too).
+- Per-thread provenance: "Answered by [Advisor], AFSL-verified" vs "Research Team" vs "Community member" — three visually distinct reply styles.
+- Compliance banner via `lib/compliance.ts` + banner visual tokens from `components/foreign-investment/banner-tokens.ts`; reuse `components/directory/*` primitives for sort/filter/empty states rather than bespoke widgets.
+
+**Empty states & honesty**
+- Keep the current "suggested topics" empty state; add the answer-guarantee framing. Never pad with fake activity; show real seeded prompts with real bylines.
+- Show real counts only (post-0.5); if a number would embarrass us, design hides the number, not inflates it.
+
+**Mobile**
+- Reading: sticky reply bar, collapsed nested replies (>2 levels behind "show thread").
+- Bottom-nav: no change until Phase 3; interim discoverability via footer link (add to Learn column — 1-line change) and article/quiz cross-links.
+
+---
+
+## 6. Compliance & safety architecture (the non-negotiables)
+
+- Pre-AFSL: everything factual/general; `GENERAL_ADVICE_WARNING` on every community surface; FAQ copy must match shipped reality.
+- **Hot zone** = specific-security buy/sell/hold solicitations, return promises, "guaranteed", pump patterns (multiple accounts/posts, same ticker): auto-flag, never auto-publish; repeat → lock + ban path. INFO 269 context: we must not host de-facto unlicensed advice.
+- Advisors answering = general information; their AFSL details surface via the badge; conflicts/disclosure rules in house rules.
+- **No paid influence on answer ranking or thread placement — ever** (RG 246 hygiene). Monetisation stays out of the discussion surface (§7).
+- No DMs in any phase covered by this doc (off-platform advice solicitation channel).
+- Escalation mapping: classifier flag → admin queue (Tier 1 auto-hold); pump-pattern/coordinated → Tier 3; legal threat/regulator mention → Tier 4. Moderation latency is a tracked SLO (§9).
+- Avoid-list tripwires that live nearby: no money pooling in any future clubs feature; no execution/order-routing; CSF adjacency if startup raises get discussed → factual-listing framing only.
+
+## 7. Monetisation (deliberately indirect, all existing levers)
+
+| Mechanism | Lever | Notes |
+|---|---|---|
+| Unanswered/complex thread → "Get matched" CTA; advisor answers carry profile links | Lead gen (existing funnel) | The primary money path: community as top-of-funnel for the $39+/lead engine |
+| Advisor Pro tier perks: quick-post studio, follower analytics, AMA hosting, priority in *expert recruitment* (not answer ranking) | B2B subscription (existing Stripe/Pro) | Community becomes an advisor-retention feature |
+| Newsletter community-digest block sponsor slot | Newsletter sponsorship (allowed lever) | Disclosed, outside the discussion surface |
+| Anonymised question-trend data | Market-intel #11 (later) | Corpus value compounds from day one |
+| **Not done:** display ads in threads, paid placement of answers/threads, charging users | — | #21 NEVER + RG 246 |
+
+## 8. Cold-start playbook (tactics summary)
+
+1. Supply before demand: Founding Experts + QotD + Research-Team SLA make the room feel alive *honestly* before traffic exists.
+2. Density over breadth: 3 promoted categories until thresholds met (§4 1.9).
+3. Borrow existing demand: article footers, quiz results, broker pages, newsletter — the site already has the traffic; route slivers of it to threads.
+4. Rituals over campaigns: daily QotD, weekly digest, monthly AMA, quarterly survey — agent-automatable cadences, not one-off pushes.
+5. Integrity as strategy: visible moderation + real numbers + named experts is the differentiation from every anonymous finance forum in Australia.
+
+## 9. Metrics, SLOs, kill criteria
+
+- **North star: expert-answered questions per week.**
+- Supply: active verified advisors posting/wk; median time-to-first quality reply (target <24h, SLA backstop 100%).
+- Demand: organic (non-seeded, non-agent) threads/wk; posting users WAU; 4-week poster retention.
+- Safety SLOs: median flag→decision <12h; % auto-published posts later removed <2%; zero hot-zone auto-publishes.
+- GEO/SEO: curated reference pages live; community pages cited in `ai_referral` events (instrumentation exists); long-tail impressions on `/community/*` + `/questions/*`.
+- Business: community-attributed matched leads/mo; newsletter signups from community surfaces.
+- **Kill/pivot criterion:** if by end of Q1 2027 (one quarter after the open-doors push) organic threads <25/wk **or** active answering advisors <8, collapse the forum surface into the structured Q&A product (question intake → expert/Research-Team answer → reference page) and keep the corpus + SLA. The asset is the question pipeline and answer library, not the forum shape — this pivot loses almost nothing.
+
+## 10. Risks
+
+| Risk | Mitigation |
+|---|---|
+| Unmoderated UGC ships harm pre-AFSL | Phase 0 is a precondition for everything; kill switch wraps the surface |
+| Empty rooms damage trust at launch | Phases gate nav promotion on real liquidity; guarantee-SLA reframes emptiness as service |
+| Thin UGC indexed during domain cutover | 0.7 indexing policy + Phase-2 structural freeze |
+| Moderation load outgrows team | Classifier first-line + agent triage + escalation tiers; volume thresholds throttle category openings |
+| Advisors won't post | Their incentive is leads (proven motivator); programme + weekly prompt digests lower effort to ~10 min/wk; if still flat, the Q&A pivot (§9) needs only ~8 committed experts |
+| Temptation to fake liquidity | Pillar 5; counters reconciled in 0.5; CI anonymity/honesty culture already established (#1489) |
+| Forum + advisor-feed fragmentation | Phase 1 integrates (advisor posts surface in community digest; one identity/badge system); Phase 4 unifies via `feed_events` |
+
+## 11. Founder decisions needed
+
+1. **Approve Phase 0 now** (safety/integrity — recommend treating as not-optional; it also protects the existing live surface even if we never grow community).
+2. Founding Experts incentive: free Pro-tier window (6 or 12 mo) + does Co-Founder own the 10–20 recruit target?
+3. Research-Team 24h SLA: approve agent-drafted, human-gated, clearly-bylined baseline answers — yes/no + publish tier (recommend Tier 2: notify+proceed).
+4. Indexing bar for threads (recommend: mod-approved OR expert-answered).
+5. Confessions: keep prominently featured (great differentiation) but noindex until Phase 0 ships — confirm.
+6. Phase-3 mobile nav: which of the 4 tabs yields a slot (or none — header entry only)?
+
+## 12. Build order (first PRs, all schema-free)
+
+1. **PR-C1** — moderation gate + hot-zone flagging + kill switch + PostHog events (0.1, 0.2, 0.8) — Tier B
+2. **PR-C2** — admin queue + report flow + guidelines page + FAQ copy fix (0.3, 0.4) — Tier B
+3. **PR-C3** — counter reconciliation + indexing policy + compliance banner + footer link (0.5, 0.6, 0.7) — Tier A
+4. **PR-C4** — reply notifications + thread-watch via existing notifications (0.9) — Tier B
+5. **PR-C5** — advisor quick-post + follow button + feed tabs (1.2, 1.3) — Tier B
+6. **PR-C6** — QotD ritual + Research-Team SLA pipeline + Ask-an-Advisor category (1.4, 1.5, 1.6) — Tier B/C (agent cadence touches cron)
+
+---
+
+*Maintenance: append decisions + shipped items below; don't rewrite history.*

--- a/docs/strategy/FIN_NOTEBOOK.md
+++ b/docs/strategy/FIN_NOTEBOOK.md
@@ -795,6 +795,17 @@ never let community pool money or drift toward execution (avoid-list).
 **Revisit:** 2026-07-10 — founder verdict on sequencing; if agreed, brief the
 data-news stream (rate-change log + `/rates/today`) as the first build.
 
+**Update (same day):** founder asked for the full community plan → written to
+`docs/plans/COMMUNITY_MASTER_PLAN.md` (positioning, 5 phases, UX spec, cold-start
+playbook, metrics/kill criteria, 6 founder decisions). **Two P0 findings from the
+code audit:** (1) community thread/post POSTs run **zero text moderation** —
+everything auto-publishes onto indexed pages (article comments and Q&A are
+moderated; the forum is not); (2) the seed migration **inflates reply/vote
+counters** beyond actual seeded rows (same ACL s18 family as the fabricated
+counter killed in #1489). Plan's Phase 0 fixes both schema-free (migration
+ledger still frozen). These two are worth fixing even if community is never
+promoted.
+
 ---
 
 ## Open commitments / revisit-by dates

--- a/docs/strategy/FIN_NOTEBOOK.md
+++ b/docs/strategy/FIN_NOTEBOOK.md
@@ -822,6 +822,23 @@ no UI), QotD ritual + 24h Research-Team SLA (needs founder call on §11 D2/D3),
 confessions composer bug (`?thread_type=` ignored — Confess CTA makes a
 normal thread).
 
+**Update 3 (same day) — "continue": Phase 1 grounding + increment 2 shipped.**
+Grepping before building (again the lesson): quick-post composer
+(`advisor-portal/FeedTab.tsx` → `/api/advisor-auth/posts`), Follow button
+(`components/FollowAdvisorButton.tsx` on advisor profiles, follower_count
+live) and `/feed` All/Following tabs **already existed** — the master plan's
+1.2/1.3 were stale-scoped from the June audit; corrected in place. What was
+genuinely missing, now shipped on #1493: (1) **advisor posts had NO publish
+gate** (same hole as the forum, worse optics — authoritative voices) →
+`classifyText` with new `advisor_post` surface; non-clean verdicts bounce
+with the specific rule (RG 170 forward-looking message) rather than a hidden
+hold; (2) **follower notifications** — follows previously had zero pull;
+publishing now fans out capped (500) deduped announcements to followers;
+(3) confessions composer fixed (`?thread_type=` honoured, anonymity toggle,
+confession banner). Remaining genuinely-unbuilt Phase 1: QotD + 24h SLA
+(founder §11 D2/D3), article→thread cross-links, newsletter community-digest
+block, Founding-Experts BD motion.
+
 ---
 
 ## Open commitments / revisit-by dates

--- a/docs/strategy/FIN_NOTEBOOK.md
+++ b/docs/strategy/FIN_NOTEBOOK.md
@@ -742,6 +742,59 @@ Evaluated in conversation. Reframe: not "recruiter search" but "firm-to-advisor 
 
 The narrower, cheaper variant: a "Careers" tab on `/firm/[slug]` profiles. ~half day. Reveals demand without a marketplace build. **Provisional P2 sub-task — bundle into a future firm-profile-improvements stream.**
 
+### 2026-06-10 — News & community: lean in? (exploration, founder decision pending)
+
+Founder asked whether to lean further into news + community (e.g. a News tab in
+the top bar). Explored in conversation with Claude, grounded in the codebase.
+Verdicts provisional until founder confirms.
+
+**Grounding discoveries — most of it is already built, just unlit:**
+- `/community` (Reddit-style forum: seeded threads, confessions/debate formats,
+  RLS'd, index=true) and `/feed` (advisor insights feed) are LIVE but linked
+  from **nowhere in the header**.
+- Editorial (~740 pages: /articles, /learn, /how-to, /glossary) appears in the
+  nav only as a sidebar block inside the Tools mega-menu — no top-level entry.
+- Newsletter infra complete (segments, double opt-in, weekly + personalized
+  digest crons); archive noindexed while empty. No `/news` route exists.
+
+**Verdicts (provisional):**
+1. **Traditional newsroom / News tab now: NO.** (a) Commodity treadmill vs
+   AFR/Livewire/Stockhead, no data moat; (b) news monetises via display ads —
+   explicitly NEVER (#21); (c) zero-click/AI Overviews eat news summaries first,
+   counter to the GEO pivot (2026-05-21); (d) **pre-AFSL, market commentary
+   ("analysts see upside") drifts from the s766B factual carve-out toward
+   general advice** — widens the compliance surface exactly when it must stay
+   narrow; (e) homepage was cut 24→13 sections today for bloat — adding a
+   top-bar tab the same day cuts against that call.
+2. **Data-news ("what changed today"): YES — this is our version of news.**
+   Rate-change board / `/rates/today`, RBA-day + EOFY market-events calendar,
+   fee-change log, IPO alerts. Proprietary (we already track fees/rates),
+   factual (clean under the carve-out), GEO-citable, monetises through existing
+   levers (affiliate + newsletter sponsor). = DAILY_ENGAGEMENT_IDEAS Tier 1
+   #2/#6 + Tier 3 #18; the new `HomeMarketToday` band is the beachhead.
+3. **Community: YES strategically — the real moat (UGC = content AI can't get
+   elsewhere + retention) — but SEQUENCE it.** Pre-launch it's an empty
+   restaurant, and thin UGC pages indexed during the Oct–Dec migration window
+   add SEO risk at the worst possible moment. Seed supply-side first (advisor
+   question-of-the-day, office-hours transcripts → Q&A pages), noindex threads
+   below a quality threshold, promote to nav only post-cutover.
+4. **Nav: no News tab.** The real gap is ONE consolidated top-level content
+   entry ("Learn" / "Insights & Community") post-cutover, folding
+   articles/guides/glossary/Q&A/community — not two new tabs.
+
+**Sequencing:** now→Sep: data-news surfaces + Morning-Brief newsletter habit;
+community stays soft-launched/expert-seeded. Oct–Dec: freeze new surfaces
+(migration window). Q1 2027 (post-AFSL): commentary loosens (general advice
+covered), open community posting wider, add the consolidated nav entry.
+
+**Compliance tripwires if pursued:** market commentary pre-AFSL (above); UGC
+moderation duty (existing classifyText pipeline + house rules; specific-security
+"should I buy X" threads are the hot zone — ASIC INFO 269 finfluencer context);
+never let community pool money or drift toward execution (avoid-list).
+
+**Revisit:** 2026-07-10 — founder verdict on sequencing; if agreed, brief the
+data-news stream (rate-change log + `/rates/today`) as the first build.
+
 ---
 
 ## Open commitments / revisit-by dates

--- a/docs/strategy/FIN_NOTEBOOK.md
+++ b/docs/strategy/FIN_NOTEBOOK.md
@@ -806,6 +806,22 @@ counter killed in #1489). Plan's Phase 0 fixes both schema-free (migration
 ledger still frozen). These two are worth fixing even if community is never
 promoted.
 
+**Update 2 (same day) — founder said "do it all"; Phase 0 BUILT on PR #1493:**
+publish gate (classifyText, new forum surfaces) on thread/reply POSTs with
+held-for-review path into forum_reports; `/admin/community` queue
+(approve/remove/dismiss + live-row recounts); kill switch + hold_all raid dial;
+expert-answer elevation + licence-mode-aware adviser CTA on threads (the
+user-asks→expert-answers wire into the lead funnel); per-thread noindex until
+pinned/voted/expert-answered (migration protection); reply notifications;
+composer held-state + advice-phrasing nudge; /community/guidelines; footer
+link; PostHog gate events; DML-only counter-reconciliation script (run
+post-merge: `npx tsx --env-file=.env.local scripts/community-reconcile-counters.ts`
+— also seeds the Ask-an-Advisor category). 101 tests green, tsc/eslint clean.
+**Next up (Phase 1):** advisor quick-post UI + follow button (tables exist,
+no UI), QotD ritual + 24h Research-Team SLA (needs founder call on §11 D2/D3),
+confessions composer bug (`?thread_type=` ignored — Confess CTA makes a
+normal thread).
+
 ---
 
 ## Open commitments / revisit-by dates

--- a/lib/community/moderation.ts
+++ b/lib/community/moderation.ts
@@ -1,0 +1,90 @@
+/**
+ * Forum publish gate — wraps the shared `classifyText` classifier for the
+ * community surface and maps its verdict onto the forum's three outcomes:
+ *
+ *   - publish: insert visible (is_removed=false), bump counters
+ *   - hold:    insert hidden (is_removed=true) + open an auto-moderation
+ *              row in forum_reports so the /admin/community queue sees it
+ *   - reject:  400 to the author, nothing persisted
+ *
+ * Forum content was the one UGC surface that bypassed `classifyText`
+ * entirely (reviews, switch stories, advisor articles and Q&A answers all
+ * run it) — every thread and reply auto-published unscreened. This module
+ * closes that gap.
+ *
+ * Operational dials (no deploy needed):
+ *   - automation_kill_switches row `community_posting` → pauses all posting
+ *   - classifier_config forum_moderation.hold_all = 1 → every submission
+ *     is held for human review (raid/attack mode)
+ */
+
+import { classifyText } from "@/lib/text-moderation";
+import { getThreshold, isFeatureDisabled } from "@/lib/admin/classifier-config";
+
+export const COMMUNITY_POSTING_FEATURE = "community_posting";
+
+export type ForumGateAction = "publish" | "hold" | "reject";
+
+export interface ForumGateInput {
+  kind: "thread" | "post";
+  title?: string | null;
+  body: string;
+}
+
+export interface ForumGateResult {
+  action: ForumGateAction;
+  riskScore: number;
+  reasons: string[];
+}
+
+export const FORUM_DISABLED_MESSAGE =
+  "Community posting is temporarily paused. Please try again later.";
+
+export const FORUM_REJECT_MESSAGE =
+  "Your post can't be published because it appears to breach our community guidelines (spam, scam language, or prohibited content). Edit it and try again — see /community/guidelines.";
+
+export const FORUM_HOLD_MESSAGE =
+  "Thanks — your post has been submitted and is awaiting a quick moderator review before it goes live. This usually takes a few hours.";
+
+export async function isCommunityPostingDisabled(): Promise<boolean> {
+  return isFeatureDisabled(COMMUNITY_POSTING_FEATURE);
+}
+
+export async function gateForumContent(
+  input: ForumGateInput,
+): Promise<ForumGateResult> {
+  const result = classifyText({
+    text: input.body,
+    title: input.title ?? null,
+    surface: input.kind === "thread" ? "forum_thread" : "forum_post",
+  });
+
+  if (result.verdict === "auto_reject") {
+    return { action: "reject", riskScore: result.riskScore, reasons: result.reasons };
+  }
+
+  // Raid mode: hold everything regardless of classifier verdict.
+  const holdAll = await getThreshold("forum_moderation", "hold_all", 0);
+  if (result.verdict === "escalate" || holdAll >= 1) {
+    const reasons =
+      holdAll >= 1 && result.verdict !== "escalate"
+        ? ["hold_all_active", ...result.reasons]
+        : result.reasons;
+    return { action: "hold", riskScore: result.riskScore, reasons };
+  }
+
+  return { action: "publish", riskScore: result.riskScore, reasons: result.reasons };
+}
+
+/**
+ * Reason string stored on the auto-opened forum_reports row for held
+ * content. The `auto_moderation:` prefix is how the admin queue tells a
+ * classifier hold apart from a user report (column is capped at 500).
+ */
+export function autoModerationReason(reasons: string[]): string {
+  return `auto_moderation:${reasons.join(",")}`.slice(0, 500);
+}
+
+export function isAutoModerationReason(reason: string | null): boolean {
+  return reason != null && reason.startsWith("auto_moderation:");
+}

--- a/lib/community/recount.ts
+++ b/lib/community/recount.ts
@@ -1,0 +1,129 @@
+/**
+ * Forum counter recounts — recompute denormalised counters from the actual
+ * underlying rows instead of incrementing/decrementing in place.
+ *
+ * Counters must reflect *visible* (is_removed=false) content only: the seed
+ * migration initialised reply_count/vote_score above the real row counts
+ * (an honesty bug — see FIN_NOTEBOOK 2026-06-10), and the moderation
+ * approve/remove flow flips visibility after the original bumps ran.
+ * Recounting from source rows is idempotent and self-healing, so both the
+ * moderate route and the reconciliation script call these.
+ *
+ * Service-role rationale: counters span other users' rows and run from
+ * admin/moderator paths and ops scripts only (per the CLAUDE.md
+ * service-role scope: admin routes + cross-user lib helpers).
+ */
+
+// eslint-disable-next-line no-restricted-imports -- Cross-user query: recounts span every author's threads/posts/votes and run only from moderator routes and ops scripts, where no user JWT could pass RLS for other users' rows. Documented service-role-legitimate exception per CLAUDE.md "Two Supabase clients".
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+const log = logger("community:recount");
+
+/** Recompute reply_count + vote_score for one thread from live rows. */
+export async function recountThread(threadId: number): Promise<void> {
+  const admin = createAdminClient();
+
+  const { count: replyCount, error: postsError } = await admin
+    .from("forum_posts")
+    .select("id", { count: "exact", head: true })
+    .eq("thread_id", threadId)
+    .eq("is_removed", false);
+
+  const { data: votes, error: votesError } = await admin
+    .from("forum_votes")
+    .select("vote")
+    .eq("target_type", "thread")
+    .eq("target_id", threadId);
+
+  if (postsError || votesError) {
+    log.warn("recountThread query failed", {
+      threadId,
+      postsError: postsError?.message,
+      votesError: votesError?.message,
+    });
+    return;
+  }
+
+  const voteScore = (votes ?? []).reduce((sum, v) => sum + (v.vote ?? 0), 0);
+
+  const { error: updateError } = await admin
+    .from("forum_threads")
+    .update({ reply_count: replyCount ?? 0, vote_score: voteScore })
+    .eq("id", threadId);
+
+  if (updateError) {
+    log.warn("recountThread update failed", { threadId, error: updateError.message });
+  }
+}
+
+/** Recompute thread_count + post_count for one category from live rows. */
+export async function recountCategory(categoryId: string): Promise<void> {
+  const admin = createAdminClient();
+
+  const { data: threads, error: threadsError } = await admin
+    .from("forum_threads")
+    .select("id")
+    .eq("category_id", categoryId)
+    .eq("is_removed", false);
+
+  if (threadsError) {
+    log.warn("recountCategory threads query failed", {
+      categoryId,
+      error: threadsError.message,
+    });
+    return;
+  }
+
+  const threadIds = (threads ?? []).map((t) => t.id);
+
+  let postCount = 0;
+  if (threadIds.length > 0) {
+    const { count, error: postsError } = await admin
+      .from("forum_posts")
+      .select("id", { count: "exact", head: true })
+      .in("thread_id", threadIds)
+      .eq("is_removed", false);
+    if (postsError) {
+      log.warn("recountCategory posts query failed", {
+        categoryId,
+        error: postsError.message,
+      });
+      return;
+    }
+    postCount = count ?? 0;
+  }
+
+  const { error: updateError } = await admin
+    .from("forum_categories")
+    .update({ thread_count: threadIds.length, post_count: postCount })
+    .eq("id", categoryId);
+
+  if (updateError) {
+    log.warn("recountCategory update failed", { categoryId, error: updateError.message });
+  }
+}
+
+/**
+ * Full-forum reconciliation: every category and every thread. Used by
+ * scripts/community-reconcile-counters.ts; bounded by forum size, so fine
+ * to run synchronously at current scale (hundreds of rows).
+ */
+export async function recountAllForumCounters(): Promise<{
+  categories: number;
+  threads: number;
+}> {
+  const admin = createAdminClient();
+
+  const { data: categories } = await admin.from("forum_categories").select("id");
+  for (const cat of categories ?? []) {
+    await recountCategory(cat.id);
+  }
+
+  const { data: threads } = await admin.from("forum_threads").select("id");
+  for (const thread of threads ?? []) {
+    await recountThread(thread.id);
+  }
+
+  return { categories: categories?.length ?? 0, threads: threads?.length ?? 0 };
+}

--- a/lib/posthog/events.ts
+++ b/lib/posthog/events.ts
@@ -7,6 +7,8 @@ export type EventName =
   | 'advisor_response'
   | 'lead_outcome'
   | 'ai_referral'
+  | 'community_thread_submitted'
+  | 'community_post_submitted'
 
 export interface EventProps {
   quiz_started: {
@@ -70,6 +72,22 @@ export interface EventProps {
     vendor: string
     kind: 'assistant' | 'answer_engine'
     landing_path: string
+  }
+  /** Forum thread submission, captured server-side with the publish-gate outcome. */
+  community_thread_submitted: {
+    category_slug: string
+    thread_type: string
+    gate_action: 'publish' | 'hold' | 'reject'
+    risk_score: number
+    gate_reasons: string
+  }
+  /** Forum reply submission, captured server-side with the publish-gate outcome. */
+  community_post_submitted: {
+    thread_id: number
+    gate_action: 'publish' | 'hold' | 'reject'
+    risk_score: number
+    gate_reasons: string
+    is_nested_reply: boolean
   }
 }
 

--- a/lib/text-moderation.ts
+++ b/lib/text-moderation.ts
@@ -9,6 +9,7 @@
  *   - advisor articles (advisor_articles)
  *   - broker Q&A answers (broker_answers)
  *   - community forum threads + replies (forum_threads / forum_posts)
+ *   - advisor feed quick posts (advisor_posts)
  *
  * Same pure-classifier pattern as the dispute resolver, listing
  * scam classifier, and advisor verification classifier. Takes text
@@ -44,7 +45,8 @@ export interface ModerationContext {
     | "advisor_article"
     | "qa_answer"
     | "forum_thread"
-    | "forum_post";
+    | "forum_post"
+    | "advisor_post";
   /** Author identifier — used only for duplicate detection (cross-surface) */
   authorId?: string | null;
   /** Whether the author is a verified identity (auth'd user with history) */
@@ -313,6 +315,7 @@ export function classifyText(ctx: ModerationContext): ModerationResult {
     ctx.surface === "qa_answer" ? 30 :
     ctx.surface === "forum_post" ? 2 :
     ctx.surface === "forum_thread" ? 20 :
+    ctx.surface === "advisor_post" ? 10 :
     50;
   if (trimmed.length < minLength) {
     return {

--- a/lib/text-moderation.ts
+++ b/lib/text-moderation.ts
@@ -8,6 +8,7 @@
  *   - switch stories (switch_stories)
  *   - advisor articles (advisor_articles)
  *   - broker Q&A answers (broker_answers)
+ *   - community forum threads + replies (forum_threads / forum_posts)
  *
  * Same pure-classifier pattern as the dispute resolver, listing
  * scam classifier, and advisor verification classifier. Takes text
@@ -41,7 +42,9 @@ export interface ModerationContext {
     | "advisor_review"
     | "switch_story"
     | "advisor_article"
-    | "qa_answer";
+    | "qa_answer"
+    | "forum_thread"
+    | "forum_post";
   /** Author identifier — used only for duplicate detection (cross-surface) */
   authorId?: string | null;
   /** Whether the author is a verified identity (auth'd user with history) */
@@ -301,9 +304,15 @@ export function classifyText(ctx: ModerationContext): ModerationResult {
   // spam AND never clearly publishable. Always escalate so a human
   // decides — one-sentence reviews frequently carry important context
   // but rarely contain enough for automated judgement.
+  // Forum replies are conversational — "Thanks, that helped" is legitimate
+  // content, not low-quality spam — so the floor is near-zero. Thread bodies
+  // get a small floor: the route already enforces >=10 chars, this only
+  // catches sub-minimum noise that slipped past surface validation.
   const minLength =
     ctx.surface === "advisor_article" ? 300 :
     ctx.surface === "qa_answer" ? 30 :
+    ctx.surface === "forum_post" ? 2 :
+    ctx.surface === "forum_thread" ? 20 :
     50;
   if (trimmed.length < minLength) {
     return {

--- a/scripts/community-reconcile-counters.ts
+++ b/scripts/community-reconcile-counters.ts
@@ -1,0 +1,79 @@
+/**
+ * Forum counter reconciliation + Ask-an-Advisor category seed.
+ *
+ * Why this exists: the forum seed migration (20260802000000) initialised
+ * thread reply_count (0-7) and vote_score (4-16) ABOVE the rows it actually
+ * inserted (1-2 replies, 0 votes) — displayed numbers the underlying data
+ * can't back (same ACL s18 family as the fabricated social-proof counter
+ * removed in PR #1489). This script recomputes every forum counter from
+ * live rows, and idempotently creates the "Ask an Advisor" category that
+ * the /community FAQ promises.
+ *
+ * DML only — no DDL, safe under the migration-ledger freeze
+ * (docs/runbooks/MIGRATION_LEDGER_RECONCILIATION.md).
+ *
+ * Usage (needs NEXT_PUBLIC_SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY):
+ *   npx tsx --env-file=.env.local scripts/community-reconcile-counters.ts
+ *
+ * Idempotent — safe to re-run any time counters drift.
+ */
+
+import { createAdminClient } from "../lib/supabase/admin";
+import { recountAllForumCounters } from "../lib/community/recount";
+
+const ASK_AN_ADVISOR_CATEGORY = {
+  slug: "ask-an-advisor",
+  name: "Ask an Advisor",
+  description:
+    "Pose general questions for verified financial professionals to answer. General information only — not personal advice.",
+  icon: "user-check",
+  color: "#06b6d4",
+  status: "active",
+};
+
+async function ensureAskAnAdvisorCategory(): Promise<"created" | "exists"> {
+  const admin = createAdminClient();
+
+  const { data: existing } = await admin
+    .from("forum_categories")
+    .select("id")
+    .eq("slug", ASK_AN_ADVISOR_CATEGORY.slug)
+    .maybeSingle();
+  if (existing) return "exists";
+
+  const { data: maxSort } = await admin
+    .from("forum_categories")
+    .select("sort_order")
+    .order("sort_order", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  const { error } = await admin.from("forum_categories").insert({
+    ...ASK_AN_ADVISOR_CATEGORY,
+    sort_order: (maxSort?.sort_order ?? 0) + 1,
+    thread_count: 0,
+    post_count: 0,
+  });
+  if (error) throw new Error(`ask-an-advisor insert failed: ${error.message}`);
+  return "created";
+}
+
+async function main() {
+  console.log("Reconciling forum counters from live rows…");
+  const { categories, threads } = await recountAllForumCounters();
+  console.log(`  ✓ recounted ${categories} categories, ${threads} threads`);
+
+  const categoryResult = await ensureAskAnAdvisorCategory();
+  console.log(
+    categoryResult === "created"
+      ? "  ✓ created 'Ask an Advisor' category"
+      : "  ✓ 'Ask an Advisor' category already exists",
+  );
+
+  console.log("Done.");
+}
+
+main().catch((err) => {
+  console.error("Reconciliation failed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
Strategy docs + the community build the founder greenlit ("yes do it all" → "continue"). Four code commits on top of the plan docs:

**Docs**: `FIN_NOTEBOOK.md` news/community verdicts + `docs/plans/COMMUNITY_MASTER_PLAN.md` (positioning, 5-phase roadmap, UX spec, metrics/kill criteria, founder decisions §11) + in-place status updates as increments shipped.

**Phase 0 — forum safety layer** (schema-free; migration ledger frozen):
- Publish gate on forum thread/reply POSTs via shared `classifyText` (new `forum_thread`/`forum_post` surfaces): clean → publish, escalations → held hidden + queued in `forum_reports` (`auto_moderation:` prefix), violations → 400. `community_posting` kill switch + `forum_moderation.hold_all` raid dial (DB config, no deploy).
- `/admin/community` moderation queue (holds + reports) with approve / remove / dismiss; actions resolve reports and recount counters from live rows (`lib/community/recount`).
- Honest counters: recount helpers + DML-only `scripts/community-reconcile-counters.ts` for the inflated seed values; also seeds the promised Ask-an-Advisor category. **Post-merge op:** `npx tsx --env-file=.env.local scripts/community-reconcile-counters.ts` (idempotent).
- Expert answers: first verified-adviser reply pinned above the fold; threads without one get a licence-mode-aware Get-Matched/Browse-Advisers CTA.
- UGC indexing bar (noindex until pinned / vote_score ≥ 5 / expert-answered), reply notifications, composer 202-held state + advice-phrasing nudge, `/community/guidelines`, footer link, PostHog gate events.

**Phase 1 increment — expert supply side**:
- Advisor quick-post composer, Follow button, and /feed Following tabs **already existed** (plan 1.2/1.3 were stale-scoped; corrected in notebook). Genuinely missing, now shipped:
- `/api/advisor-auth/posts` publish gate (new `advisor_post` classifier surface) — advisor posts were the last unmoderated UGC surface; non-clean verdicts bounce 400 with the specific tripped rule (RG 170 wording for forward-looking language).
- Follower fan-out notifications on advisor post publish (capped 500, deduped, never fails the post) — gives the existing follow mechanic actual pull.
- Confessions composer fix: `?thread_type=` honoured, anonymous-by-default confessions + toggle.

**Verification**: 108 tests green across 6 touched suites (all pre-existing pass), `tsc --noEmit` clean, eslint zero warnings, rate-limit audit 100%, bundle delta +0.2% (advisory-green), perf budgets green.

**Still open (next PRs)**: QotD ritual + 24h Research-Team SLA (founder decisions §11 D2/D3), article→thread cross-links, newsletter community-digest block.

https://claude.ai/code/session_017y4MnruPudSpcLLKarEWRr