### PR TITLE
refactor(ux): collapse footer link sections on mobile (F8)

### DIFF
--- a/__tests__/components/Footer.test.tsx
+++ b/__tests__/components/Footer.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { fireEvent } from "@testing-library/react";
+import { render, screen } from "./setup";
+import Footer from "@/components/Footer";
+
+const SECTION_TITLES = [
+  "Browse Opportunities",
+  "Compare Platforms",
+  "Find Experts & Property",
+  "Property",
+  "Learn",
+  "Company",
+];
+
+describe("Footer — mobile collapsible link sections", () => {
+  it("renders every section heading as a tappable, collapsed-by-default control", () => {
+    render(<Footer />);
+    for (const title of SECTION_TITLES) {
+      // Exact-string name match so "Property" doesn't collide with
+      // "Find Experts & Property".
+      const btn = screen.getByRole("button", { name: title });
+      expect(btn).toHaveAttribute("aria-expanded", "false");
+    }
+  });
+
+  it("expands a section's links when its heading is tapped", () => {
+    render(<Footer />);
+    const browse = screen.getByRole("button", { name: "Browse Opportunities" });
+    fireEvent.click(browse);
+    expect(browse).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("keeps all links in the DOM regardless of open state (crawlable + desktop-visible)", () => {
+    render(<Footer />);
+    expect(screen.getByRole("link", { name: "All Opportunities" })).toHaveAttribute("href", "/invest");
+    expect(screen.getByRole("link", { name: "ETF Hub" })).toHaveAttribute("href", "/etfs");
+    expect(screen.getByRole("link", { name: "Advisor Directory" })).toHaveAttribute("href", "/advisors");
+    expect(screen.getByRole("link", { name: "Glossary" })).toHaveAttribute("href", "/glossary");
+    expect(screen.getByRole("link", { name: "About Us" })).toHaveAttribute("href", "/about");
+  });
+
+  it("toggles each section independently", () => {
+    render(<Footer />);
+    const compare = screen.getByRole("button", { name: "Compare Platforms" });
+    const property = screen.getByRole("button", { name: "Property" });
+    fireEvent.click(compare);
+    expect(compare).toHaveAttribute("aria-expanded", "true");
+    expect(property).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("still renders the persistent general-advice warning and ASIC registration", () => {
+    render(<Footer />);
+    expect(screen.getByText("General Advice Warning")).toBeInTheDocument();
+    expect(screen.getByText(/Registered with ASIC/i)).toBeInTheDocument();
+  });
+});

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { useId, useState } from "react";
+import type { ReactNode } from "react";
 import Link from "next/link";
 import { GENERAL_ADVICE_WARNING, ADVERTISER_DISCLOSURE, CRYPTO_WARNING, REGULATORY_NOTE, AFSL_STATUS_DISCLOSURE, FSG_NOTE, COMPANY_LEGAL_NAME, COMPANY_ACN, COMPANY_ABN, ASIC_REGISTER_URL } from "@/lib/compliance";
 
@@ -11,6 +12,55 @@ const collapsibleSections = [
   { title: "Crypto Warning", content: CRYPTO_WARNING },
   { title: "Regulatory Note", content: REGULATORY_NOTE },
 ];
+
+/**
+ * One footer link column. On desktop (md+) it renders as a static heading
+ * above an always-visible list — identical to the legacy layout. On mobile
+ * the heading becomes a tap target that expands/collapses its list (collapsed
+ * by default), so the footer is a short stack of ~6 headings instead of 70+
+ * stacked links. Every link stays in the DOM (CSS `hidden`, not unmounted),
+ * so crawlers still see them and desktop is unchanged.
+ */
+function FooterLinkSection({
+  title,
+  children,
+  className = "",
+}: {
+  title: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const listId = useId();
+  return (
+    <div className={className}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-controls={listId}
+        className="flex w-full items-center justify-between gap-2 mb-2 md:mb-3 md:pointer-events-none md:cursor-default"
+      >
+        <h4 className="text-white font-semibold text-xs md:text-sm">{title}</h4>
+        <svg
+          className={`w-4 h-4 shrink-0 text-slate-400 transition-transform duration-200 md:hidden ${open ? "rotate-180" : ""}`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+      <ul
+        id={listId}
+        className={`${open ? "block" : "hidden"} md:block space-y-1.5 md:space-y-2 text-xs md:text-sm`}
+      >
+        {children}
+      </ul>
+    </div>
+  );
+}
 
 export default function Footer() {
   const [openIndex, setOpenIndex] = useState<number | null>(null);
@@ -89,11 +139,11 @@ export default function Footer() {
       {/* Footer */}
       <footer className="bg-slate-800 text-slate-300">
         <div className="container-custom py-6 md:py-12">
-          {/* 6-column grid */}
-          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-4 md:gap-6">
+          {/* 6-column grid — link lists collapse per-section on mobile, stay open on desktop */}
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-x-4 gap-y-1 md:gap-6">
 
             {/* Brand */}
-            <div className="col-span-2 sm:col-span-3 md:col-span-1">
+            <div className="col-span-2 sm:col-span-3 md:col-span-1 mb-3 md:mb-0">
               <h3 className="text-white font-extrabold text-sm md:text-base mb-2 md:mb-3">
                 Invest<span className="text-amber-400">.com.au</span>
               </h3>
@@ -116,91 +166,78 @@ export default function Footer() {
             </div>
 
             {/* Browse Opportunities */}
-            <div>
-              <h4 className="text-white font-semibold mb-2 md:mb-3 text-xs md:text-sm">Browse Opportunities</h4>
-              <ul className="space-y-1.5 md:space-y-2 text-xs md:text-sm">
-                <li><Link href="/invest" className="hover:text-white transition-colors inline-block py-0.5">All Opportunities</Link></li>
-                <li><Link href="/invest/funds" className="hover:text-white transition-colors inline-block py-0.5">Fund Opportunities</Link></li>
-                <li><Link href="/foreign-investment/siv" className="hover:text-white transition-colors inline-block py-0.5">Significant Investor Visa</Link></li>
-                <li><Link href="/invest/mining" className="hover:text-white transition-colors inline-block py-0.5">Mining & Resources</Link></li>
-                <li><Link href="/invest/oil-gas" className="hover:text-white transition-colors inline-block py-0.5">Oil &amp; Gas (sector hub)</Link></li>
-                <li><Link href="/invest/lithium" className="hover:text-white transition-colors inline-block py-0.5">Lithium (sector hub)</Link></li>
-                <li><Link href="/invest/uranium" className="hover:text-white transition-colors inline-block py-0.5">Uranium (sector hub)</Link></li>
-                <li><Link href="/invest/hydrogen" className="hover:text-white transition-colors inline-block py-0.5">Hydrogen (sector hub)</Link></li>
-                <li><Link href="/invest/buy-business" className="hover:text-white transition-colors inline-block py-0.5">Buy a Business</Link></li>
-                <li><Link href="/invest/franchise" className="hover:text-white transition-colors inline-block py-0.5">Franchises</Link></li>
-                <li><Link href="/invest/farmland" className="hover:text-white transition-colors inline-block py-0.5">Farmland</Link></li>
-                <li><Link href="/invest/commercial-property" className="hover:text-white transition-colors inline-block py-0.5">Commercial Property</Link></li>
-                <li><Link href="/invest/renewable-energy" className="hover:text-white transition-colors inline-block py-0.5">Renewable Energy</Link></li>
-                <li><Link href="/invest/startups" className="hover:text-white transition-colors inline-block py-0.5">Startups & Tech</Link></li>
-                <li><Link href="/invest/private-credit" className="hover:text-white transition-colors inline-block py-0.5">Private Credit</Link></li>
-                <li><Link href="/invest/private-equity" className="hover:text-white transition-colors inline-block py-0.5">Private Equity</Link></li>
-                <li><Link href="/invest/pre-ipo" className="hover:text-white transition-colors inline-block py-0.5">Pre-IPO (Wholesale)</Link></li>
-                <li><Link href="/invest/royalties" className="hover:text-white transition-colors inline-block py-0.5">Royalties</Link></li>
-                <li><Link href="/invest/income-assets" className="hover:text-white transition-colors inline-block py-0.5">Income-Asset Businesses</Link></li>
-                <li><Link href="/invest/list" className="hover:text-white transition-colors inline-block py-0.5">List an Opportunity</Link></li>
-                <li><Link href="/sell-business" className="hover:text-white transition-colors inline-block py-0.5">Sell a Business</Link></li>
-              </ul>
-            </div>
+            <FooterLinkSection title="Browse Opportunities">
+              <li><Link href="/invest" className="hover:text-white transition-colors inline-block py-0.5">All Opportunities</Link></li>
+              <li><Link href="/invest/funds" className="hover:text-white transition-colors inline-block py-0.5">Fund Opportunities</Link></li>
+              <li><Link href="/foreign-investment/siv" className="hover:text-white transition-colors inline-block py-0.5">Significant Investor Visa</Link></li>
+              <li><Link href="/invest/mining" className="hover:text-white transition-colors inline-block py-0.5">Mining & Resources</Link></li>
+              <li><Link href="/invest/oil-gas" className="hover:text-white transition-colors inline-block py-0.5">Oil &amp; Gas (sector hub)</Link></li>
+              <li><Link href="/invest/lithium" className="hover:text-white transition-colors inline-block py-0.5">Lithium (sector hub)</Link></li>
+              <li><Link href="/invest/uranium" className="hover:text-white transition-colors inline-block py-0.5">Uranium (sector hub)</Link></li>
+              <li><Link href="/invest/hydrogen" className="hover:text-white transition-colors inline-block py-0.5">Hydrogen (sector hub)</Link></li>
+              <li><Link href="/invest/buy-business" className="hover:text-white transition-colors inline-block py-0.5">Buy a Business</Link></li>
+              <li><Link href="/invest/franchise" className="hover:text-white transition-colors inline-block py-0.5">Franchises</Link></li>
+              <li><Link href="/invest/farmland" className="hover:text-white transition-colors inline-block py-0.5">Farmland</Link></li>
+              <li><Link href="/invest/commercial-property" className="hover:text-white transition-colors inline-block py-0.5">Commercial Property</Link></li>
+              <li><Link href="/invest/renewable-energy" className="hover:text-white transition-colors inline-block py-0.5">Renewable Energy</Link></li>
+              <li><Link href="/invest/startups" className="hover:text-white transition-colors inline-block py-0.5">Startups & Tech</Link></li>
+              <li><Link href="/invest/private-credit" className="hover:text-white transition-colors inline-block py-0.5">Private Credit</Link></li>
+              <li><Link href="/invest/private-equity" className="hover:text-white transition-colors inline-block py-0.5">Private Equity</Link></li>
+              <li><Link href="/invest/pre-ipo" className="hover:text-white transition-colors inline-block py-0.5">Pre-IPO (Wholesale)</Link></li>
+              <li><Link href="/invest/royalties" className="hover:text-white transition-colors inline-block py-0.5">Royalties</Link></li>
+              <li><Link href="/invest/income-assets" className="hover:text-white transition-colors inline-block py-0.5">Income-Asset Businesses</Link></li>
+              <li><Link href="/invest/list" className="hover:text-white transition-colors inline-block py-0.5">List an Opportunity</Link></li>
+              <li><Link href="/sell-business" className="hover:text-white transition-colors inline-block py-0.5">Sell a Business</Link></li>
+            </FooterLinkSection>
 
             {/* Compare Platforms */}
-            <div>
-              <h4 className="text-white font-semibold mb-2 md:mb-3 text-xs md:text-sm">Compare Platforms</h4>
-              <ul className="space-y-1.5 md:space-y-2 text-xs md:text-sm">
-                <li><Link href="/compare" className="hover:text-white transition-colors inline-block py-0.5">Compare All</Link></li>
-                <li><Link href="/share-trading" className="hover:text-white transition-colors inline-block py-0.5">Share Trading</Link></li>
-                <li><Link href="/crypto" className="hover:text-white transition-colors inline-block py-0.5">Crypto Exchanges</Link></li>
-                <li><Link href="/super" className="hover:text-white transition-colors inline-block py-0.5">Super Funds</Link></li>
-                <li><Link href="/cfd" className="hover:text-white transition-colors inline-block py-0.5">CFD &amp; Forex</Link></li>
-                <li><Link href="/best/robo-advisors" className="hover:text-white transition-colors inline-block py-0.5">Robo-Advisors</Link></li>
-                <li><Link href="/savings" className="hover:text-white transition-colors inline-block py-0.5">Savings Accounts</Link></li>
-                <li><Link href="/etfs" className="hover:text-white transition-colors inline-block py-0.5">ETF Hub</Link></li>
-                <li><Link href="/dividends" className="hover:text-white transition-colors inline-block py-0.5">Dividend Hub</Link></li>
-                <li><Link href="/fee-tracker" className="hover:text-white transition-colors inline-block py-0.5">Fee Tracker</Link></li>
-                <li><Link href="/versus" className="hover:text-white transition-colors inline-block py-0.5">Head-to-Head</Link></li>
-                <li><Link href="/deals" className="hover:text-white transition-colors inline-block py-0.5">Deals</Link></li>
-              </ul>
-            </div>
+            <FooterLinkSection title="Compare Platforms">
+              <li><Link href="/compare" className="hover:text-white transition-colors inline-block py-0.5">Compare All</Link></li>
+              <li><Link href="/share-trading" className="hover:text-white transition-colors inline-block py-0.5">Share Trading</Link></li>
+              <li><Link href="/crypto" className="hover:text-white transition-colors inline-block py-0.5">Crypto Exchanges</Link></li>
+              <li><Link href="/super" className="hover:text-white transition-colors inline-block py-0.5">Super Funds</Link></li>
+              <li><Link href="/cfd" className="hover:text-white transition-colors inline-block py-0.5">CFD &amp; Forex</Link></li>
+              <li><Link href="/best/robo-advisors" className="hover:text-white transition-colors inline-block py-0.5">Robo-Advisors</Link></li>
+              <li><Link href="/savings" className="hover:text-white transition-colors inline-block py-0.5">Savings Accounts</Link></li>
+              <li><Link href="/etfs" className="hover:text-white transition-colors inline-block py-0.5">ETF Hub</Link></li>
+              <li><Link href="/dividends" className="hover:text-white transition-colors inline-block py-0.5">Dividend Hub</Link></li>
+              <li><Link href="/fee-tracker" className="hover:text-white transition-colors inline-block py-0.5">Fee Tracker</Link></li>
+              <li><Link href="/versus" className="hover:text-white transition-colors inline-block py-0.5">Head-to-Head</Link></li>
+              <li><Link href="/deals" className="hover:text-white transition-colors inline-block py-0.5">Deals</Link></li>
+            </FooterLinkSection>
 
-            {/* Find Experts & Property — own column */}
-            <div>
-              <h4 className="text-white font-semibold mb-2 md:mb-3 text-xs md:text-sm">Find Experts &amp; Property</h4>
-              <ul className="space-y-1.5 md:space-y-2 text-xs md:text-sm">
-                <li><Link href="/quotes/post" className="hover:text-white transition-colors inline-block py-0.5">Post a Request</Link></li>
-                <li><Link href="/get-matched" className="hover:text-white transition-colors inline-block py-0.5">Get Matched</Link></li>
-                <li><Link href="/find-advisor" className="hover:text-white transition-colors inline-block py-0.5">Find My Advisor — Free</Link></li>
-                <li><Link href="/advisors" className="hover:text-white transition-colors inline-block py-0.5">Advisor Directory</Link></li>
-                <li><Link href="/advisors?provider_type=firm" className="hover:text-white transition-colors inline-block py-0.5">Advisor Firms</Link></li>
-                <li><Link href="/advisors?provider_type=team" className="hover:text-white transition-colors inline-block py-0.5">Expert Teams</Link></li>
-                <li><Link href="/advisors/mortgage-brokers" className="hover:text-white transition-colors inline-block py-0.5">Mortgage Brokers</Link></li>
-                <li><Link href="/advisors/financial-planners" className="hover:text-white transition-colors inline-block py-0.5">Financial Planners</Link></li>
-                <li><Link href="/advisors/smsf-accountants" className="hover:text-white transition-colors inline-block py-0.5">SMSF Accountants</Link></li>
-                <li><Link href="/advisors/mining-lawyers" className="hover:text-white transition-colors inline-block py-0.5">Mining Lawyers</Link></li>
-                <li><Link href="/advisors/business-brokers" className="hover:text-white transition-colors inline-block py-0.5">Business Brokers</Link></li>
-                <li><Link href="/for-advisors" className="hover:text-white transition-colors inline-block py-0.5">List Your Practice</Link></li>
-                <li><Link href="/for-providers" className="hover:text-white transition-colors inline-block py-0.5">List Your Courses</Link></li>
-                <li><Link href="/listings/new" className="hover:text-white transition-colors inline-block py-0.5">List a Property or Business</Link></li>
-                <li><Link href="/listings" className="hover:text-white transition-colors inline-block py-0.5">Browse Listings</Link></li>
-              </ul>
-            </div>
+            {/* Find Experts & Property */}
+            <FooterLinkSection title="Find Experts & Property">
+              <li><Link href="/quotes/post" className="hover:text-white transition-colors inline-block py-0.5">Post a Request</Link></li>
+              <li><Link href="/get-matched" className="hover:text-white transition-colors inline-block py-0.5">Get Matched</Link></li>
+              <li><Link href="/find-advisor" className="hover:text-white transition-colors inline-block py-0.5">Find My Advisor — Free</Link></li>
+              <li><Link href="/advisors" className="hover:text-white transition-colors inline-block py-0.5">Advisor Directory</Link></li>
+              <li><Link href="/advisors?provider_type=firm" className="hover:text-white transition-colors inline-block py-0.5">Advisor Firms</Link></li>
+              <li><Link href="/advisors?provider_type=team" className="hover:text-white transition-colors inline-block py-0.5">Expert Teams</Link></li>
+              <li><Link href="/advisors/mortgage-brokers" className="hover:text-white transition-colors inline-block py-0.5">Mortgage Brokers</Link></li>
+              <li><Link href="/advisors/financial-planners" className="hover:text-white transition-colors inline-block py-0.5">Financial Planners</Link></li>
+              <li><Link href="/advisors/smsf-accountants" className="hover:text-white transition-colors inline-block py-0.5">SMSF Accountants</Link></li>
+              <li><Link href="/advisors/mining-lawyers" className="hover:text-white transition-colors inline-block py-0.5">Mining Lawyers</Link></li>
+              <li><Link href="/advisors/business-brokers" className="hover:text-white transition-colors inline-block py-0.5">Business Brokers</Link></li>
+              <li><Link href="/for-advisors" className="hover:text-white transition-colors inline-block py-0.5">List Your Practice</Link></li>
+              <li><Link href="/for-providers" className="hover:text-white transition-colors inline-block py-0.5">List Your Courses</Link></li>
+              <li><Link href="/listings/new" className="hover:text-white transition-colors inline-block py-0.5">List a Property or Business</Link></li>
+              <li><Link href="/listings" className="hover:text-white transition-colors inline-block py-0.5">Browse Listings</Link></li>
+            </FooterLinkSection>
 
-            {/* Property — own column */}
-            <div>
-              <h4 className="text-white font-semibold mb-2 md:mb-3 text-xs md:text-sm">Property</h4>
-              <ul className="space-y-1.5 md:space-y-2 text-xs md:text-sm">
-                <li><Link href="/property" className="hover:text-white transition-colors inline-block py-0.5">Property Hub</Link></li>
-                <li><Link href="/property/listings" className="hover:text-white transition-colors inline-block py-0.5">New Developments</Link></li>
-                <li><Link href="/property/buyer-agents" className="hover:text-white transition-colors inline-block py-0.5">Buyer&apos;s Agents</Link></li>
-                <li><Link href="/property/suburbs" className="hover:text-white transition-colors inline-block py-0.5">Suburb Research</Link></li>
-                <li><Link href="/property/finance" className="hover:text-white transition-colors inline-block py-0.5">Investment Loans</Link></li>
-                <li><Link href="/articles?category=property" className="hover:text-white transition-colors inline-block py-0.5">Property Guides</Link></li>
-              </ul>
-            </div>
+            {/* Property */}
+            <FooterLinkSection title="Property">
+              <li><Link href="/property" className="hover:text-white transition-colors inline-block py-0.5">Property Hub</Link></li>
+              <li><Link href="/property/listings" className="hover:text-white transition-colors inline-block py-0.5">New Developments</Link></li>
+              <li><Link href="/property/buyer-agents" className="hover:text-white transition-colors inline-block py-0.5">Buyer&apos;s Agents</Link></li>
+              <li><Link href="/property/suburbs" className="hover:text-white transition-colors inline-block py-0.5">Suburb Research</Link></li>
+              <li><Link href="/property/finance" className="hover:text-white transition-colors inline-block py-0.5">Investment Loans</Link></li>
+              <li><Link href="/articles?category=property" className="hover:text-white transition-colors inline-block py-0.5">Property Guides</Link></li>
+            </FooterLinkSection>
 
-            {/* Learn + About (consolidated) */}
+            {/* Learn + Company (consolidated column) */}
             <div>
-              <h4 className="text-white font-semibold mb-2 md:mb-3 text-xs md:text-sm">Learn</h4>
-              <ul className="space-y-1.5 md:space-y-2 text-xs md:text-sm mb-4 md:mb-5">
+              <FooterLinkSection title="Learn" className="mb-4 md:mb-5">
                 <li><Link href="/learn" className="hover:text-white transition-colors inline-block py-0.5">Learn to Invest</Link></li>
                 <li><Link href="/articles" className="hover:text-white transition-colors inline-block py-0.5">Articles &amp; Guides</Link></li>
                 <li><Link href="/community" className="hover:text-white transition-colors inline-block py-0.5">Community Forum</Link></li>
@@ -216,9 +253,8 @@ export default function Footer() {
                 <li><Link href="/calculators" className="hover:text-white transition-colors inline-block py-0.5">Calculators</Link></li>
                 <li><Link href="/glossary" className="hover:text-white transition-colors inline-block py-0.5">Glossary</Link></li>
                 <li><Link href="/get-matched" className="hover:text-white transition-colors inline-block py-0.5">Get Matched</Link></li>
-              </ul>
-              <h4 className="text-white font-semibold mb-2 md:mb-3 text-xs md:text-sm">Company</h4>
-              <ul className="space-y-1.5 md:space-y-2 text-xs md:text-sm">
+              </FooterLinkSection>
+              <FooterLinkSection title="Company">
                 <li><Link href="/about" className="hover:text-white transition-colors inline-block py-0.5">About Us</Link></li>
                 <li><Link href="/methodology" className="hover:text-white transition-colors inline-block py-0.5">Methodology</Link></li>
                 <li><Link href="/editorial-policy" className="hover:text-white transition-colors inline-block py-0.5">Editorial Policy</Link></li>
@@ -227,7 +263,7 @@ export default function Footer() {
                 <li><Link href="/contact" className="hover:text-white transition-colors inline-block py-0.5">Contact</Link></li>
                 <li><Link href="/advertise/featured-placement" className="hover:text-white transition-colors inline-block py-0.5">Advertise With Us</Link></li>
                 <li><Link href="/legal" className="hover:text-white transition-colors inline-block py-0.5">Legal</Link></li>
-              </ul>
+              </FooterLinkSection>
             </div>
           </div>
 


### PR DESCRIPTION
Addresses the F8 footer finding in `docs/plans/UX_UI_FINTECH_ALIGNMENT.md` — the "unscannable bloat" visible in the founder screenshot.

**Problem.** `components/Footer.tsx` carries ~70 links across six columns. On desktop that's a fine scannable sitemap; on mobile (`grid-cols-2`) it collapses into a very long, unscannable stack of links before the user reaches the copyright.

**Change.** A new `FooterLinkSection` client component wraps each link column: the heading becomes a tap target that expands/collapses its list — **collapsed by default on mobile, always open on desktop** (`md:block` + `md:pointer-events-none`, chevron is `md:hidden`, `aria-expanded`/`aria-controls` wired). The mobile footer is now a short stack of six tappable headings instead of seventy links.

**Safety / non-regression:**
- Every link and `href` is preserved verbatim; the desktop six-column grid is unchanged.
- Lists toggle via CSS `hidden` (not unmount), so all links stay in the DOM — crawlable, and desktop renders them exactly as before. No SEO/link-equity change.
- Legal banner, additional-disclosures accordion, brand column, ASIC registration and copyright are untouched.

**Deferred (founder calls):** the opinionated 4-bucket IA re-group (rest of F8) and the legal-accordion consolidation (F9) — these change *which* links live *where*, so they want a founder decision rather than an autonomous pick.

Validation: new `__tests__/components/Footer.test.tsx` (5 tests: collapsed-by-default, independent toggle, all links present in DOM, persistent warning) green; `eslint --max-warnings 0` clean; `tsc --noEmit` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdSEBPnPofJaBPhWy1dggf)_