### PR TITLE
refactor(ux): unify pillar + hub heroes on the compact light header (E8/E9)

### DIFF
--- a/__tests__/components/HubHero.test.tsx
+++ b/__tests__/components/HubHero.test.tsx
@@ -263,11 +263,11 @@ describe("HubHero", () => {
   });
 
   describe("theming", () => {
-    it("applies the default slate-900 panel when no className override is supplied", () => {
+    it("applies the default compact light header when no className override is supplied", () => {
       render(<HubHero hero={baseHero} breadcrumbs={baseCrumbs} />);
       const section = screen.getByTestId("hub-hero");
-      expect(section.className).toContain("bg-slate-900");
-      expect(section.className).toContain("text-white");
+      expect(section.className).toContain("bg-white");
+      expect(section.className).toContain("border-slate-100");
     });
 
     it("allows overriding the section className for hub-specific theming", () => {

--- a/__tests__/integration/o-iter6.rls.int.test.ts
+++ b/__tests__/integration/o-iter6.rls.int.test.ts
@@ -37,7 +37,7 @@ import path from "node:path";
 
 const MIGRATION_PATH = path.join(
   process.cwd(),
-  "supabase/migrations/20260429_o_iter6_rls_forum.sql",
+  "supabase/migrations/archive/20260429_o_iter6_rls_forum.sql",
 );
 
 const FORUM_TABLES = [

--- a/__tests__/integration/o-iter7.rls.int.test.ts
+++ b/__tests__/integration/o-iter7.rls.int.test.ts
@@ -30,7 +30,7 @@ import path from "node:path";
 
 const MIGRATION_PATH = path.resolve(
   __dirname,
-  "../../supabase/migrations/20260429_o_iter7_rls_editorial_obs_secrets.sql",
+  "../../supabase/migrations/archive/20260429_o_iter7_rls_editorial_obs_secrets.sql",
 );
 const SQL = readFileSync(MIGRATION_PATH, "utf8");
 

--- a/__tests__/integration/o-iter8.rls.int.test.ts
+++ b/__tests__/integration/o-iter8.rls.int.test.ts
@@ -26,7 +26,7 @@ import path from "node:path";
 
 const MIGRATION_PATH = path.resolve(
   __dirname,
-  "../../supabase/migrations/20260501_o_iter8_rls_observability.sql",
+  "../../supabase/migrations/archive/20260501_o_iter8_rls_observability.sql",
 );
 const SQL = readFileSync(MIGRATION_PATH, "utf8");
 

--- a/__tests__/integration/quarterly-reports-rls.int.test.ts
+++ b/__tests__/integration/quarterly-reports-rls.int.test.ts
@@ -27,7 +27,7 @@ import path from "node:path";
 
 const MIGRATION_PATH = path.resolve(
   __dirname,
-  "../../supabase/migrations/20260501_c05b_quarterly_reports_rls.sql",
+  "../../supabase/migrations/archive/20260501_c05b_quarterly_reports_rls.sql",
 );
 const SQL = readFileSync(MIGRATION_PATH, "utf8");
 

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -100,7 +100,7 @@ export default async function AccountPage() {
       {dashboard && (
         <div className="max-w-4xl mx-auto px-4 sm:px-6 pt-8 space-y-4">
           <AccountHero hero={dashboard.hero} />
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-2.5">
             <Kpi label="Action plans" value={String(dashboard.kpis.plans)} />
             <Kpi label="Match Requests" value={String(dashboard.kpis.briefs)} />
             <Kpi
@@ -241,7 +241,7 @@ function Kpi({
     ? "bg-amber-50 border-amber-200 text-amber-900"
     : "bg-white border-slate-200 text-slate-900";
   return (
-    <div className={`rounded-xl border p-4 ${cls}`}>
+    <div className={`rounded-xl border p-3 ${cls}`}>
       <p className="text-[11px] uppercase tracking-widest mb-1 opacity-80">{label}</p>
       <p className="text-2xl font-extrabold">{value}</p>
     </div>

--- a/app/account/profile/ProfileClient.tsx
+++ b/app/account/profile/ProfileClient.tsx
@@ -245,7 +245,7 @@ export default function ProfileClient() {
   }
 
   return (
-    <div className="py-5 md:py-12">
+    <div className="py-4 md:py-6">
       <div className="container-custom max-w-2xl">
         {/* Header */}
         <div className="flex items-center gap-3 mb-8">

--- a/app/account/saved/SavedComparisonsClient.tsx
+++ b/app/account/saved/SavedComparisonsClient.tsx
@@ -127,7 +127,7 @@ export default function SavedComparisonsClient() {
 
   if (userLoading || loading) {
     return (
-      <div className="py-16">
+      <div className="py-6">
         <div className="container-custom max-w-2xl">
           <div className="animate-pulse space-y-4" aria-busy="true" aria-label="Loading saved comparisons…">
             <div className="h-8 bg-slate-200 rounded w-56" />
@@ -142,7 +142,7 @@ export default function SavedComparisonsClient() {
   if (!user) return null;
 
   return (
-    <div className="py-5 md:py-12">
+    <div className="py-4 md:py-6">
       <div className="container-custom max-w-2xl">
         {/* Header */}
         <div className="flex items-center gap-3 mb-6">

--- a/app/account/select-workspace/page.tsx
+++ b/app/account/select-workspace/page.tsx
@@ -13,7 +13,6 @@ import { createClient } from "@/lib/supabase/server";
 import {
   getKindsForUser,
   type KindMembership,
-  type WorkspaceKind,
 } from "@/lib/account-kinds";
 import SelectWorkspaceClient from "./SelectWorkspaceClient";
 
@@ -50,14 +49,14 @@ export default async function SelectWorkspacePage() {
       ];
 
   return (
-    <main className="bg-slate-50 min-h-[60vh]">
-      <div className="max-w-2xl mx-auto px-4 sm:px-6 py-12">
-        <header className="mb-8 text-center">
+    <main className="bg-slate-50">
+      <div className="max-w-2xl mx-auto px-4 sm:px-6 py-6 md:py-8">
+        <header className="mb-6 text-center">
           <h1 className="text-2xl font-bold text-slate-900 mb-2">
             Choose your workspace
           </h1>
           <p className="text-sm text-slate-600">
-            You have multiple roles on Invest.com.au. Pick the workspace you'd like to start in — you can switch any time from the header menu.
+            You have multiple roles on Invest.com.au. Pick the workspace you&apos;d like to start in — you can switch any time from the header menu.
           </p>
         </header>
         <SelectWorkspaceClient memberships={augmented} />

--- a/app/advisor-portal/briefs/page.tsx
+++ b/app/advisor-portal/briefs/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import BriefsInboxClient from "./BriefsInboxClient";
 
 export const metadata: Metadata = {
@@ -11,11 +12,16 @@ export const dynamic = "force-dynamic";
 export default function AdvisorPortalBriefsPage() {
   return (
     <div className="min-h-screen bg-slate-50">
-      <div className="max-w-5xl mx-auto px-4 py-8 sm:py-12">
-        <h1 className="text-2xl sm:text-3xl font-extrabold text-slate-900 mb-1">
+      <div className="max-w-5xl mx-auto px-4 pt-4 pb-10 md:pt-5">
+        <nav aria-label="Breadcrumb" className="mb-1.5 text-[11px] md:text-xs text-slate-400">
+          <Link href="/advisor-portal" className="hover:text-slate-700">Advisor Portal</Link>
+          <span className="mx-1.5" aria-hidden>/</span>
+          <span className="text-slate-600">Brief inbox</span>
+        </nav>
+        <h1 className="text-2xl font-extrabold leading-tight tracking-tight text-slate-900 md:text-[1.9rem]">
           Investor Brief inbox
         </h1>
-        <p className="text-sm text-slate-500 mb-8">
+        <p className="mt-1 mb-5 max-w-2xl text-[12.5px] leading-snug text-slate-500 md:text-[13.5px]">
           Verified providers see masked previews. Accept a brief to unlock the
           consumer&apos;s contact details — your credit balance is debited at
           the moment of acceptance.

--- a/app/advisors/[type]/[state]/page.tsx
+++ b/app/advisors/[type]/[state]/page.tsx
@@ -238,12 +238,12 @@ export default async function AdvisorTypeLocationPage({ params }: { params: Prom
         pageDescription={pageDesc}
       />
       <div className="container-custom max-w-3xl pb-10">
-        <section className="mt-10">
-          <h2 className="text-xl font-extrabold text-slate-900 mb-5">Frequently asked questions</h2>
+        <section className="mt-6">
+          <h2 className="text-lg font-extrabold text-slate-900 mb-3">Frequently asked questions</h2>
           <div className="space-y-3">
             {pageFaqs.map((faq) => (
               <details key={faq.q} className="group rounded-xl border border-slate-200 bg-slate-50">
-                <summary className="flex cursor-pointer items-center justify-between gap-4 px-5 py-4 font-semibold text-slate-900 list-none">
+                <summary className="flex cursor-pointer items-center justify-between gap-4 px-4 py-3 font-semibold text-slate-900 list-none">
                   {faq.q}
                   <span className="shrink-0 text-slate-400 group-open:rotate-180 transition-transform" aria-hidden="true">▾</span>
                 </summary>

--- a/app/advisors/compare/AdvisorCompareClient.tsx
+++ b/app/advisors/compare/AdvisorCompareClient.tsx
@@ -204,14 +204,14 @@ export default function AdvisorCompareClient() {
             <thead>
               <tr className="border-b border-slate-200">
                 {/* Feature label header */}
-                <th scope="col" className="px-4 py-4 text-left text-xs font-semibold text-slate-500 uppercase tracking-wide bg-slate-50 sticky left-0 z-10 min-w-[9rem]">
+                <th scope="col" className="px-3 py-3 text-left text-xs font-semibold text-slate-500 uppercase tracking-wide bg-slate-50 sticky left-0 z-10 min-w-[8rem] md:min-w-[9rem]">
                   Feature
                 </th>
 
                 {columns.map((col) => {
                   const advisor = advisors.find((a) => a.slug === col.slug);
                   return (
-                    <th scope="col" key={col.slug} className="px-4 py-4 text-center min-w-[200px] align-top">
+                    <th scope="col" key={col.slug} className="px-3 py-3 text-center min-w-[150px] md:min-w-[170px] lg:min-w-[200px] align-top">
                       {/* Remove button */}
                       <div className="flex justify-end mb-1">
                         <button

--- a/app/advisors/compare/page.tsx
+++ b/app/advisors/compare/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 
 export default function AdvisorComparePage() {
   return (
-    <div className="max-w-6xl mx-auto px-4 pt-5 pb-10 md:pt-10 md:pb-14">
+    <div className="max-w-6xl mx-auto px-4 pt-3 pb-6 md:pt-4 md:pb-8">
       <Suspense
         fallback={
           <div className="animate-pulse space-y-4">

--- a/app/advisors/page.tsx
+++ b/app/advisors/page.tsx
@@ -144,7 +144,7 @@ export default function AdvisorsPage() {
         <NextActions surface="advisors" />
       </Suspense>
       <HomeToolsStrip />
-      <section className="py-10 bg-white border-t border-slate-200">
+      <section className="py-6 md:py-8 bg-white border-t border-slate-200">
         <div className="container-custom max-w-3xl">
           <h2 className="text-lg font-bold text-slate-900 mb-4">Frequently asked questions</h2>
           <div className="space-y-3">

--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -648,7 +648,7 @@ function ArticleCard({ article, priority = false }: { article: Article; priority
         priority={priority}
         sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
       />
-      <div className="p-2.5 md:p-6 flex flex-col flex-1">
+      <div className="p-3 md:p-4 flex flex-col flex-1">
         {/* Badges Row */}
         <div className="flex items-center gap-1 md:gap-2 mb-1 md:mb-3">
           {article.category && (

--- a/app/calculators/_components/CalcShared.tsx
+++ b/app/calculators/_components/CalcShared.tsx
@@ -131,7 +131,7 @@ export function InputField({ label, value, onChange, placeholder, prefix, suffix
   const id = useId();
   return (
     <div>
-      <label htmlFor={id} className="block text-[0.69rem] md:text-xs font-bold uppercase tracking-wider text-slate-500 mb-1 md:mb-1.5">{label}</label>
+      <label htmlFor={id} className="block text-[0.69rem] md:text-xs font-bold uppercase tracking-wider text-slate-500 mb-1">{label}</label>
       <div className="relative">
         {prefix && <div className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 font-medium text-sm">{prefix}</div>}
         <input
@@ -140,7 +140,7 @@ export function InputField({ label, value, onChange, placeholder, prefix, suffix
           value={value}
           onChange={(e) => onChange(e.target.value)}
           placeholder={placeholder}
-          className={`w-full bg-white border border-slate-200 rounded-lg py-2.5 md:py-2.5 min-h-11 text-sm shadow-sm focus:outline-none focus:border-blue-700 focus:ring-1 focus:ring-blue-700 transition-all font-medium ${prefix ? "pl-7" : "pl-3 md:pl-4"} ${suffix ? "pr-10" : "pr-3 md:pr-4"}`}
+          className={`w-full bg-white border border-slate-200 rounded-lg py-2 min-h-11 text-sm shadow-sm focus:outline-none focus:border-blue-700 focus:ring-1 focus:ring-blue-700 transition-all font-medium ${prefix ? "pl-7" : "pl-3 md:pl-4"} ${suffix ? "pr-10" : "pr-3 md:pr-4"}`}
         />
         {suffix && <div className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 font-medium text-sm">{suffix}</div>}
       </div>

--- a/app/calculators/page.tsx
+++ b/app/calculators/page.tsx
@@ -142,15 +142,15 @@ export default async function CalculatorsPage() {
           subtitle="Answer 5-7 quick questions — we'll match you to the right platform, opportunity, or verified pro for your situation."
         />
         <ComplianceFooter variant="calculator" />
-        <div className="mt-8 space-y-3">
+        <div className="mt-8 space-y-2.5">
           <h2 className="text-lg font-bold text-slate-900 mb-4">Frequently asked questions</h2>
           {CALCULATORS_FAQS.map((faq) => (
             <details key={faq.q} className="bg-slate-50 border border-slate-200 rounded-xl overflow-hidden group">
-              <summary className="px-5 py-4 text-sm font-bold text-slate-900 cursor-pointer hover:bg-slate-100 flex items-center justify-between">
+              <summary className="px-4 py-3 text-sm font-bold text-slate-900 cursor-pointer hover:bg-slate-100 flex items-center justify-between">
                 {faq.q}
                 <span className="text-slate-400 group-open:rotate-180 transition-transform ml-2 shrink-0" aria-hidden="true">▾</span>
               </summary>
-              <div className="px-5 pb-4">
+              <div className="px-4 pb-3">
                 <p className="text-sm text-slate-600 leading-relaxed">{faq.a}</p>
               </div>
             </details>

--- a/app/learn/page.tsx
+++ b/app/learn/page.tsx
@@ -163,7 +163,7 @@ export default async function LearnHubPage() {
             <p className="text-sm text-slate-600 mb-8">
               Pick the path closest to where you are now. Progress is saved per path so you can pause and come back.
             </p>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3 md:gap-4">
               {LEARNING_PATHS.map((path) => {
                 const accent = PATH_ACCENTS[path.colorClass] ?? PATH_ACCENTS["teal"]!;
                 const totalMins = sumEstimatedMinutes(path);
@@ -172,7 +172,7 @@ export default async function LearnHubPage() {
                   <Link
                     key={path.slug}
                     href={`/learn/${path.slug}`}
-                    className={`group flex flex-col rounded-2xl border bg-white p-5 transition-all duration-150 hover:shadow-md hover:${accent.border} ${accent.border}`}
+                    className={`group flex flex-col rounded-xl border bg-white p-4 transition-all duration-150 hover:shadow-md hover:${accent.border} ${accent.border}`}
                   >
                     <div className="flex items-start justify-between gap-3 mb-3">
                       <h3 className={`font-extrabold text-slate-900 leading-snug group-hover:${accent.text} transition-colors text-base`}>

--- a/app/shortlist/advisors/page.tsx
+++ b/app/shortlist/advisors/page.tsx
@@ -10,9 +10,9 @@ export const metadata: Metadata = {
 
 export default function AdvisorShortlistPage() {
   return (
-    <div className="max-w-4xl mx-auto px-4 pt-5 pb-8 md:pt-10 md:pb-12">
+    <div className="max-w-4xl mx-auto px-4 pt-3 pb-6 md:pt-4 md:pb-8">
       <div className="mb-4 md:mb-6">
-        <h1 className="text-xl md:text-3xl font-extrabold text-slate-900">My Saved Advisors</h1>
+        <h1 className="text-lg md:text-xl font-extrabold text-slate-900">My Saved Advisors</h1>
         <p className="text-xs md:text-sm text-slate-500 mt-0.5">
           Tap the bookmark on any advisor to save them here. Compare up to 4 side by side.
         </p>

--- a/components/HubHero.tsx
+++ b/components/HubHero.tsx
@@ -38,17 +38,18 @@ interface HubHeroProps {
   className?: string;
 }
 
-/** Default theme — slate-900 panel; matches the existing /smsf and /grants heroes. */
+/** Default theme — compact light header (the shared DirectoryHero idiom:
+ *  content near the fold, no full-bleed dark band). */
 const DEFAULT_SECTION_CLASS =
-  "bg-slate-900 text-white py-10 md:py-14";
+  "bg-white border-b border-slate-100 py-4 md:py-5";
 
 /** Primary CTA button class — amber pill, matches the existing hubs. */
 const PRIMARY_CTA_CLASS =
   "inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-extrabold text-sm md:text-base px-6 py-3 rounded-lg transition-colors";
 
-/** Secondary CTA button class — translucent ghost button. */
+/** Secondary CTA button class — outlined ghost button on the light header. */
 const SECONDARY_CTA_CLASS =
-  "inline-flex items-center gap-2 bg-white/10 hover:bg-white/20 border border-white/20 text-white font-bold text-sm md:text-base px-5 py-3 rounded-lg transition-colors";
+  "inline-flex items-center gap-2 bg-white hover:bg-slate-50 border border-slate-200 text-slate-700 font-bold text-sm md:text-base px-5 py-3 rounded-lg transition-colors";
 
 export default function HubHero({
   hero,
@@ -78,10 +79,10 @@ export default function HubHero({
       <div className="container-custom">
         <BreadcrumbNav crumbs={breadcrumbs} />
 
-        <h1 className="text-3xl md:text-4xl lg:text-5xl font-extrabold leading-tight mb-3 max-w-3xl">
+        <h1 className="text-2xl md:text-[1.9rem] font-extrabold leading-tight tracking-tight text-slate-900 mb-1.5 max-w-3xl">
           {hero.headline}
         </h1>
-        <p className="text-base md:text-lg text-slate-300 leading-relaxed max-w-3xl mb-6">
+        <p className="text-[12.5px] md:text-[13.5px] text-slate-500 leading-snug max-w-2xl mb-4">
           {hero.subhead}
         </p>
 
@@ -94,12 +95,12 @@ export default function HubHero({
             {visibleStats.map((stat) => (
               <div
                 key={stat.label}
-                className="bg-white/10 border border-white/10 rounded-lg px-3 py-2.5"
+                className="bg-white border border-slate-200 rounded-lg px-3 py-2"
               >
-                <dt className="text-[10px] font-bold uppercase text-slate-400 tracking-wide">
+                <dt className="text-[10px] font-bold uppercase text-slate-500 tracking-wide">
                   {stat.label}
                 </dt>
-                <dd className="text-xl md:text-2xl font-extrabold text-white mt-0.5">
+                <dd className="iv2-bignum text-lg md:text-xl text-slate-900 mt-0.5">
                   <DatedStatBadge
                     value={stat.value}
                     stalesAt={stat.stalesAt}
@@ -107,14 +108,14 @@ export default function HubHero({
                   />
                 </dd>
                 {stat.subtitle && (
-                  <dd className="text-[10px] text-slate-400 mt-0.5">{stat.subtitle}</dd>
+                  <dd className="text-[10px] text-slate-500 mt-0.5">{stat.subtitle}</dd>
                 )}
                 {stat.source && (
-                  <dd className="text-[10px] text-slate-400 mt-0.5">
+                  <dd className="text-[10px] text-slate-500 mt-0.5">
                     Source:{" "}
                     <a
                       href={stat.source}
-                      className="underline hover:text-slate-200"
+                      className="underline hover:text-slate-700"
                       rel="nofollow noopener"
                       target="_blank"
                     >
@@ -127,7 +128,7 @@ export default function HubHero({
           </dl>
         )}
 
-        <div className="mt-6 flex flex-wrap gap-3">
+        <div className="mt-4 flex flex-wrap gap-3">
           <Link
             href={hero.primaryCta.href}
             className={PRIMARY_CTA_CLASS}
@@ -157,18 +158,18 @@ function BreadcrumbNav({ crumbs }: { crumbs: BreadcrumbCrumb[] }) {
   if (crumbs.length === 0) return null;
   return (
     <nav
-      className="flex items-center gap-1.5 text-xs text-slate-400 mb-5"
+      className="flex items-center gap-1.5 text-xs text-slate-500 mb-2"
       aria-label="Breadcrumb"
     >
       {crumbs.map((crumb, idx) => {
         const isLast = idx === crumbs.length - 1;
         return (
           <span key={`${crumb.name}-${idx}`} className="flex items-center gap-1.5">
-            {idx > 0 && <span className="text-slate-600">/</span>}
+            {idx > 0 && <span className="text-slate-300">/</span>}
             {isLast || !crumb.href ? (
-              <span className="text-white font-medium">{crumb.name}</span>
+              <span className="text-slate-700 font-medium">{crumb.name}</span>
             ) : (
-              <Link href={crumb.href} className="hover:text-white">
+              <Link href={crumb.href} className="hover:text-slate-900">
                 {crumb.name}
               </Link>
             )}

--- a/components/VerticalPillarPage.tsx
+++ b/components/VerticalPillarPage.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 import type { Broker, Article } from "@/lib/types";
 import type { VerticalConfig } from "@/lib/verticals";
 import { getRelatedVerticals } from "@/lib/verticals";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 import {
   absoluteUrl,
   breadcrumbJsonLd,
@@ -147,7 +148,7 @@ export default function VerticalPillarPage({
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbs) }}
       />
 
-      <div className="py-5 md:py-12">
+      <div className="pb-6 md:pb-10">
         <OnThisPage
           items={[
             ...(topPick ? [{ id: "top-pick", label: "Top Pick" }] : []),
@@ -168,56 +169,29 @@ export default function VerticalPillarPage({
           ]}
         />
 
-        <div className="container-custom max-w-4xl">
-          {/* Breadcrumb */}
-          <nav className="text-xs md:text-sm text-slate-500 mb-3 md:mb-6">
-            <Link href="/" className="hover:text-slate-900">
-              Home
-            </Link>
-            <span className="mx-2">/</span>
-            <span className="text-slate-700">{config.h1}</span>
-          </nav>
-
-          {/* ─── Hero ─── */}
-          <div
-            className={`bg-gradient-to-br ${config.color.gradient} border ${config.color.border} rounded-2xl p-4 md:p-8 mb-3 md:mb-4`}
-          >
-            <h1 className="text-xl md:text-4xl font-extrabold mb-2 md:mb-3 text-slate-900">
-              {config.heroHeadline}
-            </h1>
-            <p className="text-xs md:text-base text-slate-600 mb-4 max-w-2xl">
-              {config.heroSubtext}
+        {/* ─── Hero — the shared compact light DirectoryHero (one header
+              pattern across /invest, /advisors, /compare and the pillars;
+              replaces the per-vertical gradient box). Disclosure lines render
+              in the hero's light band below. ─── */}
+        <DirectoryHero
+          tone="light"
+          breadcrumbLabel={config.h1}
+          headlineLead={config.heroHeadline}
+          subtitle={config.heroSubtext}
+          stats={config.stats.slice(0, 4).map((s) => ({ v: s.value, l: s.label }))}
+          containerClassName="container-custom max-w-4xl"
+        >
+          <p className="text-[0.62rem] md:text-xs text-slate-500">
+            {ADVERTISER_DISCLOSURE_SHORT}
+          </p>
+          {hasSponsored && (
+            <p className="text-[0.62rem] md:text-xs text-blue-500 mt-1">
+              {SPONSORED_DISCLOSURE_SHORT}
             </p>
+          )}
+        </DirectoryHero>
 
-            {/* Key stats */}
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-2 md:gap-3">
-              {config.stats.map((stat, i) => (
-                <div
-                  key={i}
-                  className="bg-white/70 border border-white rounded-xl px-3 py-2 text-center"
-                >
-                  <div
-                    className={`text-base md:text-xl font-extrabold ${config.color.text}`}
-                  >
-                    {stat.value}
-                  </div>
-                  <div className="text-[0.6rem] md:text-xs text-slate-500 font-medium">
-                    {stat.label}
-                  </div>
-                </div>
-              ))}
-            </div>
-
-            <p className="text-[0.62rem] md:text-xs text-slate-500 mt-3">
-              {ADVERTISER_DISCLOSURE_SHORT}
-            </p>
-            {hasSponsored && (
-              <p className="text-[0.62rem] md:text-xs text-blue-500 mt-1">
-                {SPONSORED_DISCLOSURE_SHORT}
-              </p>
-            )}
-          </div>
-
+        <div className="container-custom max-w-4xl pt-3 md:pt-4">
           {/* General Advice Warning */}
           <div className="hidden md:block bg-slate-50 border border-slate-200 rounded-lg p-3 mb-3 text-[0.69rem] text-slate-500 leading-relaxed">
             <strong className="text-slate-600">


### PR DESCRIPTION
## E8/E9 — the last two competing hero patterns, unified on the compact light header

From `docs/plans/UX_UI_FINTECH_ALIGNMENT.md` (the remaining **P0** structural item). The site had four header patterns; after #1500 two remained:

### E8 — `VerticalPillarPage` → shared `DirectoryHero`
Every vertical pillar (share-trading, crypto, super, cfd, savings, …) drops its per-vertical **gradient hero box** + bespoke breadcrumb for `DirectoryHero tone="light"` (breadcrumb, tight headline, 1-line subtitle, 4 stat pills), aligned to the page's `max-w-4xl` container. Advertiser/sponsored disclosure lines move to the hero's light band; the `py-5 md:py-12` wrapper tightens now the hero owns its spacing. Per-vertical colour identity remains in the category chips/cards below the fold.

### E9 — `HubHero` restyled (deliberately *not* swapped)
The shared hero behind **8+ HubPage hubs** (/super, /smsf, /grants, /tax-return, /first-home-buyer, /home-loans, /insurance, /inheritance, /redundancy) goes from the full-bleed `slate-900` band to the same compact light idiom. A restyle rather than a `DirectoryHero` swap because HubHero carries contracts DirectoryHero doesn't: **`DatedStatBadge`** (the stale-stats CI gate), stat subtitles/sources, CTA levers, and testids — all preserved. Stat values now use `iv2-bignum`; the secondary CTA becomes an outlined ghost; breadcrumbs flip to light tokens. No hub overrides the default theme, so all of them convert.

### Verification
HubHero **22/22** (one theming test updated to assert the new light default — the old one asserted `bg-slate-900` by design) · HubPage **19/19** · `eslint --max-warnings 0` + `tsc` clean. No logic, API or schema changes; net −25 lines.

Loop queue after this: invest listing-detail/sector headers (E1/E3/E7), auth primitive migration (D1/D6/D7), contrast wave 2, B-leftovers, footer IA (F8).

https://claude.ai/code/session_01FdSEBPnPofJaBPhWy1dggf

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdSEBPnPofJaBPhWy1dggf)_