### PR TITLE
refactor(ux): Wave-2 density batch — advisors, account, calculators, content

### DIFF
--- a/__tests__/integration/o-iter6.rls.int.test.ts
+++ b/__tests__/integration/o-iter6.rls.int.test.ts
@@ -37,7 +37,7 @@ import path from "node:path";
 
 const MIGRATION_PATH = path.join(
   process.cwd(),
-  "supabase/migrations/20260429_o_iter6_rls_forum.sql",
+  "supabase/migrations/archive/20260429_o_iter6_rls_forum.sql",
 );
 
 const FORUM_TABLES = [

--- a/__tests__/integration/o-iter7.rls.int.test.ts
+++ b/__tests__/integration/o-iter7.rls.int.test.ts
@@ -30,7 +30,7 @@ import path from "node:path";
 
 const MIGRATION_PATH = path.resolve(
   __dirname,
-  "../../supabase/migrations/20260429_o_iter7_rls_editorial_obs_secrets.sql",
+  "../../supabase/migrations/archive/20260429_o_iter7_rls_editorial_obs_secrets.sql",
 );
 const SQL = readFileSync(MIGRATION_PATH, "utf8");
 

--- a/__tests__/integration/o-iter8.rls.int.test.ts
+++ b/__tests__/integration/o-iter8.rls.int.test.ts
@@ -26,7 +26,7 @@ import path from "node:path";
 
 const MIGRATION_PATH = path.resolve(
   __dirname,
-  "../../supabase/migrations/20260501_o_iter8_rls_observability.sql",
+  "../../supabase/migrations/archive/20260501_o_iter8_rls_observability.sql",
 );
 const SQL = readFileSync(MIGRATION_PATH, "utf8");
 

--- a/__tests__/integration/quarterly-reports-rls.int.test.ts
+++ b/__tests__/integration/quarterly-reports-rls.int.test.ts
@@ -27,7 +27,7 @@ import path from "node:path";
 
 const MIGRATION_PATH = path.resolve(
   __dirname,
-  "../../supabase/migrations/20260501_c05b_quarterly_reports_rls.sql",
+  "../../supabase/migrations/archive/20260501_c05b_quarterly_reports_rls.sql",
 );
 const SQL = readFileSync(MIGRATION_PATH, "utf8");
 

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -100,7 +100,7 @@ export default async function AccountPage() {
       {dashboard && (
         <div className="max-w-4xl mx-auto px-4 sm:px-6 pt-8 space-y-4">
           <AccountHero hero={dashboard.hero} />
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-2.5">
             <Kpi label="Action plans" value={String(dashboard.kpis.plans)} />
             <Kpi label="Match Requests" value={String(dashboard.kpis.briefs)} />
             <Kpi
@@ -241,7 +241,7 @@ function Kpi({
     ? "bg-amber-50 border-amber-200 text-amber-900"
     : "bg-white border-slate-200 text-slate-900";
   return (
-    <div className={`rounded-xl border p-4 ${cls}`}>
+    <div className={`rounded-xl border p-3 ${cls}`}>
       <p className="text-[11px] uppercase tracking-widest mb-1 opacity-80">{label}</p>
       <p className="text-2xl font-extrabold">{value}</p>
     </div>

--- a/app/account/profile/ProfileClient.tsx
+++ b/app/account/profile/ProfileClient.tsx
@@ -245,7 +245,7 @@ export default function ProfileClient() {
   }
 
   return (
-    <div className="py-5 md:py-12">
+    <div className="py-4 md:py-6">
       <div className="container-custom max-w-2xl">
         {/* Header */}
         <div className="flex items-center gap-3 mb-8">

--- a/app/account/saved/SavedComparisonsClient.tsx
+++ b/app/account/saved/SavedComparisonsClient.tsx
@@ -127,7 +127,7 @@ export default function SavedComparisonsClient() {
 
   if (userLoading || loading) {
     return (
-      <div className="py-16">
+      <div className="py-6">
         <div className="container-custom max-w-2xl">
           <div className="animate-pulse space-y-4" aria-busy="true" aria-label="Loading saved comparisons…">
             <div className="h-8 bg-slate-200 rounded w-56" />
@@ -142,7 +142,7 @@ export default function SavedComparisonsClient() {
   if (!user) return null;
 
   return (
-    <div className="py-5 md:py-12">
+    <div className="py-4 md:py-6">
       <div className="container-custom max-w-2xl">
         {/* Header */}
         <div className="flex items-center gap-3 mb-6">

--- a/app/account/select-workspace/page.tsx
+++ b/app/account/select-workspace/page.tsx
@@ -13,7 +13,6 @@ import { createClient } from "@/lib/supabase/server";
 import {
   getKindsForUser,
   type KindMembership,
-  type WorkspaceKind,
 } from "@/lib/account-kinds";
 import SelectWorkspaceClient from "./SelectWorkspaceClient";
 
@@ -50,14 +49,14 @@ export default async function SelectWorkspacePage() {
       ];
 
   return (
-    <main className="bg-slate-50 min-h-[60vh]">
-      <div className="max-w-2xl mx-auto px-4 sm:px-6 py-12">
-        <header className="mb-8 text-center">
+    <main className="bg-slate-50">
+      <div className="max-w-2xl mx-auto px-4 sm:px-6 py-6 md:py-8">
+        <header className="mb-6 text-center">
           <h1 className="text-2xl font-bold text-slate-900 mb-2">
             Choose your workspace
           </h1>
           <p className="text-sm text-slate-600">
-            You have multiple roles on Invest.com.au. Pick the workspace you'd like to start in — you can switch any time from the header menu.
+            You have multiple roles on Invest.com.au. Pick the workspace you&apos;d like to start in — you can switch any time from the header menu.
           </p>
         </header>
         <SelectWorkspaceClient memberships={augmented} />

--- a/app/advisor-portal/briefs/page.tsx
+++ b/app/advisor-portal/briefs/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import BriefsInboxClient from "./BriefsInboxClient";
 
 export const metadata: Metadata = {
@@ -11,11 +12,16 @@ export const dynamic = "force-dynamic";
 export default function AdvisorPortalBriefsPage() {
   return (
     <div className="min-h-screen bg-slate-50">
-      <div className="max-w-5xl mx-auto px-4 py-8 sm:py-12">
-        <h1 className="text-2xl sm:text-3xl font-extrabold text-slate-900 mb-1">
+      <div className="max-w-5xl mx-auto px-4 pt-4 pb-10 md:pt-5">
+        <nav aria-label="Breadcrumb" className="mb-1.5 text-[11px] md:text-xs text-slate-400">
+          <Link href="/advisor-portal" className="hover:text-slate-700">Advisor Portal</Link>
+          <span className="mx-1.5" aria-hidden>/</span>
+          <span className="text-slate-600">Brief inbox</span>
+        </nav>
+        <h1 className="text-2xl font-extrabold leading-tight tracking-tight text-slate-900 md:text-[1.9rem]">
           Investor Brief inbox
         </h1>
-        <p className="text-sm text-slate-500 mb-8">
+        <p className="mt-1 mb-5 max-w-2xl text-[12.5px] leading-snug text-slate-500 md:text-[13.5px]">
           Verified providers see masked previews. Accept a brief to unlock the
           consumer&apos;s contact details — your credit balance is debited at
           the moment of acceptance.

--- a/app/advisors/[type]/[state]/page.tsx
+++ b/app/advisors/[type]/[state]/page.tsx
@@ -238,12 +238,12 @@ export default async function AdvisorTypeLocationPage({ params }: { params: Prom
         pageDescription={pageDesc}
       />
       <div className="container-custom max-w-3xl pb-10">
-        <section className="mt-10">
-          <h2 className="text-xl font-extrabold text-slate-900 mb-5">Frequently asked questions</h2>
+        <section className="mt-6">
+          <h2 className="text-lg font-extrabold text-slate-900 mb-3">Frequently asked questions</h2>
           <div className="space-y-3">
             {pageFaqs.map((faq) => (
               <details key={faq.q} className="group rounded-xl border border-slate-200 bg-slate-50">
-                <summary className="flex cursor-pointer items-center justify-between gap-4 px-5 py-4 font-semibold text-slate-900 list-none">
+                <summary className="flex cursor-pointer items-center justify-between gap-4 px-4 py-3 font-semibold text-slate-900 list-none">
                   {faq.q}
                   <span className="shrink-0 text-slate-400 group-open:rotate-180 transition-transform" aria-hidden="true">▾</span>
                 </summary>

--- a/app/advisors/compare/AdvisorCompareClient.tsx
+++ b/app/advisors/compare/AdvisorCompareClient.tsx
@@ -204,14 +204,14 @@ export default function AdvisorCompareClient() {
             <thead>
               <tr className="border-b border-slate-200">
                 {/* Feature label header */}
-                <th scope="col" className="px-4 py-4 text-left text-xs font-semibold text-slate-500 uppercase tracking-wide bg-slate-50 sticky left-0 z-10 min-w-[9rem]">
+                <th scope="col" className="px-3 py-3 text-left text-xs font-semibold text-slate-500 uppercase tracking-wide bg-slate-50 sticky left-0 z-10 min-w-[8rem] md:min-w-[9rem]">
                   Feature
                 </th>
 
                 {columns.map((col) => {
                   const advisor = advisors.find((a) => a.slug === col.slug);
                   return (
-                    <th scope="col" key={col.slug} className="px-4 py-4 text-center min-w-[200px] align-top">
+                    <th scope="col" key={col.slug} className="px-3 py-3 text-center min-w-[150px] md:min-w-[170px] lg:min-w-[200px] align-top">
                       {/* Remove button */}
                       <div className="flex justify-end mb-1">
                         <button

--- a/app/advisors/compare/page.tsx
+++ b/app/advisors/compare/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 
 export default function AdvisorComparePage() {
   return (
-    <div className="max-w-6xl mx-auto px-4 pt-5 pb-10 md:pt-10 md:pb-14">
+    <div className="max-w-6xl mx-auto px-4 pt-3 pb-6 md:pt-4 md:pb-8">
       <Suspense
         fallback={
           <div className="animate-pulse space-y-4">

--- a/app/advisors/page.tsx
+++ b/app/advisors/page.tsx
@@ -144,7 +144,7 @@ export default function AdvisorsPage() {
         <NextActions surface="advisors" />
       </Suspense>
       <HomeToolsStrip />
-      <section className="py-10 bg-white border-t border-slate-200">
+      <section className="py-6 md:py-8 bg-white border-t border-slate-200">
         <div className="container-custom max-w-3xl">
           <h2 className="text-lg font-bold text-slate-900 mb-4">Frequently asked questions</h2>
           <div className="space-y-3">

--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -648,7 +648,7 @@ function ArticleCard({ article, priority = false }: { article: Article; priority
         priority={priority}
         sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
       />
-      <div className="p-2.5 md:p-6 flex flex-col flex-1">
+      <div className="p-3 md:p-4 flex flex-col flex-1">
         {/* Badges Row */}
         <div className="flex items-center gap-1 md:gap-2 mb-1 md:mb-3">
           {article.category && (

--- a/app/calculators/_components/CalcShared.tsx
+++ b/app/calculators/_components/CalcShared.tsx
@@ -131,7 +131,7 @@ export function InputField({ label, value, onChange, placeholder, prefix, suffix
   const id = useId();
   return (
     <div>
-      <label htmlFor={id} className="block text-[0.69rem] md:text-xs font-bold uppercase tracking-wider text-slate-500 mb-1 md:mb-1.5">{label}</label>
+      <label htmlFor={id} className="block text-[0.69rem] md:text-xs font-bold uppercase tracking-wider text-slate-500 mb-1">{label}</label>
       <div className="relative">
         {prefix && <div className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 font-medium text-sm">{prefix}</div>}
         <input
@@ -140,7 +140,7 @@ export function InputField({ label, value, onChange, placeholder, prefix, suffix
           value={value}
           onChange={(e) => onChange(e.target.value)}
           placeholder={placeholder}
-          className={`w-full bg-white border border-slate-200 rounded-lg py-2.5 md:py-2.5 min-h-11 text-sm shadow-sm focus:outline-none focus:border-blue-700 focus:ring-1 focus:ring-blue-700 transition-all font-medium ${prefix ? "pl-7" : "pl-3 md:pl-4"} ${suffix ? "pr-10" : "pr-3 md:pr-4"}`}
+          className={`w-full bg-white border border-slate-200 rounded-lg py-2 min-h-11 text-sm shadow-sm focus:outline-none focus:border-blue-700 focus:ring-1 focus:ring-blue-700 transition-all font-medium ${prefix ? "pl-7" : "pl-3 md:pl-4"} ${suffix ? "pr-10" : "pr-3 md:pr-4"}`}
         />
         {suffix && <div className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 font-medium text-sm">{suffix}</div>}
       </div>

--- a/app/calculators/page.tsx
+++ b/app/calculators/page.tsx
@@ -142,15 +142,15 @@ export default async function CalculatorsPage() {
           subtitle="Answer 5-7 quick questions — we'll match you to the right platform, opportunity, or verified pro for your situation."
         />
         <ComplianceFooter variant="calculator" />
-        <div className="mt-8 space-y-3">
+        <div className="mt-8 space-y-2.5">
           <h2 className="text-lg font-bold text-slate-900 mb-4">Frequently asked questions</h2>
           {CALCULATORS_FAQS.map((faq) => (
             <details key={faq.q} className="bg-slate-50 border border-slate-200 rounded-xl overflow-hidden group">
-              <summary className="px-5 py-4 text-sm font-bold text-slate-900 cursor-pointer hover:bg-slate-100 flex items-center justify-between">
+              <summary className="px-4 py-3 text-sm font-bold text-slate-900 cursor-pointer hover:bg-slate-100 flex items-center justify-between">
                 {faq.q}
                 <span className="text-slate-400 group-open:rotate-180 transition-transform ml-2 shrink-0" aria-hidden="true">▾</span>
               </summary>
-              <div className="px-5 pb-4">
+              <div className="px-4 pb-3">
                 <p className="text-sm text-slate-600 leading-relaxed">{faq.a}</p>
               </div>
             </details>

--- a/app/learn/page.tsx
+++ b/app/learn/page.tsx
@@ -163,7 +163,7 @@ export default async function LearnHubPage() {
             <p className="text-sm text-slate-600 mb-8">
               Pick the path closest to where you are now. Progress is saved per path so you can pause and come back.
             </p>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3 md:gap-4">
               {LEARNING_PATHS.map((path) => {
                 const accent = PATH_ACCENTS[path.colorClass] ?? PATH_ACCENTS["teal"]!;
                 const totalMins = sumEstimatedMinutes(path);
@@ -172,7 +172,7 @@ export default async function LearnHubPage() {
                   <Link
                     key={path.slug}
                     href={`/learn/${path.slug}`}
-                    className={`group flex flex-col rounded-2xl border bg-white p-5 transition-all duration-150 hover:shadow-md hover:${accent.border} ${accent.border}`}
+                    className={`group flex flex-col rounded-xl border bg-white p-4 transition-all duration-150 hover:shadow-md hover:${accent.border} ${accent.border}`}
                   >
                     <div className="flex items-start justify-between gap-3 mb-3">
                       <h3 className={`font-extrabold text-slate-900 leading-snug group-hover:${accent.text} transition-colors text-base`}>

--- a/app/shortlist/advisors/page.tsx
+++ b/app/shortlist/advisors/page.tsx
@@ -10,9 +10,9 @@ export const metadata: Metadata = {
 
 export default function AdvisorShortlistPage() {
   return (
-    <div className="max-w-4xl mx-auto px-4 pt-5 pb-8 md:pt-10 md:pb-12">
+    <div className="max-w-4xl mx-auto px-4 pt-3 pb-6 md:pt-4 md:pb-8">
       <div className="mb-4 md:mb-6">
-        <h1 className="text-xl md:text-3xl font-extrabold text-slate-900">My Saved Advisors</h1>
+        <h1 className="text-lg md:text-xl font-extrabold text-slate-900">My Saved Advisors</h1>
         <p className="text-xs md:text-sm text-slate-500 mt-0.5">
           Tap the bookmark on any advisor to save them here. Compare up to 4 side by side.
         </p>


### PR DESCRIPTION
## Wave-2 density batch (UX_UI_FINTECH_ALIGNMENT items B12, C7–C11, D2, D4, D5, D10, F2, F3, F5, F7)

Sixteen audited S-effort fixes, all class-level — no logic, API or schema changes:

**Advisors**
- Typed/state + index FAQ sections tightened (`py-10 → py-6/8`, `px-5 py-4 → px-4 py-3`)
- Compare page container `pt-10/pb-14 → pt-4/pb-8`; compare table gets **responsive column widths** (`min-w 150/170/200px` — the flat 200px forced horizontal scroll on tablets) and `px-3 py-3` cells
- Saved-advisors shortlist header compacted

**Account**
- Profile + saved wrappers `md:py-12 → md:py-6`; saved skeleton `py-16 → py-6`
- Select-workspace drops `min-h-[60vh]` + `py-12 → py-6/8` (utility chooser, not a splash) — also clears two pre-existing lint warnings there
- Dashboard KPI pills `p-4/gap-3 → p-3/gap-2.5`

**Advisor portal**
- Brief-inbox page gets the compact light-header idiom (breadcrumb + tight headline, `pt-4` instead of `py-12`)

**Calculators / content**
- Shared `InputField` `py-2.5 → py-2`, uniform label margin; calculators FAQ density standardised
- Learn path cards `rounded-2xl p-5 → rounded-xl p-4`; article card bodies `p-2.5/p-6 → p-3/p-4`

### Verification
`eslint --max-warnings 0` clean · `tsc` clean · Calculator + ArticleSidebar suites green (31 tests).

Part of the `/loop` finishing pass over `docs/plans/UX_UI_FINTECH_ALIGNMENT.md`. Next iterations: VerticalPillarPage/HubPage hero consolidation (E8/E9), invest listing-detail + sector headers (E1/E3/E7), auth-form primitive migration (D1/D6/D7), contrast wave 2.

https://claude.ai/code/session_01FdSEBPnPofJaBPhWy1dggf

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdSEBPnPofJaBPhWy1dggf)_