### PR TITLE
refactor(auth): house Input/Button primitives + compact auth wrappers (D6/D7)

### DIFF
--- a/__tests__/integration/o-iter6.rls.int.test.ts
+++ b/__tests__/integration/o-iter6.rls.int.test.ts
@@ -37,7 +37,7 @@ import path from "node:path";
 
 const MIGRATION_PATH = path.join(
   process.cwd(),
-  "supabase/migrations/20260429_o_iter6_rls_forum.sql",
+  "supabase/migrations/archive/20260429_o_iter6_rls_forum.sql",
 );
 
 const FORUM_TABLES = [

--- a/__tests__/integration/o-iter7.rls.int.test.ts
+++ b/__tests__/integration/o-iter7.rls.int.test.ts
@@ -30,7 +30,7 @@ import path from "node:path";
 
 const MIGRATION_PATH = path.resolve(
   __dirname,
-  "../../supabase/migrations/20260429_o_iter7_rls_editorial_obs_secrets.sql",
+  "../../supabase/migrations/archive/20260429_o_iter7_rls_editorial_obs_secrets.sql",
 );
 const SQL = readFileSync(MIGRATION_PATH, "utf8");
 

--- a/__tests__/integration/o-iter8.rls.int.test.ts
+++ b/__tests__/integration/o-iter8.rls.int.test.ts
@@ -26,7 +26,7 @@ import path from "node:path";
 
 const MIGRATION_PATH = path.resolve(
   __dirname,
-  "../../supabase/migrations/20260501_o_iter8_rls_observability.sql",
+  "../../supabase/migrations/archive/20260501_o_iter8_rls_observability.sql",
 );
 const SQL = readFileSync(MIGRATION_PATH, "utf8");
 

--- a/__tests__/integration/quarterly-reports-rls.int.test.ts
+++ b/__tests__/integration/quarterly-reports-rls.int.test.ts
@@ -27,7 +27,7 @@ import path from "node:path";
 
 const MIGRATION_PATH = path.resolve(
   __dirname,
-  "../../supabase/migrations/20260501_c05b_quarterly_reports_rls.sql",
+  "../../supabase/migrations/archive/20260501_c05b_quarterly_reports_rls.sql",
 );
 const SQL = readFileSync(MIGRATION_PATH, "utf8");
 

--- a/app/auth/auth-error/page.tsx
+++ b/app/auth/auth-error/page.tsx
@@ -38,7 +38,7 @@ export default async function AuthErrorPage({
   const { title, explanation } = describeReason(reason);
 
   return (
-    <div className="py-10 md:py-16">
+    <div className="py-8 md:py-10">
       <div className="container-custom max-w-md">
         <div className="bg-white border border-slate-200 rounded-2xl shadow-sm p-6 md:p-8">
           <div className="text-center mb-5">

--- a/app/auth/login/LoginClient.tsx
+++ b/app/auth/login/LoginClient.tsx
@@ -5,6 +5,8 @@ import { useSearchParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/client";
 import { safeNextPath } from "@/lib/safe-next";
+import { Input } from "@/components/ui/Input";
+import { Button } from "@/components/ui/Button";
 
 type Tab = "magic-link" | "password";
 
@@ -164,7 +166,7 @@ export default function LoginClient() {
 
   if (sent) {
     return (
-      <div className="py-16">
+      <div className="py-8 md:py-10">
         <div className="container-custom max-w-md">
           <div className="bg-white border border-slate-200 rounded-2xl p-8 text-center">
             <div className="w-16 h-16 bg-slate-50 rounded-full flex items-center justify-center mx-auto mb-4">
@@ -195,7 +197,7 @@ export default function LoginClient() {
 
   if (resetSent) {
     return (
-      <div className="py-16">
+      <div className="py-8 md:py-10">
         <div className="container-custom max-w-md">
           <div className="bg-white border border-slate-200 rounded-2xl p-8 text-center">
             <div className="w-16 h-16 bg-slate-50 rounded-full flex items-center justify-center mx-auto mb-4">
@@ -225,7 +227,7 @@ export default function LoginClient() {
   }
 
   return (
-    <div className="py-16">
+    <div className="py-8 md:py-10">
       <div className="container-custom max-w-md">
         <div className="bg-white border border-slate-200 rounded-2xl p-8">
           <div className="text-center mb-6">
@@ -268,58 +270,49 @@ export default function LoginClient() {
           {/* Magic Link Tab */}
           {tab === "magic-link" && (
             <form onSubmit={handleMagicLink} noValidate className="space-y-4">
-              <div>
-                <label htmlFor="login-email" className="block text-sm font-semibold text-slate-700 mb-1">
-                  Email address
-                </label>
-                <input
-                  id="login-email"
-                  type="email" autoCapitalize="off" autoCorrect="off" spellCheck={false}
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  placeholder="you@example.com"
-                  autoFocus
-                  autoComplete="email"
-                  aria-required="true"
-                  aria-describedby={error ? errorId : undefined}
-                  className="w-full bg-white border border-slate-200 rounded-xl px-4 py-2.5 text-sm text-slate-900 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-700/30 focus:border-blue-700"
-                />
-              </div>
+              <Input
+                id="login-email"
+                label="Email address"
+                type="email"
+                autoCapitalize="off"
+                autoCorrect="off"
+                spellCheck={false}
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="you@example.com"
+                autoFocus
+                autoComplete="email"
+                aria-required="true"
+                aria-describedby={error ? errorId : undefined}
+              />
 
               {error && (
                 <p id={errorId} role="alert" className="text-sm text-red-600 bg-red-50 rounded-lg px-3 py-2">{error}</p>
               )}
 
-              <button
-                type="submit"
-                disabled={loading}
-                aria-busy={loading}
-                className="w-full px-4 py-2.5 bg-slate-900 text-white text-sm font-semibold rounded-xl hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-blue-700/40 focus:ring-offset-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-              >
+              <Button type="submit" loading={loading} className="w-full">
                 {loading ? "Sending..." : "Send Magic Link"}
-              </button>
+              </Button>
             </form>
           )}
 
           {/* Password Tab */}
           {tab === "password" && (
             <form onSubmit={handlePasswordLogin} noValidate className="space-y-4">
-              <div>
-                <label htmlFor="login-pw-email" className="block text-sm font-semibold text-slate-700 mb-1">
-                  Email address
-                </label>
-                <input
-                  id="login-pw-email"
-                  type="email" autoCapitalize="off" autoCorrect="off" spellCheck={false}
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  placeholder="you@example.com"
-                  autoComplete="email"
-                  aria-required="true"
-                  aria-describedby={error ? errorId : undefined}
-                  className="w-full bg-white border border-slate-200 rounded-xl px-4 py-2.5 text-sm text-slate-900 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-700/30 focus:border-blue-700"
-                />
-              </div>
+              <Input
+                id="login-pw-email"
+                label="Email address"
+                type="email"
+                autoCapitalize="off"
+                autoCorrect="off"
+                spellCheck={false}
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="you@example.com"
+                autoComplete="email"
+                aria-required="true"
+                aria-describedby={error ? errorId : undefined}
+              />
 
               <div>
                 <div className="flex items-center justify-between mb-1">
@@ -345,7 +338,7 @@ export default function LoginClient() {
                     autoComplete="current-password"
                     aria-required="true"
                     aria-describedby={error ? errorId : undefined}
-                    className="w-full bg-white border border-slate-200 rounded-xl px-4 py-2.5 pr-11 text-sm text-slate-900 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-700/30 focus:border-blue-700"
+                    className="w-full bg-white border border-slate-200 rounded-xl px-4 py-3 pr-11 text-sm text-slate-900 placeholder:text-slate-500 transition-all duration-150 hover:border-slate-300 focus:outline-none focus:ring-2 focus:ring-amber-400 focus:border-amber-400"
                   />
                   <button
                     type="button"
@@ -362,14 +355,9 @@ export default function LoginClient() {
                 <p id={errorId} role="alert" className="text-sm text-red-600 bg-red-50 rounded-lg px-3 py-2">{error}</p>
               )}
 
-              <button
-                type="submit"
-                disabled={loading}
-                aria-busy={loading}
-                className="w-full px-4 py-2.5 bg-slate-900 text-white text-sm font-semibold rounded-xl hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-blue-700/40 focus:ring-offset-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-              >
+              <Button type="submit" loading={loading} className="w-full">
                 {loading ? "Signing in..." : "Sign In"}
-              </button>
+              </Button>
             </form>
           )}
 

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -10,7 +10,7 @@ export default function LoginPage() {
   return (
     <Suspense
       fallback={
-        <div className="py-8 md:py-16">
+        <div className="py-8">
           <div className="container-custom max-w-md">
             <div className="bg-white border border-slate-200 rounded-2xl p-8 animate-pulse">
               <div className="h-8 bg-slate-200 rounded w-48 mx-auto mb-2" />

--- a/app/auth/reset-password/ResetPasswordClient.tsx
+++ b/app/auth/reset-password/ResetPasswordClient.tsx
@@ -101,7 +101,7 @@ export default function ResetPasswordClient() {
 
   if (success) {
     return (
-      <div className="py-16">
+      <div className="py-8 md:py-10">
         <div className="container-custom max-w-md">
           <div className="bg-white border border-slate-200 rounded-2xl p-8 text-center">
             <div className="w-16 h-16 bg-emerald-50 rounded-full flex items-center justify-center mx-auto mb-4">
@@ -127,7 +127,7 @@ export default function ResetPasswordClient() {
 
   if (sessionError && !sessionReady) {
     return (
-      <div className="py-16">
+      <div className="py-8 md:py-10">
         <div className="container-custom max-w-md">
           <div className="bg-white border border-slate-200 rounded-2xl p-8 text-center">
             <div className="w-16 h-16 bg-red-50 rounded-full flex items-center justify-center mx-auto mb-4">
@@ -153,7 +153,7 @@ export default function ResetPasswordClient() {
 
   if (!sessionReady) {
     return (
-      <div className="py-16">
+      <div className="py-8 md:py-10">
         <div className="container-custom max-w-md">
           <div className="bg-white border border-slate-200 rounded-2xl p-8 text-center animate-pulse">
             <div className="h-8 bg-slate-200 rounded w-48 mx-auto mb-2" />
@@ -167,7 +167,7 @@ export default function ResetPasswordClient() {
   }
 
   return (
-    <div className="py-16">
+    <div className="py-8 md:py-10">
       <div className="container-custom max-w-md">
         <div className="bg-white border border-slate-200 rounded-2xl p-8">
           <div className="text-center mb-6">

--- a/app/auth/reset-password/page.tsx
+++ b/app/auth/reset-password/page.tsx
@@ -10,7 +10,7 @@ export default function ResetPasswordPage() {
   return (
     <Suspense
       fallback={
-        <div className="py-8 md:py-16">
+        <div className="py-8">
           <div className="container-custom max-w-md">
             <div className="bg-white border border-slate-200 rounded-2xl p-8 animate-pulse">
               <div className="h-8 bg-slate-200 rounded w-48 mx-auto mb-2" />

--- a/app/auth/signup/SignupClient.tsx
+++ b/app/auth/signup/SignupClient.tsx
@@ -4,6 +4,8 @@ import { useState, useId } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/client";
+import { Input } from "@/components/ui/Input";
+import { Button } from "@/components/ui/Button";
 
 type Tab = "password" | "magic-link";
 
@@ -142,7 +144,7 @@ export default function SignupClient() {
 
   if (sent) {
     return (
-      <div className="py-16">
+      <div className="py-8 md:py-10">
         <div className="container-custom max-w-md">
           <div className="bg-white border border-slate-200 rounded-2xl p-8 text-center">
             <div className="w-16 h-16 bg-slate-50 rounded-full flex items-center justify-center mx-auto mb-4">
@@ -180,7 +182,7 @@ export default function SignupClient() {
   const strength = getPasswordStrength(password);
 
   return (
-    <div className="py-16">
+    <div className="py-8 md:py-10">
       <div className="container-custom max-w-md">
         <div className="bg-white border border-slate-200 rounded-2xl p-8">
           <div className="text-center mb-6">
@@ -221,23 +223,21 @@ export default function SignupClient() {
           {/* Email & Password Tab */}
           {tab === "password" && (
             <form onSubmit={handlePasswordSignup} noValidate className="space-y-4">
-              <div>
-                <label htmlFor="signup-email" className="block text-sm font-semibold text-slate-700 mb-1">
-                  Email address
-                </label>
-                <input
-                  id="signup-email"
-                  type="email" autoCapitalize="off" autoCorrect="off" spellCheck={false}
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  placeholder="you@example.com"
-                  autoComplete="email"
-                  autoFocus
-                  aria-required="true"
-                  aria-describedby={error ? errorId : undefined}
-                  className="w-full bg-white border border-slate-200 rounded-xl px-4 py-2.5 text-sm text-slate-900 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-700/30 focus:border-blue-700"
-                />
-              </div>
+              <Input
+                id="signup-email"
+                label="Email address"
+                type="email"
+                autoCapitalize="off"
+                autoCorrect="off"
+                spellCheck={false}
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="you@example.com"
+                autoComplete="email"
+                autoFocus
+                aria-required="true"
+                aria-describedby={error ? errorId : undefined}
+              />
 
               <div>
                 <label htmlFor="signup-password" className="block text-sm font-semibold text-slate-700 mb-1">
@@ -253,7 +253,7 @@ export default function SignupClient() {
                     autoComplete="new-password"
                     aria-required="true"
                     aria-describedby={error ? `password-strength ${errorId}` : "password-strength"}
-                    className="w-full bg-white border border-slate-200 rounded-xl px-4 py-2.5 pr-11 text-sm text-slate-900 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-700/30 focus:border-blue-700"
+                    className="w-full bg-white border border-slate-200 rounded-xl px-4 py-3 pr-11 text-sm text-slate-900 placeholder:text-slate-500 transition-all duration-150 hover:border-slate-300 focus:outline-none focus:ring-2 focus:ring-amber-400 focus:border-amber-400"
                   />
                   <button
                     type="button"
@@ -292,7 +292,7 @@ export default function SignupClient() {
                     autoComplete="new-password"
                     aria-required="true"
                     aria-describedby={error ? errorId : undefined}
-                    className="w-full bg-white border border-slate-200 rounded-xl px-4 py-2.5 pr-11 text-sm text-slate-900 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-700/30 focus:border-blue-700"
+                    className="w-full bg-white border border-slate-200 rounded-xl px-4 py-3 pr-11 text-sm text-slate-900 placeholder:text-slate-500 transition-all duration-150 hover:border-slate-300 focus:outline-none focus:ring-2 focus:ring-amber-400 focus:border-amber-400"
                   />
                   <button
                     type="button"
@@ -309,49 +309,37 @@ export default function SignupClient() {
                 <p id={errorId} role="alert" className="text-sm text-red-600 bg-red-50 rounded-lg px-3 py-2">{error}</p>
               )}
 
-              <button
-                type="submit"
-                disabled={loading}
-                aria-busy={loading}
-                className="w-full px-4 py-2.5 bg-slate-900 text-white text-sm font-semibold rounded-xl hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-blue-700/40 focus:ring-offset-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-              >
+              <Button type="submit" loading={loading} className="w-full">
                 {loading ? "Creating account..." : "Create Account"}
-              </button>
+              </Button>
             </form>
           )}
 
           {/* Magic Link Tab */}
           {tab === "magic-link" && (
             <form onSubmit={handleMagicLinkSignup} noValidate className="space-y-4">
-              <div>
-                <label htmlFor="signup-magic-email" className="block text-sm font-semibold text-slate-700 mb-1">
-                  Email address
-                </label>
-                <input
-                  id="signup-magic-email"
-                  type="email" autoCapitalize="off" autoCorrect="off" spellCheck={false}
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  placeholder="you@example.com"
-                  autoComplete="email"
-                  aria-required="true"
-                  aria-describedby={error ? errorId : undefined}
-                  className="w-full bg-white border border-slate-200 rounded-xl px-4 py-2.5 text-sm text-slate-900 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-700/30 focus:border-blue-700"
-                />
-              </div>
+              <Input
+                id="signup-magic-email"
+                label="Email address"
+                type="email"
+                autoCapitalize="off"
+                autoCorrect="off"
+                spellCheck={false}
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="you@example.com"
+                autoComplete="email"
+                aria-required="true"
+                aria-describedby={error ? errorId : undefined}
+              />
 
               {error && (
                 <p id={errorId} role="alert" className="text-sm text-red-600 bg-red-50 rounded-lg px-3 py-2">{error}</p>
               )}
 
-              <button
-                type="submit"
-                disabled={loading}
-                aria-busy={loading}
-                className="w-full px-4 py-2.5 bg-slate-900 text-white text-sm font-semibold rounded-xl hover:bg-slate-800 focus:outline-none focus:ring-2 focus:ring-blue-700/40 focus:ring-offset-2 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-              >
+              <Button type="submit" loading={loading} className="w-full">
                 {loading ? "Sending..." : "Send Magic Link"}
-              </button>
+              </Button>
             </form>
           )}
 

--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -10,7 +10,7 @@ export default function SignupPage() {
   return (
     <Suspense
       fallback={
-        <div className="py-8 md:py-16">
+        <div className="py-8">
           <div className="container-custom max-w-md">
             <div className="bg-white border border-slate-200 rounded-2xl p-8 animate-pulse">
               <div className="h-8 bg-slate-200 rounded w-48 mx-auto mb-2" />


### PR DESCRIPTION
## D6/D7 — the auth family on house primitives + compact wrappers

From `docs/plans/UX_UI_FINTECH_ALIGNMENT.md`. Engineering judgement documented where the audit's suggestion would have hurt:

### Migrated
- **Email fields** (login ×2 tabs, signup ×2 tabs) → shared `<Input>` (label, amber focus ring, error/hint contract)
- **All four submit buttons** → `<Button type="submit" loading>` — gains the built-in spinner + `aria-busy` and the house primary
- **Wrapper density across the whole family**: login/signup/reset-password `py-16 → py-8 md:py-10` (cards + sent/reset confirmation states), page Suspense fallbacks `md:py-16 → py-8`, auth-error tightened

### Deliberately kept hand-rolled
- **Password + confirm fields** — the eye-toggle adornment has no slot in `<Input>`; forcing it would be a hack. They instead adopt the house amber focus ring, hover border, and `py-3` scale so the two field styles match visually.
- **Password-strength meter** — its red/amber/green semantics out-communicate the fixed-gradient `ProgressBar`.

### Untouched
All flows, validation, and a11y (`aria-describedby`/`required`, `role=alert`, the `safeNextPath` open-redirect guard).

### Verification
`eslint --max-warnings 0` + `tsc` clean. Net **−24 lines**. No logic, API or schema changes.

Loop status: #1510 + #1511 are re-running CI with the RLS-test path repair (the baseline-squash latent breakage — fixed on both branches, lands on main with whichever merges first).

https://claude.ai/code/session_01FdSEBPnPofJaBPhWy1dggf

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdSEBPnPofJaBPhWy1dggf)_