### PR TITLE
refactor(content): compact light heroes — learn, articles, community, quotes, intake (F4/F6/F10/B10/B13)

### DIFF
--- a/__tests__/integration/o-iter6.rls.int.test.ts
+++ b/__tests__/integration/o-iter6.rls.int.test.ts
@@ -37,7 +37,7 @@ import path from "node:path";
 
 const MIGRATION_PATH = path.join(
   process.cwd(),
-  "supabase/migrations/20260429_o_iter6_rls_forum.sql",
+  "supabase/migrations/archive/20260429_o_iter6_rls_forum.sql",
 );
 
 const FORUM_TABLES = [

--- a/__tests__/integration/o-iter7.rls.int.test.ts
+++ b/__tests__/integration/o-iter7.rls.int.test.ts
@@ -30,7 +30,7 @@ import path from "node:path";
 
 const MIGRATION_PATH = path.resolve(
   __dirname,
-  "../../supabase/migrations/20260429_o_iter7_rls_editorial_obs_secrets.sql",
+  "../../supabase/migrations/archive/20260429_o_iter7_rls_editorial_obs_secrets.sql",
 );
 const SQL = readFileSync(MIGRATION_PATH, "utf8");
 

--- a/__tests__/integration/o-iter8.rls.int.test.ts
+++ b/__tests__/integration/o-iter8.rls.int.test.ts
@@ -26,7 +26,7 @@ import path from "node:path";
 
 const MIGRATION_PATH = path.resolve(
   __dirname,
-  "../../supabase/migrations/20260501_o_iter8_rls_observability.sql",
+  "../../supabase/migrations/archive/20260501_o_iter8_rls_observability.sql",
 );
 const SQL = readFileSync(MIGRATION_PATH, "utf8");
 

--- a/__tests__/integration/quarterly-reports-rls.int.test.ts
+++ b/__tests__/integration/quarterly-reports-rls.int.test.ts
@@ -27,7 +27,7 @@ import path from "node:path";
 
 const MIGRATION_PATH = path.resolve(
   __dirname,
-  "../../supabase/migrations/20260501_c05b_quarterly_reports_rls.sql",
+  "../../supabase/migrations/archive/20260501_c05b_quarterly_reports_rls.sql",
 );
 const SQL = readFileSync(MIGRATION_PATH, "utf8");
 

--- a/app/articles/page.tsx
+++ b/app/articles/page.tsx
@@ -354,12 +354,12 @@ export default async function ArticlesPage({
           <span className="text-slate-700">Guides &amp; Articles</span>
         </nav>
 
-        {/* Page Header */}
-        <div className="bg-gradient-to-r from-slate-50 to-white border border-slate-200 rounded-2xl p-4 md:p-8 mb-3 md:mb-8">
-          <h1 className="text-lg md:text-4xl font-extrabold mb-0.5 md:mb-3 text-slate-900">
+        {/* Page Header — compact light (F6) */}
+        <div className="bg-white border border-slate-200 rounded-xl p-3 md:p-4 mb-3 md:mb-4">
+          <h1 className="text-xl md:text-2xl font-extrabold tracking-tight mb-0.5 md:mb-1 text-slate-900">
             Guides &amp; Articles
           </h1>
-          <p className="text-[0.69rem] md:text-lg text-slate-500 max-w-2xl">
+          <p className="text-[12.5px] md:text-[13.5px] leading-snug text-slate-500 max-w-2xl">
             Expert guides on shares, crypto, super, property, ETFs, tax &amp; more — written for Australian investors.
           </p>
         </div>

--- a/app/briefs/[slug]/intake/page.tsx
+++ b/app/briefs/[slug]/intake/page.tsx
@@ -6,6 +6,7 @@ import { createClient } from "@/lib/supabase/server";
 import { SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import { getQuestionsForBrief } from "@/lib/pro-intake";
 import type { BriefRow } from "@/lib/briefs/types";
+import Icon from "@/components/Icon";
 
 import IntakeAnswerForm from "./IntakeAnswerForm";
 
@@ -47,51 +48,70 @@ export default async function BriefIntakePage({
 
   return (
     <div className="min-h-screen bg-slate-50">
-      <div className="max-w-3xl mx-auto px-4 py-8 sm:py-12">
-        <div className="flex items-center gap-2 text-xs text-slate-500 mb-4">
+      <div className="max-w-3xl mx-auto px-4 pt-4 pb-10 md:pt-5">
+        {/* Compact light header (B13) */}
+        <nav aria-label="Breadcrumb" className="mb-1.5 text-[11px] md:text-xs text-slate-500">
           <Link href={`/briefs/${slug}`} className="hover:text-slate-700">
             Brief status
           </Link>
-          <span>/</span>
-          <span className="text-slate-700">Additional info</span>
-        </div>
+          <span className="mx-1.5" aria-hidden>/</span>
+          <span className="text-slate-600">Additional info</span>
+        </nav>
 
-        <h1 className="text-2xl sm:text-3xl font-extrabold text-slate-900 mb-2">
+        <h1 className="text-2xl font-extrabold leading-tight tracking-tight text-slate-900 md:text-[1.9rem]">
           A few extra details
         </h1>
-        <p className="text-sm text-slate-600 mb-6">{brief.job_title}</p>
+        <p className="mt-1 max-w-2xl text-[12.5px] leading-snug text-slate-500 md:text-[13.5px]">
+          {brief.job_title}
+        </p>
 
-        {!acceptedYet && (
-          <div className="rounded-2xl border border-amber-200 bg-amber-50 p-5 text-sm text-amber-900">
-            <p className="font-semibold">Waiting on a provider</p>
-            <p className="mt-1">
-              We&apos;ll surface these questions once a verified provider accepts your
-              brief. Check back from your{" "}
-              <Link href={`/briefs/${slug}`} className="underline">
-                brief status page
-              </Link>
-              .
-            </p>
-          </div>
-        )}
+        <div className="mt-4">
+          {!acceptedYet && (
+            <div className="flex items-start gap-3 rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+              <Icon name="clock" size={16} className="mt-0.5 shrink-0 text-amber-600" />
+              <div>
+                <p className="font-semibold">Waiting on a provider</p>
+                <p className="mt-1">
+                  We&apos;ll surface these questions once a verified provider accepts your
+                  brief. Check back from your{" "}
+                  <Link href={`/briefs/${slug}`} className="underline">
+                    brief status page
+                  </Link>
+                  .
+                </p>
+              </div>
+            </div>
+          )}
 
-        {acceptedYet && questions.length === 0 && (
-          <div className="rounded-2xl border border-emerald-200 bg-emerald-50 p-5 text-sm text-emerald-900">
-            <p className="font-semibold">You&apos;re all set.</p>
-            <p className="mt-1">
-              Your provider didn&apos;t request any extra info. They&apos;ll be in
-              touch directly.{" "}
-              <Link href={`/briefs/${slug}`} className="underline">
-                Back to brief status
-              </Link>
-              .
-            </p>
-          </div>
-        )}
+          {acceptedYet && questions.length === 0 && (
+            <div className="flex items-start gap-3 rounded-xl border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-900">
+              <Icon name="check-circle" size={16} className="mt-0.5 shrink-0 text-emerald-600" />
+              <div>
+                <p className="font-semibold">You&apos;re all set.</p>
+                <p className="mt-1">
+                  Your provider didn&apos;t request any extra info. They&apos;ll be in
+                  touch directly.{" "}
+                  <Link href={`/briefs/${slug}`} className="underline">
+                    Back to brief status
+                  </Link>
+                  .
+                </p>
+              </div>
+            </div>
+          )}
 
-        {acceptedYet && questions.length > 0 && (
-          <IntakeAnswerForm slug={brief.slug} questions={questions} />
-        )}
+          {acceptedYet && questions.length > 0 && (
+            <>
+              <span className="inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-2.5 py-1 text-xs font-semibold text-slate-600">
+                <Icon name="clipboard-list" size={12} className="shrink-0" />
+                {questions.length} {questions.length === 1 ? "question" : "questions"} from your provider
+              </span>
+              <div className="mt-3">
+                <IntakeAnswerForm slug={brief.slug} questions={questions} />
+              </div>
+            </>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/app/community/page.tsx
+++ b/app/community/page.tsx
@@ -2,6 +2,7 @@ import { createClient } from "@/lib/supabase/server";
 import { absoluteUrl, breadcrumbJsonLd } from "@/lib/seo";
 import Link from "next/link";
 import Icon from "@/components/Icon";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 import { faqJsonLd } from "@/lib/schema-markup";
 import NewsletterSignup from "@/components/NewsletterSignup";
 
@@ -96,78 +97,47 @@ export default async function CommunityPage() {
         />
       )}
 
-      {/* Hero */}
-      <section className="bg-gradient-to-br from-slate-900 to-slate-800 text-white py-16">
-        <div className="container-custom max-w-4xl text-center">
-          <h1 className="text-3xl md:text-4xl font-extrabold mb-4">
-            Community Forum
-          </h1>
-          <p className="text-slate-300 text-lg max-w-2xl mx-auto mb-8">
+      {/* Compact light hero (F10) — breadcrumb, stats and CTAs in one header */}
+      <DirectoryHero
+        tone="light"
+        containerClassName="container-custom max-w-4xl"
+        breadcrumbLabel="Community"
+        headlineLead="Community Forum"
+        subtitle={
+          <>
             A place for Australian investors to compare notes on strategies,
             brokers, and opportunities. Start a thread or jump into the
             discussion.
-          </p>
+          </>
+        }
+        stats={
+          totalThreads > 0
+            ? [
+                { v: totalThreads.toLocaleString(), l: "threads" },
+                { v: totalPosts.toLocaleString(), l: "posts" },
+              ]
+            : undefined
+        }
+      >
+        <div className="flex flex-wrap items-center gap-3">
           <Link
             href="/community/new"
-            className="inline-flex items-center gap-2 bg-emerald-700 hover:bg-emerald-800 text-white font-semibold px-6 py-3 rounded-xl transition-colors"
+            className="inline-flex items-center gap-2 bg-emerald-700 hover:bg-emerald-800 text-white text-sm font-semibold px-4 py-2 rounded-lg transition-colors"
           >
-            <Icon name="plus" size={18} />
+            <Icon name="plus" size={16} />
             New Thread
           </Link>
-          <p className="mt-4">
-            <Link
-              href="/community/guidelines"
-              className="text-xs text-slate-400 hover:text-slate-200 underline transition-colors"
-            >
-              Community guidelines
-            </Link>
-          </p>
+          <Link
+            href="/community/guidelines"
+            className="text-xs text-slate-500 hover:text-slate-700 underline transition-colors"
+          >
+            Community guidelines
+          </Link>
         </div>
-      </section>
-
-      {/* Breadcrumbs */}
-      <div className="container-custom max-w-4xl mt-6">
-        <nav aria-label="Breadcrumb" className="text-sm text-slate-500 mb-6">
-          <ol className="flex items-center gap-1">
-            <li>
-              <Link href="/" className="hover:text-slate-700">
-                Home
-              </Link>
-            </li>
-            <li>
-              <Icon name="chevron-right" size={14} className="text-slate-400" />
-            </li>
-            <li className="text-slate-900 font-medium">Community</li>
-          </ol>
-        </nav>
-      </div>
-
-      {/* Stats Bar */}
-      <div className="container-custom max-w-4xl mb-8">
-        <div className="flex flex-wrap gap-6 bg-white border border-slate-200 rounded-xl px-6 py-4">
-          <div className="flex items-center gap-2">
-            <Icon name="message-circle" size={18} className="text-slate-400" />
-            <span className="text-sm text-slate-600">
-              <span className="font-semibold text-slate-900">
-                {totalThreads.toLocaleString()}
-              </span>{" "}
-              threads
-            </span>
-          </div>
-          <div className="flex items-center gap-2">
-            <Icon name="users" size={18} className="text-slate-400" />
-            <span className="text-sm text-slate-600">
-              <span className="font-semibold text-slate-900">
-                {totalPosts.toLocaleString()}
-              </span>{" "}
-              posts
-            </span>
-          </div>
-        </div>
-      </div>
+      </DirectoryHero>
 
       {/* Featured — confessions */}
-      <div className="container-custom max-w-4xl mb-6">
+      <div className="container-custom max-w-4xl mt-5 mb-6">
         <Link
           href="/community/confessions"
           className="flex items-center justify-between gap-4 bg-slate-800 hover:bg-slate-700 text-white rounded-xl px-5 py-4 transition-colors group"

--- a/app/learn/page.tsx
+++ b/app/learn/page.tsx
@@ -4,6 +4,7 @@ import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR, absoluteUrl } from "@/lib/seo
 import { faqJsonLd } from "@/lib/schema-markup";
 import { createClient } from "@/lib/supabase/server";
 import Icon from "@/components/Icon";
+import DirectoryHero from "@/components/directory/DirectoryHero";
 import NewsletterCta from "./NewsletterCta";
 import { LEARNING_PATHS, sumEstimatedMinutes } from "@/lib/learning-paths";
 import { Suspense } from "react";
@@ -108,6 +109,10 @@ export default async function LearnHubPage() {
   const articles = await fetchBeginnerArticles();
   const showArticles = articles.length > 0 ? articles : FALLBACK_ARTICLES.map((a) => ({ ...a, category: "beginners" as string | null }));
 
+  // Honest hero stats derived from the path registry.
+  const totalSteps = LEARNING_PATHS.reduce((s, p) => s + p.steps.length, 0);
+  const totalContentMins = LEARNING_PATHS.reduce((s, p) => s + sumEstimatedMinutes(p), 0);
+
   const breadcrumb = breadcrumbJsonLd([
     { name: "Home", url: `${SITE_URL}/` },
     { name: "Learn", url: absoluteUrl("/learn") },
@@ -138,24 +143,26 @@ export default async function LearnHubPage() {
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(hubItemListLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(learnHubFaqLd) }} />
       <div className="bg-white min-h-screen">
-        <section className="bg-slate-900 text-white py-10 md:py-14">
-          <div className="container-custom">
-            <nav className="flex items-center gap-1.5 text-xs text-slate-400 mb-5" aria-label="Breadcrumb">
-              <Link href="/" className="hover:text-white">Home</Link>
-              <span className="text-slate-600">/</span>
-              <span className="text-white font-medium">Learn</span>
-            </nav>
-            <h1 className="text-3xl md:text-4xl lg:text-5xl font-extrabold leading-tight mb-3 max-w-3xl">
-              Learning Paths for Australian Investors
-            </h1>
-            <p className="text-base md:text-lg text-slate-300 leading-relaxed max-w-3xl">
+        <DirectoryHero
+          tone="light"
+          breadcrumbLabel="Learn"
+          headlineLead="Learning Paths"
+          headlineAccent="for Australian Investors"
+          subtitle={
+            <>
               Structured paths through our guides, calculators, and Q&amp;A — from first investment to tax-smart retirement. Tick off steps as you go; progress saves automatically.
-            </p>
-          </div>
-        </section>
+            </>
+          }
+          stats={[
+            { v: `${LEARNING_PATHS.length}`, l: "learning paths" },
+            { v: `${totalSteps}`, l: "guided steps" },
+            { v: totalContentMins < 60 ? `${totalContentMins} min` : `~${Math.round(totalContentMins / 60)} hrs`, l: "of content" },
+            { v: "Free", l: "no sign-in needed" },
+          ]}
+        />
 
         {/* ── Learning Paths grid ── */}
-        <section className="py-12 bg-white" aria-labelledby="paths-heading">
+        <section className="pt-6 pb-12 bg-white" aria-labelledby="paths-heading">
           <div className="container-custom max-w-6xl">
             <h2 id="paths-heading" className="text-2xl md:text-3xl font-extrabold text-slate-900 mb-2">
               Choose a learning path

--- a/app/quotes/QuotesFilterClient.tsx
+++ b/app/quotes/QuotesFilterClient.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback, useTransition } from "react";
 import Link from "next/link";
 import Icon from "@/components/Icon";
+import { Select } from "@/components/ui/Select";
 import CountdownBadge from "./CountdownBadge";
 import type { JobRow } from "./page";
 
@@ -111,57 +112,49 @@ export default function QuotesFilterClient({ initialJobs }: Props) {
 
   return (
     <>
-      {/* Hero */}
-      <section className="bg-gradient-to-b from-slate-900 to-slate-800 text-white">
-        <div className="max-w-6xl mx-auto px-4 py-14 sm:py-20">
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-10 items-center">
-            <div>
-              <p className="text-amber-400 text-xs font-semibold uppercase tracking-widest mb-3 flex items-center gap-2">
-                <span className="w-2 h-2 bg-emerald-400 rounded-full animate-pulse" />
-                Live advisor marketplace
-              </p>
-              <h1 className="text-3xl sm:text-5xl font-extrabold mb-4">
-                Real Australians. Real quotes. Live now.
-              </h1>
-              <p className="text-slate-300 leading-relaxed mb-6 max-w-xl">
-                Like a marketplace for advice — consumers post what they need help with, verified Australian advisors quote, the consumer picks. Free to post, free to compare, no obligation.
-              </p>
-              <div className="flex flex-col sm:flex-row gap-3">
-                <Link
-                  href="/quotes/post"
-                  className="inline-flex items-center justify-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold px-7 py-3 rounded-xl"
-                >
-                  Get a quote — free
-                  <Icon name="arrow-right" size={16} />
-                </Link>
-                <Link
-                  href="/advisors"
-                  className="inline-flex items-center justify-center gap-2 bg-white/10 hover:bg-white/20 text-white font-semibold px-7 py-3 rounded-xl border border-white/20"
-                >
-                  Browse advisors directly
-                </Link>
-              </div>
-            </div>
-            <div className="hidden lg:flex items-center justify-center">
-              <div className="bg-white/5 border border-white/10 rounded-2xl p-6 w-full max-w-sm">
-                <p className="text-amber-400 text-xs font-semibold uppercase tracking-widest mb-3 flex items-center gap-2">
-                  <span className="w-2 h-2 bg-emerald-400 rounded-full animate-pulse" />
-                  Live now
-                </p>
-                <p className="text-5xl font-extrabold text-white mb-1">{initialJobs.length}</p>
-                <p className="text-sm text-slate-300">open requests accepting quotes</p>
-                <div className="border-t border-white/10 my-4" />
-                <p className="text-xs text-slate-400 leading-relaxed">
-                  Average request gets <span className="text-white font-semibold">3–5 quotes</span> within the first 24 hours.
-                </p>
-              </div>
-            </div>
+      {/* Compact light header (B10) — live count as one honest stat pill */}
+      <section className="bg-white border-b border-slate-200">
+        <div className="max-w-6xl mx-auto px-4 pt-4 pb-5 md:pt-5">
+          <nav aria-label="Breadcrumb" className="mb-1.5 text-[11px] md:text-xs text-slate-500">
+            <Link href="/" className="hover:text-slate-700">Home</Link>
+            <span className="mx-1.5" aria-hidden>/</span>
+            <span className="text-slate-600">Quotes</span>
+          </nav>
+          <h1 className="text-2xl font-extrabold leading-tight tracking-tight text-slate-900 md:text-[1.9rem]">
+            Real Australians. Real quotes. <span className="text-coral-600">Live now.</span>
+          </h1>
+          <p className="mt-1 max-w-2xl text-[12.5px] leading-snug text-slate-500 md:text-[13.5px]">
+            Like a marketplace for advice — consumers post what they need help with, verified Australian advisors quote, the consumer picks. Free to post, free to compare, no obligation.
+          </p>
+          <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-2">
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-200 bg-emerald-50 px-2.5 py-1 text-xs font-semibold text-emerald-700">
+              <span aria-hidden className="h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-500" />
+              {initialJobs.length} open {initialJobs.length === 1 ? "request" : "requests"} accepting quotes
+            </span>
+            <span className="text-xs text-slate-500">
+              Average request gets <span className="font-semibold text-slate-700">3–5 quotes</span> within the first 24 hours.
+            </span>
+          </div>
+          <div className="mt-4 flex flex-col sm:flex-row gap-2.5">
+            <Link
+              href="/quotes/post"
+              className="inline-flex items-center justify-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 text-sm font-bold px-5 py-2.5 rounded-lg"
+            >
+              Get a quote — free
+              <Icon name="arrow-right" size={14} />
+            </Link>
+            <Link
+              href="/advisors"
+              className="inline-flex items-center justify-center gap-2 bg-white hover:bg-slate-50 text-slate-700 text-sm font-semibold px-5 py-2.5 rounded-lg border border-slate-200"
+            >
+              Browse advisors directly
+            </Link>
           </div>
         </div>
       </section>
 
       {/* Listings */}
-      <section className="bg-slate-50 py-12 sm:py-16">
+      <section className="bg-slate-50 py-8">
         <div className="max-w-6xl mx-auto px-4">
           <div className="flex items-end justify-between mb-4">
             <div>
@@ -183,40 +176,37 @@ export default function QuotesFilterClient({ initialJobs }: Props) {
             </Link>
           </div>
 
-          {/* Filter bar */}
+          {/* Filter bar — house Select (B11) */}
           <div className="flex flex-wrap items-center gap-2 mb-6">
-            <select
-              value={advisorType}
-              onChange={(e) => handleAdvisorType(e.target.value)}
-              className="text-sm border border-slate-200 bg-white rounded-lg px-3 py-2 text-slate-700 focus:outline-none focus:ring-2 focus:ring-amber-400"
-              aria-label="Filter by advisor type"
-            >
-              {ADVISOR_TYPE_OPTIONS.map((o) => (
-                <option key={o.value} value={o.value}>{o.label}</option>
-              ))}
-            </select>
+            <div className="w-full sm:w-52">
+              <Select
+                id="quotes-filter-advisor-type"
+                aria-label="Filter by advisor type"
+                value={advisorType}
+                onChange={(e) => handleAdvisorType(e.target.value)}
+                options={ADVISOR_TYPE_OPTIONS}
+              />
+            </div>
 
-            <select
-              value={state}
-              onChange={(e) => handleState(e.target.value)}
-              className="text-sm border border-slate-200 bg-white rounded-lg px-3 py-2 text-slate-700 focus:outline-none focus:ring-2 focus:ring-amber-400"
-              aria-label="Filter by state"
-            >
-              {STATE_OPTIONS.map((o) => (
-                <option key={o.value} value={o.value}>{o.label}</option>
-              ))}
-            </select>
+            <div className="w-full sm:w-36">
+              <Select
+                id="quotes-filter-state"
+                aria-label="Filter by state"
+                value={state}
+                onChange={(e) => handleState(e.target.value)}
+                options={STATE_OPTIONS}
+              />
+            </div>
 
-            <select
-              value={budget}
-              onChange={(e) => handleBudget(e.target.value)}
-              className="text-sm border border-slate-200 bg-white rounded-lg px-3 py-2 text-slate-700 focus:outline-none focus:ring-2 focus:ring-amber-400"
-              aria-label="Filter by budget"
-            >
-              {BUDGET_OPTIONS.map((o) => (
-                <option key={o.value} value={o.value}>{o.label}</option>
-              ))}
-            </select>
+            <div className="w-full sm:w-44">
+              <Select
+                id="quotes-filter-budget"
+                aria-label="Filter by budget"
+                value={budget}
+                onChange={(e) => handleBudget(e.target.value)}
+                options={BUDGET_OPTIONS}
+              />
+            </div>
 
             {hasFilters && (
               <button
@@ -307,7 +297,7 @@ export default function QuotesFilterClient({ initialJobs }: Props) {
       </section>
 
       {/* How it works */}
-      <section className="bg-white py-12 sm:py-16">
+      <section className="bg-white py-8">
         <div className="max-w-4xl mx-auto px-4">
           <h2 className="text-2xl sm:text-3xl font-extrabold text-slate-900 mb-2 text-center">How it works</h2>
           <p className="text-sm text-slate-500 mb-10 text-center">A two-sided marketplace for financial advice — built on top of our verified advisor directory.</p>

--- a/app/quotes/post/page.tsx
+++ b/app/quotes/post/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import Icon from "@/components/Icon";
 import JobPostForm from "./JobPostForm";
@@ -33,27 +34,29 @@ export default function PostJobPage() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
 
-      {/* Hero */}
-      <section className="bg-gradient-to-b from-slate-900 via-slate-900 to-slate-800 text-white">
-        <div className="max-w-5xl mx-auto px-4 py-16 sm:py-20">
-          <div className="text-center">
-            <p className="text-amber-400 text-xs font-semibold uppercase tracking-widest mb-3">
-              Free advisor quotes — Australia-wide
-            </p>
-            <h1 className="text-3xl sm:text-5xl font-extrabold mb-4">
-              Post a request — verified advisors will quote you
-            </h1>
-            <p className="text-slate-300 max-w-2xl mx-auto leading-relaxed">
-              Post what you need help with — mortgage, financial planning, SMSF, tax, property, insurance — and Australian advisors will compete for your business. You pick. Free to post.
-            </p>
-          </div>
+      {/* Compact light header (B9 restyle) */}
+      <section className="bg-white border-b border-slate-200">
+        <div className="max-w-5xl mx-auto px-4 pt-4 pb-5 md:pt-5">
+          <nav aria-label="Breadcrumb" className="mb-1.5 text-[11px] md:text-xs text-slate-500">
+            <Link href="/" className="hover:text-slate-700">Home</Link>
+            <span className="mx-1.5" aria-hidden>/</span>
+            <Link href="/quotes" className="hover:text-slate-700">Quotes</Link>
+            <span className="mx-1.5" aria-hidden>/</span>
+            <span className="text-slate-600">Post a Request</span>
+          </nav>
+          <h1 className="text-2xl font-extrabold leading-tight tracking-tight text-slate-900 md:text-[1.9rem]">
+            Post a request — <span className="text-coral-600">verified advisors will quote you</span>
+          </h1>
+          <p className="mt-1 max-w-2xl text-[12.5px] leading-snug text-slate-500 md:text-[13.5px]">
+            Post what you need help with — mortgage, financial planning, SMSF, tax, property, insurance — and Australian advisors will compete for your business. You pick. Free to post.
+          </p>
 
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 sm:gap-6 max-w-4xl mx-auto mt-12">
+          <div className="grid grid-cols-2 lg:grid-cols-4 gap-2.5 mt-4">
             {TRUST.map((t) => (
-              <div key={t.title} className="bg-white/5 rounded-xl p-4 border border-white/10">
-                <Icon name={t.icon} size={20} className="text-amber-400 mb-2" />
-                <p className="text-sm font-bold text-white mb-1">{t.title}</p>
-                <p className="text-xs text-slate-400 leading-snug">{t.desc}</p>
+              <div key={t.title} className="rounded-lg border border-slate-200 bg-white p-3">
+                <Icon name={t.icon} size={16} className="text-amber-600 mb-1.5" />
+                <p className="text-xs font-bold text-slate-900">{t.title}</p>
+                <p className="mt-0.5 text-[11px] text-slate-500 leading-snug">{t.desc}</p>
               </div>
             ))}
           </div>
@@ -61,14 +64,14 @@ export default function PostJobPage() {
       </section>
 
       {/* Form */}
-      <section className="bg-slate-50 py-12 sm:py-16">
+      <section className="bg-slate-50 py-8">
         <div className="max-w-3xl mx-auto px-4">
           <JobPostForm />
         </div>
       </section>
 
       {/* How it works */}
-      <section className="bg-white py-12 sm:py-16">
+      <section className="bg-white py-8">
         <div className="max-w-4xl mx-auto px-4">
           <h2 className="text-2xl sm:text-3xl font-extrabold text-slate-900 mb-2 text-center">How it works</h2>
           <p className="text-sm text-slate-500 mb-10 text-center">Like Airtasker, but for financial advice.</p>


### PR DESCRIPTION
Content-surface hero alignment per `docs/plans/UX_UI_FINTECH_ALIGNMENT.md` — class/markup only; copy, metadata, JSON-LD, `revalidate` and data flow unchanged.

- **F4 `/learn`** — full-bleed dark hero (`bg-slate-900 py-10 md:py-14`, 5xl headline) → `DirectoryHero tone="light"` with honest stats derived from the path registry (paths / steps / hours / free). Note: `next.config.ts:361` currently 308s `/learn` → `/articles`, so this page is shadowed at its URL; converted per the audit item regardless.
- **F6 `/articles`** — gradient header box `p-4 md:p-8` + 4xl headline → white bordered `p-3 md:p-4`, `text-xl md:text-2xl`, tighter mb.
- **F10 `/community`** — dark gradient hero + separate breadcrumb nav + stats bar → one `DirectoryHero tone="light"` (threads/posts as stat pills, hidden while both are 0 in the launch-soon state); New Thread CTA + guidelines link move into the hero's light band.
- **B10 `/quotes`** (hero lives in `QuotesFilterClient`) — dark gradient hero + redundant right-side "live now" card → hand-matched compact light header; live count is now ONE emerald-pulse stat pill, the 3–5-quotes fact stays as a muted line; listings/how-it-works bands `py-12 sm:py-16` → `py-8` so requests sit near the fold.
- **B11 `/quotes`** — three bare `<select>` filters → house `components/ui/Select`.
- **B9-restyle `/quotes/post`** — no redirect (founder decision pending); dark `py-16 sm:py-20` hero → compact light header, 4 trust items kept as a compact bordered-card row, body bands → `py-8`.
- **B13 `/briefs/[slug]/intake`** — hand-rolled header → compact idiom (breadcrumb + tight title + question-count pill); the two state banners in this file unified to a single `p-4` icon pattern (`clock` / `check-circle`). The third (post-submit) banner lives in `IntakeAnswerForm.tsx`, outside this chunk's sanctioned file list — left for a follow-up.

Validation: `eslint` 0 warnings on all six files; `tsc --noEmit` clean; `__tests__/app/community-thread-detail-page.test.tsx` 4/4 green; dev-server smoke confirmed the new compact h1 renders on `/articles`, `/community`, `/quotes`, `/quotes/post` and no `from-slate-900` hero remains. Includes cherry-pick `51a2e767` (RLS-test archive paths) per the epic's shared-base instruction.

https://claude.ai/code/session_01FdSEBPnPofJaBPhWy1dggf

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdSEBPnPofJaBPhWy1dggf)_