### PR TITLE
feat(advisor-portal): canonical specialty chips + portal-wide setup nudge

### DIFF
--- a/__tests__/components/OnboardingWizard.test.tsx
+++ b/__tests__/components/OnboardingWizard.test.tsx
@@ -86,7 +86,7 @@ describe("OnboardingWizard", () => {
     render(
       <OnboardingWizard advisor={advisor} onAdvisorChange={() => {}} onClose={() => {}} initialStep="specialties" />,
     );
-    const input = screen.getByLabelText("Add a specialty, then press Enter");
+    const input = screen.getByLabelText("Or type your own, then press Enter");
     await userEvent.type(input, "SMSF setup{Enter}");
     await userEvent.type(input, "Retirement{Enter}");
     expect(screen.getByText("SMSF setup")).toBeInTheDocument();
@@ -138,5 +138,80 @@ describe("OnboardingWizard", () => {
     await userEvent.type(screen.getByLabelText("Bio"), "Hello");
     // bio (20) filled in the draft → live progress update.
     expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "20");
+  });
+
+  describe("specialty suggestions (canonical taxonomy)", () => {
+    it("offers type-appropriate canonical chips and tap-to-add works", async () => {
+      const fetchMock = mockFetchOk();
+      render(
+        <OnboardingWizard advisor={advisor} onAdvisorChange={() => {}} onClose={() => {}} initialStep="specialties" />,
+      );
+      // Canonical financial_planner entries from SPECIALTIES_BY_TYPE.
+      const chip = screen.getByRole("button", { name: /Retirement Planning/ });
+      await userEvent.click(chip);
+
+      // Added to the selected list…
+      const selected = screen.getByRole("list", { name: "Your specialties" });
+      expect(selected).toHaveTextContent("Retirement Planning");
+      // …and no longer offered as a suggestion.
+      const suggestions = screen.getByRole("list", { name: "Suggested specialties" });
+      expect(suggestions).not.toHaveTextContent("Retirement Planning");
+
+      await userEvent.click(screen.getByRole("button", { name: "Save & continue" }));
+      const body = JSON.parse((fetchMock.mock.calls[0]![1] as RequestInit).body as string);
+      expect(body).toEqual({ specialties: ["Retirement Planning"] });
+    });
+
+    it("already-selected specialties are excluded case-insensitively", () => {
+      render(
+        <OnboardingWizard
+          advisor={{ ...advisor, specialties: ["retirement planning"] }}
+          onAdvisorChange={() => {}}
+          onClose={() => {}}
+          initialStep="specialties"
+        />,
+      );
+      const suggestions = screen.getByRole("list", { name: "Suggested specialties" });
+      expect(suggestions).not.toHaveTextContent(/Retirement Planning/);
+    });
+
+    it("falls back to the global canonical list for an unknown advisor type", () => {
+      render(
+        <OnboardingWizard
+          advisor={{ ...advisor, type: "mystery_type" }}
+          onAdvisorChange={() => {}}
+          onClose={() => {}}
+          initialStep="specialties"
+        />,
+      );
+      const suggestions = screen.getByRole("list", { name: "Suggested specialties" });
+      expect(suggestions.querySelectorAll("button").length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("bio quality hint", () => {
+    it("counts down to the 50-char directory quality floor while the bio is short", async () => {
+      render(
+        <OnboardingWizard advisor={advisor} onAdvisorChange={() => {}} onClose={() => {}} initialStep="bio" />,
+      );
+      await userEvent.type(screen.getByLabelText("Bio"), "Ten chars!");
+      expect(
+        screen.getByText(/40 more characters to pass the directory quality check/),
+      ).toBeInTheDocument();
+    });
+
+    it("shows the general guidance once the floor is met", () => {
+      render(
+        <OnboardingWizard
+          advisor={{ ...advisor, bio: "x".repeat(60) }}
+          onAdvisorChange={() => {}}
+          onClose={() => {}}
+          initialStep="bio"
+        />,
+      );
+      expect(
+        screen.getByText(/profiles with a real bio pass the directory quality check/),
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/app/advisor-portal/OnboardingWizard.tsx
+++ b/app/advisor-portal/OnboardingWizard.tsx
@@ -8,6 +8,10 @@ import {
   deriveProfileCompleteness,
   type WizardStepId,
 } from "@/lib/advisor-portal/profile-completeness";
+import {
+  ALL_ADVISOR_SPECIALTIES,
+  SPECIALTIES_BY_TYPE,
+} from "@/lib/advisor-specialties";
 import type { Advisor } from "./types";
 
 /**
@@ -41,6 +45,28 @@ const AVAILABILITY_OPTIONS: { value: "open" | "waitlist" | "closed"; label: stri
   { value: "waitlist", label: "Waitlist", dot: "bg-amber-400" },
   { value: "closed", label: "Not taking clients", dot: "bg-slate-400" },
 ];
+
+/** Directory quality gate wants a real bio — mirror its 50-char floor here. */
+const BIO_QUALITY_MIN = 50;
+
+/** Max canonical suggestions to show — enough to seed, not a wall of chips. */
+const SPECIALTY_SUGGESTION_CAP = 12;
+
+/**
+ * Canonical, matching-aligned specialty suggestions for this advisor's type.
+ * The quiz and ranker match on these exact strings, so seeding them (instead
+ * of free-text-only) keeps the taxonomy coherent and the advisor routable.
+ */
+function specialtySuggestionsFor(advisorType: string | undefined): string[] {
+  const byType =
+    advisorType && advisorType in SPECIALTIES_BY_TYPE
+      ? SPECIALTIES_BY_TYPE[advisorType as keyof typeof SPECIALTIES_BY_TYPE]
+      : null;
+  return (byType && byType.length > 0 ? byType : ALL_ADVISOR_SPECIALTIES).slice(
+    0,
+    SPECIALTY_SUGGESTION_CAP,
+  );
+}
 
 /** The PATCH body for each step — only allowlisted fields, only this step's. */
 function stepPatchBody(step: WizardStepId, draft: Advisor): Record<string, unknown> | null {
@@ -94,15 +120,22 @@ export default function OnboardingWizard({ advisor, onAdvisorChange, onClose, in
 
   const set = (patch: Partial<Advisor>) => setDraft((d) => ({ ...d, ...patch }));
 
-  const addSpecialty = () => {
-    const value = specialtyInput.trim().replace(/,$/, "");
+  const addSpecialty = (raw?: string) => {
+    const value = (raw ?? specialtyInput).trim().replace(/,$/, "");
     if (!value) return;
     const current = draft.specialties || [];
     if (!current.some((s) => s.toLowerCase() === value.toLowerCase())) {
       set({ specialties: [...current, value] });
     }
-    setSpecialtyInput("");
+    if (raw === undefined) setSpecialtyInput("");
   };
+
+  const specialtySuggestions = useMemo(() => {
+    const selected = new Set((draft.specialties || []).map((s) => s.toLowerCase()));
+    return specialtySuggestionsFor(draft.type).filter(
+      (s) => !selected.has(s.toLowerCase()),
+    );
+  }, [draft.type, draft.specialties]);
 
   const removeSpecialty = (value: string) =>
     set({ specialties: (draft.specialties || []).filter((s) => s !== value) });
@@ -247,7 +280,13 @@ export default function OnboardingWizard({ advisor, onAdvisorChange, onClose, in
                     onChange={(e) => set({ bio: e.target.value })}
                     className={inputClass}
                     placeholder="Tell investors about your experience and approach..."
+                    aria-describedby="ow-bio-hint"
                   />
+                  <p id="ow-bio-hint" className="text-[0.68rem] text-slate-500 mt-1">
+                    {(draft.bio || "").trim().length > 0 && (draft.bio || "").trim().length < BIO_QUALITY_MIN
+                      ? `${BIO_QUALITY_MIN - (draft.bio || "").trim().length} more characters to pass the directory quality check.`
+                      : "Aim for at least a few sentences — profiles with a real bio pass the directory quality check and convert more matches."}
+                  </p>
                 </div>
                 <div>
                   <label htmlFor="ow-website" className="block text-xs font-semibold text-slate-600 mb-1">
@@ -267,8 +306,29 @@ export default function OnboardingWizard({ advisor, onAdvisorChange, onClose, in
 
             {step.id === "specialties" && (
               <div>
+                {specialtySuggestions.length > 0 && (
+                  <div className="mb-4">
+                    <p className="text-xs font-semibold text-slate-600 mb-1.5">
+                      Tap to add — these are the specialties investors search and the quiz matches on
+                    </p>
+                    <ul className="flex flex-wrap gap-1.5" aria-label="Suggested specialties">
+                      {specialtySuggestions.map((s) => (
+                        <li key={s}>
+                          <button
+                            type="button"
+                            onClick={() => addSpecialty(s)}
+                            className="flex items-center gap-1 border border-slate-200 bg-white hover:border-violet-300 hover:bg-violet-50 text-slate-700 text-xs font-medium rounded-full px-2.5 py-1.5 min-h-8 transition-colors"
+                          >
+                            <span aria-hidden className="text-violet-500 font-bold">+</span>
+                            {s}
+                          </button>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
                 <label htmlFor="ow-specialty" className="block text-xs font-semibold text-slate-600 mb-1">
-                  Add a specialty, then press Enter
+                  Or type your own, then press Enter
                 </label>
                 <input
                   id="ow-specialty"
@@ -280,7 +340,7 @@ export default function OnboardingWizard({ advisor, onAdvisorChange, onClose, in
                       addSpecialty();
                     }
                   }}
-                  onBlur={addSpecialty}
+                  onBlur={() => addSpecialty()}
                   className={inputClass}
                   placeholder="e.g. SMSF setup, First-home buyers, Retirement planning"
                 />

--- a/app/advisor-portal/page.tsx
+++ b/app/advisor-portal/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import Icon from "@/components/Icon";
 import AdvisorPortalLogin from "./AdvisorPortalLogin";
 import { anyFetchFailed } from "@/lib/advisor-portal/load-state";
+import { deriveProfileCompleteness } from "@/lib/advisor-portal/profile-completeness";
 import type {
   Advisor,
   Lead, Stats, ViewDay, Review, WeeklyEnquiry, ProfileCompleteness,
@@ -430,6 +431,61 @@ export default function AdvisorPortalPage() {
             </div>
           </div>
         )}
+
+        {/* ─── PORTAL-WIDE SETUP NUDGE ───
+            The dashboard carries the full onboarding checklist; every OTHER
+            tab gets this slim strip so an incomplete profile is never out of
+            sight. Completeness derives live from the advisor row (same lib as
+            the wizard + dashboard API), and the CTA lands on the dashboard
+            where the checklist + wizard live. Respects the same dismissal. */}
+        {advisor &&
+          view !== "dashboard" &&
+          !dismissedOnboarding &&
+          (() => {
+            const completeness = deriveProfileCompleteness(
+              advisor as unknown as Record<string, unknown>,
+            );
+            if (completeness.score >= 80) return null;
+            const next = completeness.steps.find((s) => !s.complete);
+            return (
+              <div className="bg-violet-50 border border-violet-200 rounded-xl px-4 py-2.5 mb-6 flex items-center gap-3">
+                <div
+                  className="hidden sm:block w-20 h-1.5 bg-violet-100 rounded-full overflow-hidden shrink-0"
+                  role="progressbar"
+                  aria-valuenow={completeness.score}
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                  aria-label={`Profile ${completeness.score}% complete`}
+                >
+                  <div
+                    className="h-full bg-violet-500 rounded-full"
+                    style={{ width: `${completeness.score}%` }}
+                  />
+                </div>
+                <p className="text-xs text-violet-900 flex-1 min-w-0 truncate">
+                  <span className="font-bold">{completeness.score}% complete</span>
+                  {next && (
+                    <span className="text-violet-700">
+                      {" "}— next: {next.title.toLowerCase()}
+                    </span>
+                  )}
+                </p>
+                <button
+                  onClick={() => setView("dashboard")}
+                  className="shrink-0 text-xs font-bold text-violet-700 hover:text-violet-900 underline underline-offset-2 min-h-11 px-1"
+                >
+                  Continue setup →
+                </button>
+                <button
+                  onClick={() => setDismissedOnboarding(true)}
+                  aria-label="Dismiss setup reminder"
+                  className="shrink-0 w-8 h-8 min-h-0 flex items-center justify-center rounded-lg text-violet-400 hover:text-violet-600 hover:bg-violet-100"
+                >
+                  ✕
+                </button>
+              </div>
+            );
+          })()}
 
         {/* ─── DASHBOARD ─── */}
         {view === "dashboard" && (


### PR DESCRIPTION
## Task 2 — advisor onboarding wizard, elevated

Audit first (per the brief): the 5-step wizard, the derive-based completeness lib, and the dashboard checklist **already exist and are solid** (`OnboardingWizard.tsx`, `lib/advisor-portal/profile-completeness.ts`). This PR preserves all of it and fixes the three real gaps the audit found:

### 1. Canonical specialty chips (matching quality)
The specialties step was free-text only — but the quiz and ranker match on the **exact canonical strings** in `lib/advisor-specialties.ts`, so free-text variants ("SMSF" vs "SMSF setup") quietly made advisors unroutable. The step now seeds **type-appropriate, tap-to-add suggestion chips** from `SPECIALTIES_BY_TYPE` (global fallback for unknown types), case-insensitively deduped against selections, with free text kept as a fallback.

### 2. Bio quality-gate hint (activation)
The directory visibility gate requires a ≥50-char bio, but the wizard never said so — advisors could "complete" the step and still silently fail the gate. The bio field now shows a live countdown to the floor, then commercial guidance once met.

### 3. Portal-wide setup nudge (always-visible next action)
The completeness checklist only existed on the Dashboard tab; every other tab let an incomplete profile drop out of sight. A slim, dismissable `X% complete — next: <step>` strip now renders on all non-dashboard tabs (score < 80, same dismissal state), with the CTA landing on the dashboard where the checklist + wizard live. Completeness derives live from the same shared lib — no new state, no drift.

### Constraints honoured
- **No schema, no new routes** — saves flow through the existing `PATCH /api/advisor-auth/profile` allowlist; completeness stays derived.
- Existing wizard behaviour, API shapes, and the completeness contract untouched.

### Verification
`tsc` clean · `eslint --max-warnings 0` clean · OnboardingWizard suite extended **9 → 14 tests** (chips add/dedupe/fallback, bio hint both states), all green. Manual click-through of the portal is limited in this sandbox (no Supabase env for the auth-gated portal); the wizard itself is fully exercised via RTL interaction tests.

### Note on branching
`claude/epic-newton-g5ml7l` holds unmerged in-flight quiz-engine work from a prior session (currently paused), so Task 2 ships on this dedicated branch to keep the two workstreams and their reviews separate.

https://claude.ai/code/session_01FdSEBPnPofJaBPhWy1dggf

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdSEBPnPofJaBPhWy1dggf)_