### PR TITLE
refactor(ux): tighten /invest/list + /invest/alternatives density (E11/E14)

### DIFF
--- a/app/invest/alternatives/page.tsx
+++ b/app/invest/alternatives/page.tsx
@@ -118,10 +118,10 @@ export default function AlternativesHubPage() {
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(financialServiceJsonLd) }} />
 
-      <div className="py-5 md:py-12">
+      <div className="pt-3 pb-6 md:pt-4 md:pb-10">
         <div className="container-custom max-w-4xl">
           {/* Breadcrumb */}
-          <nav aria-label="Breadcrumb" className="text-xs md:text-sm text-slate-500 mb-3 md:mb-6">
+          <nav aria-label="Breadcrumb" className="text-xs text-slate-500 mb-2 md:mb-3">
             <Link href="/" className="hover:text-slate-900">Home</Link>
             <span className="mx-2">/</span>
             <Link href="/invest" className="hover:text-slate-900">Invest</Link>
@@ -130,15 +130,15 @@ export default function AlternativesHubPage() {
           </nav>
 
           {/* Hero — uses vertical config heading/subtext */}
-          <div className="bg-gradient-to-br from-rose-50 to-white border border-rose-200/50 rounded-2xl p-4 md:p-6 mb-3 md:mb-4">
-            <h1 className="text-xl md:text-4xl font-extrabold mb-2 md:mb-3 text-slate-900">
+          <div className="bg-gradient-to-br from-rose-50 to-white border border-rose-200/50 rounded-2xl p-4 md:p-5 mb-3 md:mb-4">
+            <h1 className="text-2xl md:text-[1.9rem] font-extrabold leading-tight tracking-tight mb-2 text-slate-900">
               {vertical?.heroHeadline ?? "Compare Alternative Investment Platforms in Australia"}
             </h1>
-            <p className="text-xs md:text-base text-slate-600 mb-2">
+            <p className="text-[13px] md:text-base text-slate-600 mb-2">
               {vertical?.heroSubtext ??
                 `Diversify beyond shares and property with wine, art, classic cars, watches, rare coins, and whisky. Compare platforms, browse listings, and learn how Australians are accessing alternative asset classes in ${CURRENT_YEAR}.`}
             </p>
-            <p className="text-[0.56rem] md:text-xs text-slate-500">
+            <p className="text-[10px] md:text-xs text-slate-500">
               {ADVERTISER_DISCLOSURE_SHORT}
             </p>
           </div>

--- a/app/invest/list/page.tsx
+++ b/app/invest/list/page.tsx
@@ -131,14 +131,14 @@ export default function ListInvestmentPage() {
       </section>
 
       {/* Form section */}
-      <section className="py-14 bg-slate-50">
+      <section className="py-8 md:py-10 bg-slate-50">
         <div className="container-custom">
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-10">
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
             {/* Main form */}
             <div className="lg:col-span-2">
-              <div className="bg-white border border-slate-200 rounded-2xl p-8 shadow-sm">
+              <div className="bg-white border border-slate-200 rounded-2xl p-4 md:p-6 shadow-sm">
                 <h2 className="text-xl font-extrabold text-slate-900 mb-1">Submit Your Listing</h2>
-                <p className="text-sm text-slate-500 mb-8">Complete the steps below. Our team will review and publish within 1–2 business days.</p>
+                <p className="text-sm text-slate-500 mb-6">Complete the steps below. Our team will review and publish within 1–2 business days.</p>
                 <ListingSubmitForm />
               </div>
             </div>
@@ -207,10 +207,10 @@ export default function ListInvestmentPage() {
       </section>
 
       {/* FAQ */}
-      <section className="py-14 bg-white border-t border-slate-100">
+      <section className="py-8 md:py-10 bg-white border-t border-slate-100">
         <div className="container-custom max-w-3xl">
-          <h2 className="text-2xl font-extrabold text-slate-900 mb-8 text-center">Frequently Asked Questions</h2>
-          <div className="space-y-5">
+          <h2 className="text-2xl font-extrabold text-slate-900 mb-6 text-center">Frequently Asked Questions</h2>
+          <div className="space-y-2.5">
             {[
               {
                 q: "How long does it take for my listing to go live?",
@@ -247,7 +247,7 @@ export default function ListInvestmentPage() {
       </section>
 
       {/* Bottom CTA */}
-      <section className="py-12 bg-amber-50 border-t border-amber-100">
+      <section className="py-8 bg-amber-50 border-t border-amber-100">
         <div className="container-custom text-center">
           <h2 className="text-xl font-extrabold text-slate-900 mb-2">Looking to Invest, Not Sell?</h2>
           <p className="text-slate-500 text-sm mb-6 max-w-md mx-auto">


### PR DESCRIPTION
Two invest-vertical density passes left over from `docs/plans/UX_UI_FINTECH_ALIGNMENT.md` after #1516 covered the sector pillars/listings/detail. Class/markup only — no copy, data-flow, metadata or JSON-LD changes.

**E11 — `/invest/list`** (listing submission). Form/FAQ/bottom-CTA bands `py-14`/`py-12` → `py-8 md:py-10`; form grid `gap-10` → `gap-6`; form card `p-8` → `p-4 md:p-6`; FAQ list `space-y-5` → `space-y-2.5`. The submission form now sits nearer the fold. (The 2-col hero swap to DirectoryHero — E10 — and FormStepper adoption — E12 — are deliberately left for a dedicated form pass.)

**E14 — `/invest/alternatives`.** Wrapper `py-5 md:py-12` → `pt-3 pb-6 md:pt-4 md:pb-10`; breadcrumb to the house `text-xs` scale; hero headline `text-xl md:text-4xl` → the compact `text-2xl md:text-[1.9rem]`; advertiser disclosure bumped off the sub-readable `text-[0.56rem]` to `text-[10px]` (AA legibility). The rose vertical theming is intentional and preserved — this is a density tightening, not a hero swap.

Validation: `eslint --max-warnings 0` clean on both files; pure className changes (no TS surface).

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdSEBPnPofJaBPhWy1dggf)_