### PR TITLE
refactor(invest): compact light headers for sector pillars, listings and detail (E1/E3/E7)

### DIFF
--- a/__tests__/integration/o-iter6.rls.int.test.ts
+++ b/__tests__/integration/o-iter6.rls.int.test.ts
@@ -37,7 +37,7 @@ import path from "node:path";
 
 const MIGRATION_PATH = path.join(
   process.cwd(),
-  "supabase/migrations/20260429_o_iter6_rls_forum.sql",
+  "supabase/migrations/archive/20260429_o_iter6_rls_forum.sql",
 );
 
 const FORUM_TABLES = [

--- a/__tests__/integration/o-iter7.rls.int.test.ts
+++ b/__tests__/integration/o-iter7.rls.int.test.ts
@@ -30,7 +30,7 @@ import path from "node:path";
 
 const MIGRATION_PATH = path.resolve(
   __dirname,
-  "../../supabase/migrations/20260429_o_iter7_rls_editorial_obs_secrets.sql",
+  "../../supabase/migrations/archive/20260429_o_iter7_rls_editorial_obs_secrets.sql",
 );
 const SQL = readFileSync(MIGRATION_PATH, "utf8");
 

--- a/__tests__/integration/o-iter8.rls.int.test.ts
+++ b/__tests__/integration/o-iter8.rls.int.test.ts
@@ -26,7 +26,7 @@ import path from "node:path";
 
 const MIGRATION_PATH = path.resolve(
   __dirname,
-  "../../supabase/migrations/20260501_o_iter8_rls_observability.sql",
+  "../../supabase/migrations/archive/20260501_o_iter8_rls_observability.sql",
 );
 const SQL = readFileSync(MIGRATION_PATH, "utf8");
 

--- a/__tests__/integration/quarterly-reports-rls.int.test.ts
+++ b/__tests__/integration/quarterly-reports-rls.int.test.ts
@@ -27,7 +27,7 @@ import path from "node:path";
 
 const MIGRATION_PATH = path.resolve(
   __dirname,
-  "../../supabase/migrations/20260501_c05b_quarterly_reports_rls.sql",
+  "../../supabase/migrations/archive/20260501_c05b_quarterly_reports_rls.sql",
 );
 const SQL = readFileSync(MIGRATION_PATH, "utf8");
 

--- a/app/invest/[slug]/listings/page.tsx
+++ b/app/invest/[slug]/listings/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Suspense } from "react";
 import { notFound } from "next/navigation";
 import { breadcrumbJsonLd, SITE_URL } from "@/lib/seo";
@@ -13,6 +14,7 @@ import {
 } from "@/lib/investment-listings-query";
 import type { InvestListingVertical } from "@/lib/types";
 import InvestListingsClient from "@/components/InvestListingsClient";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 import SubCategoryNav from "@/components/SubCategoryNav";
 
 export const revalidate = 300;
@@ -99,7 +101,25 @@ export default async function GenericCategoryListingsPage({
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
-      <div className="container-custom pt-6">
+      {/* House-standard compact light header (E7) — replaces the client's
+          tall page-title band so results land near the fold. */}
+      <DirectoryHero
+        tone="light"
+        breadcrumbLabel={`${cat.label} / Listings`}
+        headlineLead={cat.label}
+        headlineAccent="opportunities"
+        subtitle={cat.intro}
+        stats={listings.length > 0 ? [{ v: String(listings.length), l: "Live listings" }] : undefined}
+        containerClassName="container-custom"
+      >
+        <Link
+          href="/invest"
+          className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1 text-[0.65rem] font-semibold text-slate-600 shadow-sm transition-colors hover:bg-slate-50 md:text-xs"
+        >
+          ← Browse all investment sectors
+        </Link>
+      </DirectoryHero>
+      <div className="container-custom pt-4">
         <SubCategoryNav category={cat} />
       </div>
       <Suspense fallback={<div className="py-12 text-center text-slate-400">Loading listings...</div>}>
@@ -111,8 +131,6 @@ export default async function GenericCategoryListingsPage({
           // the tabs render (categories with no subcategories keep the chips,
           // since DB-derived sub-types are then the only narrowing UI).
           hideSubCategoryChips={cat.subcategories.length > 0}
-          pageTitle={`${cat.label} Investment Listings`}
-          pageSubtitle={cat.intro}
         />
       </Suspense>
     </>

--- a/app/invest/[slug]/page.tsx
+++ b/app/invest/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { breadcrumbJsonLd, absoluteUrl, SITE_URL, SITE_NAME, CURRENT_YEAR } from
 import { faqJsonLd } from "@/lib/schema-markup";
 import Icon from "@/components/Icon";
 import SectionHeading from "@/components/SectionHeading";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 import { logger } from "@/lib/logger";
 
 const log = logger("invest-vertical-slug");
@@ -799,83 +800,45 @@ export default async function InvestVerticalPage({
         dangerouslySetInnerHTML={{ __html: JSON.stringify(verticalFaqLd) }}
       />
 
-      {/* Hero */}
-      <section className="relative bg-white border-b border-slate-100 overflow-hidden py-8 md:py-12">
-        <div className="container-custom">
-          {/* Breadcrumbs */}
-          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-6">
-            <Link href="/" className="hover:text-slate-900 transition-colors">
-              Home
-            </Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" />
-            <Link href="/invest" className="hover:text-slate-900 transition-colors">
-              Invest
-            </Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" />
-            <span className="text-slate-900 font-medium">{v.name}</span>
-          </nav>
-
-          {/* Badges */}
-          <div className="flex flex-wrap items-center gap-2 mb-4">
-            <span className="text-xs font-semibold bg-amber-500 text-slate-900 px-3 py-1 rounded-full">
-              Updated {CURRENT_YEAR}
-            </span>
+      {/* Hero — house-standard compact light header (E3). The browse-listings
+          entry point and the domestic/international badge live in the light
+          band below, replacing the standalone CTA band (E4). */}
+      <DirectoryHero
+        tone="light"
+        breadcrumbLabel={v.name}
+        headlineLead={v.hero_title ?? v.name}
+        subtitle={v.hero_subtitle ?? undefined}
+        containerClassName="container-custom"
+      >
+        {LISTINGS_LINKS[slug] || showIntlBadge ? (
+          <div className="flex flex-wrap items-center gap-2">
+            {LISTINGS_LINKS[slug] && (
+              <Link
+                href={LISTINGS_LINKS[slug].href}
+                className="inline-flex items-center gap-1.5 rounded-full border border-coral-200 bg-coral-50 px-3 py-1 text-[0.65rem] font-semibold text-coral-700 shadow-sm transition-colors hover:bg-coral-100 md:text-xs"
+              >
+                {LISTINGS_LINKS[slug].label} →
+              </Link>
+            )}
             {showIntlBadge && (
-              <span className="text-xs font-semibold bg-slate-100 text-slate-600 px-3 py-1 rounded-full flex items-center gap-1">
-                <Icon name="globe" size={12} />
+              <span className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-white px-3 py-1 text-[0.65rem] font-semibold text-slate-600 md:text-xs">
+                <Icon name="globe" size={11} />
                 Domestic + International
               </span>
             )}
           </div>
-
-          <h1 className="text-3xl md:text-4xl lg:text-5xl font-extrabold leading-tight mb-4 max-w-3xl text-slate-900">
-            {v.hero_title ?? v.name}
-          </h1>
-          {v.hero_subtitle && (
-            <p className="text-lg text-slate-600 leading-relaxed max-w-2xl">
-              {v.hero_subtitle}
-            </p>
-          )}
-        </div>
-      </section>
+        ) : null}
+      </DirectoryHero>
 
       {/* Main content */}
-      <section className="py-14 bg-white">
+      <section className="py-8 md:py-10 bg-white">
         <div className="container-custom max-w-4xl">
           <VerticalContent slug={slug} />
         </div>
       </section>
 
-      {/* Browse Listings CTA */}
-      {LISTINGS_LINKS[slug] && (
-        <section className="py-10 bg-slate-50 border-t border-slate-100">
-          <div className="container-custom">
-            <div className="max-w-3xl mx-auto bg-white border border-amber-200 rounded-xl p-8 flex flex-col md:flex-row items-start md:items-center gap-6">
-              <div className="w-12 h-12 rounded-xl bg-amber-50 flex items-center justify-center shrink-0">
-                <Icon name="trending-up" size={24} className="text-amber-500" />
-              </div>
-              <div className="flex-1">
-                <h2 className="text-lg font-bold text-slate-900 mb-1">
-                  Ready to Browse Active Listings?
-                </h2>
-                <p className="text-sm text-slate-500">
-                  Explore real {v.name.toLowerCase()} investment opportunities available in Australia — with enquiry details and agent contact information.
-                </p>
-              </div>
-              <Link
-                href={LISTINGS_LINKS[slug].href}
-                className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-semibold text-sm px-5 py-2.5 rounded-lg transition-colors shrink-0"
-              >
-                {LISTINGS_LINKS[slug].label}
-                <Icon name="arrow-right" size={15} />
-              </Link>
-            </div>
-          </div>
-        </section>
-      )}
-
       {/* International investors callout */}
-      <section className="py-10 bg-amber-50">
+      <section className="py-6 md:py-8 bg-amber-50">
         <div className="container-custom">
           <div className="max-w-3xl mx-auto bg-amber-500 rounded-xl p-8 text-slate-900">
             <div className="flex items-start gap-4">
@@ -903,7 +866,7 @@ export default async function InvestVerticalPage({
       </section>
 
       {/* FAQ accordion */}
-      <section className="py-10 bg-white border-t border-slate-100">
+      <section className="py-6 md:py-8 bg-white border-t border-slate-100">
         <div className="container-custom max-w-3xl">
           <h2 className="text-xl font-bold text-slate-900 mb-6">
             Frequently asked questions — {v.name} investing in Australia
@@ -932,7 +895,7 @@ export default async function InvestVerticalPage({
       </section>
 
       {/* Find a Specialist Advisor */}
-      <section className="py-14 bg-slate-50">
+      <section className="py-8 md:py-10 bg-slate-50">
         <div className="container-custom">
           <div className="max-w-3xl mx-auto bg-white border border-slate-200 rounded-xl p-8 flex flex-col md:flex-row items-start md:items-center gap-6">
             <div className="w-12 h-12 rounded-xl bg-amber-50 flex items-center justify-center shrink-0">

--- a/app/invest/alternatives/listings/[slug]/page.tsx
+++ b/app/invest/alternatives/listings/[slug]/page.tsx
@@ -159,10 +159,11 @@ export default async function AlternativesListingDetailPage({
       />
       <ListingSchemaScripts listing={l} vertical={CATEGORY_SLUG} />
 
-      {/* Hero */}
-      <section className="bg-white border-b border-slate-100 py-12">
+      {/* Compact header (E1) — breadcrumb + badges + title + location only,
+          so the gallery and metrics sit near the fold. */}
+      <section className="bg-white border-b border-slate-100 py-3 md:py-4">
         <div className="container-custom">
-          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-4">
+          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-2">
             <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
             <Icon name="chevron-right" size={12} className="text-slate-300" aria-hidden="true" />
             <Link href="/invest" className="hover:text-slate-900 transition-colors">Invest</Link>
@@ -172,7 +173,7 @@ export default async function AlternativesListingDetailPage({
             <span className="text-slate-900 font-medium truncate max-w-40">{l.title}</span>
           </nav>
 
-          <div className="flex flex-wrap gap-2 mb-3">
+          <div className="flex flex-wrap gap-2 mb-2">
             {l.listing_type === "featured" && (
               <span className="bg-amber-500 text-slate-900 text-xs font-bold px-2.5 py-0.5 rounded-full">Featured</span>
             )}
@@ -200,14 +201,14 @@ export default async function AlternativesListingDetailPage({
       </section>
 
       {/* Main content */}
-      <section className="py-10 bg-slate-50">
+      <section className="py-6 md:py-8 bg-slate-50">
         <div className="container-custom">
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
             {/* Left: details */}
             <div className="lg:col-span-2 space-y-6">
               <ListingImageGallery images={l.images} alt={l.title} vertical={l.vertical} listingId={l.id} subCategory={l.sub_category} />
               {/* Price card */}
-              <div className="bg-white border border-slate-200 rounded-xl p-6">
+              <div className="bg-white border border-slate-200 rounded-xl p-4">
                 <div className="flex flex-wrap items-center justify-between gap-4">
                   <div>
                     <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1">Estimated Value</p>

--- a/app/invest/alternatives/listings/page.tsx
+++ b/app/invest/alternatives/listings/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Suspense } from "react";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import { getAllInvestCategories, getInvestCategoryBySlug } from "@/lib/invest-categories";
@@ -8,6 +9,7 @@ import {
   ALTERNATIVES_SUB_CATEGORIES,
 } from "@/lib/investment-listings-query";
 import InvestListingsClient from "@/components/InvestListingsClient";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 import SubCategoryNav from "@/components/SubCategoryNav";
 
 export const revalidate = 300;
@@ -57,8 +59,26 @@ export default async function AlternativesListingsPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
+      {/* House-standard compact light header (E7) — replaces the client's
+          tall page-title band so results land near the fold. */}
+      <DirectoryHero
+        tone="light"
+        breadcrumbLabel="Alternative Investments / Listings"
+        headlineLead="Alternative investment"
+        headlineAccent="opportunities"
+        subtitle="Browse Australian alternative investment opportunities — art, wine, collectibles and non-correlated assets."
+        stats={listings.length > 0 ? [{ v: String(listings.length), l: "Live listings" }] : undefined}
+        containerClassName="container-custom"
+      >
+        <Link
+          href="/invest"
+          className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1 text-[0.65rem] font-semibold text-slate-600 shadow-sm transition-colors hover:bg-slate-50 md:text-xs"
+        >
+          ← Browse all investment sectors
+        </Link>
+      </DirectoryHero>
       {category && (
-        <div className="container-custom pt-6">
+        <div className="container-custom pt-4">
           <SubCategoryNav category={category} />
         </div>
       )}
@@ -67,8 +87,6 @@ export default async function AlternativesListingsPage() {
           listings={listings}
           categories={categoryTabs}
           lockedCategory="alternatives"
-          pageTitle="Alternative Investment Investment Listings"
-          pageSubtitle="Browse Australian alternative investment opportunities — art, wine, collectibles and non-correlated assets."
         />
       </Suspense>
     </>

--- a/app/invest/aquaculture/listings/page.tsx
+++ b/app/invest/aquaculture/listings/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Suspense } from "react";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import { getAllInvestCategories } from "@/lib/invest-categories";
@@ -7,6 +8,7 @@ import {
   countListingsByVertical,
 } from "@/lib/investment-listings-query";
 import InvestListingsClient from "@/components/InvestListingsClient";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 import ListingComplianceNotice from "@/components/invest/ListingComplianceNotice";
 import WholesaleAttestationGate from "@/components/invest/WholesaleAttestationGate";
 
@@ -49,6 +51,24 @@ export default async function AquacultureListingsPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
+      {/* House-standard compact light header (E7) — replaces the client's
+          tall page-title band so results land near the fold. */}
+      <DirectoryHero
+        tone="light"
+        breadcrumbLabel="Aquaculture & Marine / Listings"
+        headlineLead="Aquaculture & marine"
+        headlineAccent="opportunities"
+        subtitle="Browse Australian aquaculture and marine investment opportunities — salmon farming operations, oyster leases, abalone farms, prawn aquaculture, mussel cultivation, land-based RAS facilities and fishing quota."
+        stats={listings.length > 0 ? [{ v: String(listings.length), l: "Live listings" }] : undefined}
+        containerClassName="container-custom"
+      >
+        <Link
+          href="/invest"
+          className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1 text-[0.65rem] font-semibold text-slate-600 shadow-sm transition-colors hover:bg-slate-50 md:text-xs"
+        >
+          ← Browse all investment sectors
+        </Link>
+      </DirectoryHero>
       <ListingComplianceNotice
         productLabel="aquaculture and marine investment opportunities (including syndicated leases and farm operations)"
         classification="Aquaculture investments listed here may be regulated managed investment schemes."
@@ -64,8 +84,6 @@ export default async function AquacultureListingsPage() {
               listings={listings}
               categories={categoryTabs}
               lockedCategory="aquaculture"
-              pageTitle="Aquaculture & Marine Investment Listings"
-              pageSubtitle="Browse Australian aquaculture and marine investment opportunities — salmon farming operations, oyster leases, abalone farms, prawn aquaculture, mussel cultivation, land-based RAS facilities and fishing quota."
             />
           </Suspense>
         </WholesaleAttestationGate>

--- a/app/invest/buy-business/listings/[slug]/page.tsx
+++ b/app/invest/buy-business/listings/[slug]/page.tsx
@@ -124,10 +124,11 @@ export default async function BusinessListingDetailPage({
       />
       <ListingSchemaScripts listing={l} vertical={CATEGORY_SLUG} />
 
-      {/* Hero */}
-      <section className="bg-white border-b border-slate-100 py-12">
+      {/* Compact header (E1) — breadcrumb + badges + title + location only,
+          so the gallery and metrics sit near the fold. */}
+      <section className="bg-white border-b border-slate-100 py-3 md:py-4">
         <div className="container-custom">
-          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-4">
+          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-2">
             <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
             <Icon name="chevron-right" size={12} className="text-slate-300" />
             <Link href="/invest" className="hover:text-slate-900 transition-colors">Invest</Link>
@@ -137,7 +138,7 @@ export default async function BusinessListingDetailPage({
             <span className="text-slate-900 font-medium truncate max-w-40">{l.title}</span>
           </nav>
 
-          <div className="flex flex-wrap gap-2 mb-3">
+          <div className="flex flex-wrap gap-2 mb-2">
             {l.listing_type === "featured" && (
               <span className="bg-amber-500 text-slate-900 text-xs font-bold px-2.5 py-0.5 rounded-full">Featured</span>
             )}
@@ -165,14 +166,14 @@ export default async function BusinessListingDetailPage({
       </section>
 
       {/* Main content */}
-      <section className="py-10 bg-slate-50">
+      <section className="py-6 md:py-8 bg-slate-50">
         <div className="container-custom">
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
             {/* Left: details */}
             <div className="lg:col-span-2 space-y-6">
               <ListingImageGallery images={l.images} alt={l.title} vertical={l.vertical} listingId={l.id} subCategory={l.sub_category} />
               {/* Price card */}
-              <div className="bg-white border border-slate-200 rounded-xl p-6">
+              <div className="bg-white border border-slate-200 rounded-xl p-4">
                 <div className="flex flex-wrap items-center justify-between gap-4">
                   <div>
                     <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1">Asking Price</p>

--- a/app/invest/buy-business/listings/page.tsx
+++ b/app/invest/buy-business/listings/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Suspense } from "react";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import { getAllInvestCategories, getInvestCategoryBySlug } from "@/lib/invest-categories";
@@ -7,6 +8,7 @@ import {
   countListingsByVertical,
 } from "@/lib/investment-listings-query";
 import InvestListingsClient from "@/components/InvestListingsClient";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 import SubCategoryNav from "@/components/SubCategoryNav";
 
 export const revalidate = 300;
@@ -47,8 +49,26 @@ export default async function BusinessListingsPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
+      {/* House-standard compact light header (E7) — replaces the client's
+          tall page-title band so results land near the fold. */}
+      <DirectoryHero
+        tone="light"
+        breadcrumbLabel="Buy a Business / Listings"
+        headlineLead="Businesses"
+        headlineAccent="for sale"
+        subtitle="Browse Australian businesses for sale — cafes, agencies, franchises, professional practices and e-commerce."
+        stats={listings.length > 0 ? [{ v: String(listings.length), l: "Live listings" }] : undefined}
+        containerClassName="container-custom"
+      >
+        <Link
+          href="/invest"
+          className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1 text-[0.65rem] font-semibold text-slate-600 shadow-sm transition-colors hover:bg-slate-50 md:text-xs"
+        >
+          ← Browse all investment sectors
+        </Link>
+      </DirectoryHero>
       {category && (
-        <div className="container-custom pt-6">
+        <div className="container-custom pt-4">
           <SubCategoryNav category={category} />
         </div>
       )}
@@ -57,8 +77,6 @@ export default async function BusinessListingsPage() {
           listings={listings}
           categories={categoryTabs}
           lockedCategory="buy-business"
-          pageTitle="Buy a Business Investment Listings"
-          pageSubtitle="Browse Australian businesses for sale — cafes, agencies, franchises, professional practices and e-commerce."
         />
       </Suspense>
     </>

--- a/app/invest/buy-business/page.tsx
+++ b/app/invest/buy-business/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import Icon from "@/components/Icon";
 import SectionHeading from "@/components/SectionHeading";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 import { faqJsonLd } from "@/lib/schema-markup";
 
 const BUY_BUSINESS_FAQS = [
@@ -60,83 +61,32 @@ export default function BuyBusinessPage() {
         <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(buyBusinessFaqLd) }} />
       )}
 
-      {/* Hero */}
-      <section className="relative bg-white border-b border-slate-100 overflow-hidden py-8 md:py-12">
-        <div className="container-custom">
-          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-6">
-            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" />
-            <Link href="/invest" className="hover:text-slate-900 transition-colors">Invest</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" />
-            <span className="text-slate-900 font-medium">Buy a Business</span>
-          </nav>
-
-          <div className="flex flex-wrap items-center gap-2 mb-4">
-            <span className="text-xs font-semibold bg-amber-500 text-slate-900 px-3 py-1 rounded-full">
-              Updated {CURRENT_YEAR}
-            </span>
-            <span className="text-xs font-semibold bg-slate-100 text-slate-600 px-3 py-1 rounded-full">
-              Australian Guide
-            </span>
-          </div>
-
-          <h1 className="text-3xl md:text-4xl lg:text-5xl font-extrabold leading-tight mb-4 max-w-3xl text-slate-900">
-            Buy a Business in Australia
-          </h1>
-          <p className="text-lg text-slate-600 leading-relaxed max-w-2xl mb-8">
-            From small cafes to established manufacturing businesses. Everything you need to know about acquiring a business in Australia — including visa pathways for international buyers.
-          </p>
-
-          <Link
-            href="/invest/buy-business/listings"
-            className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold text-base px-7 py-3.5 rounded-xl transition-colors shadow-lg"
-          >
-            Browse Businesses for Sale
-            <Icon name="arrow-right" size={18} />
-          </Link>
-        </div>
-      </section>
-
-      {/* Browse Listings CTA */}
-      <section className="bg-white pt-8">
-        <div className="container-custom">
-          <Link
-            href="/invest/buy-business/listings"
-            className="group flex items-center justify-between gap-4 p-5 bg-gradient-to-r from-emerald-50 to-emerald-100/40 border border-emerald-200 rounded-2xl mb-8 hover:border-emerald-300 hover:shadow-md transition-all"
-          >
-            <div>
-              <p className="text-xs font-extrabold uppercase tracking-wider text-emerald-700 mb-1">Browse Listings</p>
-              <p className="text-lg font-extrabold text-slate-900">View all businesses for sale &rarr;</p>
-              <p className="text-sm text-slate-600 mt-0.5">Active deals, FIRB-eligible, sub-categories &amp; more</p>
-            </div>
-            <svg className="w-8 h-8 text-emerald-600 shrink-0 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-            </svg>
-          </Link>
-        </div>
-      </section>
-
-      {/* Quick stats */}
-      <section className="py-10 bg-amber-50 border-b border-amber-100">
-        <div className="container-custom">
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            {[
-              { value: "50,000+", label: "Businesses sold annually" },
-              { value: "$800K", label: "188A minimum business value" },
-              { value: "$5M", label: "SIV complying investment" },
-              { value: "$268M", label: "FIRB general threshold" },
-            ].map((s) => (
-              <div key={s.label} className="bg-white border border-amber-100 rounded-xl p-4 text-center">
-                <p className="text-2xl font-extrabold text-amber-600">{s.value}</p>
-                <p className="text-xs text-slate-600 mt-1">{s.label}</p>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
+      {/* Hero — house-standard compact light header (E3). The old stat band
+          rides as pills beside the title; the browse-all entry point lives in
+          the light band below, replacing the standalone CTA band (E4). */}
+      <DirectoryHero
+        tone="light"
+        breadcrumbLabel="Buy a Business"
+        headlineLead="Buy a Business in Australia"
+        subtitle="From small cafes to established manufacturing businesses. Everything you need to know about acquiring a business in Australia — including visa pathways for international buyers."
+        stats={[
+          { v: "50,000+", l: "Businesses sold annually" },
+          { v: "$800K", l: "188A minimum business value" },
+          { v: "$5M", l: "SIV complying investment" },
+          { v: "$268M", l: "FIRB general threshold" },
+        ]}
+        containerClassName="container-custom"
+      >
+        <Link
+          href="/invest/buy-business/listings"
+          className="inline-flex items-center gap-1.5 rounded-full border border-coral-200 bg-coral-50 px-3 py-1 text-[0.65rem] font-semibold text-coral-700 shadow-sm transition-colors hover:bg-coral-100 md:text-xs"
+        >
+          Browse all businesses for sale →
+        </Link>
+      </DirectoryHero>
 
       {/* Business types */}
-      <section className="py-14 bg-white">
+      <section className="py-8 md:py-10 bg-white">
         <div className="container-custom max-w-4xl">
           <SectionHeading
             eyebrow="Types of businesses"
@@ -327,7 +277,7 @@ export default function BuyBusinessPage() {
       </section>
 
       {/* Browse CTA */}
-      <section className="py-14 bg-white border-t border-slate-100">
+      <section className="py-8 md:py-10 bg-white border-t border-slate-100">
         <div className="container-custom">
           <div className="max-w-3xl mx-auto bg-white border border-slate-200 rounded-xl p-8 text-center">
             <h2 className="text-2xl font-extrabold text-slate-900 mb-3">Ready to Find Your Business?</h2>
@@ -354,7 +304,7 @@ export default function BuyBusinessPage() {
         </div>
       </section>
 
-      <section className="py-10 bg-white border-t border-slate-200">
+      <section className="py-6 md:py-8 bg-white border-t border-slate-200">
         <div className="container-custom max-w-3xl">
           <h2 className="text-lg font-bold text-slate-900 mb-4">Frequently asked questions</h2>
           <div className="space-y-3">

--- a/app/invest/carbon-environmental-markets/listings/page.tsx
+++ b/app/invest/carbon-environmental-markets/listings/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Suspense } from "react";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import { getAllInvestCategories } from "@/lib/invest-categories";
@@ -7,6 +8,7 @@ import {
   countListingsByVertical,
 } from "@/lib/investment-listings-query";
 import InvestListingsClient from "@/components/InvestListingsClient";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 import ListingComplianceNotice from "@/components/invest/ListingComplianceNotice";
 import WholesaleAttestationGate from "@/components/invest/WholesaleAttestationGate";
 
@@ -50,6 +52,24 @@ export default async function CarbonEnvironmentalMarketsListingsPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
+      {/* House-standard compact light header (E7) — replaces the client's
+          tall page-title band so results land near the fold. */}
+      <DirectoryHero
+        tone="light"
+        breadcrumbLabel="Carbon & Environmental Markets / Listings"
+        headlineLead="Carbon & environmental markets"
+        headlineAccent="opportunities"
+        subtitle="Browse Australian carbon and environmental market investment opportunities — ACCUs, voluntary carbon credits, biodiversity offsets, carbon farming projects and nature-positive assets."
+        stats={listings.length > 0 ? [{ v: String(listings.length), l: "Live listings" }] : undefined}
+        containerClassName="container-custom"
+      >
+        <Link
+          href="/invest"
+          className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1 text-[0.65rem] font-semibold text-slate-600 shadow-sm transition-colors hover:bg-slate-50 md:text-xs"
+        >
+          ← Browse all investment sectors
+        </Link>
+      </DirectoryHero>
       <ListingComplianceNotice
         productLabel="Australian Carbon Credit Units (ACCUs) and related environmental-market products"
         classification="ACCUs are financial products under the Corporations Act 2001."
@@ -65,8 +85,6 @@ export default async function CarbonEnvironmentalMarketsListingsPage() {
               listings={listings}
               categories={categoryTabs}
               lockedCategory="carbon-environmental-markets"
-              pageTitle="Carbon & Environmental Markets Investment Listings"
-              pageSubtitle="Browse Australian carbon and environmental market investment opportunities — ACCUs, voluntary carbon credits, biodiversity offsets, carbon farming projects and nature-positive assets."
             />
           </Suspense>
         </WholesaleAttestationGate>

--- a/app/invest/commercial-property/listings/[slug]/page.tsx
+++ b/app/invest/commercial-property/listings/[slug]/page.tsx
@@ -125,9 +125,11 @@ export default async function CommercialListingDetailPage({
       />
       <ListingSchemaScripts listing={l} vertical={CATEGORY_SLUG} />
 
-      <section className="bg-white border-b border-slate-100 py-12">
+      {/* Compact header (E1) — breadcrumb + badges + title + location only,
+          so the gallery and metrics sit near the fold. */}
+      <section className="bg-white border-b border-slate-100 py-3 md:py-4">
         <div className="container-custom">
-          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-4">
+          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-2">
             <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
             <Icon name="chevron-right" size={12} className="text-slate-300" />
             <Link href="/invest/commercial-property/listings" className="hover:text-slate-900 transition-colors">Commercial Properties</Link>
@@ -135,7 +137,7 @@ export default async function CommercialListingDetailPage({
             <span className="text-slate-900 font-medium truncate max-w-40">{l.title}</span>
           </nav>
 
-          <div className="flex flex-wrap gap-2 mb-3">
+          <div className="flex flex-wrap gap-2 mb-2">
             {l.listing_type === "featured" && (
               <span className="bg-amber-500 text-slate-900 text-xs font-bold px-2.5 py-0.5 rounded-full">Featured</span>
             )}
@@ -164,12 +166,12 @@ export default async function CommercialListingDetailPage({
         </div>
       </section>
 
-      <section className="py-10 bg-slate-50">
+      <section className="py-6 md:py-8 bg-slate-50">
         <div className="container-custom">
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
             <div className="lg:col-span-2 space-y-6">
               <ListingImageGallery images={l.images} alt={l.title} vertical={l.vertical} listingId={l.id} subCategory={l.sub_category} />
-              <div className="bg-white border border-slate-200 rounded-xl p-6">
+              <div className="bg-white border border-slate-200 rounded-xl p-4">
                 <div className="flex flex-wrap items-center justify-between gap-4">
                   <div>
                     <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1">Asking Price</p>

--- a/app/invest/commercial-property/listings/page.tsx
+++ b/app/invest/commercial-property/listings/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Suspense } from "react";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import { getAllInvestCategories, getInvestCategoryBySlug } from "@/lib/invest-categories";
@@ -7,6 +8,7 @@ import {
   countListingsByVertical,
 } from "@/lib/investment-listings-query";
 import InvestListingsClient from "@/components/InvestListingsClient";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 import SubCategoryNav from "@/components/SubCategoryNav";
 
 export const revalidate = 300;
@@ -45,8 +47,26 @@ export default async function CommercialListingsPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
+      {/* House-standard compact light header (E7) — replaces the client's
+          tall page-title band so results land near the fold. */}
+      <DirectoryHero
+        tone="light"
+        breadcrumbLabel="Commercial Property / Listings"
+        headlineLead="Commercial property"
+        headlineAccent="opportunities"
+        subtitle="Browse Australian commercial property investment opportunities — office, industrial, retail, healthcare and childcare."
+        stats={listings.length > 0 ? [{ v: String(listings.length), l: "Live listings" }] : undefined}
+        containerClassName="container-custom"
+      >
+        <Link
+          href="/invest"
+          className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1 text-[0.65rem] font-semibold text-slate-600 shadow-sm transition-colors hover:bg-slate-50 md:text-xs"
+        >
+          ← Browse all investment sectors
+        </Link>
+      </DirectoryHero>
       {category && (
-        <div className="container-custom pt-6">
+        <div className="container-custom pt-4">
           <SubCategoryNav category={category} />
         </div>
       )}
@@ -55,8 +75,6 @@ export default async function CommercialListingsPage() {
           listings={listings}
           categories={categoryTabs}
           lockedCategory="commercial-property"
-          pageTitle="Commercial Property Investment Listings"
-          pageSubtitle="Browse Australian commercial property investment opportunities — office, industrial, retail, healthcare and childcare."
         />
       </Suspense>
     </>

--- a/app/invest/commercial-property/page.tsx
+++ b/app/invest/commercial-property/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR, UPDATED_LABEL } from "@/lib/seo";
 import { faqJsonLd } from "@/lib/schema-markup";
 import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 import Link from "next/link";
 
 export const revalidate = 86400;
@@ -195,45 +196,29 @@ export default function CommercialPropertyPage() {
         />
       )}
 
-      {/* ── Hero ─────────────────────────────────────────────────────── */}
-      <section className="relative bg-white border-b border-slate-100 overflow-hidden py-8 md:py-12">
-        <div className="container-custom">
-          <nav
-            className="flex items-center gap-1.5 text-xs text-slate-500 mb-6 flex-wrap"
-            aria-label="Breadcrumb"
+      {/* ── Hero — house-standard compact light header (E3). The guide badge
+            and the browse-all entry point live in the light band below. ── */}
+      <DirectoryHero
+        tone="light"
+        breadcrumbLabel="Commercial Property"
+        headlineLead="Commercial Property Investment in Australia"
+        headlineAccent={`(${CURRENT_YEAR})`}
+        subtitle="Commercial property covers office, retail, industrial, and specialised assets leased to businesses rather than households. As an asset class it tends to offer higher income yields than residential property, but it carries a different risk profile — and there are several different ways to gain exposure, from owning a building outright to buying a listed trust on the ASX. This is a plain-English explainer of what commercial property investment is and how it works."
+        containerClassName="container-custom"
+      >
+        <div className="flex flex-wrap items-center gap-2">
+          <Link
+            href="/invest/commercial-property/listings"
+            className="inline-flex items-center gap-1.5 rounded-full border border-coral-200 bg-coral-50 px-3 py-1 text-[0.65rem] font-semibold text-coral-700 shadow-sm transition-colors hover:bg-coral-100 md:text-xs"
           >
-            <Link href="/" className="hover:text-slate-900 transition-colors">
-              Home
-            </Link>
-            <span className="text-slate-300">/</span>
-            <Link href="/invest" className="hover:text-slate-900 transition-colors">
-              Investing
-            </Link>
-            <span className="text-slate-300">/</span>
-            <span className="text-slate-900 font-medium">Commercial Property</span>
-          </nav>
-
-          <div className="max-w-3xl">
-            <div className="inline-flex items-center gap-2 px-3 py-1 bg-slate-100 border border-slate-200 rounded-full text-xs font-semibold text-slate-600 mb-4">
-              <span className="w-1.5 h-1.5 bg-slate-400 rounded-full" />
-              Asset-class guide · {UPDATED_LABEL}
-            </div>
-            <h1 className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-extrabold leading-[1.1] mb-4 tracking-tight text-slate-900">
-              Commercial Property Investment in Australia{" "}
-              <span className="text-amber-600">({CURRENT_YEAR})</span>
-            </h1>
-            <p className="text-base md:text-lg text-slate-600 leading-relaxed">
-              Commercial property covers office, retail, industrial, and specialised
-              assets leased to businesses rather than households. As an asset class it
-              tends to offer higher income yields than residential property, but it
-              carries a different risk profile — and there are several different ways to
-              gain exposure, from owning a building outright to buying a listed trust on
-              the ASX. This is a plain-English explainer of what commercial property
-              investment is and how it works.
-            </p>
-          </div>
+            Browse all commercial property listings →
+          </Link>
+          <span className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-100 px-3 py-1 text-[0.65rem] font-semibold text-slate-600 md:text-xs">
+            <span className="w-1.5 h-1.5 bg-slate-400 rounded-full" />
+            Asset-class guide · {UPDATED_LABEL}
+          </span>
         </div>
-      </section>
+      </DirectoryHero>
 
       {/* ── Quick framing ────────────────────────────────────────────── */}
       <section className="py-8 bg-slate-50 border-b border-slate-200">
@@ -273,7 +258,7 @@ export default function CommercialPropertyPage() {
       </section>
 
       {/* ── Commercial vs residential ────────────────────────────────── */}
-      <section className="py-10 md:py-14">
+      <section className="py-8 md:py-10">
         <div className="container-custom max-w-4xl">
           <p className="text-xs font-bold uppercase tracking-wider text-amber-700 mb-1">
             How it compares
@@ -313,7 +298,7 @@ export default function CommercialPropertyPage() {
       </section>
 
       {/* ── Types of commercial property ─────────────────────────────── */}
-      <section className="py-10 md:py-14 bg-slate-50 border-y border-slate-200">
+      <section className="py-8 md:py-10 bg-slate-50 border-y border-slate-200">
         <div className="container-custom max-w-4xl">
           <p className="text-xs font-bold uppercase tracking-wider text-amber-700 mb-1">
             The sectors
@@ -340,7 +325,7 @@ export default function CommercialPropertyPage() {
       </section>
 
       {/* ── Ways to invest ───────────────────────────────────────────── */}
-      <section className="py-10 md:py-14">
+      <section className="py-8 md:py-10">
         <div className="container-custom max-w-4xl">
           <p className="text-xs font-bold uppercase tracking-wider text-amber-700 mb-1">
             Routes to exposure
@@ -397,7 +382,7 @@ export default function CommercialPropertyPage() {
       </section>
 
       {/* ── A-REITs explained ────────────────────────────────────────── */}
-      <section className="py-10 md:py-14 bg-slate-50 border-y border-slate-200">
+      <section className="py-8 md:py-10 bg-slate-50 border-y border-slate-200">
         <div className="container-custom max-w-3xl">
           <p className="text-xs font-bold uppercase tracking-wider text-amber-700 mb-1">
             Listed property
@@ -434,7 +419,7 @@ export default function CommercialPropertyPage() {
       </section>
 
       {/* ── Yields and returns ───────────────────────────────────────── */}
-      <section className="py-10 md:py-14">
+      <section className="py-8 md:py-10">
         <div className="container-custom max-w-3xl">
           <p className="text-xs font-bold uppercase tracking-wider text-amber-700 mb-1">
             The numbers
@@ -469,7 +454,7 @@ export default function CommercialPropertyPage() {
       </section>
 
       {/* ── Net leases and outgoings ─────────────────────────────────── */}
-      <section className="py-10 md:py-14 bg-slate-50 border-y border-slate-200">
+      <section className="py-8 md:py-10 bg-slate-50 border-y border-slate-200">
         <div className="container-custom max-w-3xl">
           <p className="text-xs font-bold uppercase tracking-wider text-amber-700 mb-1">
             Lease structure
@@ -503,7 +488,7 @@ export default function CommercialPropertyPage() {
       </section>
 
       {/* ── Risks ────────────────────────────────────────────────────── */}
-      <section className="py-10 md:py-14">
+      <section className="py-8 md:py-10">
         <div className="container-custom max-w-4xl">
           <p className="text-xs font-bold uppercase tracking-wider text-amber-700 mb-1">
             What can go wrong
@@ -530,7 +515,7 @@ export default function CommercialPropertyPage() {
       </section>
 
       {/* ── Tax treatment ────────────────────────────────────────────── */}
-      <section className="py-10 md:py-14 bg-slate-50 border-y border-slate-200">
+      <section className="py-8 md:py-10 bg-slate-50 border-y border-slate-200">
         <div className="container-custom max-w-3xl">
           <p className="text-xs font-bold uppercase tracking-wider text-amber-700 mb-1">
             Tax
@@ -572,7 +557,7 @@ export default function CommercialPropertyPage() {
       </section>
 
       {/* ── Industrial / logistics ───────────────────────────────────── */}
-      <section className="py-10 md:py-14">
+      <section className="py-8 md:py-10">
         <div className="container-custom max-w-3xl">
           <p className="text-xs font-bold uppercase tracking-wider text-amber-700 mb-1">
             A standout sector
@@ -609,7 +594,7 @@ export default function CommercialPropertyPage() {
       </section>
 
       {/* ── How to start (educational) ───────────────────────────────── */}
-      <section className="py-10 md:py-14 bg-slate-50 border-y border-slate-200">
+      <section className="py-8 md:py-10 bg-slate-50 border-y border-slate-200">
         <div className="container-custom max-w-3xl">
           <p className="text-xs font-bold uppercase tracking-wider text-amber-700 mb-1">
             Getting oriented
@@ -647,7 +632,7 @@ export default function CommercialPropertyPage() {
       </section>
 
       {/* ── FAQs ─────────────────────────────────────────────────────── */}
-      <section className="py-10 md:py-14">
+      <section className="py-8 md:py-10">
         <div className="container-custom max-w-2xl">
           <p className="text-xs font-bold uppercase tracking-wider text-amber-700 mb-1">
             FAQ
@@ -672,7 +657,7 @@ export default function CommercialPropertyPage() {
       </section>
 
       {/* ── Related asset classes ────────────────────────────────────── */}
-      <section className="py-10 md:py-12 bg-slate-50 border-t border-slate-200">
+      <section className="py-6 md:py-8 bg-slate-50 border-t border-slate-200">
         <div className="container-custom max-w-3xl">
           <p className="text-xs font-bold uppercase tracking-wider text-amber-700 mb-1">
             Keep reading

--- a/app/invest/digital-infrastructure/listings/page.tsx
+++ b/app/invest/digital-infrastructure/listings/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Suspense } from "react";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import { getAllInvestCategories } from "@/lib/invest-categories";
@@ -7,6 +8,7 @@ import {
   countListingsByVertical,
 } from "@/lib/investment-listings-query";
 import InvestListingsClient from "@/components/InvestListingsClient";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 
 export const revalidate = 300;
 
@@ -43,13 +45,29 @@ export default async function DigitalInfrastructureListingsPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
+      {/* House-standard compact light header (E7) — replaces the client's
+          tall page-title band so results land near the fold. */}
+      <DirectoryHero
+        tone="light"
+        breadcrumbLabel="Digital Infrastructure / Listings"
+        headlineLead="Digital infrastructure"
+        headlineAccent="opportunities"
+        subtitle="Browse Australian digital infrastructure investment opportunities — data centres, fibre networks, subsea cables, AI compute and tower assets."
+        stats={listings.length > 0 ? [{ v: String(listings.length), l: "Live listings" }] : undefined}
+        containerClassName="container-custom"
+      >
+        <Link
+          href="/invest"
+          className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1 text-[0.65rem] font-semibold text-slate-600 shadow-sm transition-colors hover:bg-slate-50 md:text-xs"
+        >
+          ← Browse all investment sectors
+        </Link>
+      </DirectoryHero>
       <Suspense fallback={<div className="py-12 text-center text-slate-400">Loading listings...</div>}>
         <InvestListingsClient
           listings={listings}
           categories={categoryTabs}
           lockedCategory="digital-infrastructure"
-          pageTitle="Digital Infrastructure Investment Listings"
-          pageSubtitle="Browse Australian digital infrastructure investment opportunities — data centres, fibre networks, subsea cables, AI compute and tower assets."
         />
       </Suspense>
     </>

--- a/app/invest/digital-infrastructure/page.tsx
+++ b/app/invest/digital-infrastructure/page.tsx
@@ -3,6 +3,7 @@ import { createClient } from "@/lib/supabase/server";
 import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL, SITE_NAME, CURRENT_YEAR } from "@/lib/seo";
 import ContextualLeadMagnet from "@/components/ContextualLeadMagnet";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 
 export const metadata: Metadata = {
   title: `Digital Infrastructure Investment in Australia (${CURRENT_YEAR})`,
@@ -146,75 +147,43 @@ export default async function DigitalInfrastructurePage() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
       />
 
-      {/* Hero */}
-      <section className="relative bg-white border-b border-slate-100 overflow-hidden py-8 md:py-12">
-        <div className="container-custom">
-          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-6">
-            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
-            <span className="text-slate-300">/</span>
-            <Link href="/invest" className="hover:text-slate-900 transition-colors">Invest</Link>
-            <span className="text-slate-300">/</span>
-            <span className="text-slate-900 font-medium">Digital Infrastructure</span>
-          </nav>
-
-          <div className="flex flex-wrap items-center gap-2 mb-4">
-            <span className="text-xs font-semibold bg-amber-500 text-slate-900 px-3 py-1 rounded-full">
-              Updated {CURRENT_YEAR}
-            </span>
-            <span className="text-xs font-semibold bg-slate-100 text-slate-600 px-3 py-1 rounded-full">
-              Highest-Growth Infrastructure Sub-Sector
-            </span>
-          </div>
-
-          <h1 className="text-slate-900 text-3xl md:text-4xl lg:text-5xl font-extrabold leading-tight mb-4 max-w-3xl">
-            Digital Infrastructure Investment in Australia
-          </h1>
-          <p className="text-lg text-slate-600 leading-relaxed max-w-2xl">
-            Data centres, fibre and subsea cables, AI-compute facilities and tower portfolios. AU is one of the fastest-growing data-centre markets globally — anchored by hyperscaler buildout, AI-training demand, and sovereign-cloud requirements.
-          </p>
-          <div className="flex flex-wrap gap-3 mt-6">
-            <Link
-              href="/invest/digital-infrastructure/listings"
-              className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-semibold text-sm px-5 py-2.5 rounded-lg transition-colors"
-            >
-              Browse {listings?.length ?? 10}+ Live Opportunities &rarr;
-            </Link>
-            <Link
-              href="/invest/list"
-              className="inline-flex items-center gap-2 border border-slate-200 text-slate-700 hover:bg-slate-50 hover:border-slate-300 font-semibold text-sm px-5 py-2.5 rounded-lg transition-colors"
-            >
-              List Your Project
-            </Link>
-          </div>
+      {/* Hero — house-standard compact light header (E3). The old stat band
+          rides as pills beside the title; the browse-all and list-your-project
+          entry points live in the light band below (E4). */}
+      <DirectoryHero
+        tone="light"
+        breadcrumbLabel="Digital Infrastructure"
+        headlineLead="Digital Infrastructure Investment in Australia"
+        subtitle="Data centres, fibre and subsea cables, AI-compute facilities and tower portfolios. AU is one of the fastest-growing data-centre markets globally — anchored by hyperscaler buildout, AI-training demand, and sovereign-cloud requirements."
+        stats={[
+          { v: "$24B", l: "AirTrunk sale to Blackstone (2024)" },
+          { v: "~5GW", l: "Goodman Group data-centre pipeline" },
+          { v: "300MW+", l: "NEXTDC operating capacity" },
+          { v: "8–18%", l: "Target IRR range (build-and-hold)" },
+        ]}
+        containerClassName="container-custom"
+      >
+        <div className="flex flex-wrap items-center gap-2">
+          <Link
+            href="/invest/digital-infrastructure/listings"
+            className="inline-flex items-center gap-1.5 rounded-full border border-coral-200 bg-coral-50 px-3 py-1 text-[0.65rem] font-semibold text-coral-700 shadow-sm transition-colors hover:bg-coral-100 md:text-xs"
+          >
+            Browse {listings?.length ?? 10}+ live opportunities →
+          </Link>
+          <Link
+            href="/invest/list"
+            className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1 text-[0.65rem] font-semibold text-slate-600 shadow-sm transition-colors hover:bg-slate-50 md:text-xs"
+          >
+            List your project
+          </Link>
+          <span className="inline-flex items-center rounded-full border border-slate-200 bg-white px-3 py-1 text-[0.65rem] font-semibold text-slate-600 md:text-xs">
+            Highest-Growth Infrastructure Sub-Sector
+          </span>
         </div>
-      </section>
-
-      {/* Key stats */}
-      <section className="bg-slate-50 border-b border-slate-100 py-6 md:py-8">
-        <div className="container-custom">
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 md:gap-6">
-            <div>
-              <div className="text-2xl md:text-3xl font-bold text-slate-900">$24B</div>
-              <div className="text-xs text-slate-500 mt-1">AirTrunk sale to Blackstone (2024)</div>
-            </div>
-            <div>
-              <div className="text-2xl md:text-3xl font-bold text-slate-900">~5GW</div>
-              <div className="text-xs text-slate-500 mt-1">Goodman Group data-centre pipeline</div>
-            </div>
-            <div>
-              <div className="text-2xl md:text-3xl font-bold text-slate-900">300MW+</div>
-              <div className="text-xs text-slate-500 mt-1">NEXTDC operating capacity</div>
-            </div>
-            <div>
-              <div className="text-2xl md:text-3xl font-bold text-slate-900">8–18%</div>
-              <div className="text-xs text-slate-500 mt-1">Target IRR range (build-and-hold)</div>
-            </div>
-          </div>
-        </div>
-      </section>
+      </DirectoryHero>
 
       {/* Sub-categories */}
-      <section className="py-10 md:py-14">
+      <section className="py-8 md:py-10">
         <div className="container-custom">
           <h2 className="text-2xl md:text-3xl font-bold text-slate-900 mb-2">Sub-categories</h2>
           <p className="text-sm md:text-base text-slate-600 mb-6 max-w-2xl">
@@ -243,7 +212,7 @@ export default async function DigitalInfrastructurePage() {
 
       {/* Live listings */}
       {listings && listings.length > 0 && (
-        <section className="bg-slate-50 border-y border-slate-100 py-10 md:py-14">
+        <section className="bg-slate-50 border-y border-slate-100 py-8 md:py-10">
           <div className="container-custom">
             <div className="flex items-end justify-between mb-6">
               <div>
@@ -290,7 +259,7 @@ export default async function DigitalInfrastructurePage() {
       )}
 
       {/* How to invest */}
-      <section className="py-10 md:py-14">
+      <section className="py-8 md:py-10">
         <div className="container-custom max-w-4xl">
           <h2 className="text-2xl md:text-3xl font-bold text-slate-900 mb-6">How to invest</h2>
           <div className="space-y-6">
@@ -333,7 +302,7 @@ export default async function DigitalInfrastructurePage() {
 
       {/* Advisors */}
       {advisors && advisors.length > 0 && (
-        <section className="bg-slate-50 border-t border-slate-100 py-10 md:py-14">
+        <section className="bg-slate-50 border-t border-slate-100 py-8 md:py-10">
           <div className="container-custom">
             <h2 className="text-2xl md:text-3xl font-bold text-slate-900 mb-2">Specialist advisors</h2>
             <p className="text-sm md:text-base text-slate-600 mb-6 max-w-2xl">
@@ -360,7 +329,7 @@ export default async function DigitalInfrastructurePage() {
       )}
 
       {/* FAQ */}
-      <section className="py-10 md:py-14">
+      <section className="py-8 md:py-10">
         <div className="container-custom max-w-4xl">
           <h2 className="text-2xl md:text-3xl font-bold text-slate-900 mb-6">FAQ</h2>
           <div className="space-y-4">

--- a/app/invest/farmland/listings/[slug]/page.tsx
+++ b/app/invest/farmland/listings/[slug]/page.tsx
@@ -124,9 +124,11 @@ export default async function FarmlandListingDetailPage({
       />
       <ListingSchemaScripts listing={l} vertical={CATEGORY_SLUG} />
 
-      <section className="bg-white border-b border-slate-100 py-12">
+      {/* Compact header (E1) — breadcrumb + badges + title + location only,
+          so the gallery and metrics sit near the fold. */}
+      <section className="bg-white border-b border-slate-100 py-3 md:py-4">
         <div className="container-custom">
-          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-4">
+          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-2">
             <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
             <Icon name="chevron-right" size={12} className="text-slate-300" />
             <Link href="/invest/farmland/listings" className="hover:text-slate-900 transition-colors">Farmland Listings</Link>
@@ -134,7 +136,7 @@ export default async function FarmlandListingDetailPage({
             <span className="text-slate-900 font-medium truncate max-w-40">{l.title}</span>
           </nav>
 
-          <div className="flex flex-wrap gap-2 mb-3">
+          <div className="flex flex-wrap gap-2 mb-2">
             {l.listing_type === "featured" && (
               <span className="bg-amber-500 text-slate-900 text-xs font-bold px-2.5 py-0.5 rounded-full">Featured</span>
             )}
@@ -158,12 +160,12 @@ export default async function FarmlandListingDetailPage({
         </div>
       </section>
 
-      <section className="py-10 bg-slate-50">
+      <section className="py-6 md:py-8 bg-slate-50">
         <div className="container-custom">
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
             <div className="lg:col-span-2 space-y-6">
               <ListingImageGallery images={l.images} alt={l.title} vertical={l.vertical} listingId={l.id} subCategory={l.sub_category} />
-              <div className="bg-white border border-slate-200 rounded-xl p-6">
+              <div className="bg-white border border-slate-200 rounded-xl p-4">
                 <div className="flex flex-wrap items-center justify-between gap-4">
                   <div>
                     <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1">Asking Price</p>

--- a/app/invest/farmland/listings/page.tsx
+++ b/app/invest/farmland/listings/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Suspense } from "react";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import { getAllInvestCategories, getInvestCategoryBySlug } from "@/lib/invest-categories";
@@ -7,6 +8,7 @@ import {
   countListingsByVertical,
 } from "@/lib/investment-listings-query";
 import InvestListingsClient from "@/components/InvestListingsClient";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 import SubCategoryNav from "@/components/SubCategoryNav";
 
 export const revalidate = 300;
@@ -45,8 +47,26 @@ export default async function FarmlandListingsPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
+      {/* House-standard compact light header (E7) — replaces the client's
+          tall page-title band so results land near the fold. */}
+      <DirectoryHero
+        tone="light"
+        breadcrumbLabel="Farmland / Listings"
+        headlineLead="Farmland & agriculture"
+        headlineAccent="opportunities"
+        subtitle="Browse Australian farmland and agricultural investments — cropping, dairy, viticulture and horticulture across NSW, VIC, QLD, WA and SA."
+        stats={listings.length > 0 ? [{ v: String(listings.length), l: "Live listings" }] : undefined}
+        containerClassName="container-custom"
+      >
+        <Link
+          href="/invest"
+          className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1 text-[0.65rem] font-semibold text-slate-600 shadow-sm transition-colors hover:bg-slate-50 md:text-xs"
+        >
+          ← Browse all investment sectors
+        </Link>
+      </DirectoryHero>
       {category && (
-        <div className="container-custom pt-6">
+        <div className="container-custom pt-4">
           <SubCategoryNav category={category} />
         </div>
       )}
@@ -55,8 +75,6 @@ export default async function FarmlandListingsPage() {
           listings={listings}
           categories={categoryTabs}
           lockedCategory="farmland"
-          pageTitle="Farmland & Agriculture Investment Listings"
-          pageSubtitle="Browse Australian farmland and agricultural investments — cropping, dairy, viticulture and horticulture across NSW, VIC, QLD, WA and SA."
         />
       </Suspense>
     </>

--- a/app/invest/farmland/page.tsx
+++ b/app/invest/farmland/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import Icon from "@/components/Icon";
 import SectionHeading from "@/components/SectionHeading";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 import { faqJsonLd } from "@/lib/schema-markup";
 
 const FARMLAND_FAQS = [
@@ -59,83 +60,37 @@ export default function FarmlandPage() {
         <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(farmlandFaqLd) }} />
       )}
 
-      {/* Hero */}
-      <section className="relative bg-white border-b border-slate-100 overflow-hidden py-8 md:py-12">
-        <div className="container-custom">
-          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-6">
-            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" />
-            <Link href="/invest" className="hover:text-slate-900 transition-colors">Invest</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" />
-            <span className="text-slate-900 font-medium">Farmland</span>
-          </nav>
-
-          <div className="flex flex-wrap items-center gap-2 mb-4">
-            <span className="text-xs font-semibold bg-amber-500 text-slate-900 px-3 py-1 rounded-full">
-              Updated {CURRENT_YEAR}
-            </span>
-            <span className="text-xs font-semibold bg-blue-600 text-white px-3 py-1 rounded-full">
-              FIRB Applicable
-            </span>
-          </div>
-
-          <h1 className="text-3xl md:text-4xl lg:text-5xl font-extrabold leading-tight mb-4 max-w-3xl text-slate-900">
-            Invest in Australian Farmland
-          </h1>
-          <p className="text-lg text-slate-600 leading-relaxed max-w-2xl mb-8">
-            Australia has 450 million hectares of agricultural land. From cropping and grazing to horticulture and water rights — a proven inflation hedge with strong long-run capital growth.
-          </p>
-
+      {/* Hero — house-standard compact light header (E3). The old stat band
+          rides as pills beside the title; the browse-all entry point lives in
+          the light band below, replacing the standalone CTA band (E4). */}
+      <DirectoryHero
+        tone="light"
+        breadcrumbLabel="Farmland"
+        headlineLead="Invest in Australian Farmland"
+        subtitle="Australia has 450 million hectares of agricultural land. From cropping and grazing to horticulture and water rights — a proven inflation hedge with strong long-run capital growth."
+        stats={[
+          { v: "450M", l: "hectares agricultural land" },
+          { v: "13%", l: "foreign owned" },
+          { v: "$15M", l: "FIRB threshold" },
+          { v: "4–8%", l: "typical total return p.a." },
+        ]}
+        containerClassName="container-custom"
+      >
+        <div className="flex flex-wrap items-center gap-2">
           <Link
             href="/invest/farmland/listings"
-            className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold text-base px-7 py-3.5 rounded-xl transition-colors shadow-lg"
+            className="inline-flex items-center gap-1.5 rounded-full border border-coral-200 bg-coral-50 px-3 py-1 text-[0.65rem] font-semibold text-coral-700 shadow-sm transition-colors hover:bg-coral-100 md:text-xs"
           >
-            Browse Farmland Listings
-            <Icon name="arrow-right" size={18} />
+            Browse all farmland listings →
           </Link>
+          <span className="inline-flex items-center rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-[0.65rem] font-semibold text-blue-700 md:text-xs">
+            FIRB Applicable
+          </span>
         </div>
-      </section>
-
-      {/* Browse Listings CTA */}
-      <section className="bg-white pt-8">
-        <div className="container-custom">
-          <Link
-            href="/invest/farmland/listings"
-            className="group flex items-center justify-between gap-4 p-5 bg-gradient-to-r from-emerald-50 to-emerald-100/40 border border-emerald-200 rounded-2xl mb-8 hover:border-emerald-300 hover:shadow-md transition-all"
-          >
-            <div>
-              <p className="text-xs font-extrabold uppercase tracking-wider text-emerald-700 mb-1">Browse Listings</p>
-              <p className="text-lg font-extrabold text-slate-900">View all farms for sale &rarr;</p>
-              <p className="text-sm text-slate-600 mt-0.5">Active deals, FIRB-eligible, sub-categories &amp; more</p>
-            </div>
-            <svg className="w-8 h-8 text-emerald-600 shrink-0 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-            </svg>
-          </Link>
-        </div>
-      </section>
-
-      {/* Stats */}
-      <section className="py-10 bg-white border-b border-slate-100">
-        <div className="container-custom">
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            {[
-              { value: "450M", label: "hectares agricultural land" },
-              { value: "13%", label: "foreign owned" },
-              { value: "$15M", label: "FIRB threshold" },
-              { value: "4–8%", label: "typical total return p.a." },
-            ].map((s) => (
-              <div key={s.label} className="bg-amber-50 border border-amber-100 rounded-xl p-4 text-center">
-                <p className="text-2xl font-extrabold text-amber-600">{s.value}</p>
-                <p className="text-xs text-slate-600 mt-1">{s.label}</p>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
+      </DirectoryHero>
 
       {/* Content */}
-      <section className="py-14 bg-white">
+      <section className="py-8 md:py-10 bg-white">
         <div className="container-custom max-w-4xl">
           <SectionHeading
             eyebrow="Property types"
@@ -223,7 +178,7 @@ export default function FarmlandPage() {
       </section>
 
       {/* CTA */}
-      <section className="py-14 bg-white border-t border-slate-100">
+      <section className="py-8 md:py-10 bg-white border-t border-slate-100">
         <div className="container-custom">
           <div className="max-w-3xl mx-auto bg-white border border-slate-200 rounded-xl p-8 text-center">
             <h2 className="text-2xl font-extrabold text-slate-900 mb-3">Browse Farmland Listings</h2>
@@ -249,7 +204,7 @@ export default function FarmlandPage() {
         </div>
       </section>
 
-      <section className="py-10 bg-white border-t border-slate-200">
+      <section className="py-6 md:py-8 bg-white border-t border-slate-200">
         <div className="container-custom max-w-3xl">
           <h2 className="text-lg font-bold text-slate-900 mb-4">Frequently asked questions</h2>
           <div className="space-y-3">

--- a/app/invest/franchise/listings/[slug]/page.tsx
+++ b/app/invest/franchise/listings/[slug]/page.tsx
@@ -124,9 +124,11 @@ export default async function FranchiseListingDetailPage({
       />
       <ListingSchemaScripts listing={l} vertical={CATEGORY_SLUG} />
 
-      <section className="bg-white border-b border-slate-100 py-12">
+      {/* Compact header (E1) — breadcrumb + badges + title + location only,
+          so the gallery and metrics sit near the fold. */}
+      <section className="bg-white border-b border-slate-100 py-3 md:py-4">
         <div className="container-custom">
-          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-4">
+          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-2">
             <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
             <Icon name="chevron-right" size={12} className="text-slate-300" />
             <Link href="/invest/franchise/listings" className="hover:text-slate-900 transition-colors">Franchise Listings</Link>
@@ -134,7 +136,7 @@ export default async function FranchiseListingDetailPage({
             <span className="text-slate-900 font-medium truncate max-w-40">{l.title}</span>
           </nav>
 
-          <div className="flex flex-wrap gap-2 mb-3">
+          <div className="flex flex-wrap gap-2 mb-2">
             {l.listing_type === "featured" && (
               <span className="bg-amber-500 text-slate-900 text-xs font-bold px-2.5 py-0.5 rounded-full">Featured</span>
             )}
@@ -160,12 +162,12 @@ export default async function FranchiseListingDetailPage({
         </div>
       </section>
 
-      <section className="py-10 bg-slate-50">
+      <section className="py-6 md:py-8 bg-slate-50">
         <div className="container-custom">
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
             <div className="lg:col-span-2 space-y-6">
               <ListingImageGallery images={l.images} alt={l.title} vertical={l.vertical} listingId={l.id} subCategory={l.sub_category} />
-              <div className="bg-white border border-slate-200 rounded-xl p-6">
+              <div className="bg-white border border-slate-200 rounded-xl p-4">
                 <div className="flex flex-wrap items-center justify-between gap-4">
                   <div>
                     <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1">Total Investment From</p>

--- a/app/invest/franchise/listings/page.tsx
+++ b/app/invest/franchise/listings/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Suspense } from "react";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import { getAllInvestCategories, getInvestCategoryBySlug } from "@/lib/invest-categories";
@@ -7,6 +8,7 @@ import {
   countListingsByVertical,
 } from "@/lib/investment-listings-query";
 import InvestListingsClient from "@/components/InvestListingsClient";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 import SubCategoryNav from "@/components/SubCategoryNav";
 
 export const revalidate = 300;
@@ -45,8 +47,26 @@ export default async function FranchiseListingsPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
+      {/* House-standard compact light header (E7) — replaces the client's
+          tall page-title band so results land near the fold. */}
+      <DirectoryHero
+        tone="light"
+        breadcrumbLabel="Franchise / Listings"
+        headlineLead="Franchise"
+        headlineAccent="opportunities"
+        subtitle="Browse Australian franchise opportunities — food, fitness, automotive and service businesses with proven models."
+        stats={listings.length > 0 ? [{ v: String(listings.length), l: "Live listings" }] : undefined}
+        containerClassName="container-custom"
+      >
+        <Link
+          href="/invest"
+          className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1 text-[0.65rem] font-semibold text-slate-600 shadow-sm transition-colors hover:bg-slate-50 md:text-xs"
+        >
+          ← Browse all investment sectors
+        </Link>
+      </DirectoryHero>
       {category && (
-        <div className="container-custom pt-6">
+        <div className="container-custom pt-4">
           <SubCategoryNav category={category} />
         </div>
       )}
@@ -55,8 +75,6 @@ export default async function FranchiseListingsPage() {
           listings={listings}
           categories={categoryTabs}
           lockedCategory="franchise"
-          pageTitle="Franchise Investment Listings"
-          pageSubtitle="Browse Australian franchise opportunities — food, fitness, automotive and service businesses with proven models."
         />
       </Suspense>
     </>

--- a/app/invest/franchise/page.tsx
+++ b/app/invest/franchise/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import Icon from "@/components/Icon";
 import SectionHeading from "@/components/SectionHeading";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 import { faqJsonLd } from "@/lib/schema-markup";
 
 const FRANCHISE_FAQS = [
@@ -59,80 +60,32 @@ export default function FranchisePage() {
         <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(franchiseFaqLd) }} />
       )}
 
-      {/* Hero */}
-      <section className="relative bg-white border-b border-slate-100 overflow-hidden py-8 md:py-12">
-        <div className="container-custom">
-          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-6">
-            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" />
-            <Link href="/invest" className="hover:text-slate-900 transition-colors">Invest</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" />
-            <span className="text-slate-900 font-medium">Franchise</span>
-          </nav>
-
-          <div className="flex flex-wrap items-center gap-2 mb-4">
-            <span className="text-xs font-semibold bg-amber-500 text-slate-900 px-3 py-1 rounded-full">
-              Updated {CURRENT_YEAR}
-            </span>
-          </div>
-
-          <h1 className="text-3xl md:text-4xl lg:text-5xl font-extrabold leading-tight mb-4 max-w-3xl text-slate-900">
-            Franchise Investment Opportunities in Australia
-          </h1>
-          <p className="text-lg text-slate-600 leading-relaxed max-w-2xl mb-8">
-            Buy into a proven business system with established brand recognition, training, and ongoing support. Australia has over 1,300 active franchise systems with 90,000+ outlets.
-          </p>
-
-          <Link
-            href="/invest/franchise/listings"
-            className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold text-base px-7 py-3.5 rounded-xl transition-colors shadow-lg"
-          >
-            Browse Franchise Opportunities
-            <Icon name="arrow-right" size={18} />
-          </Link>
-        </div>
-      </section>
-
-      {/* Browse Listings CTA */}
-      <section className="bg-white pt-8">
-        <div className="container-custom">
-          <Link
-            href="/invest/franchise/listings"
-            className="group flex items-center justify-between gap-4 p-5 bg-gradient-to-r from-emerald-50 to-emerald-100/40 border border-emerald-200 rounded-2xl mb-8 hover:border-emerald-300 hover:shadow-md transition-all"
-          >
-            <div>
-              <p className="text-xs font-extrabold uppercase tracking-wider text-emerald-700 mb-1">Browse Listings</p>
-              <p className="text-lg font-extrabold text-slate-900">View all franchise opportunities &rarr;</p>
-              <p className="text-sm text-slate-600 mt-0.5">Active territories, investment levels, sub-categories &amp; more</p>
-            </div>
-            <svg className="w-8 h-8 text-emerald-600 shrink-0 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-            </svg>
-          </Link>
-        </div>
-      </section>
-
-      {/* Stats */}
-      <section className="py-10 bg-white border-b border-slate-100">
-        <div className="container-custom">
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            {[
-              { value: "1,300+", label: "franchise systems" },
-              { value: "90,000+", label: "franchise outlets" },
-              { value: "$182B", label: "annual industry revenue" },
-              { value: "Lower", label: "failure rate vs independent" },
-            ].map((s) => (
-              <div key={s.label} className="bg-amber-50 border border-amber-100 rounded-xl p-4 text-center">
-                <p className="text-2xl font-extrabold text-amber-600">{s.value}</p>
-                <p className="text-xs text-slate-600 mt-1">{s.label}</p>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
+      {/* Hero — house-standard compact light header (E3). The old stat band
+          rides as pills beside the title; the browse-all entry point lives in
+          the light band below, replacing the standalone CTA band (E4). */}
+      <DirectoryHero
+        tone="light"
+        breadcrumbLabel="Franchise"
+        headlineLead="Franchise Investment Opportunities in Australia"
+        subtitle="Buy into a proven business system with established brand recognition, training, and ongoing support. Australia has over 1,300 active franchise systems with 90,000+ outlets."
+        stats={[
+          { v: "1,300+", l: "franchise systems" },
+          { v: "90,000+", l: "franchise outlets" },
+          { v: "$182B", l: "annual industry revenue" },
+          { v: "Lower", l: "failure rate vs independent" },
+        ]}
+        containerClassName="container-custom"
+      >
+        <Link
+          href="/invest/franchise/listings"
+          className="inline-flex items-center gap-1.5 rounded-full border border-coral-200 bg-coral-50 px-3 py-1 text-[0.65rem] font-semibold text-coral-700 shadow-sm transition-colors hover:bg-coral-100 md:text-xs"
+        >
+          Browse all franchise opportunities →
+        </Link>
+      </DirectoryHero>
 
       {/* Content */}
-      <section className="py-14 bg-white">
+      <section className="py-8 md:py-10 bg-white">
         <div className="container-custom max-w-4xl">
           <SectionHeading
             eyebrow="Franchise categories"
@@ -218,7 +171,7 @@ export default function FranchisePage() {
       </section>
 
       {/* CTA */}
-      <section className="py-14 bg-white border-t border-slate-100">
+      <section className="py-8 md:py-10 bg-white border-t border-slate-100">
         <div className="container-custom">
           <div className="max-w-3xl mx-auto bg-white border border-slate-200 rounded-xl p-8 text-center">
             <h2 className="text-2xl font-extrabold text-slate-900 mb-3">Browse Franchise Opportunities</h2>
@@ -244,7 +197,7 @@ export default function FranchisePage() {
         </div>
       </section>
 
-      <section className="py-10 bg-white border-t border-slate-200">
+      <section className="py-6 md:py-8 bg-white border-t border-slate-200">
         <div className="container-custom max-w-3xl">
           <h2 className="text-lg font-bold text-slate-900 mb-4">Frequently asked questions</h2>
           <div className="space-y-3">

--- a/app/invest/funds/listings/page.tsx
+++ b/app/invest/funds/listings/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Suspense } from "react";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import { getAllInvestCategories, getInvestCategoryBySlug } from "@/lib/invest-categories";
@@ -7,6 +8,7 @@ import {
   countListingsByVertical,
 } from "@/lib/investment-listings-query";
 import InvestListingsClient from "@/components/InvestListingsClient";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 import SubCategoryNav from "@/components/SubCategoryNav";
 
 export const revalidate = 300;
@@ -45,8 +47,26 @@ export default async function FundsListingsPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
+      {/* House-standard compact light header (E7) — replaces the client's
+          tall page-title band so results land near the fold. */}
+      <DirectoryHero
+        tone="light"
+        breadcrumbLabel="Funds / Listings"
+        headlineLead="Fund"
+        headlineAccent="opportunities"
+        subtitle="Browse Australian fund investment opportunities — managed funds, syndicated property funds, infrastructure funds and wholesale vehicles open to qualified investors."
+        stats={listings.length > 0 ? [{ v: String(listings.length), l: "Live listings" }] : undefined}
+        containerClassName="container-custom"
+      >
+        <Link
+          href="/invest"
+          className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1 text-[0.65rem] font-semibold text-slate-600 shadow-sm transition-colors hover:bg-slate-50 md:text-xs"
+        >
+          ← Browse all investment sectors
+        </Link>
+      </DirectoryHero>
       {category && (
-        <div className="container-custom pt-6">
+        <div className="container-custom pt-4">
           <SubCategoryNav category={category} />
         </div>
       )}
@@ -63,8 +83,6 @@ export default async function FundsListingsPage() {
           // Mirrors the SubCategoryNav render condition above — when the tab
           // bar shows, the in-results chips would duplicate it.
           hideSubCategoryChips={Boolean(category && category.subcategories.length > 0)}
-          pageTitle="Fund Investment Listings"
-          pageSubtitle="Browse Australian fund investment opportunities — managed funds, syndicated property funds, infrastructure funds and wholesale vehicles open to qualified investors."
         />
       </Suspense>
     </>

--- a/app/invest/infrastructure/listings/[slug]/page.tsx
+++ b/app/invest/infrastructure/listings/[slug]/page.tsx
@@ -140,10 +140,11 @@ export default async function InfrastructureListingDetailPage({
       />
       <ListingSchemaScripts listing={l} vertical={CATEGORY_SLUG} />
 
-      {/* Hero */}
-      <section className="bg-white border-b border-slate-100 py-12">
+      {/* Compact header (E1) — breadcrumb + badges + title + location only,
+          so the gallery and metrics sit near the fold. */}
+      <section className="bg-white border-b border-slate-100 py-3 md:py-4">
         <div className="container-custom">
-          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-4">
+          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-2">
             <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
             <Icon name="chevron-right" size={12} className="text-slate-300" />
             <Link href="/invest" className="hover:text-slate-900 transition-colors">Invest</Link>
@@ -153,7 +154,7 @@ export default async function InfrastructureListingDetailPage({
             <span className="text-slate-900 font-medium truncate max-w-40">{l.title}</span>
           </nav>
 
-          <div className="flex flex-wrap gap-2 mb-3">
+          <div className="flex flex-wrap gap-2 mb-2">
             {l.listing_type === "featured" && (
               <span className="bg-amber-500 text-slate-900 text-xs font-bold px-2.5 py-0.5 rounded-full">Featured</span>
             )}
@@ -181,14 +182,14 @@ export default async function InfrastructureListingDetailPage({
       </section>
 
       {/* Main content */}
-      <section className="py-10 bg-slate-50">
+      <section className="py-6 md:py-8 bg-slate-50">
         <div className="container-custom">
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
             {/* Left: details */}
             <div className="lg:col-span-2 space-y-6">
               <ListingImageGallery images={l.images} alt={l.title} vertical={l.vertical} listingId={l.id} subCategory={l.sub_category} />
               {/* Price card */}
-              <div className="bg-white border border-slate-200 rounded-xl p-6">
+              <div className="bg-white border border-slate-200 rounded-xl p-4">
                 <div className="flex flex-wrap items-center justify-between gap-4">
                   <div>
                     <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1">Investment Value</p>

--- a/app/invest/infrastructure/listings/page.tsx
+++ b/app/invest/infrastructure/listings/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Suspense } from "react";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import { getAllInvestCategories, getInvestCategoryBySlug } from "@/lib/invest-categories";
@@ -8,6 +9,7 @@ import {
   INFRASTRUCTURE_SUB_CATEGORIES,
 } from "@/lib/investment-listings-query";
 import InvestListingsClient from "@/components/InvestListingsClient";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 import SubCategoryNav from "@/components/SubCategoryNav";
 
 export const revalidate = 300;
@@ -56,8 +58,26 @@ export default async function InfrastructureListingsPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
+      {/* House-standard compact light header (E7) — replaces the client's
+          tall page-title band so results land near the fold. */}
+      <DirectoryHero
+        tone="light"
+        breadcrumbLabel="Infrastructure / Listings"
+        headlineLead="Infrastructure"
+        headlineAccent="opportunities"
+        subtitle="Browse Australian infrastructure investment opportunities — toll roads, airports, utilities and public-private partnerships."
+        stats={listings.length > 0 ? [{ v: String(listings.length), l: "Live listings" }] : undefined}
+        containerClassName="container-custom"
+      >
+        <Link
+          href="/invest"
+          className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1 text-[0.65rem] font-semibold text-slate-600 shadow-sm transition-colors hover:bg-slate-50 md:text-xs"
+        >
+          ← Browse all investment sectors
+        </Link>
+      </DirectoryHero>
       {category && (
-        <div className="container-custom pt-6">
+        <div className="container-custom pt-4">
           <SubCategoryNav category={category} />
         </div>
       )}
@@ -69,8 +89,6 @@ export default async function InfrastructureListingsPage() {
           // Mirrors the SubCategoryNav render condition above — when the tab
           // bar shows, the in-results chips would duplicate it.
           hideSubCategoryChips={Boolean(category && category.subcategories.length > 0)}
-          pageTitle="Infrastructure Investment Listings"
-          pageSubtitle="Browse Australian infrastructure investment opportunities — toll roads, airports, utilities and public-private partnerships."
         />
       </Suspense>
     </>

--- a/app/invest/infrastructure/page.tsx
+++ b/app/invest/infrastructure/page.tsx
@@ -4,6 +4,7 @@ import { createClient } from "@/lib/supabase/server";
 import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL, SITE_NAME, CURRENT_YEAR } from "@/lib/seo";
 import ContextualLeadMagnet from "@/components/ContextualLeadMagnet";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 import { SHOW_RATINGS, SHOW_EDITORIAL_BADGES, SHOW_ADVISOR_RATINGS, SHOW_ADVISOR_VERIFIED_BADGE, FACTUAL_COMPARISON_DISCLAIMER, ADVISOR_DIRECTORY_HEADING, ADVISOR_DIRECTORY_SUBTEXT } from "@/lib/compliance-config";
 
 export const metadata: Metadata = {
@@ -85,89 +86,37 @@ export default async function InfrastructurePage() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
       />
 
-      {/* Hero */}
-      <section className="relative bg-white border-b border-slate-100 overflow-hidden py-8 md:py-12">
-        <div className="container-custom">
-          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-6">
-            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
-            <span className="text-slate-300">/</span>
-            <Link href="/invest" className="hover:text-slate-900 transition-colors">Invest</Link>
-            <span className="text-slate-300">/</span>
-            <span className="text-slate-900 font-medium">Infrastructure</span>
-          </nav>
-
-          <div className="flex flex-wrap items-center gap-2 mb-4">
-            <span className="text-xs font-semibold bg-amber-500 text-slate-900 px-3 py-1 rounded-full">
-              Updated {CURRENT_YEAR}
-            </span>
-            <span className="text-xs font-semibold bg-slate-100 text-slate-600 px-3 py-1 rounded-full">
-              Toll Roads &middot; Airports &middot; Utilities &middot; Ports
-            </span>
-          </div>
-
-          <h1 className="text-slate-900 text-3xl md:text-4xl lg:text-5xl font-extrabold leading-tight mb-4 max-w-3xl">
-            Infrastructure Investment in Australia
-          </h1>
-          <p className="text-lg text-slate-600 leading-relaxed max-w-2xl">
-            Infrastructure assets — toll roads, airports, utilities, and ports — offer stable, inflation-linked cash flows. They are a core allocation for Australian super funds and increasingly accessible to retail and foreign investors.
-          </p>
-          <div className="flex flex-wrap gap-3 mt-6">
-            <Link
-              href="/advisors"
-              className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-semibold text-sm px-5 py-2.5 rounded-lg transition-colors"
-            >
-              Browse Directories &rarr;
-            </Link>
-            <Link
-              href="/compare"
-              className="inline-flex items-center gap-2 border-slate-200 text-slate-700 hover:bg-slate-50 hover:border-slate-300 font-semibold text-sm px-5 py-2.5 rounded-lg border transition-colors"
-            >
-              Filter Brokers
-            </Link>
-          </div>
-        </div>
-      </section>
-
-      {/* Browse Listings CTA */}
-      <section className="bg-white pt-8">
-        <div className="container-custom">
+      {/* Hero — house-standard compact light header (E3). The old stat band
+          rides as pills beside the title; the browse-all entry point lives in
+          the light band below, replacing the standalone CTA band (E4). */}
+      <DirectoryHero
+        tone="light"
+        breadcrumbLabel="Infrastructure"
+        headlineLead="Infrastructure Investment in Australia"
+        subtitle="Infrastructure assets — toll roads, airports, utilities, and ports — offer stable, inflation-linked cash flows. They are a core allocation for Australian super funds and increasingly accessible to retail and foreign investors."
+        stats={[
+          { v: "$250B+", l: "Australian infrastructure pipeline (govt)" },
+          { v: "7–10%", l: "Historical listed infra returns p.a." },
+          { v: "4–6%", l: "Typical distribution yield" },
+          { v: "CPI-linked", l: "Revenue often inflation-protected" },
+        ]}
+        containerClassName="container-custom"
+      >
+        <div className="flex flex-wrap items-center gap-2">
           <Link
             href="/invest/infrastructure/listings"
-            className="group flex items-center justify-between gap-4 p-5 bg-gradient-to-r from-emerald-50 to-emerald-100/40 border border-emerald-200 rounded-2xl mb-8 hover:border-emerald-300 hover:shadow-md transition-all"
+            className="inline-flex items-center gap-1.5 rounded-full border border-coral-200 bg-coral-50 px-3 py-1 text-[0.65rem] font-semibold text-coral-700 shadow-sm transition-colors hover:bg-coral-100 md:text-xs"
           >
-            <div>
-              <p className="text-xs font-extrabold uppercase tracking-wider text-emerald-700 mb-1">Browse Listings</p>
-              <p className="text-lg font-extrabold text-slate-900">View all infrastructure opportunities &rarr;</p>
-              <p className="text-sm text-slate-600 mt-0.5">Toll roads, airports, utilities, sub-categories &amp; more</p>
-            </div>
-            <svg className="w-8 h-8 text-emerald-600 shrink-0 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-            </svg>
+            Browse all infrastructure opportunities →
           </Link>
+          <span className="inline-flex items-center rounded-full border border-slate-200 bg-white px-3 py-1 text-[0.65rem] font-semibold text-slate-600 md:text-xs">
+            Toll Roads &middot; Airports &middot; Utilities &middot; Ports
+          </span>
         </div>
-      </section>
-
-      {/* Key stats */}
-      <section className="py-10 bg-white border-b border-slate-100">
-        <div className="container-custom">
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            {[
-              { value: "$250B+", label: "Australian infrastructure pipeline (govt)" },
-              { value: "7–10%", label: "Historical listed infra returns p.a." },
-              { value: "4–6%", label: "Typical distribution yield" },
-              { value: "CPI-linked", label: "Revenue often inflation-protected" },
-            ].map((s) => (
-              <div key={s.label} className="bg-amber-50 border border-amber-100 rounded-xl p-4 text-center">
-                <p className="text-2xl font-extrabold text-amber-600">{s.value}</p>
-                <p className="text-xs text-slate-600 mt-1">{s.label}</p>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
+      </DirectoryHero>
 
       {/* Section 1: Why Infrastructure */}
-      <section className="py-14 bg-white">
+      <section className="py-8 md:py-10 bg-white">
         <div className="container-custom max-w-4xl">
           <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">Section 1</p>
           <h2 className="text-2xl font-extrabold text-slate-900 mb-4">Why Invest in Infrastructure?</h2>
@@ -189,7 +138,7 @@ export default async function InfrastructurePage() {
       </section>
 
       {/* Section 2: ASX-Listed Infrastructure */}
-      <section className="py-14 bg-slate-50">
+      <section className="py-8 md:py-10 bg-slate-50">
         <div className="container-custom max-w-4xl">
           <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">Section 2</p>
           <h2 className="text-2xl font-extrabold text-slate-900 mb-6">ASX-Listed Infrastructure Stocks</h2>
@@ -238,14 +187,14 @@ export default async function InfrastructurePage() {
       </section>
 
       {/* Lead Magnet */}
-      <section className="py-14 bg-white">
+      <section className="py-8 md:py-10 bg-white">
         <div className="container-custom max-w-4xl">
           <ContextualLeadMagnet segment="fee-audit" />
         </div>
       </section>
 
       {/* Section 3: Infrastructure Funds & ETFs */}
-      <section className="py-14 bg-white">
+      <section className="py-8 md:py-10 bg-white">
         <div className="container-custom max-w-4xl">
           <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">Section 3</p>
           <h2 className="text-2xl font-extrabold text-slate-900 mb-6">Infrastructure Funds &amp; ETFs</h2>
@@ -276,7 +225,7 @@ export default async function InfrastructurePage() {
       </section>
 
       {/* Section 4: SIV & Foreign Investors */}
-      <section className="py-14 bg-slate-50">
+      <section className="py-8 md:py-10 bg-slate-50">
         <div className="container-custom max-w-4xl">
           <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">Section 4</p>
           <h2 className="text-2xl font-extrabold text-slate-900 mb-4">Infrastructure for Foreign &amp; SIV Investors</h2>
@@ -296,7 +245,7 @@ export default async function InfrastructurePage() {
       </section>
 
       {/* Risk */}
-      <section className="py-14 bg-white">
+      <section className="py-8 md:py-10 bg-white">
         <div className="container-custom max-w-4xl">
           <div className="bg-red-50 border border-red-200 rounded-xl p-5">
             <h3 className="font-bold text-red-800 mb-2">Key Risks</h3>
@@ -312,7 +261,7 @@ export default async function InfrastructurePage() {
       </section>
 
       {/* FAQ */}
-      <section className="py-14 bg-white">
+      <section className="py-8 md:py-10 bg-white">
         <div className="container-custom max-w-4xl">
           <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">FAQ</p>
           <h2 className="text-2xl font-extrabold text-slate-900 mb-6">Frequently Asked Questions</h2>
@@ -333,7 +282,7 @@ export default async function InfrastructurePage() {
 
       {/* Compare Brokers */}
       {brokers && brokers.length > 0 && (
-        <section className="py-14 bg-slate-50">
+        <section className="py-8 md:py-10 bg-slate-50">
           <div className="container-custom max-w-4xl">
             <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">Compare Brokers</p>
             <h2 className="text-2xl font-extrabold text-slate-900 mb-2">Where to Buy Infrastructure Stocks</h2>
@@ -391,7 +340,7 @@ export default async function InfrastructurePage() {
 
       {/* Find an Advisor */}
       {advisors && advisors.length > 0 && (
-        <section className="py-14 bg-white">
+        <section className="py-8 md:py-10 bg-white">
           <div className="container-custom max-w-4xl">
             <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">Expert Advisors</p>
             <h2 className="text-2xl font-extrabold text-slate-900 mb-2">{ADVISOR_DIRECTORY_HEADING}</h2>
@@ -434,7 +383,7 @@ export default async function InfrastructurePage() {
         </section>
       )}
       {/* Related guides */}
-      <section className="py-14 bg-white">
+      <section className="py-8 md:py-10 bg-white">
         <div className="container-custom max-w-4xl">
           <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">Related Guides</p>
           <h2 className="text-2xl font-extrabold text-slate-900 mb-6">Explore Related Investment Guides</h2>
@@ -456,7 +405,7 @@ export default async function InfrastructurePage() {
       </section>
 
       {/* CTA */}
-      <section className="py-14 bg-slate-50">
+      <section className="py-8 md:py-10 bg-slate-50">
         <div className="container-custom">
           <div className="max-w-3xl mx-auto bg-white border border-slate-200 rounded-xl p-8 flex flex-col md:flex-row items-start md:items-center gap-6">
             <div className="w-12 h-12 rounded-xl bg-amber-50 flex items-center justify-center shrink-0">

--- a/app/invest/insurance-linked-securities/listings/page.tsx
+++ b/app/invest/insurance-linked-securities/listings/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Suspense } from "react";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import { getAllInvestCategories } from "@/lib/invest-categories";
@@ -7,6 +8,7 @@ import {
   countListingsByVertical,
 } from "@/lib/investment-listings-query";
 import InvestListingsClient from "@/components/InvestListingsClient";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 
 export const revalidate = 300;
 
@@ -46,6 +48,24 @@ export default async function InsuranceLinkedSecuritiesListingsPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
+      {/* House-standard compact light header (E7) — replaces the client's
+          tall page-title band so results land near the fold. */}
+      <DirectoryHero
+        tone="light"
+        breadcrumbLabel="Insurance-Linked Securities / Listings"
+        headlineLead="Insurance-linked securities"
+        headlineAccent="opportunities"
+        subtitle="Browse Australian insurance-linked securities investment opportunities — catastrophe bonds, reinsurance sidecars, collateralised reinsurance and industry loss warranty structures for wholesale investors seeking non-correlated yield."
+        stats={listings.length > 0 ? [{ v: String(listings.length), l: "Live listings" }] : undefined}
+        containerClassName="container-custom"
+      >
+        <Link
+          href="/invest"
+          className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1 text-[0.65rem] font-semibold text-slate-600 shadow-sm transition-colors hover:bg-slate-50 md:text-xs"
+        >
+          ← Browse all investment sectors
+        </Link>
+      </DirectoryHero>
       <div className="bg-amber-50 border border-amber-200 rounded-lg mx-4 mt-6 p-4 text-sm text-amber-900">
         <p className="font-semibold mb-1">⚠️ Wholesale Investor Access Required (s708 Corporations Act)</p>
         <p className="mb-2">
@@ -68,8 +88,6 @@ export default async function InsuranceLinkedSecuritiesListingsPage() {
           listings={listings}
           categories={categoryTabs}
           lockedCategory="insurance-linked-securities"
-          pageTitle="Insurance-Linked Securities Listings"
-          pageSubtitle="Browse Australian insurance-linked securities investment opportunities — catastrophe bonds, reinsurance sidecars, collateralised reinsurance and industry loss warranty structures for wholesale investors seeking non-correlated yield."
         />
       </Suspense>
     </>

--- a/app/invest/listed-securities/listings/page.tsx
+++ b/app/invest/listed-securities/listings/page.tsx
@@ -6,6 +6,7 @@ import { getAllInvestCategories, getInvestCategoryBySlug } from "@/lib/invest-ca
 import { fetchListingsByKind, countListingsByKind } from "@/lib/investment-listings-query";
 import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
 import InvestListingsClient from "@/components/InvestListingsClient";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 import Icon from "@/components/Icon";
 
 export const revalidate = 300;
@@ -49,9 +50,27 @@ export default async function ListedSecuritiesPage() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
 
+      {/* House-standard compact light header (E7) — replaces the client's
+          tall page-title band so results land near the fold. */}
+      <DirectoryHero
+        tone="light"
+        breadcrumbLabel="Listed Securities / Listings"
+        headlineLead={cat?.h1 ?? "ASX-Listed Securities"}
+        subtitle={cat?.intro}
+        stats={listings.length > 0 ? [{ v: String(listings.length), l: "Live listings" }] : undefined}
+        containerClassName="container-custom"
+      >
+        <Link
+          href="/invest"
+          className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1 text-[0.65rem] font-semibold text-slate-600 shadow-sm transition-colors hover:bg-slate-50 md:text-xs"
+        >
+          ← Browse all investment sectors
+        </Link>
+      </DirectoryHero>
+
       {/* Factual / general-information notice — these are public securities,
           not an offer or recommendation (lean lane per REGULATORY-AVOID-LIST). */}
-      <div className="container-custom pt-6">
+      <div className="container-custom pt-4">
         <div className="flex gap-2.5 rounded-xl border border-blue-200 bg-blue-50 px-4 py-3 text-xs leading-relaxed text-blue-800">
           <Icon name="shield-check" size={15} className="mt-0.5 shrink-0 text-blue-600" />
           <p>
@@ -68,8 +87,6 @@ export default async function ListedSecuritiesPage() {
           listings={listings}
           categories={categoryTabs}
           lockedCategory="listed-securities"
-          pageTitle={cat?.h1 ?? "ASX-Listed Securities"}
-          pageSubtitle={cat?.intro}
         />
       </Suspense>
     </>

--- a/app/invest/litigation-funding/listings/page.tsx
+++ b/app/invest/litigation-funding/listings/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Suspense } from "react";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import { getAllInvestCategories } from "@/lib/invest-categories";
@@ -7,6 +8,7 @@ import {
   countListingsByVertical,
 } from "@/lib/investment-listings-query";
 import InvestListingsClient from "@/components/InvestListingsClient";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 
 export const revalidate = 300;
 
@@ -46,6 +48,24 @@ export default async function LitigationFundingListingsPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
+      {/* House-standard compact light header (E7) — replaces the client's
+          tall page-title band so results land near the fold. */}
+      <DirectoryHero
+        tone="light"
+        breadcrumbLabel="Litigation Funding / Listings"
+        headlineLead="Litigation funding"
+        headlineAccent="opportunities"
+        subtitle="Browse Australian litigation funding investment opportunities — class action portfolios, commercial dispute funding, international arbitration and single-case structures for wholesale investors."
+        stats={listings.length > 0 ? [{ v: String(listings.length), l: "Live listings" }] : undefined}
+        containerClassName="container-custom"
+      >
+        <Link
+          href="/invest"
+          className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1 text-[0.65rem] font-semibold text-slate-600 shadow-sm transition-colors hover:bg-slate-50 md:text-xs"
+        >
+          ← Browse all investment sectors
+        </Link>
+      </DirectoryHero>
       <div className="bg-amber-50 border border-amber-200 rounded-lg mx-4 mt-6 p-4 text-sm text-amber-900">
         <p className="font-semibold mb-1">⚠️ Wholesale Investor Access Required (s708 Corporations Act)</p>
         <p className="mb-2">
@@ -68,8 +88,6 @@ export default async function LitigationFundingListingsPage() {
           listings={listings}
           categories={categoryTabs}
           lockedCategory="litigation-funding"
-          pageTitle="Litigation Funding Investment Listings"
-          pageSubtitle="Browse Australian litigation funding investment opportunities — class action portfolios, commercial dispute funding, international arbitration and single-case structures for wholesale investors."
         />
       </Suspense>
     </>

--- a/app/invest/livestock/listings/page.tsx
+++ b/app/invest/livestock/listings/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Suspense } from "react";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import { getAllInvestCategories } from "@/lib/invest-categories";
@@ -7,6 +8,7 @@ import {
   countListingsByVertical,
 } from "@/lib/investment-listings-query";
 import InvestListingsClient from "@/components/InvestListingsClient";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 import ListingComplianceNotice from "@/components/invest/ListingComplianceNotice";
 import WholesaleAttestationGate from "@/components/invest/WholesaleAttestationGate";
 
@@ -49,6 +51,24 @@ export default async function LivestockListingsPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
+      {/* House-standard compact light header (E7) — replaces the client's
+          tall page-title band so results land near the fold. */}
+      <DirectoryHero
+        tone="light"
+        breadcrumbLabel="Livestock & Equine / Listings"
+        headlineLead="Livestock & equine"
+        headlineAccent="opportunities"
+        subtitle="Browse Australian livestock and equine investment opportunities — thoroughbred racehorse syndications via Magic Millions and Inglis, cattle herd programs, sheep and wool breeding, stud rights and genetic investment programs."
+        stats={listings.length > 0 ? [{ v: String(listings.length), l: "Live listings" }] : undefined}
+        containerClassName="container-custom"
+      >
+        <Link
+          href="/invest"
+          className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1 text-[0.65rem] font-semibold text-slate-600 shadow-sm transition-colors hover:bg-slate-50 md:text-xs"
+        >
+          ← Browse all investment sectors
+        </Link>
+      </DirectoryHero>
       <ListingComplianceNotice
         productLabel="livestock and equine investment opportunities (including racehorse and breeding syndications)"
         classification="Livestock and equine syndications listed here are commonly regulated managed investment schemes."
@@ -64,8 +84,6 @@ export default async function LivestockListingsPage() {
               listings={listings}
               categories={categoryTabs}
               lockedCategory="livestock"
-              pageTitle="Livestock & Equine Investment Listings"
-              pageSubtitle="Browse Australian livestock and equine investment opportunities — thoroughbred racehorse syndications via Magic Millions and Inglis, cattle herd programs, sheep and wool breeding, stud rights and genetic investment programs."
             />
           </Suspense>
         </WholesaleAttestationGate>

--- a/app/invest/mining/listings/[slug]/page.tsx
+++ b/app/invest/mining/listings/[slug]/page.tsx
@@ -129,9 +129,11 @@ export default async function MiningOpportunityDetailPage({
       />
       <ListingSchemaScripts listing={l} vertical={CATEGORY_SLUG} />
 
-      <section className="bg-white border-b border-slate-100 py-12">
+      {/* Compact header (E1) — breadcrumb + badges + title + location only,
+          so the gallery and metrics sit near the fold. */}
+      <section className="bg-white border-b border-slate-100 py-3 md:py-4">
         <div className="container-custom">
-          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-4">
+          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-2">
             <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
             <Icon name="chevron-right" size={12} className="text-slate-300" />
             <Link href="/invest/mining/listings" className="hover:text-slate-900 transition-colors">Mining Opportunities</Link>
@@ -139,7 +141,7 @@ export default async function MiningOpportunityDetailPage({
             <span className="text-slate-900 font-medium truncate max-w-40">{l.title}</span>
           </nav>
 
-          <div className="flex flex-wrap gap-2 mb-3">
+          <div className="flex flex-wrap gap-2 mb-2">
             {l.listing_type === "featured" && (
               <span className="bg-amber-500 text-slate-900 text-xs font-bold px-2.5 py-0.5 rounded-full">Featured</span>
             )}
@@ -168,13 +170,13 @@ export default async function MiningOpportunityDetailPage({
         </div>
       </section>
 
-      <section className="py-10 bg-slate-50">
+      <section className="py-6 md:py-8 bg-slate-50">
         <div className="container-custom">
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
             <div className="lg:col-span-2 space-y-6">
               <ListingImageGallery images={l.images} alt={l.title} vertical={l.vertical} listingId={l.id} subCategory={l.sub_category} />
               {/* Price */}
-              <div className="bg-white border border-slate-200 rounded-xl p-6">
+              <div className="bg-white border border-slate-200 rounded-xl p-4">
                 <div className="flex flex-wrap items-center justify-between gap-4">
                   <div>
                     <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1">Investment Required</p>

--- a/app/invest/mining/listings/page.tsx
+++ b/app/invest/mining/listings/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Suspense } from "react";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import { getAllInvestCategories, getInvestCategoryBySlug } from "@/lib/invest-categories";
@@ -7,6 +8,7 @@ import {
   countListingsByVertical,
 } from "@/lib/investment-listings-query";
 import InvestListingsClient from "@/components/InvestListingsClient";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 import SubCategoryNav from "@/components/SubCategoryNav";
 
 export const revalidate = 300;
@@ -45,8 +47,26 @@ export default async function MiningOpportunitiesPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
+      {/* House-standard compact light header (E7) — replaces the client's
+          tall page-title band so results land near the fold. */}
+      <DirectoryHero
+        tone="light"
+        breadcrumbLabel="Mining / Listings"
+        headlineLead="Mining"
+        headlineAccent="opportunities"
+        subtitle="Browse Australian mining investment opportunities — filter by commodity (lithium, gold, copper, iron ore, rare earths), project stage and state."
+        stats={listings.length > 0 ? [{ v: String(listings.length), l: "Live listings" }] : undefined}
+        containerClassName="container-custom"
+      >
+        <Link
+          href="/invest"
+          className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1 text-[0.65rem] font-semibold text-slate-600 shadow-sm transition-colors hover:bg-slate-50 md:text-xs"
+        >
+          ← Browse all investment sectors
+        </Link>
+      </DirectoryHero>
       {category && (
-        <div className="container-custom pt-6">
+        <div className="container-custom pt-4">
           <SubCategoryNav category={category} />
         </div>
       )}
@@ -58,8 +78,6 @@ export default async function MiningOpportunitiesPage() {
           // Mirrors the SubCategoryNav render condition above — when the tab
           // bar shows, the in-results chips would duplicate it.
           hideSubCategoryChips={Boolean(category && category.subcategories.length > 0)}
-          pageTitle="Mining Investment Listings"
-          pageSubtitle="Browse Australian mining investment opportunities — filter by commodity (lithium, gold, copper, iron ore, rare earths), project stage and state."
         />
       </Suspense>
     </>

--- a/app/invest/mining/page.tsx
+++ b/app/invest/mining/page.tsx
@@ -25,6 +25,7 @@ const MINING_FAQS = [
 const miningFaqLd = faqJsonLd(MINING_FAQS);
 import Icon from "@/components/Icon";
 import SectionHeading from "@/components/SectionHeading";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 import VerticalMarketplaceListings from "@/components/marketplace/VerticalMarketplaceListings";
 
 export const revalidate = 3600;
@@ -60,74 +61,45 @@ export default function MiningPage() {
         <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(miningFaqLd) }} />
       )}
 
-      {/* Hero */}
-      <section className="relative bg-white border-b border-slate-100 overflow-hidden py-8 md:py-12">
+      {/* Hero — house-standard compact light header (E3). The old stat band
+          rides as pills beside the title; the browse-all entry point lives in
+          the light band below, replacing the standalone CTA band (E4). */}
+      <DirectoryHero
+        tone="light"
+        breadcrumbLabel="Mining"
+        headlineLead="Invest in Australian Mining"
+        subtitle="Australia is the world's largest exporter of iron ore and lithium — and the centre of a critical minerals investment boom backed by bilateral government frameworks worth over $8.5 billion."
+        stats={[
+          { v: "$8.5B+", l: "Government-Backed Pipeline" },
+          { v: "#1", l: "Lithium & Iron Ore Exporter" },
+          { v: "130+", l: "Critical Mineral Projects" },
+          { v: "45%", l: "of Global Rare Earth Exploration" },
+        ]}
+        containerClassName="container-custom"
+      >
+        <Link
+          href="/invest/mining/listings"
+          className="inline-flex items-center gap-1.5 rounded-full border border-coral-200 bg-coral-50 px-3 py-1 text-[0.65rem] font-semibold text-coral-700 shadow-sm transition-colors hover:bg-coral-100 md:text-xs"
+        >
+          Browse all mining opportunities →
+        </Link>
+      </DirectoryHero>
+
+      {/* Critical Minerals Boom — light card (E5) */}
+      <section className="pt-4 bg-white">
         <div className="container-custom">
-          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-6">
-            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" />
-            <Link href="/invest" className="hover:text-slate-900 transition-colors">Invest</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" />
-            <span className="text-slate-900 font-medium">Mining</span>
-          </nav>
-
-          <div className="flex flex-wrap items-center gap-2 mb-4">
-            <span className="text-xs font-semibold bg-amber-500 text-slate-900 px-3 py-1 rounded-full">
-              Updated {CURRENT_YEAR}
-            </span>
-          </div>
-
-          <h1 className="text-3xl md:text-4xl lg:text-5xl font-extrabold leading-tight mb-4 max-w-3xl text-slate-900">
-            Invest in Australian Mining
-          </h1>
-          <p className="text-lg text-slate-600 leading-relaxed max-w-2xl mb-8">
-            Australia is the world&apos;s largest exporter of iron ore and lithium — and the centre of a critical minerals investment boom backed by bilateral government frameworks worth over $8.5 billion.
-          </p>
-
-          <Link
-            href="/invest/mining/listings"
-            className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold text-base px-7 py-3.5 rounded-xl transition-colors shadow-lg"
-          >
-            Browse Mining Opportunities
-            <Icon name="arrow-right" size={18} />
-          </Link>
-        </div>
-      </section>
-
-      {/* Browse Listings CTA */}
-      <section className="bg-white pt-8">
-        <div className="container-custom">
-          <Link
-            href="/invest/mining/listings"
-            className="group flex items-center justify-between gap-4 p-5 bg-gradient-to-r from-emerald-50 to-emerald-100/40 border border-emerald-200 rounded-2xl mb-8 hover:border-emerald-300 hover:shadow-md transition-all"
-          >
-            <div>
-              <p className="text-xs font-extrabold uppercase tracking-wider text-emerald-700 mb-1">Browse Listings</p>
-              <p className="text-lg font-extrabold text-slate-900">View all mining opportunities &rarr;</p>
-              <p className="text-sm text-slate-600 mt-0.5">Active deals, FIRB-eligible, sub-categories &amp; more</p>
-            </div>
-            <svg className="w-8 h-8 text-emerald-600 shrink-0 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-            </svg>
-          </Link>
-        </div>
-      </section>
-
-      {/* Critical Minerals Boom Banner */}
-      <section className="py-6 bg-gradient-to-r from-emerald-600 to-emerald-700 text-white">
-        <div className="container-custom">
-          <div className="flex flex-col md:flex-row md:items-center gap-4 md:gap-8">
+          <div className="flex flex-col md:flex-row md:items-center gap-4 md:gap-8 rounded-xl border border-emerald-200 bg-emerald-50 p-4 md:px-5">
             <div className="flex items-center gap-3">
-              <span className="text-xs font-extrabold uppercase tracking-wider bg-white/20 px-3 py-1 rounded-full">
+              <span className="text-xs font-extrabold uppercase tracking-wider bg-emerald-100 text-emerald-800 px-3 py-1 rounded-full">
                 {CURRENT_YEAR} Critical Minerals Boom
               </span>
             </div>
-            <p className="text-sm text-emerald-100 leading-relaxed flex-1">
+            <p className="text-sm text-slate-700 leading-relaxed flex-1">
               The US-Australia bilateral framework has mobilised $8.5B+ in critical minerals investment. The EU-Australia FTA eliminates 99% of tariffs on mineral exports. Australia&apos;s Critical Minerals Strategic Reserve launches H2 {CURRENT_YEAR}.
             </p>
             <Link
               href="/article/australias-critical-minerals-boom-how-to-invest"
-              className="inline-flex items-center gap-2 bg-white text-emerald-700 font-bold text-sm px-5 py-2.5 rounded-lg hover:bg-emerald-50 transition-colors whitespace-nowrap"
+              className="inline-flex items-center gap-2 bg-white border border-emerald-200 text-emerald-700 font-bold text-sm px-5 py-2.5 rounded-lg hover:bg-emerald-100 transition-colors whitespace-nowrap"
             >
               Read the Deep Dive
               <Icon name="arrow-right" size={16} />
@@ -136,27 +108,8 @@ export default function MiningPage() {
         </div>
       </section>
 
-      {/* Stats */}
-      <section className="py-10 bg-amber-50 border-b border-amber-100">
-        <div className="container-custom">
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            {[
-              { value: "$8.5B+", label: "Government-Backed Pipeline" },
-              { value: "#1", label: "Lithium & Iron Ore Exporter" },
-              { value: "130+", label: "Critical Mineral Projects" },
-              { value: "45%", label: "of Global Rare Earth Exploration" },
-            ].map((s) => (
-              <div key={s.label} className="bg-white border border-amber-100 rounded-xl p-4 text-center">
-                <p className="text-2xl font-extrabold text-amber-600">{s.value}</p>
-                <p className="text-xs text-slate-600 mt-1">{s.label}</p>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
       {/* Content */}
-      <section className="py-14 bg-white">
+      <section className="py-8 md:py-10 bg-white">
         <div className="container-custom max-w-4xl">
           <SectionHeading
             eyebrow="Commodities"
@@ -257,7 +210,7 @@ export default function MiningPage() {
       </section>
 
       {/* Browse CTA */}
-      <section className="py-14 bg-white border-t border-slate-100">
+      <section className="py-8 md:py-10 bg-white border-t border-slate-100">
         <div className="container-custom">
           <div className="max-w-3xl mx-auto bg-white border border-slate-200 rounded-xl p-8 text-center">
             <h2 className="text-2xl font-extrabold text-slate-900 mb-3">Browse Mining Investment Opportunities</h2>
@@ -284,7 +237,7 @@ export default function MiningPage() {
       </section>
 
       {/* Advisor CTA — specialist multi-type */}
-      <section className="py-12 md:py-14 bg-slate-900 text-white" id="find-advisor">
+      <section className="py-8 md:py-10 bg-slate-900 text-white" id="find-advisor">
         <div className="container-custom max-w-4xl">
           <p className="text-xs font-bold uppercase tracking-wider text-amber-400 mb-2">
             Get specialist help
@@ -383,7 +336,7 @@ export default function MiningPage() {
       />
 
       {/* Foreign investor note */}
-      <section className="py-10 md:py-12 bg-white border-t border-slate-100" id="foreign-investors">
+      <section className="py-6 md:py-8 bg-white border-t border-slate-100" id="foreign-investors">
         <div className="container-custom max-w-4xl">
           <p className="text-xs font-bold uppercase tracking-wider text-amber-600 mb-1">
             International investors
@@ -446,7 +399,7 @@ export default function MiningPage() {
       </section>
 
       {/* FAQ */}
-      <section className="py-10 bg-white border-t border-slate-200">
+      <section className="py-6 md:py-8 bg-white border-t border-slate-200">
         <div className="max-w-3xl mx-auto px-4 container-custom">
           <h2 className="text-lg font-bold text-slate-900 mb-4">Frequently asked questions</h2>
           <div className="space-y-3">

--- a/app/invest/pre-ipo/listings/[slug]/page.tsx
+++ b/app/invest/pre-ipo/listings/[slug]/page.tsx
@@ -111,9 +111,11 @@ export default async function PreIpoOpportunityDetailPage({
         </div>
       </section>
 
-      <section className="bg-white border-b border-slate-100 py-12">
+      {/* Compact header (E1) — breadcrumb + badges + title + location only,
+          so the gallery and metrics sit near the fold. */}
+      <section className="bg-white border-b border-slate-100 py-3 md:py-4">
         <div className="container-custom">
-          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-4">
+          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-2">
             <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
             <Icon name="chevron-right" size={12} className="text-slate-300" />
             <Link href="/invest/pre-ipo/listings" className="hover:text-slate-900 transition-colors">Pre-IPO Opportunities</Link>
@@ -121,7 +123,7 @@ export default async function PreIpoOpportunityDetailPage({
             <span className="text-slate-900 font-medium truncate max-w-40">{l.title}</span>
           </nav>
 
-          <div className="flex flex-wrap gap-2 mb-3">
+          <div className="flex flex-wrap gap-2 mb-2">
             <span className="bg-red-600 text-white text-xs font-bold px-2.5 py-0.5 rounded-full">Wholesale Only</span>
             {l.listing_type === "featured" && (
               <span className="bg-amber-500 text-slate-900 text-xs font-bold px-2.5 py-0.5 rounded-full">Featured</span>
@@ -148,12 +150,12 @@ export default async function PreIpoOpportunityDetailPage({
         </div>
       </section>
 
-      <section className="py-10 bg-slate-50">
+      <section className="py-6 md:py-8 bg-slate-50">
         <div className="container-custom">
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
             <div className="lg:col-span-2 space-y-6">
               <ListingImageGallery images={l.images} alt={l.title} vertical={l.vertical} listingId={l.id} subCategory={l.sub_category} />
-              <div className="bg-white border border-slate-200 rounded-xl p-6">
+              <div className="bg-white border border-slate-200 rounded-xl p-4">
                 <div className="flex flex-wrap items-center justify-between gap-4">
                   <div>
                     <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1">

--- a/app/invest/pre-ipo/listings/page.tsx
+++ b/app/invest/pre-ipo/listings/page.tsx
@@ -8,6 +8,7 @@ import {
   countListingsByVertical,
 } from "@/lib/investment-listings-query";
 import InvestListingsClient from "@/components/InvestListingsClient";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 import Icon from "@/components/Icon";
 
 export const revalidate = 300;
@@ -46,6 +47,25 @@ export default async function PreIpoOpportunitiesPage() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
 
+      {/* House-standard compact light header (E7) — replaces the client's
+          tall page-title band so results land near the fold. */}
+      <DirectoryHero
+        tone="light"
+        breadcrumbLabel="Pre-IPO / Listings"
+        headlineLead="Pre-IPO"
+        headlineAccent="opportunities"
+        subtitle="Browse Australian late-stage private deals — convertible notes, preference share rounds, secondary share buys and broker-syndicated pre-IPO placements. Wholesale and sophisticated investors only."
+        stats={listings.length > 0 ? [{ v: String(listings.length), l: "Live listings" }] : undefined}
+        containerClassName="container-custom"
+      >
+        <Link
+          href="/invest"
+          className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1 text-[0.65rem] font-semibold text-slate-600 shadow-sm transition-colors hover:bg-slate-50 md:text-xs"
+        >
+          ← Browse all investment sectors
+        </Link>
+      </DirectoryHero>
+
       <section className="bg-red-50 border-b-2 border-red-200 py-6">
         <div className="container-custom">
           <div className="flex items-start gap-3 max-w-4xl">
@@ -76,8 +96,6 @@ export default async function PreIpoOpportunitiesPage() {
           listings={listings}
           categories={categoryTabs}
           lockedCategory="pre-ipo"
-          pageTitle="Pre-IPO Investment Listings"
-          pageSubtitle="Browse Australian late-stage private deals — convertible notes, preference share rounds, secondary share buys and broker-syndicated pre-IPO placements. Wholesale and sophisticated investors only."
         />
       </Suspense>
     </>

--- a/app/invest/pre-ipo/page.tsx
+++ b/app/invest/pre-ipo/page.tsx
@@ -8,6 +8,7 @@ import {
   CURRENT_YEAR,
 } from "@/lib/seo";
 import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 
 export const revalidate = 3600;
 // Build-touch 2026-05-03 — force fresh prerender (cached version had stuck client-render).
@@ -137,71 +138,40 @@ export default function PreIpoPage() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPage) }}
       />
 
-      {/* Hero */}
-      <section className="relative bg-white border-b border-slate-100 overflow-hidden py-8 md:py-12">
-        <div className="container-custom">
-          <nav
-            className="flex items-center gap-1.5 text-xs text-slate-500 mb-6"
-            aria-label="Breadcrumb"
+      {/* Hero — house-standard compact light header (E3). The in-hero stat
+          grid rides as pills beside the title; the compliance badges and the
+          browse-all entry point live in the light band below (E4). */}
+      <DirectoryHero
+        tone="light"
+        breadcrumbLabel="Pre-IPO"
+        headlineLead="Pre-IPO Investing in Australia"
+        subtitle="Late-stage private company investments before initial public offering — accessible only to sophisticated and wholesale investors under the Corporations Act section 708 exemptions. Material risks, illiquidity and IPO timing variance."
+        stats={[
+          { v: "$50K–$1M", l: "Typical ticket size" },
+          { v: "15–30%", l: "Discount-to-IPO heuristic" },
+          { v: "1–3 years", l: "Holding period" },
+          { v: "$2.5M / $250K", l: "Sophisticated threshold" },
+        ]}
+        containerClassName="container-custom"
+      >
+        <div className="flex flex-wrap items-center gap-2">
+          <Link
+            href="/invest/pre-ipo/listings"
+            className="inline-flex items-center gap-1.5 rounded-full border border-coral-200 bg-coral-50 px-3 py-1 text-[0.65rem] font-semibold text-coral-700 shadow-sm transition-colors hover:bg-coral-100 md:text-xs"
           >
-            <Link href="/" className="hover:text-slate-900 transition-colors">
-              Home
-            </Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" />
-            <Link href="/invest" className="hover:text-slate-900 transition-colors">
-              Invest
-            </Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" />
-            <span className="text-slate-900 font-medium">Pre-IPO</span>
-          </nav>
-
-          <div className="flex flex-wrap items-center gap-2 mb-4">
-            <span className="text-[11px] font-bold uppercase px-2.5 py-0.5 rounded-full bg-red-100 text-red-800">
-              Wholesale only
-            </span>
-            <span className="text-[11px] font-bold uppercase px-2.5 py-0.5 rounded-full bg-amber-100 text-amber-800">
-              High risk
-            </span>
-            <span className="text-[11px] font-bold uppercase px-2.5 py-0.5 rounded-full bg-slate-100 text-slate-700">
-              Independent research
-            </span>
-            <span className="text-[11px] font-bold uppercase px-2.5 py-0.5 rounded-full bg-slate-100 text-slate-700">
-              Updated {CURRENT_YEAR}
-            </span>
-          </div>
-
-          <h1 className="text-3xl md:text-4xl lg:text-5xl font-extrabold leading-tight mb-4 max-w-3xl text-slate-900">
-            Pre-IPO Investing in Australia
-          </h1>
-          <p className="text-base md:text-lg text-slate-600 leading-relaxed max-w-2xl mb-6">
-            Late-stage private company investments before initial public
-            offering — accessible only to sophisticated and wholesale investors
-            under the Corporations Act section 708 exemptions. Material risks,
-            illiquidity and IPO timing variance.
-          </p>
-
-          <dl className="grid grid-cols-2 md:grid-cols-4 gap-3 max-w-2xl">
-            {[
-              { label: "Typical ticket size", value: "$50K–$1M" },
-              { label: "Discount-to-IPO heuristic", value: "15–30%" },
-              { label: "Holding period", value: "1–3 years" },
-              { label: "Sophisticated threshold", value: "$2.5M / $250K" },
-            ].map((s) => (
-              <div
-                key={s.label}
-                className="border border-slate-200 rounded-lg bg-slate-50 px-3 py-2"
-              >
-                <dt className="text-[10px] font-bold uppercase text-slate-500 tracking-wide">
-                  {s.label}
-                </dt>
-                <dd className="text-sm font-extrabold text-slate-900 mt-0.5">
-                  {s.value}
-                </dd>
-              </div>
-            ))}
-          </dl>
+            Browse all pre-IPO opportunities →
+          </Link>
+          <span className="text-[11px] font-bold uppercase px-2.5 py-0.5 rounded-full bg-red-100 text-red-800">
+            Wholesale only
+          </span>
+          <span className="text-[11px] font-bold uppercase px-2.5 py-0.5 rounded-full bg-amber-100 text-amber-800">
+            High risk
+          </span>
+          <span className="text-[11px] font-bold uppercase px-2.5 py-0.5 rounded-full bg-slate-100 text-slate-700">
+            Independent research
+          </span>
         </div>
-      </section>
+      </DirectoryHero>
 
       {/* Wholesale-only declaration banner */}
       <section className="py-8 md:py-10 bg-red-50 border-y-2 border-red-200">
@@ -253,7 +223,7 @@ export default function PreIpoPage() {
       </section>
 
       {/* Sections */}
-      <section className="py-10 md:py-12 bg-white" id="sections">
+      <section className="py-6 md:py-8 bg-white" id="sections">
         <div className="container-custom">
           <div className="mb-6 max-w-3xl">
             <p className="text-xs font-bold uppercase tracking-wider text-red-600 mb-1">
@@ -311,7 +281,7 @@ export default function PreIpoPage() {
       </section>
 
       {/* Honest risk block */}
-      <section className="py-10 md:py-12 bg-amber-50 border-y border-amber-200">
+      <section className="py-6 md:py-8 bg-amber-50 border-y border-amber-200">
         <div className="container-custom max-w-4xl">
           <div className="flex items-start gap-4">
             <div className="w-10 h-10 rounded-lg bg-amber-200 flex items-center justify-center shrink-0 mt-0.5">
@@ -359,7 +329,7 @@ export default function PreIpoPage() {
       </section>
 
       {/* FAQs */}
-      <section className="py-10 md:py-12 bg-white" id="faqs">
+      <section className="py-6 md:py-8 bg-white" id="faqs">
         <div className="container-custom max-w-4xl">
           <p className="text-xs font-bold uppercase tracking-wider text-red-600 mb-1">
             Section 2 &middot; FAQs
@@ -392,7 +362,7 @@ export default function PreIpoPage() {
       </section>
 
       {/* Advisor CTA */}
-      <section className="py-12 md:py-14 bg-slate-900 text-white" id="find-advisor">
+      <section className="py-8 md:py-10 bg-slate-900 text-white" id="find-advisor">
         <div className="container-custom max-w-4xl">
           <p className="text-xs font-bold uppercase tracking-wider text-red-400 mb-2">
             Section 3 &middot; Get specialist help

--- a/app/invest/private-credit/listings/[slug]/page.tsx
+++ b/app/invest/private-credit/listings/[slug]/page.tsx
@@ -140,10 +140,11 @@ export default async function PrivateCreditListingDetailPage({
       />
       <ListingSchemaScripts listing={l} vertical={CATEGORY_SLUG} />
 
-      {/* Hero */}
-      <section className="bg-white border-b border-slate-100 py-12">
+      {/* Compact header (E1) — breadcrumb + badges + title + location only,
+          so the gallery and metrics sit near the fold. */}
+      <section className="bg-white border-b border-slate-100 py-3 md:py-4">
         <div className="container-custom">
-          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-4">
+          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-2">
             <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
             <Icon name="chevron-right" size={12} className="text-slate-300" />
             <Link href="/invest" className="hover:text-slate-900 transition-colors">Invest</Link>
@@ -153,7 +154,7 @@ export default async function PrivateCreditListingDetailPage({
             <span className="text-slate-900 font-medium truncate max-w-40">{l.title}</span>
           </nav>
 
-          <div className="flex flex-wrap gap-2 mb-3">
+          <div className="flex flex-wrap gap-2 mb-2">
             {l.listing_type === "featured" && (
               <span className="bg-amber-500 text-slate-900 text-xs font-bold px-2.5 py-0.5 rounded-full">Featured</span>
             )}
@@ -181,14 +182,14 @@ export default async function PrivateCreditListingDetailPage({
       </section>
 
       {/* Main content */}
-      <section className="py-10 bg-slate-50">
+      <section className="py-6 md:py-8 bg-slate-50">
         <div className="container-custom">
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
             {/* Left: details */}
             <div className="lg:col-span-2 space-y-6">
               <ListingImageGallery images={l.images} alt={l.title} vertical={l.vertical} listingId={l.id} subCategory={l.sub_category} />
               {/* Price card */}
-              <div className="bg-white border border-slate-200 rounded-xl p-6">
+              <div className="bg-white border border-slate-200 rounded-xl p-4">
                 <div className="flex flex-wrap items-center justify-between gap-4">
                   <div>
                     <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1">Minimum Investment</p>

--- a/app/invest/private-credit/listings/page.tsx
+++ b/app/invest/private-credit/listings/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Suspense } from "react";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import { getAllInvestCategories, getInvestCategoryBySlug } from "@/lib/invest-categories";
@@ -8,6 +9,7 @@ import {
   PRIVATE_CREDIT_SUB_CATEGORIES,
 } from "@/lib/investment-listings-query";
 import InvestListingsClient from "@/components/InvestListingsClient";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 import SubCategoryNav from "@/components/SubCategoryNav";
 
 export const revalidate = 300;
@@ -56,8 +58,26 @@ export default async function PrivateCreditListingsPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
+      {/* House-standard compact light header (E7) — replaces the client's
+          tall page-title band so results land near the fold. */}
+      <DirectoryHero
+        tone="light"
+        breadcrumbLabel="Private Credit / Listings"
+        headlineLead="Private credit"
+        headlineAccent="opportunities"
+        subtitle="Browse Australian private credit investment opportunities — senior secured loans, mezzanine debt and structured credit."
+        stats={listings.length > 0 ? [{ v: String(listings.length), l: "Live listings" }] : undefined}
+        containerClassName="container-custom"
+      >
+        <Link
+          href="/invest"
+          className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1 text-[0.65rem] font-semibold text-slate-600 shadow-sm transition-colors hover:bg-slate-50 md:text-xs"
+        >
+          ← Browse all investment sectors
+        </Link>
+      </DirectoryHero>
       {category && (
-        <div className="container-custom pt-6">
+        <div className="container-custom pt-4">
           <SubCategoryNav category={category} />
         </div>
       )}
@@ -69,8 +89,6 @@ export default async function PrivateCreditListingsPage() {
           // Mirrors the SubCategoryNav render condition above — when the tab
           // bar shows, the in-results chips would duplicate it.
           hideSubCategoryChips={Boolean(category && category.subcategories.length > 0)}
-          pageTitle="Private Credit Investment Listings"
-          pageSubtitle="Browse Australian private credit investment opportunities — senior secured loans, mezzanine debt and structured credit."
         />
       </Suspense>
     </>

--- a/app/invest/private-credit/page.tsx
+++ b/app/invest/private-credit/page.tsx
@@ -4,6 +4,7 @@ import { createClient } from "@/lib/supabase/server";
 import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL, SITE_NAME, CURRENT_YEAR } from "@/lib/seo";
 import ContextualLeadMagnet from "@/components/ContextualLeadMagnet";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 import { SHOW_ADVISOR_RATINGS, SHOW_ADVISOR_VERIFIED_BADGE, ADVISOR_DIRECTORY_HEADING, ADVISOR_DIRECTORY_SUBTEXT } from "@/lib/compliance-config";
 
 export const metadata: Metadata = {
@@ -77,89 +78,32 @@ export default async function PrivateCreditPage() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
       />
 
-      {/* Hero */}
-      <section className="relative bg-white border-b border-slate-100 overflow-hidden py-8 md:py-12">
-        <div className="container-custom">
-          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-6">
-            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
-            <span className="text-slate-300">/</span>
-            <Link href="/invest" className="hover:text-slate-900 transition-colors">Invest</Link>
-            <span className="text-slate-300">/</span>
-            <span className="text-slate-900 font-medium">Private Credit &amp; P2P Lending</span>
-          </nav>
-
-          <div className="flex flex-wrap items-center gap-2 mb-4">
-            <span className="text-xs font-semibold bg-amber-500 text-slate-900 px-3 py-1 rounded-full">
-              Updated {CURRENT_YEAR}
-            </span>
-            <span className="text-xs font-semibold bg-slate-100 text-slate-600 px-3 py-1 rounded-full">
-              Hottest Alternative Asset Class
-            </span>
-          </div>
-
-          <h1 className="text-slate-900 text-3xl md:text-4xl lg:text-5xl font-extrabold leading-tight mb-4 max-w-3xl">
-            Private Credit &amp; P2P Lending in Australia
-          </h1>
-          <p className="text-lg text-slate-600 leading-relaxed max-w-2xl">
-            Private credit is Australia&apos;s fastest-growing alternative asset class. Institutional capital is pouring in, and retail investors — especially SMSF trustees — are following for yields well above term deposits.
-          </p>
-          <div className="flex flex-wrap gap-3 mt-6">
-            <Link
-              href="/advisors"
-              className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-semibold text-sm px-5 py-2.5 rounded-lg transition-colors"
-            >
-              Browse Directories &rarr;
-            </Link>
-            <Link
-              href="/compare"
-              className="inline-flex items-center gap-2 border-slate-200 text-slate-700 hover:bg-slate-50 hover:border-slate-300 font-semibold text-sm px-5 py-2.5 rounded-lg border transition-colors"
-            >
-              Filter Platforms
-            </Link>
-          </div>
-        </div>
-      </section>
-
-      {/* Browse Listings CTA */}
-      <section className="bg-white pt-8">
-        <div className="container-custom">
-          <Link
-            href="/invest/private-credit/listings"
-            className="group flex items-center justify-between gap-4 p-5 bg-gradient-to-r from-emerald-50 to-emerald-100/40 border border-emerald-200 rounded-2xl mb-8 hover:border-emerald-300 hover:shadow-md transition-all"
-          >
-            <div>
-              <p className="text-xs font-extrabold uppercase tracking-wider text-emerald-700 mb-1">Browse Listings</p>
-              <p className="text-lg font-extrabold text-slate-900">View all private credit opportunities &rarr;</p>
-              <p className="text-sm text-slate-600 mt-0.5">Senior secured, mezzanine, P2P, sub-categories &amp; more</p>
-            </div>
-            <svg className="w-8 h-8 text-emerald-600 shrink-0 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-            </svg>
-          </Link>
-        </div>
-      </section>
-
-      {/* Key stats */}
-      <section className="py-10 bg-white border-b border-slate-100">
-        <div className="container-custom">
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            {[
-              { value: "$200B+", label: "Australian private credit market size" },
-              { value: "6–10%", label: "Typical annual yields" },
-              { value: "600K+", label: "Australian SMSFs seeking yield" },
-              { value: "3–5yr", label: "Common fund lock-up periods" },
-            ].map((s) => (
-              <div key={s.label} className="bg-amber-50 border border-amber-100 rounded-xl p-4 text-center">
-                <p className="text-2xl font-extrabold text-amber-600">{s.value}</p>
-                <p className="text-xs text-slate-600 mt-1">{s.label}</p>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
+      {/* Hero — house-standard compact light header (E3). The old stat band
+          rides as pills beside the title; the browse-all entry point lives in
+          the light band below, replacing the standalone CTA band (E4). */}
+      <DirectoryHero
+        tone="light"
+        breadcrumbLabel="Private Credit & P2P Lending"
+        headlineLead="Private Credit & P2P Lending in Australia"
+        subtitle="Private credit is Australia's fastest-growing alternative asset class. Institutional capital is pouring in, and retail investors — especially SMSF trustees — are following for yields well above term deposits."
+        stats={[
+          { v: "$200B+", l: "Australian private credit market size" },
+          { v: "6–10%", l: "Typical annual yields" },
+          { v: "600K+", l: "Australian SMSFs seeking yield" },
+          { v: "3–5yr", l: "Common fund lock-up periods" },
+        ]}
+        containerClassName="container-custom"
+      >
+        <Link
+          href="/invest/private-credit/listings"
+          className="inline-flex items-center gap-1.5 rounded-full border border-coral-200 bg-coral-50 px-3 py-1 text-[0.65rem] font-semibold text-coral-700 shadow-sm transition-colors hover:bg-coral-100 md:text-xs"
+        >
+          Browse all private credit opportunities →
+        </Link>
+      </DirectoryHero>
 
       {/* Section 1: What Is Private Credit */}
-      <section className="py-14 bg-white">
+      <section className="py-8 md:py-10 bg-white">
         <div className="container-custom max-w-4xl">
           <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">Section 1</p>
           <h2 className="text-2xl font-extrabold text-slate-900 mb-4">What Is Private Credit?</h2>
@@ -185,7 +129,7 @@ export default async function PrivateCreditPage() {
       </section>
 
       {/* Section 2: Key Fund Managers */}
-      <section className="py-14 bg-slate-50">
+      <section className="py-8 md:py-10 bg-slate-50">
         <div className="container-custom max-w-4xl">
           <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">Section 2</p>
           <h2 className="text-2xl font-extrabold text-slate-900 mb-6">Leading Private Credit Fund Managers</h2>
@@ -214,14 +158,14 @@ export default async function PrivateCreditPage() {
       </section>
 
       {/* Lead Magnet */}
-      <section className="py-14 bg-white">
+      <section className="py-8 md:py-10 bg-white">
         <div className="container-custom max-w-4xl">
           <ContextualLeadMagnet segment="fee-audit" />
         </div>
       </section>
 
       {/* Section 3: P2P Lending */}
-      <section className="py-14 bg-white">
+      <section className="py-8 md:py-10 bg-white">
         <div className="container-custom max-w-4xl">
           <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">Section 3</p>
           <h2 className="text-2xl font-extrabold text-slate-900 mb-4">P2P Lending Platforms</h2>
@@ -267,7 +211,7 @@ export default async function PrivateCreditPage() {
       </section>
 
       {/* Section 4: ASX-Listed Exposure */}
-      <section className="py-14 bg-slate-50">
+      <section className="py-8 md:py-10 bg-slate-50">
         <div className="container-custom max-w-4xl">
           <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">Section 4</p>
           <h2 className="text-2xl font-extrabold text-slate-900 mb-6">ASX-Listed Private Credit Exposure</h2>
@@ -307,7 +251,7 @@ export default async function PrivateCreditPage() {
       </section>
 
       {/* Section 5: SMSF & Private Credit */}
-      <section className="py-14 bg-white">
+      <section className="py-8 md:py-10 bg-white">
         <div className="container-custom max-w-4xl">
           <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">Section 5</p>
           <h2 className="text-2xl font-extrabold text-slate-900 mb-4">Private Credit for SMSF Trustees</h2>
@@ -334,7 +278,7 @@ export default async function PrivateCreditPage() {
       </section>
 
       {/* Section 6: Risk & Return */}
-      <section className="py-14 bg-slate-50">
+      <section className="py-8 md:py-10 bg-slate-50">
         <div className="container-custom max-w-4xl">
           <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">Section 6</p>
           <h2 className="text-2xl font-extrabold text-slate-900 mb-6">Risk &amp; Return Profile</h2>
@@ -394,7 +338,7 @@ export default async function PrivateCreditPage() {
 
       {/* Find an Advisor */}
       {advisors && advisors.length > 0 && (
-        <section className="py-14 bg-white">
+        <section className="py-8 md:py-10 bg-white">
           <div className="container-custom max-w-4xl">
             <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">Expert Advisors</p>
             <h2 className="text-2xl font-extrabold text-slate-900 mb-2">{ADVISOR_DIRECTORY_HEADING}</h2>
@@ -437,7 +381,7 @@ export default async function PrivateCreditPage() {
         </section>
       )}
       {/* Related guides */}
-      <section className="py-14 bg-slate-50">
+      <section className="py-8 md:py-10 bg-slate-50">
         <div className="container-custom max-w-4xl">
           <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">Related Guides</p>
           <h2 className="text-2xl font-extrabold text-slate-900 mb-6">Explore Related Investment Guides</h2>
@@ -459,7 +403,7 @@ export default async function PrivateCreditPage() {
       </section>
 
       {/* FAQ */}
-      <section className="py-14 bg-white">
+      <section className="py-8 md:py-10 bg-white">
         <div className="container-custom max-w-4xl">
           <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">FAQ</p>
           <h2 className="text-2xl font-extrabold text-slate-900 mb-6">Frequently Asked Questions</h2>
@@ -478,7 +422,7 @@ export default async function PrivateCreditPage() {
       </section>
 
       {/* CTA */}
-      <section className="py-14 bg-white">
+      <section className="py-8 md:py-10 bg-white">
         <div className="container-custom">
           <div className="max-w-3xl mx-auto bg-white border border-slate-200 rounded-xl p-8 flex flex-col md:flex-row items-start md:items-center gap-6">
             <div className="w-12 h-12 rounded-xl bg-amber-50 flex items-center justify-center shrink-0">

--- a/app/invest/private-equity/listings/page.tsx
+++ b/app/invest/private-equity/listings/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Suspense } from "react";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import { getAllInvestCategories } from "@/lib/invest-categories";
@@ -7,6 +8,7 @@ import {
   countListingsByVertical,
 } from "@/lib/investment-listings-query";
 import InvestListingsClient from "@/components/InvestListingsClient";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 
 export const revalidate = 300;
 
@@ -51,6 +53,24 @@ export default async function PrivateEquityListingsPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
+      {/* House-standard compact light header (E7) — replaces the client's
+          tall page-title band so results land near the fold. */}
+      <DirectoryHero
+        tone="light"
+        breadcrumbLabel="Private Equity & Hedge Funds / Listings"
+        headlineLead="Private equity & hedge fund"
+        headlineAccent="opportunities"
+        subtitle="Browse Australian private equity and hedge fund investment opportunities — direct fund investments, fund-of-funds, co-investment structures and separately managed accounts for wholesale investors."
+        stats={listings.length > 0 ? [{ v: String(listings.length), l: "Live listings" }] : undefined}
+        containerClassName="container-custom"
+      >
+        <Link
+          href="/invest"
+          className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1 text-[0.65rem] font-semibold text-slate-600 shadow-sm transition-colors hover:bg-slate-50 md:text-xs"
+        >
+          ← Browse all investment sectors
+        </Link>
+      </DirectoryHero>
       <div className="bg-amber-50 border border-amber-200 rounded-lg mx-4 mt-6 p-4 text-sm text-amber-900">
         <p className="font-semibold mb-1">⚠️ Wholesale Investor Access Required (s708 Corporations Act)</p>
         <p className="mb-2">
@@ -72,8 +92,6 @@ export default async function PrivateEquityListingsPage() {
           listings={listings}
           categories={categoryTabs}
           lockedCategory="private-equity"
-          pageTitle="Private Equity & Hedge Fund Listings"
-          pageSubtitle="Browse Australian private equity and hedge fund investment opportunities — direct fund investments, fund-of-funds, co-investment structures and separately managed accounts for wholesale investors."
         />
       </Suspense>
     </>

--- a/app/invest/private-equity/page.tsx
+++ b/app/invest/private-equity/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL, SITE_NAME, CURRENT_YEAR } from "@/lib/seo";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 import { faqJsonLd } from "@/lib/schema-markup";
 
 const PE_FAQS = [
@@ -69,56 +70,37 @@ export default function PrivateEquityPage() {
         <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(peFaqLd) }} />
       )}
 
-      {/* Hero */}
-      <section className="relative bg-white border-b border-slate-100 overflow-hidden py-8 md:py-12">
-        <div className="container-custom">
-          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-6">
-            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
-            <span className="text-slate-900 font-medium">/</span>
-            <Link href="/invest" className="hover:text-slate-900 transition-colors">Invest</Link>
-            <span className="text-slate-900 font-medium">/</span>
-            <span className="text-slate-900 font-medium">Private Equity &amp; Hedge Funds</span>
-          </nav>
-
-          <div className="flex flex-wrap items-center gap-2 mb-4">
-            <span className="text-xs font-semibold bg-amber-500 text-slate-900 px-3 py-1 rounded-full">
-              Updated {CURRENT_YEAR}
-            </span>
-            <span className="text-xs font-semibold bg-slate-100 text-slate-600 px-3 py-1 rounded-full">
-              Wholesale &amp; Retail Access
-            </span>
-          </div>
-
-          <h1 className="text-3xl md:text-4xl lg:text-5xl font-extrabold leading-tight mb-4 max-w-3xl text-slate-900">
-            Private Equity &amp; Hedge Fund Investment in Australia
-          </h1>
-          <p className="text-lg text-slate-600 leading-relaxed max-w-2xl">
-            Australia has a mature private equity sector managing over $40 billion and 170+ hedge funds overseeing ~$120 billion in assets. Here is how both domestic and international investors can access these markets.
-          </p>
+      {/* Hero — house-standard compact light header (E3). The old stat band
+          rides as pills beside the title; the browse-all entry point lives in
+          the light band below (E4). */}
+      <DirectoryHero
+        tone="light"
+        breadcrumbLabel="Private Equity & Hedge Funds"
+        headlineLead="Private Equity & Hedge Fund Investment in Australia"
+        subtitle="Australia has a mature private equity sector managing over $40 billion and 170+ hedge funds overseeing ~$120 billion in assets. Here is how both domestic and international investors can access these markets."
+        stats={[
+          { v: "$40B+", l: "Australian PE assets under management" },
+          { v: "170+", l: "Hedge funds operating in Australia" },
+          { v: "~$120B", l: "Hedge fund AUM" },
+          { v: "15–20%", l: "Historical PE p.a. returns" },
+        ]}
+        containerClassName="container-custom"
+      >
+        <div className="flex flex-wrap items-center gap-2">
+          <Link
+            href="/invest/private-equity/listings"
+            className="inline-flex items-center gap-1.5 rounded-full border border-coral-200 bg-coral-50 px-3 py-1 text-[0.65rem] font-semibold text-coral-700 shadow-sm transition-colors hover:bg-coral-100 md:text-xs"
+          >
+            Browse all private equity &amp; hedge fund listings →
+          </Link>
+          <span className="inline-flex items-center rounded-full border border-slate-200 bg-white px-3 py-1 text-[0.65rem] font-semibold text-slate-600 md:text-xs">
+            Wholesale &amp; Retail Access
+          </span>
         </div>
-      </section>
-
-      {/* Key stats */}
-      <section className="py-10 bg-white border-b border-slate-100">
-        <div className="container-custom">
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            {[
-              { value: "$40B+", label: "Australian PE assets under management" },
-              { value: "170+", label: "Hedge funds operating in Australia" },
-              { value: "~$120B", label: "Hedge fund AUM" },
-              { value: "15–20%", label: "Historical PE p.a. returns" },
-            ].map((s) => (
-              <div key={s.label} className="bg-amber-50 border border-amber-100 rounded-xl p-4 text-center">
-                <p className="text-2xl font-extrabold text-amber-600">{s.value}</p>
-                <p className="text-xs text-slate-600 mt-1">{s.label}</p>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
+      </DirectoryHero>
 
       {/* Section 1: Introduction & Landscape */}
-      <section className="py-14 bg-white">
+      <section className="py-8 md:py-10 bg-white">
         <div className="container-custom max-w-4xl">
           <div className="mb-2">
             <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">Section 1</p>
@@ -173,7 +155,7 @@ export default function PrivateEquityPage() {
       </section>
 
       {/* Section 2: How to Access PE in Australia */}
-      <section className="py-14 bg-slate-50">
+      <section className="py-8 md:py-10 bg-slate-50">
         <div className="container-custom max-w-4xl">
           <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">Section 2</p>
           <h2 className="text-2xl font-extrabold text-slate-900 mb-6">How to Access Private Equity in Australia</h2>
@@ -249,7 +231,7 @@ export default function PrivateEquityPage() {
       </section>
 
       {/* Section 3: SIV Complying Funds */}
-      <section className="py-14 bg-white">
+      <section className="py-8 md:py-10 bg-white">
         <div className="container-custom max-w-4xl">
           <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">Section 3</p>
           <h2 className="text-2xl font-extrabold text-slate-900 mb-4">SIV Complying PE &amp; VC Funds</h2>
@@ -287,7 +269,7 @@ export default function PrivateEquityPage() {
       </section>
 
       {/* Section 4: Risk & Return */}
-      <section className="py-14 bg-slate-50">
+      <section className="py-8 md:py-10 bg-slate-50">
         <div className="container-custom max-w-4xl">
           <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">Section 4</p>
           <h2 className="text-2xl font-extrabold text-slate-900 mb-6">Risk &amp; Return Profile</h2>
@@ -345,7 +327,7 @@ export default function PrivateEquityPage() {
       </section>
 
       {/* Section 5: Tax Treatment */}
-      <section className="py-14 bg-white">
+      <section className="py-8 md:py-10 bg-white">
         <div className="container-custom max-w-4xl">
           <p className="text-xs font-bold uppercase tracking-wider text-amber-500 mb-1">Section 5</p>
           <h2 className="text-2xl font-extrabold text-slate-900 mb-6">Tax Treatment — Domestic &amp; Foreign Investors</h2>
@@ -385,7 +367,7 @@ export default function PrivateEquityPage() {
       </section>
 
       {/* FAQ */}
-      <section className="py-10 bg-white border-t border-slate-200">
+      <section className="py-6 md:py-8 bg-white border-t border-slate-200">
         <div className="max-w-3xl mx-auto px-4 container-custom">
           <h2 className="text-lg font-bold text-slate-900 mb-4">Frequently asked questions</h2>
           <div className="space-y-3">
@@ -405,7 +387,7 @@ export default function PrivateEquityPage() {
       </section>
 
       {/* Find a Wealth Manager CTA */}
-      <section className="py-14 bg-slate-50">
+      <section className="py-8 md:py-10 bg-slate-50">
         <div className="container-custom">
           <div className="max-w-3xl mx-auto bg-white border border-slate-200 rounded-xl p-8 flex flex-col md:flex-row items-start md:items-center gap-6">
             <div className="w-12 h-12 rounded-xl bg-amber-50 flex items-center justify-center shrink-0">

--- a/app/invest/public-social-infrastructure/listings/page.tsx
+++ b/app/invest/public-social-infrastructure/listings/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Suspense } from "react";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import { getAllInvestCategories } from "@/lib/invest-categories";
@@ -7,6 +8,7 @@ import {
   countListingsByVertical,
 } from "@/lib/investment-listings-query";
 import InvestListingsClient from "@/components/InvestListingsClient";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 
 export const revalidate = 300;
 
@@ -43,13 +45,29 @@ export default async function PublicSocialInfrastructureListingsPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
+      {/* House-standard compact light header (E7) — replaces the client's
+          tall page-title band so results land near the fold. */}
+      <DirectoryHero
+        tone="light"
+        breadcrumbLabel="Public & Social Infrastructure / Listings"
+        headlineLead="Public & social infrastructure"
+        headlineAccent="opportunities"
+        subtitle="Browse Australian public and social infrastructure investment opportunities — toll roads, water utilities, hospitals, schools, social housing and PPP availability-payment assets."
+        stats={listings.length > 0 ? [{ v: String(listings.length), l: "Live listings" }] : undefined}
+        containerClassName="container-custom"
+      >
+        <Link
+          href="/invest"
+          className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1 text-[0.65rem] font-semibold text-slate-600 shadow-sm transition-colors hover:bg-slate-50 md:text-xs"
+        >
+          ← Browse all investment sectors
+        </Link>
+      </DirectoryHero>
       <Suspense fallback={<div className="py-12 text-center text-slate-400">Loading listings...</div>}>
         <InvestListingsClient
           listings={listings}
           categories={categoryTabs}
           lockedCategory="public-social-infrastructure"
-          pageTitle="Public & Social Infrastructure Investment Listings"
-          pageSubtitle="Browse Australian public and social infrastructure investment opportunities — toll roads, water utilities, hospitals, schools, social housing and PPP availability-payment assets."
         />
       </Suspense>
     </>

--- a/app/invest/renewable-energy/listings/[slug]/page.tsx
+++ b/app/invest/renewable-energy/listings/[slug]/page.tsx
@@ -125,9 +125,11 @@ export default async function EnergyProjectDetailPage({
       />
       <ListingSchemaScripts listing={l} vertical={CATEGORY_SLUG} />
 
-      <section className="bg-white border-b border-slate-100 py-12">
+      {/* Compact header (E1) — breadcrumb + badges + title + location only,
+          so the gallery and metrics sit near the fold. */}
+      <section className="bg-white border-b border-slate-100 py-3 md:py-4">
         <div className="container-custom">
-          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-4">
+          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-2">
             <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
             <Icon name="chevron-right" size={12} className="text-slate-300" />
             <Link href="/invest/renewable-energy/listings" className="hover:text-slate-900 transition-colors">Energy Projects</Link>
@@ -135,7 +137,7 @@ export default async function EnergyProjectDetailPage({
             <span className="text-slate-900 font-medium truncate max-w-40">{l.title}</span>
           </nav>
 
-          <div className="flex flex-wrap gap-2 mb-3">
+          <div className="flex flex-wrap gap-2 mb-2">
             {l.listing_type === "featured" && (
               <span className="bg-amber-500 text-slate-900 text-xs font-bold px-2.5 py-0.5 rounded-full">Featured</span>
             )}
@@ -164,12 +166,12 @@ export default async function EnergyProjectDetailPage({
         </div>
       </section>
 
-      <section className="py-10 bg-slate-50">
+      <section className="py-6 md:py-8 bg-slate-50">
         <div className="container-custom">
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
             <div className="lg:col-span-2 space-y-6">
               <ListingImageGallery images={l.images} alt={l.title} vertical={l.vertical} listingId={l.id} subCategory={l.sub_category} />
-              <div className="bg-white border border-slate-200 rounded-xl p-6">
+              <div className="bg-white border border-slate-200 rounded-xl p-4">
                 <div className="flex flex-wrap items-center justify-between gap-4">
                   <div>
                     <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1">Investment Required</p>

--- a/app/invest/renewable-energy/listings/page.tsx
+++ b/app/invest/renewable-energy/listings/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Suspense } from "react";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import { getAllInvestCategories, getInvestCategoryBySlug } from "@/lib/invest-categories";
@@ -7,6 +8,7 @@ import {
   countListingsByVertical,
 } from "@/lib/investment-listings-query";
 import InvestListingsClient from "@/components/InvestListingsClient";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 import SubCategoryNav from "@/components/SubCategoryNav";
 
 export const revalidate = 300;
@@ -45,8 +47,26 @@ export default async function EnergyProjectsPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
+      {/* House-standard compact light header (E7) — replaces the client's
+          tall page-title band so results land near the fold. */}
+      <DirectoryHero
+        tone="light"
+        breadcrumbLabel="Renewable Energy / Listings"
+        headlineLead="Renewable energy"
+        headlineAccent="opportunities"
+        subtitle="Browse Australian renewable energy investment opportunities — solar, wind, battery storage and grid-scale projects."
+        stats={listings.length > 0 ? [{ v: String(listings.length), l: "Live listings" }] : undefined}
+        containerClassName="container-custom"
+      >
+        <Link
+          href="/invest"
+          className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1 text-[0.65rem] font-semibold text-slate-600 shadow-sm transition-colors hover:bg-slate-50 md:text-xs"
+        >
+          ← Browse all investment sectors
+        </Link>
+      </DirectoryHero>
       {category && (
-        <div className="container-custom pt-6">
+        <div className="container-custom pt-4">
           <SubCategoryNav category={category} />
         </div>
       )}
@@ -55,8 +75,6 @@ export default async function EnergyProjectsPage() {
           listings={listings}
           categories={categoryTabs}
           lockedCategory="renewable-energy"
-          pageTitle="Renewable Energy Investment Listings"
-          pageSubtitle="Browse Australian renewable energy investment opportunities — solar, wind, battery storage and grid-scale projects."
         />
       </Suspense>
     </>

--- a/app/invest/renewable-energy/page.tsx
+++ b/app/invest/renewable-energy/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import Icon from "@/components/Icon";
 import SectionHeading from "@/components/SectionHeading";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 import { faqJsonLd } from "@/lib/schema-markup";
 
 const RENEWABLE_FAQS = [
@@ -59,83 +60,37 @@ export default function RenewableEnergyPage() {
         <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(renewableFaqLd) }} />
       )}
 
-      {/* Hero */}
-      <section className="relative bg-white border-b border-slate-100 overflow-hidden py-8 md:py-12">
-        <div className="container-custom">
-          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-6">
-            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" />
-            <Link href="/invest" className="hover:text-slate-900 transition-colors">Invest</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" />
-            <span className="text-slate-900 font-medium">Renewable Energy</span>
-          </nav>
-
-          <div className="flex flex-wrap items-center gap-2 mb-4">
-            <span className="text-xs font-semibold bg-amber-500 text-slate-900 px-3 py-1 rounded-full">
-              Updated {CURRENT_YEAR}
-            </span>
-            <span className="text-xs font-semibold bg-teal-600 text-white px-3 py-1 rounded-full">
-              82% Renewables Target by 2030
-            </span>
-          </div>
-
-          <h1 className="text-3xl md:text-4xl lg:text-5xl font-extrabold leading-tight mb-4 max-w-3xl text-slate-900">
-            Australia&#39;s Renewable Energy Investment Opportunity
-          </h1>
-          <p className="text-lg text-slate-600 leading-relaxed max-w-2xl mb-8">
-            Australia is targeting 82% renewable electricity by 2030. With $100B+ in required investment and world-class solar and wind resources, the opportunity is immense.
-          </p>
-
+      {/* Hero — house-standard compact light header (E3). The old stat band
+          rides as pills beside the title; the browse-all entry point lives in
+          the light band below, replacing the standalone CTA band (E4). */}
+      <DirectoryHero
+        tone="light"
+        breadcrumbLabel="Renewable Energy"
+        headlineLead="Australia's Renewable Energy Investment Opportunity"
+        subtitle="Australia is targeting 82% renewable electricity by 2030. With $100B+ in required investment and world-class solar and wind resources, the opportunity is immense."
+        stats={[
+          { v: "82%", l: "Renewable target by 2030" },
+          { v: "$100B+", l: "Investment needed" },
+          { v: "#1", l: "Solar resource quality" },
+          { v: "ARENA / CEFC", l: "Government co-investment" },
+        ]}
+        containerClassName="container-custom"
+      >
+        <div className="flex flex-wrap items-center gap-2">
           <Link
             href="/invest/renewable-energy/listings"
-            className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold text-base px-7 py-3.5 rounded-xl transition-colors shadow-lg"
+            className="inline-flex items-center gap-1.5 rounded-full border border-coral-200 bg-coral-50 px-3 py-1 text-[0.65rem] font-semibold text-coral-700 shadow-sm transition-colors hover:bg-coral-100 md:text-xs"
           >
-            Browse Energy Projects
-            <Icon name="arrow-right" size={18} />
+            Browse all renewable energy projects →
           </Link>
+          <span className="inline-flex items-center rounded-full border border-teal-200 bg-teal-50 px-3 py-1 text-[0.65rem] font-semibold text-teal-700 md:text-xs">
+            82% Renewables Target by 2030
+          </span>
         </div>
-      </section>
-
-      {/* Browse Listings CTA */}
-      <section className="bg-white pt-8">
-        <div className="container-custom">
-          <Link
-            href="/invest/renewable-energy/listings"
-            className="group flex items-center justify-between gap-4 p-5 bg-gradient-to-r from-emerald-50 to-emerald-100/40 border border-emerald-200 rounded-2xl mb-8 hover:border-emerald-300 hover:shadow-md transition-all"
-          >
-            <div>
-              <p className="text-xs font-extrabold uppercase tracking-wider text-emerald-700 mb-1">Browse Listings</p>
-              <p className="text-lg font-extrabold text-slate-900">View all renewable energy projects &rarr;</p>
-              <p className="text-sm text-slate-600 mt-0.5">Solar, wind, battery, hydrogen — sub-categories &amp; more</p>
-            </div>
-            <svg className="w-8 h-8 text-emerald-600 shrink-0 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-            </svg>
-          </Link>
-        </div>
-      </section>
-
-      {/* Stats */}
-      <section className="py-10 bg-white border-b border-slate-100">
-        <div className="container-custom">
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            {[
-              { value: "82%", label: "Renewable target by 2030" },
-              { value: "$100B+", label: "Investment needed" },
-              { value: "#1", label: "Solar resource quality" },
-              { value: "ARENA / CEFC", label: "Government co-investment" },
-            ].map((s) => (
-              <div key={s.label} className="bg-amber-50 border border-amber-100 rounded-xl p-4 text-center">
-                <p className="text-2xl font-extrabold text-amber-600">{s.value}</p>
-                <p className="text-xs text-slate-600 mt-1">{s.label}</p>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
+      </DirectoryHero>
 
       {/* Content */}
-      <section className="py-14 bg-white">
+      <section className="py-8 md:py-10 bg-white">
         <div className="container-custom max-w-4xl">
           <SectionHeading
             eyebrow="Technologies"
@@ -218,7 +173,7 @@ export default function RenewableEnergyPage() {
       </section>
 
       {/* CTA */}
-      <section className="py-14 bg-white border-t border-slate-100">
+      <section className="py-8 md:py-10 bg-white border-t border-slate-100">
         <div className="container-custom">
           <div className="max-w-3xl mx-auto bg-white border border-slate-200 rounded-xl p-8 text-center">
             <h2 className="text-2xl font-extrabold text-slate-900 mb-3">Browse Energy Projects Seeking Investment</h2>
@@ -244,7 +199,7 @@ export default function RenewableEnergyPage() {
         </div>
       </section>
 
-      <section className="py-10 bg-white border-t border-slate-200">
+      <section className="py-6 md:py-8 bg-white border-t border-slate-200">
         <div className="container-custom max-w-3xl">
           <h2 className="text-lg font-bold text-slate-900 mb-4">Frequently asked questions</h2>
           <div className="space-y-3">

--- a/app/invest/royalties/listings/page.tsx
+++ b/app/invest/royalties/listings/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Suspense } from "react";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import { getAllInvestCategories } from "@/lib/invest-categories";
@@ -7,6 +8,7 @@ import {
   countListingsByVertical,
 } from "@/lib/investment-listings-query";
 import InvestListingsClient from "@/components/InvestListingsClient";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 
 export const revalidate = 300;
 
@@ -46,13 +48,29 @@ export default async function RoyaltiesListingsPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
+      {/* House-standard compact light header (E7) — replaces the client's
+          tall page-title band so results land near the fold. */}
+      <DirectoryHero
+        tone="light"
+        breadcrumbLabel="Royalties & IP / Listings"
+        headlineLead="Royalty & IP"
+        headlineAccent="opportunities"
+        subtitle="Browse Australian royalty and intellectual property investment opportunities — mining royalties, music catalogues, patent royalties, film residuals and pharmaceutical royalties."
+        stats={listings.length > 0 ? [{ v: String(listings.length), l: "Live listings" }] : undefined}
+        containerClassName="container-custom"
+      >
+        <Link
+          href="/invest"
+          className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1 text-[0.65rem] font-semibold text-slate-600 shadow-sm transition-colors hover:bg-slate-50 md:text-xs"
+        >
+          ← Browse all investment sectors
+        </Link>
+      </DirectoryHero>
       <Suspense fallback={<div className="py-12 text-center text-slate-400">Loading listings...</div>}>
         <InvestListingsClient
           listings={listings}
           categories={categoryTabs}
           lockedCategory="royalties"
-          pageTitle="Royalty & IP Investment Listings"
-          pageSubtitle="Browse Australian royalty and intellectual property investment opportunities — mining royalties, music catalogues, patent royalties, film residuals and pharmaceutical royalties."
         />
       </Suspense>
     </>

--- a/app/invest/royalties/page.tsx
+++ b/app/invest/royalties/page.tsx
@@ -8,6 +8,7 @@ import {
   CURRENT_YEAR,
 } from "@/lib/seo";
 import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 
 export const revalidate = 3600;
 // Build-touch 2026-05-03 — force fresh prerender (cached version had stuck client-render).
@@ -137,69 +138,37 @@ export default function RoyaltiesPage() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPage) }}
       />
 
-      {/* Hero */}
-      <section className="relative bg-white border-b border-slate-100 overflow-hidden py-8 md:py-12">
-        <div className="container-custom">
-          <nav
-            className="flex items-center gap-1.5 text-xs text-slate-500 mb-6"
-            aria-label="Breadcrumb"
+      {/* Hero — house-standard compact light header (E3). The in-hero stat
+          grid rides as pills beside the title; the badges and the browse-all
+          entry point live in the light band below (E4). */}
+      <DirectoryHero
+        tone="light"
+        breadcrumbLabel="Royalties"
+        headlineLead="Invest in Royalty Streams in Australia"
+        subtitle="Royalty income — paid as a percentage of revenue or net profits from an underlying asset — sits between bonds and equity in the capital stack. Australian retail investors can access mining royalties via ASX names like Deterra (DRR), or direct music, IP and petroleum royalty deals via the wholesale market."
+        stats={[
+          { v: "~5%", l: "DRR trailing yield" },
+          { v: "$250K+", l: "Direct deal minimum" },
+          { v: "30% / DTA", l: "Royalty WHT (non-resident)" },
+          { v: "DRR · ELT", l: "ASX royalty pure-plays" },
+        ]}
+        containerClassName="container-custom"
+      >
+        <div className="flex flex-wrap items-center gap-2">
+          <Link
+            href="/invest/royalties/listings"
+            className="inline-flex items-center gap-1.5 rounded-full border border-coral-200 bg-coral-50 px-3 py-1 text-[0.65rem] font-semibold text-coral-700 shadow-sm transition-colors hover:bg-coral-100 md:text-xs"
           >
-            <Link href="/" className="hover:text-slate-900 transition-colors">
-              Home
-            </Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" />
-            <Link href="/invest" className="hover:text-slate-900 transition-colors">
-              Invest
-            </Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" />
-            <span className="text-slate-900 font-medium">Royalties</span>
-          </nav>
-
-          <div className="flex flex-wrap items-center gap-2 mb-4">
-            <span className="text-[11px] font-bold uppercase px-2.5 py-0.5 rounded-full bg-rose-100 text-rose-800">
-              Income asset
-            </span>
-            <span className="text-[11px] font-bold uppercase px-2.5 py-0.5 rounded-full bg-slate-100 text-slate-700">
-              Independent research
-            </span>
-            <span className="text-[11px] font-bold uppercase px-2.5 py-0.5 rounded-full bg-slate-100 text-slate-700">
-              Updated {CURRENT_YEAR}
-            </span>
-          </div>
-
-          <h1 className="text-3xl md:text-4xl lg:text-5xl font-extrabold leading-tight mb-4 max-w-3xl text-slate-900">
-            Invest in Royalty Streams in Australia
-          </h1>
-          <p className="text-base md:text-lg text-slate-600 leading-relaxed max-w-2xl mb-6">
-            Royalty income — paid as a percentage of revenue or net profits from
-            an underlying asset — sits between bonds and equity in the capital
-            stack. Australian retail investors can access mining royalties via
-            ASX names like Deterra (DRR), or direct music, IP and petroleum
-            royalty deals via the wholesale market.
-          </p>
-
-          <dl className="grid grid-cols-2 md:grid-cols-4 gap-3 max-w-2xl">
-            {[
-              { label: "DRR trailing yield", value: "~5%" },
-              { label: "Direct deal minimum", value: "$250K+" },
-              { label: "Royalty WHT (non-resident)", value: "30% / DTA" },
-              { label: "ASX royalty pure-plays", value: "DRR · ELT" },
-            ].map((s) => (
-              <div
-                key={s.label}
-                className="border border-slate-200 rounded-lg bg-slate-50 px-3 py-2"
-              >
-                <dt className="text-[10px] font-bold uppercase text-slate-500 tracking-wide">
-                  {s.label}
-                </dt>
-                <dd className="text-sm font-extrabold text-slate-900 mt-0.5">
-                  {s.value}
-                </dd>
-              </div>
-            ))}
-          </dl>
+            Browse all royalty &amp; IP opportunities →
+          </Link>
+          <span className="text-[11px] font-bold uppercase px-2.5 py-0.5 rounded-full bg-rose-100 text-rose-800">
+            Income asset
+          </span>
+          <span className="text-[11px] font-bold uppercase px-2.5 py-0.5 rounded-full bg-slate-100 text-slate-700">
+            Independent research
+          </span>
         </div>
-      </section>
+      </DirectoryHero>
 
       {/* Context banner */}
       <section className="py-6 md:py-8 bg-rose-50 border-y border-rose-200">
@@ -233,7 +202,7 @@ export default function RoyaltiesPage() {
       </section>
 
       {/* Ways to invest */}
-      <section className="py-10 md:py-12 bg-white" id="ways-to-invest">
+      <section className="py-6 md:py-8 bg-white" id="ways-to-invest">
         <div className="container-custom">
           <div className="mb-6 max-w-3xl">
             <p className="text-xs font-bold uppercase tracking-wider text-rose-600 mb-1">
@@ -298,7 +267,7 @@ export default function RoyaltiesPage() {
       </section>
 
       {/* Market overview */}
-      <section className="py-10 md:py-12 bg-slate-50 border-y border-slate-100">
+      <section className="py-6 md:py-8 bg-slate-50 border-y border-slate-100">
         <div className="container-custom max-w-4xl">
           <p className="text-xs font-bold uppercase tracking-wider text-rose-600 mb-1">
             Section 2 &middot; Market overview
@@ -345,7 +314,7 @@ export default function RoyaltiesPage() {
       </section>
 
       {/* FAQs */}
-      <section className="py-10 md:py-12 bg-white" id="faqs">
+      <section className="py-6 md:py-8 bg-white" id="faqs">
         <div className="container-custom max-w-4xl">
           <p className="text-xs font-bold uppercase tracking-wider text-rose-600 mb-1">
             Section 3 &middot; FAQs
@@ -378,7 +347,7 @@ export default function RoyaltiesPage() {
       </section>
 
       {/* Advisor CTA */}
-      <section className="py-12 md:py-14 bg-slate-900 text-white" id="find-advisor">
+      <section className="py-8 md:py-10 bg-slate-900 text-white" id="find-advisor">
         <div className="container-custom max-w-4xl">
           <p className="text-xs font-bold uppercase tracking-wider text-rose-400 mb-2">
             Section 4 &middot; Get specialist help

--- a/app/invest/startups/listings/[slug]/page.tsx
+++ b/app/invest/startups/listings/[slug]/page.tsx
@@ -134,9 +134,11 @@ export default async function StartupOpportunityDetailPage({
       />
       <ListingSchemaScripts listing={l} vertical={CATEGORY_SLUG} />
 
-      <section className="bg-white border-b border-slate-100 py-12">
+      {/* Compact header (E1) — breadcrumb + badges + title + location only,
+          so the gallery and metrics sit near the fold. */}
+      <section className="bg-white border-b border-slate-100 py-3 md:py-4">
         <div className="container-custom">
-          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-4">
+          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-2">
             <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
             <Icon name="chevron-right" size={12} className="text-slate-300" />
             <Link href="/invest/startups/listings" className="hover:text-slate-900 transition-colors">Startup Opportunities</Link>
@@ -144,7 +146,7 @@ export default async function StartupOpportunityDetailPage({
             <span className="text-slate-900 font-medium truncate max-w-40">{l.title}</span>
           </nav>
 
-          <div className="flex flex-wrap gap-2 mb-3">
+          <div className="flex flex-wrap gap-2 mb-2">
             {l.listing_type === "featured" && (
               <span className="bg-amber-500 text-slate-900 text-xs font-bold px-2.5 py-0.5 rounded-full">Featured</span>
             )}
@@ -173,15 +175,15 @@ export default async function StartupOpportunityDetailPage({
         </div>
       </section>
 
-      <section className="py-10 bg-slate-50">
+      <section className="py-6 md:py-8 bg-slate-50">
         <div className="container-custom">
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
             <div className="lg:col-span-2 space-y-6">
               <ListingImageGallery images={l.images} alt={l.title} vertical={l.vertical} listingId={l.id} subCategory={l.sub_category} />
               {(() => {
                 const raiseTerms = (
                   <div className="space-y-6">
-                    <div className="bg-white border border-slate-200 rounded-xl p-6">
+                    <div className="bg-white border border-slate-200 rounded-xl p-4">
                       <div className="flex flex-wrap items-center justify-between gap-4">
                         <div>
                           <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1">

--- a/app/invest/startups/listings/page.tsx
+++ b/app/invest/startups/listings/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Suspense } from "react";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import { getAllInvestCategories, getInvestCategoryBySlug } from "@/lib/invest-categories";
@@ -7,6 +8,7 @@ import {
   countListingsByVertical,
 } from "@/lib/investment-listings-query";
 import InvestListingsClient from "@/components/InvestListingsClient";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 import SubCategoryNav from "@/components/SubCategoryNav";
 
 export const revalidate = 300;
@@ -45,8 +47,26 @@ export default async function StartupOpportunitiesPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
+      {/* House-standard compact light header (E7) — replaces the client's
+          tall page-title band so results land near the fold. */}
+      <DirectoryHero
+        tone="light"
+        breadcrumbLabel="Startups / Listings"
+        headlineLead="Startups & tech"
+        headlineAccent="opportunities"
+        subtitle="Browse Australian startup investment opportunities — VC, angel rounds, SAFE notes and equity crowdfunding."
+        stats={listings.length > 0 ? [{ v: String(listings.length), l: "Live listings" }] : undefined}
+        containerClassName="container-custom"
+      >
+        <Link
+          href="/invest"
+          className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1 text-[0.65rem] font-semibold text-slate-600 shadow-sm transition-colors hover:bg-slate-50 md:text-xs"
+        >
+          ← Browse all investment sectors
+        </Link>
+      </DirectoryHero>
       {category && (
-        <div className="container-custom pt-6">
+        <div className="container-custom pt-4">
           <SubCategoryNav category={category} />
         </div>
       )}
@@ -55,8 +75,6 @@ export default async function StartupOpportunitiesPage() {
           listings={listings}
           categories={categoryTabs}
           lockedCategory="startups"
-          pageTitle="Startups & Tech Investment Listings"
-          pageSubtitle="Browse Australian startup investment opportunities — VC, angel rounds, SAFE notes and equity crowdfunding."
         />
       </Suspense>
     </>

--- a/app/invest/startups/page.tsx
+++ b/app/invest/startups/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import Icon from "@/components/Icon";
 import SectionHeading from "@/components/SectionHeading";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 import { faqJsonLd } from "@/lib/schema-markup";
 
 const STARTUP_FAQS = [
@@ -59,98 +60,44 @@ export default function StartupsPage() {
         <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(startupFaqLd) }} />
       )}
 
-      {/* Hero */}
-      <section className="relative bg-white border-b border-slate-100 overflow-hidden py-8 md:py-12">
-        <div className="container-custom">
-          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-6">
-            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" />
-            <Link href="/invest" className="hover:text-slate-900 transition-colors">Invest</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" />
-            <span className="text-slate-900 font-medium">Startups</span>
-          </nav>
-
-          <div className="flex flex-wrap items-center gap-2 mb-4">
-            <span className="text-xs font-semibold bg-amber-500 text-slate-900 px-3 py-1 rounded-full">
-              Updated {CURRENT_YEAR}
-            </span>
-            <span className="text-xs font-semibold bg-rose-600 text-white px-3 py-1 rounded-full">
-              ESIC Tax Incentives Available
-            </span>
-          </div>
-
-          <h1 className="text-3xl md:text-4xl lg:text-5xl font-extrabold leading-tight mb-4 max-w-3xl text-slate-900">
-            Invest in Australian Startups & Technology
-          </h1>
-          <p className="text-lg text-slate-600 leading-relaxed max-w-2xl mb-8">
-            Sydney and Melbourne rank in the global top 20 startup ecosystems. From Canva to Atlassian, Australia produces world-class technology companies. Invest early with generous tax incentives.
-          </p>
-
+      {/* Hero — house-standard compact light header (E3). The old stat band
+          rides as pills beside the title; the browse-all and personalised-feed
+          entry points live in the light band below, replacing the standalone
+          CTA band (E4). */}
+      <DirectoryHero
+        tone="light"
+        breadcrumbLabel="Startups"
+        headlineLead="Invest in Australian Startups & Technology"
+        subtitle="Sydney and Melbourne rank in the global top 20 startup ecosystems. From Canva to Atlassian, Australia produces world-class technology companies. Invest early with generous tax incentives."
+        stats={[
+          { v: "20%", l: "ESIC tax offset" },
+          { v: "$200K", l: "Max offset per year" },
+          { v: "10 yr", l: "CGT exemption on ESIC shares" },
+          { v: "Top 20", l: "Global startup ecosystem" },
+        ]}
+        containerClassName="container-custom"
+      >
+        <div className="flex flex-wrap items-center gap-2">
           <Link
             href="/invest/startups/listings"
-            className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold text-base px-7 py-3.5 rounded-xl transition-colors shadow-lg"
+            className="inline-flex items-center gap-1.5 rounded-full border border-coral-200 bg-coral-50 px-3 py-1 text-[0.65rem] font-semibold text-coral-700 shadow-sm transition-colors hover:bg-coral-100 md:text-xs"
           >
-            Browse Startup Opportunities
-            <Icon name="arrow-right" size={18} />
+            Browse all startup opportunities →
           </Link>
+          <Link
+            href="/invest/startups/for-you"
+            className="inline-flex items-center gap-1.5 rounded-full border border-violet-200 bg-violet-50 px-3 py-1 text-[0.65rem] font-semibold text-violet-700 shadow-sm transition-colors hover:bg-violet-100 md:text-xs"
+          >
+            Rounds matched for you →
+          </Link>
+          <span className="inline-flex items-center rounded-full border border-rose-200 bg-rose-50 px-3 py-1 text-[0.65rem] font-semibold text-rose-700 md:text-xs">
+            ESIC Tax Incentives Available
+          </span>
         </div>
-      </section>
-
-      {/* Browse Listings CTA */}
-      <section className="bg-white pt-8">
-        <div className="container-custom">
-          <div className="grid sm:grid-cols-2 gap-4 mb-8">
-            <Link
-              href="/invest/startups/listings"
-              className="group flex items-center justify-between gap-4 p-5 bg-gradient-to-r from-emerald-50 to-emerald-100/40 border border-emerald-200 rounded-2xl hover:border-emerald-300 hover:shadow-md transition-all"
-            >
-              <div>
-                <p className="text-xs font-extrabold uppercase tracking-wider text-emerald-700 mb-1">Browse Listings</p>
-                <p className="text-lg font-extrabold text-slate-900">All startup opportunities &rarr;</p>
-                <p className="text-sm text-slate-600 mt-0.5">Active raises, ESIC-eligible, sub-categories &amp; more</p>
-              </div>
-              <svg className="w-8 h-8 text-emerald-600 shrink-0 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-              </svg>
-            </Link>
-            <Link
-              href="/invest/startups/for-you"
-              className="group flex items-center justify-between gap-4 p-5 bg-gradient-to-r from-violet-50 to-violet-100/40 border border-violet-200 rounded-2xl hover:border-violet-300 hover:shadow-md transition-all"
-            >
-              <div>
-                <p className="text-xs font-extrabold uppercase tracking-wider text-violet-700 mb-1">Personalised Feed</p>
-                <p className="text-lg font-extrabold text-slate-900">Rounds matched for you &rarr;</p>
-                <p className="text-sm text-slate-600 mt-0.5">Filtered by your thesis — sector, stage, ticket size</p>
-              </div>
-              <svg className="w-8 h-8 text-violet-600 shrink-0 group-hover:translate-x-1 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-              </svg>
-            </Link>
-          </div>
-        </div>
-      </section>
-
-      {/* Stats */}
-      <section className="py-10 bg-white border-b border-slate-100">
-        <div className="container-custom">
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-            {[
-              { value: "20%", label: "ESIC tax offset" },
-              { value: "$200K", label: "Max offset per year" },
-              { value: "10 yr", label: "CGT exemption on ESIC shares" },
-              { value: "Top 20", label: "Global startup ecosystem" },
-            ].map((s) => (
-              <div key={s.label} className="bg-amber-50 border border-amber-100 rounded-xl p-4 text-center">
-                <p className="text-2xl font-extrabold text-amber-600">{s.value}</p>
-                <p className="text-xs text-slate-600 mt-1">{s.label}</p>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
+      </DirectoryHero>
 
       {/* Content */}
-      <section className="py-14 bg-white">
+      <section className="py-8 md:py-10 bg-white">
         <div className="container-custom max-w-4xl">
           <SectionHeading
             eyebrow="Tax incentives"
@@ -237,7 +184,7 @@ export default function StartupsPage() {
       </section>
 
       {/* CTA */}
-      <section className="py-14 bg-white border-t border-slate-100">
+      <section className="py-8 md:py-10 bg-white border-t border-slate-100">
         <div className="container-custom">
           <div className="max-w-3xl mx-auto bg-white border border-slate-200 rounded-xl p-8 text-center">
             <h2 className="text-2xl font-extrabold text-slate-900 mb-3">Browse Startup Investment Opportunities</h2>
@@ -263,7 +210,7 @@ export default function StartupsPage() {
         </div>
       </section>
 
-      <section className="py-10 bg-white border-t border-slate-200">
+      <section className="py-6 md:py-8 bg-white border-t border-slate-200">
         <div className="container-custom max-w-3xl">
           <h2 className="text-lg font-bold text-slate-900 mb-4">Frequently asked questions</h2>
           <div className="space-y-3">

--- a/app/invest/venture-capital/listings/page.tsx
+++ b/app/invest/venture-capital/listings/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { Suspense } from "react";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import { getAllInvestCategories } from "@/lib/invest-categories";
@@ -7,6 +8,7 @@ import {
   countListingsByVertical,
 } from "@/lib/investment-listings-query";
 import InvestListingsClient from "@/components/InvestListingsClient";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 
 export const revalidate = 300;
 
@@ -46,6 +48,24 @@ export default async function VentureCapitalListingsPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
+      {/* House-standard compact light header (E7) — replaces the client's
+          tall page-title band so results land near the fold. */}
+      <DirectoryHero
+        tone="light"
+        breadcrumbLabel="Venture Capital / Listings"
+        headlineLead="Venture capital"
+        headlineAccent="opportunities"
+        subtitle="Browse Australian venture capital investment opportunities — early-stage, growth and sector-focused VC fund mandates for wholesale investors. Compare sector focus, vintage year, fund size and minimum commitment."
+        stats={listings.length > 0 ? [{ v: String(listings.length), l: "Live listings" }] : undefined}
+        containerClassName="container-custom"
+      >
+        <Link
+          href="/invest"
+          className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-3 py-1 text-[0.65rem] font-semibold text-slate-600 shadow-sm transition-colors hover:bg-slate-50 md:text-xs"
+        >
+          ← Browse all investment sectors
+        </Link>
+      </DirectoryHero>
       <div className="bg-amber-50 border border-amber-200 rounded-lg mx-4 mt-6 p-4 text-sm text-amber-900">
         <p className="font-semibold mb-1">⚠️ Wholesale Investor Access Required (s708 Corporations Act)</p>
         <p className="mb-2">
@@ -67,8 +87,6 @@ export default async function VentureCapitalListingsPage() {
           listings={listings}
           categories={categoryTabs}
           lockedCategory="venture-capital"
-          pageTitle="Venture Capital Fund Listings"
-          pageSubtitle="Browse Australian venture capital investment opportunities — early-stage, growth and sector-focused VC fund mandates for wholesale investors. Compare sector focus, vintage year, fund size and minimum commitment."
         />
       </Suspense>
     </>


### PR DESCRIPTION
Items E1/E3/E7 (plus sub-items E2/E4/E5/E6) from `docs/plans/UX_UI_FINTECH_ALIGNMENT.md` — the invest sector heroes — applied consistently across **every** sector family (23 concrete sectors + the dynamic `[slug]` routes), touching only `app/invest/**`.

**E3 — pillar heroes (14 routes):** mining, farmland, buy-business, franchise, renewable-energy, startups, infrastructure, private-credit, private-equity, pre-ipo, royalties, digital-infrastructure, commercial-property + the dynamic `app/invest/[slug]/page.tsx` now use the shared `DirectoryHero tone="light"`. The old per-page stat bands/dl grids ride as the hero's stat pills; informational badges (FIRB / ESIC / wholesale-only / 82%-target / startups for-you feed link, etc.) are preserved in the hero's light band. `alternatives/page.tsx` left alone — its rose-gradient hero is E14, owned elsewhere.

**E4:** standalone "Browse listings" CTA bands deleted; the browse-all entry point is a pill in the hero band. Infrastructure/private-credit's generic `/advisors` + `/compare` hero buttons (pure nav duplication) were also dropped as part of the same cleanup.

**E5:** mining's dark emerald-gradient "Critical Minerals" band converted to a light `bg-emerald-50 border-emerald-200` card with dark text, copy unchanged.

**E6:** section paddings eased (`py-14` → `py-8 md:py-10`, `py-10`/`py-10 md:py-12` → `py-6 md:py-8`).

**E7 — sector listings pages (24 routes):** previously landed straight on the filter toolbar (or the client's tall `pageTitle` band). Each now renders `DirectoryHero tone="light"` (breadcrumb `Home / <Sector> / Listings`, "<Sector> opportunities" title, existing subtitle copy, live listing count sourced from the already-fetched server data — omitted when 0) before `InvestListingsClient`; `pageTitle`/`pageSubtitle` props removed so there is no double h1. Compliance notices / s708 wholesale gates / de-index robots flags untouched.

**E1/E2 — listing detail pages (11 routes):** `py-12` hero → compact `py-3 md:py-4` header (breadcrumb, all badges, title, location kept verbatim); content section `py-10` → `py-6 md:py-8`; detail grid `gap-8` → `gap-5`; price card `p-6` → `p-4`. All JSON-LD/metadata/enquiry logic unchanged.

Validation: `eslint --max-warnings 0` clean on all 49 files, `tsc --noEmit` clean, related tests (`InvestListingsClient`, `invest-listing-routes`, `listing-url`) pass. Includes cherry-pick of `51a2e767` (RLS-test archive paths) per current branch baseline. No dev-server visual pass was possible in the sandbox (no `.env.local`) — please eyeball one pillar, one listings page and one detail page on the preview deploy before un-drafting.

https://claude.ai/code/session_01FdSEBPnPofJaBPhWy1dggf

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdSEBPnPofJaBPhWy1dggf)_