### PR TITLE
fix(home): move Friday Briefing below tools & calculators strip

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -290,11 +290,11 @@ export default async function HomePage() {
       </ScrollFadeIn>
 
       <ScrollFadeIn>
-        <HomeFridayBriefing />
+        <CountryToolsStripWrapper />
       </ScrollFadeIn>
 
       <ScrollFadeIn>
-        <CountryToolsStripWrapper />
+        <HomeFridayBriefing />
       </ScrollFadeIn>
     </div>
   );


### PR DESCRIPTION
## Summary

- Swaps the order of `HomeFridayBriefing` and `CountryToolsStripWrapper` on the homepage
- Tools & calculators now appear above the Friday Briefing newsletter signup
- Keeps high-intent utility content higher in the page flow

## Test plan

- [ ] Visit homepage and confirm tools/calculators section renders before the Friday Briefing signup
- [ ] Confirm both sections still render correctly with no visual regressions

https://claude.ai/code/session_011XsHkiveGSK3L3wv9PrfiF

---
_Generated by [Claude Code](https://claude.ai/code/session_011XsHkiveGSK3L3wv9PrfiF)_