### PR TITLE
refactor(ux): Wave-3 sweep — quotes detail header, briefs next-step nudge, density

### DIFF
--- a/app/account/alerts/page.tsx
+++ b/app/account/alerts/page.tsx
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation";
 
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { Button } from "@/components/ui/Button";
 import AlertsClient from "./AlertsClient";
 import PushOptIn from "./PushOptIn";
 import MorningBriefToggle from "./MorningBriefToggle";
@@ -65,12 +66,9 @@ export default async function AccountAlertsPage() {
                 : `${alerts.length} alert${alerts.length === 1 ? "" : "s"} set up`}
             </p>
           </div>
-          <Link
-            href="/rate-alerts"
-            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-slate-900 text-white text-xs font-semibold hover:bg-slate-700 transition-colors"
-          >
+          <Button href="/rate-alerts" size="sm">
             + New alert
-          </Link>
+          </Button>
         </div>
 
         {/* Email + push notification preferences */}

--- a/app/briefs/[slug]/page.tsx
+++ b/app/briefs/[slug]/page.tsx
@@ -377,6 +377,34 @@ export default async function BriefTrackerPage({
                       response within a couple of business days.
                     </div>
                   )}
+
+                {/* Accepted-but-no-booking nudge (B6) — once a provider accepts,
+                    the generic guidance above disappears; keep the rail pointing
+                    at the single next action instead of going quiet. */}
+                {emailMatches &&
+                  brief.accepted_at &&
+                  !existingBooking &&
+                  brief.status !== "closed" &&
+                  brief.status !== "withdrawn" && (
+                    <div className="mt-3 rounded-xl border border-amber-200 bg-amber-50 px-3 py-2.5 text-xs leading-relaxed text-amber-900">
+                      <span className="font-semibold">Next step:</span>{" "}
+                      {accepted.professional?.slug ? (
+                        <>
+                          {intakeOutstanding > 0
+                            ? "answer your provider's prep questions, then book your intro call."
+                            : "book your intro call — pick a time that suits you."}{" "}
+                          <a
+                            href="#book"
+                            className="font-semibold underline underline-offset-2 hover:text-amber-700"
+                          >
+                            Go to booking →
+                          </a>
+                        </>
+                      ) : (
+                        <>message your provider in the chat below to arrange your first call.</>
+                      )}
+                    </div>
+                  )}
               </div>
 
               {/* Withdraw — the verified owner can close an open request (AJ-3).
@@ -509,16 +537,19 @@ export default async function BriefTrackerPage({
                 </div>
               )}
 
-              {/* Book consultation — only shown once the brief is accepted */}
+              {/* Book consultation — only shown once the brief is accepted.
+                  id="book" is the rail nudge's anchor target. */}
               {accepted.professional?.slug && (
-                <BookConsultationPanel
-                  briefSlug={brief.slug}
-                  proSlug={accepted.professional.slug}
-                  proName={accepted.professional.name}
-                  contactEmail={emailMatches ? email : null}
-                  existingBooking={existingBooking}
-                  existingSlot={existingSlot}
-                />
+                <div id="book" className="scroll-mt-24">
+                  <BookConsultationPanel
+                    briefSlug={brief.slug}
+                    proSlug={accepted.professional.slug}
+                    proName={accepted.professional.name}
+                    contactEmail={emailMatches ? email : null}
+                    existingBooking={existingBooking}
+                    existingSlot={existingSlot}
+                  />
+                </div>
               )}
 
               {/* Chat — visible to the brief owner and the accepted advisor only.

--- a/app/quotes/[slug]/CountdownPill.tsx
+++ b/app/quotes/[slug]/CountdownPill.tsx
@@ -42,10 +42,10 @@ export default function CountdownPill({ endsAt, status }: Props) {
 
   return (
     <span
-      className={`px-3 py-1 rounded-full font-semibold ${
+      className={`inline-flex items-center px-2.5 py-1 rounded-full font-semibold ${
         isClosed
-          ? "bg-slate-600/40 text-slate-300"
-          : "bg-emerald-500/20 text-emerald-300 border border-emerald-500/30"
+          ? "bg-slate-100 text-slate-500 border border-slate-200"
+          : "bg-emerald-50 text-emerald-700 border border-emerald-200"
       }`}
     >
       <Icon name="clock" size={12} className="inline mr-1" />

--- a/app/quotes/[slug]/page.tsx
+++ b/app/quotes/[slug]/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
 import { createClient } from "@/lib/supabase/server";
 import Icon from "@/components/Icon";
+import { Button } from "@/components/ui/Button";
 import QuoteBidsClient from "./QuoteBidsClient";
 import CountdownPill from "./CountdownPill";
 import QuoteQAClient from "./QuoteQAClient";
@@ -177,44 +178,49 @@ export default async function QuoteDetailPage({ params, searchParams }: {
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jobPostingLd) }} />
 
-      {/* Hero */}
-      <section className="bg-gradient-to-b from-slate-900 to-slate-800 text-white">
-        <div className="max-w-5xl mx-auto px-4 py-10 sm:py-14">
-          <div className="flex flex-wrap items-center gap-2 text-xs mb-4">
-            <Link href="/quotes" className="text-slate-400 hover:text-white">All quotes</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-500" />
-            <span className="text-slate-300">{job.location || "Australia"}</span>
-          </div>
+      {/* Compact light header — house directory idiom (B14) */}
+      <section className="bg-white border-b border-slate-100">
+        <div className="max-w-5xl mx-auto px-4 pt-4 pb-5 md:pt-5">
+          <nav
+            aria-label="Breadcrumb"
+            className="mb-1.5 flex flex-wrap items-center gap-1.5 text-[11px] md:text-xs text-slate-400"
+          >
+            <Link href="/quotes" className="hover:text-slate-700">All quotes</Link>
+            <Icon name="chevron-right" size={12} className="text-slate-300" />
+            <span className="text-slate-600">{job.location || "Australia"}</span>
+          </nav>
 
-          <h1 className="text-2xl sm:text-4xl font-extrabold mb-4 max-w-3xl">{job.job_title}</h1>
+          <h1 className="text-2xl font-extrabold leading-tight tracking-tight text-slate-900 md:text-[1.9rem] max-w-3xl">
+            {job.job_title}
+          </h1>
 
-          <div className="flex flex-wrap items-center gap-3 text-sm">
-            <span className="bg-white/10 border border-white/20 px-3 py-1 rounded-full font-medium">
-              <Icon name="map-pin" size={12} className="inline mr-1" />
+          <div className="mt-2.5 flex flex-wrap items-center gap-2 text-xs">
+            <span className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-white px-2.5 py-1 font-medium text-slate-700">
+              <Icon name="map-pin" size={12} className="text-slate-400" />
               {job.location || "AU"}
             </span>
-            <span className="bg-white/10 border border-white/20 px-3 py-1 rounded-full font-medium">
-              <Icon name="wallet" size={12} className="inline mr-1" />
+            <span className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-white px-2.5 py-1 font-medium text-slate-700">
+              <Icon name="wallet" size={12} className="text-slate-400" />
               {BUDGET_LABELS[job.budget_band] || "Budget TBD"}
             </span>
             <CountdownPill endsAt={job.ends_at} status={job.status} />
-            <span className="text-slate-400 text-xs">
+            <span className="text-xs text-slate-500">
               {bids.length} {bids.length === 1 ? "quote" : "quotes"}
             </span>
           </div>
         </div>
       </section>
 
-      <section className="bg-slate-50 py-10 sm:py-14">
-        <div className="max-w-5xl mx-auto px-4 grid grid-cols-1 lg:grid-cols-3 gap-6">
+      <section className="bg-slate-50 py-6 md:py-8">
+        <div className="max-w-5xl mx-auto px-4 grid grid-cols-1 lg:grid-cols-3 gap-4 lg:gap-5">
           {/* Job description */}
-          <div className="lg:col-span-2 space-y-6">
-            <div className="bg-white border border-slate-200 rounded-2xl p-6">
+          <div className="lg:col-span-2 space-y-4">
+            <div className="bg-white border border-slate-200 rounded-2xl p-4">
               <h2 className="text-base font-bold text-slate-900 mb-3">Request details</h2>
               <p className="text-sm text-slate-700 leading-relaxed whitespace-pre-wrap">{job.job_description}</p>
 
               {job.advisor_types && job.advisor_types.length > 0 && (
-                <div className="mt-5 pt-5 border-t border-slate-100">
+                <div className="mt-4 pt-4 border-t border-slate-100">
                   <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-2">Advisor types requested</p>
                   <div className="flex flex-wrap gap-1.5">
                     {job.advisor_types.map((t) => (
@@ -276,12 +282,12 @@ export default async function QuoteDetailPage({ params, searchParams }: {
 
           {/* Sidebar */}
           <aside className="space-y-4">
-            <div className="bg-white border border-slate-200 rounded-2xl p-5">
+            <div className="bg-white border border-slate-200 rounded-2xl p-4">
               <h3 className="text-sm font-bold text-slate-900 mb-3 flex items-center gap-2">
                 <Icon name="info" size={14} className="text-slate-500" />
                 How this works
               </h3>
-              <ol className="space-y-3 text-xs text-slate-600 leading-relaxed">
+              <ol className="space-y-2.5 text-xs text-slate-600 leading-relaxed">
                 <li className="flex gap-2">
                   <span className="bg-amber-500 text-slate-900 w-5 h-5 rounded-full font-bold text-[10px] flex items-center justify-center shrink-0">1</span>
                   <span>Verified advisors review your request and submit fixed-fee or hourly quotes.</span>
@@ -297,7 +303,7 @@ export default async function QuoteDetailPage({ params, searchParams }: {
               </ol>
             </div>
 
-            <div className="bg-amber-50 border border-amber-200 rounded-2xl p-5">
+            <div className="bg-amber-50 border border-amber-200 rounded-2xl p-4">
               <h3 className="text-sm font-bold text-slate-900 mb-2 flex items-center gap-2">
                 <Icon name="shield-check" size={14} className="text-amber-700" />
                 Trust &amp; safety
@@ -307,13 +313,13 @@ export default async function QuoteDetailPage({ params, searchParams }: {
               </p>
             </div>
 
-            <Link
+            <Button
               href="/quotes/post"
-              className="flex items-center justify-center gap-2 bg-slate-900 hover:bg-slate-800 text-white font-bold px-5 py-3 rounded-xl text-sm w-full"
+              className="w-full"
+              icon={<Icon name="arrow-right" size={14} />}
             >
               Post your own quote
-              <Icon name="arrow-right" size={14} />
-            </Link>
+            </Button>
           </aside>
         </div>
       </section>

--- a/app/quotes/[slug]/review/page.tsx
+++ b/app/quotes/[slug]/review/page.tsx
@@ -52,9 +52,9 @@ export default async function ReviewPage({ params, searchParams }: PageProps) {
   if (!advisor) notFound();
 
   return (
-    <section className="bg-slate-50 min-h-[70vh] py-14">
+    <section className="bg-slate-50 min-h-[70vh] py-8 md:py-10">
       <div className="max-w-xl mx-auto px-4">
-        <div className="bg-white border border-slate-200 rounded-2xl p-8 shadow-sm">
+        <div className="bg-white border border-slate-200 rounded-2xl p-5 md:p-6 shadow-sm">
           <p className="text-xs uppercase tracking-wider text-amber-600 font-bold mb-1">Share your experience</p>
           <h1 className="text-2xl font-extrabold text-slate-900 mb-2">
             How was {advisor.name as string}?

--- a/app/wealth-stack/page.tsx
+++ b/app/wealth-stack/page.tsx
@@ -84,15 +84,15 @@ export default function WealthStackPage() {
 
       <div className="border-t border-slate-200 bg-white">
         <div className="container-custom max-w-2xl py-8 md:py-10">
-          <h2 className="text-lg font-extrabold text-slate-900 mb-5">Frequently asked questions</h2>
-          <div className="space-y-3">
+          <h2 className="text-lg font-extrabold text-slate-900 mb-4">Frequently asked questions</h2>
+          <div className="space-y-2.5">
             {WEALTH_STACK_FAQS.map((faq) => (
               <details key={faq.q} className="group rounded-xl border border-slate-200 bg-slate-50">
-                <summary className="flex cursor-pointer items-center justify-between gap-4 px-5 py-4 font-semibold text-slate-900 list-none">
+                <summary className="flex cursor-pointer items-center justify-between gap-4 px-4 py-3 font-semibold text-sm text-slate-900 list-none">
                   {faq.q}
                   <span className="shrink-0 text-slate-400 group-open:rotate-180 transition-transform" aria-hidden="true">▾</span>
                 </summary>
-                <p className="px-5 pb-5 text-sm text-slate-600 leading-relaxed">{faq.a}</p>
+                <p className="px-4 pb-4 text-sm text-slate-600 leading-relaxed">{faq.a}</p>
               </details>
             ))}
           </div>

--- a/docs/plans/UX_UI_FINTECH_ALIGNMENT.md
+++ b/docs/plans/UX_UI_FINTECH_ALIGNMENT.md
@@ -147,6 +147,47 @@ Effort: S (<30 min) · M (30 min–2 h) · L (>2 h).
 
 ---
 
+## Status ledger (updated 2026-06-10)
+
+Where each item landed. Items not listed are still open.
+
+| PR | Items |
+|---|---|
+| #1500 (merged) | B1, B2, B7, C1, F1, A1 |
+| #1502 (merged) | C2, C3, C4, C5 |
+| #1510 (merged) | C7, C8, C9, C10, C11, D2, D4, D5, D10, B12, F2, F3, F5, F7 |
+| #1511 (merged) | E8, E9 |
+| #1513 (merged) | D6, D7 |
+| #1514 (open) | WCAG contrast wave 2 (Task-5 sweep, not an item number) |
+| #1516 (open) | E1, E3, E7 |
+| #1517 (open) | F4, F6, F10, B10, B11, B13, B9 (restyle branch — redirect still a founder call) |
+| w3-sweep-1 | B6, B14, D9, F13 + this ledger |
+
+**Resolved without code (verified against main):**
+
+- **C6** — `AdvisorsClient` renders the filter-reactive `DirectoryHero tone="light"`;
+  `initialType`/`initialState` seed the filters, so `/advisors/[type]`,
+  `/advisors/[type]/[state]` and the three standalone specialty pages all get
+  the contextual hero + live counts. No per-page work needed.
+- **B3/B4/B5** — superseded by the B1/B2 tracker rewrite (compact stepper,
+  Icon banners, p-4 cards).
+- **B8** — superseded by the B7 rewrite (zero inline styles/hex left).
+- **A2/A3/A4** — homepage iv2 bands/cards already at target density
+  (`28px/32px` wrappers, 11px pills) — tightened alongside A1.
+- **A5** — decision: `HomeHero` stays custom. The homepage is a deliberate
+  bespoke iv2 idiom (inline-style tokens, `font-display`, `.iv2-*` classes);
+  DirectoryHero is the standard for directory/funnel surfaces, not the
+  marketing front door. Do not fold one into the other.
+
+**Deferred (quiz pause, 2026-06-10):** A6, A7, A8, A9 — `/quiz` and
+`/find-advisor` are the find-advisor quiz funnel; paused by the founder.
+Pick these up when the quiz workstream resumes (see PR #1512).
+
+**Still open:** D1, D3, D8 (account forms → primitives) · C12, C13 (portal
+audit, advisor-apply) · E2, E4, E5, E6 (verify against #1516 after merge),
+E10, E11, E12 (listing submission), E13, E14, E15 · F8, F9 (footer IA),
+F11 (assess) · F13 (in w3-sweep-1).
+
 ## Execution plan
 
 **Wave 1 (P0 — ship first):**


### PR DESCRIPTION
Wave-3 leftovers from `docs/plans/UX_UI_FINTECH_ALIGNMENT.md`, plus a status ledger so the remaining backlog is legible. Class/markup only — no copy, metadata, JSON-LD, `revalidate` or data-flow changes.

**B14 — `/quotes/[slug]` detail page.** Legacy dark gradient hero (`from-slate-900`, `py-10 sm:py-14`) → house compact-light header (breadcrumb + tight title + inline `map-pin`/`wallet`/countdown pills). `CountdownPill` recolours to a light-surface emerald/slate. Body bands `py-10/14` → `py-6/8`, cards `p-5/6` → `p-4`, sidebar "Post your own quote" → house `Button`. `review/page.tsx` padding tightened.

**B6 — `/briefs/[slug]` next-step nudge.** Once a provider accepts, the generic "what happens next" guidance disappears and the rail went quiet. Added an accepted-but-no-booking amber nudge pointing at the booking panel (new `#book` anchor target, `scroll-mt-24`): "book your intro call" (or "answer your provider's prep questions first" when intake is outstanding), and a chat fallback when the accepted party has no booking slug.

**D9** — `/account/alerts` "New alert" CTA → house `Button size="sm"`.
**F13** — `/wealth-stack` FAQ → standard `px-4 py-3` / `space-y-2.5` disclosure density.

**Status ledger** added to the plan doc: which items landed in which PR; C6, B3–B5, B8, A2–A5 resolved without code (verified against main); A6–A9 deferred behind the quiz pause.

Validation: `eslint --max-warnings 0` clean on all six files; `tsc --noEmit` clean; `__tests__/components/briefs/` 12/12 green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdSEBPnPofJaBPhWy1dggf)_