### PR TITLE
feat(bots): AI journey suite v2 — full-signal crawl, form driver, lead flows, GHA workflow

### DIFF
--- a/.claude/commands/ai-journey.md
+++ b/.claude/commands/ai-journey.md
@@ -2,39 +2,140 @@
 description: Run the AI Journey — drive the live site as goal-directed personas (in-session, on the Max plan, no API key), verify findings, and write a report.
 ---
 
-You are running the **AI Journey** — the in-session, goal-directed bot exploration of the live site. Tooling lives in `bots/journey/ai-journey.cjs` (read `bots/journey/README.md`). Personas are in `bots/personas.ts` (`AI_PERSONAS`). Prior runs: `bots/reports/`.
+You are running the **AI Journey** — the in-session, goal-directed exploration of the live site. All tooling lives in `bots/journey/`. Read `bots/journey/README.md` for the full picture.
 
 **Cost model:** *you* (Claude) are the judgment brain, in-session on the user's Max plan — no Anthropic API key, no separate bill. The firewall keeps it safe.
 
-Args (optional, `$ARGUMENTS`): may name a persona (e.g. `first-home-buyer`), a target URL, or a free-text goal. If empty, run the three default `AI_PERSONAS`.
+Args (optional, `$ARGUMENTS`): may name a persona (e.g. `advice-seeker`), a target URL, a single flow (`journey`|`forms`|`leads`), or a free-text goal.
 
-Do this:
+---
 
-1. **Bootstrap first (the #1 reason a fresh run "doesn't work").** A freshly-cloned container has the npm package but **not** the Playwright browser binary, so `node …ai-journey.cjs` dies at launch with *"Executable doesn't exist … run npx playwright install"*. From the repo root:
-   ```bash
-   [ -d node_modules ] || npm ci          # install deps if missing
-   npx playwright install chromium        # idempotent — installs the browser binary
-   ```
-   If `npx playwright install` can't reach the CDN through a restricted network, say so and stop — the journey can't run without the browser.
+## Scripts
 
-2. **Target.** Default `JOURNEY_BASE=https://lambent-sawine-17c3dd.netlify.app` (the live Netlify deploy) unless the args / user give another (e.g. the Vercel URL once it's live). The harness sets `ignoreHTTPSErrors` for the sandbox TLS-MITM proxy and needs `NODE_PATH=node_modules`. Confirm the target is reachable first (`request.newContext({ignoreHTTPSErrors:true})` GET, expect 200).
+| Script | What it does |
+|--------|-------------|
+| `bots/journey/ai-journey.cjs` | Full-signal best-first link crawler. Captures UX, tap targets, SEO/meta, perf timing, a11y quick-scan, broken images, cookie banners. |
+| `bots/journey/ai-form.cjs` | Multi-step form driver (v2). Answers quiz questions, fills inputs, captures lead payloads, mocks Supabase auth. Works with any form URL via `FORM_*` env vars. |
+| `bots/journey/lead-flows.cjs` | Four end-to-end revenue flows (v2): get-matched quiz, adviser enquiry, broker comparison, account signup detection. Verifies lead payload is well-formed. |
+| `bots/journey/personas.cjs` | Standard persona definitions (CommonJS). `getPersona(name)` returns env var values for any script. |
 
-3. **Run** each persona (or the one in args):
-   ```bash
-   NODE_PATH=node_modules JOURNEY_NAME=<name> JOURNEY_START=<path> JOURNEY_STEPS=12 \
-   JOURNEY_GOAL="<the persona's goal>" JOURNEY_KEYWORDS="<comma,separated,goal,words>" \
-   node bots/journey/ai-journey.cjs
-   ```
-   The side-effect firewall is built in: on a live/**protected** target every payment, affiliate `/go/`, lead, email and account write is **mocked** (faithful to `bots/safety/money-paths.ts`). Never disable it against a live target. For completing a multi-step form (e.g. the get-matched quiz), use `bots/journey/ai-form.cjs` with the `FORM_*` env vars instead.
+---
 
-4. **Read it back + judge.** Open `/tmp/journey/<name>.json` and the per-step screenshots. Walk the journey as the persona: flag confusing flows, dead-ends, broken links, missing fee/risk disclosures, anything a real user trips over.
+## Step 1 — Bootstrap (the #1 reason a fresh run "doesn't work")
 
-5. **VERIFY before reporting (critical).** The sandbox network is flaky — a one-off `403`/`503`/`000` is usually transient. For every candidate finding, re-probe the route with retries (a small `request.newContext({ ignoreHTTPSErrors: true })` loop, 4–5 tries) and only call it real if the status is **consistent**. Discard transients. (The first run rejected ~6 false positives this way — don't cry wolf.)
+A freshly-cloned container has the npm package but **not** the Playwright browser binary. From the repo root:
+```bash
+[ -d node_modules ] || npm ci          # install deps if missing
+npx playwright install chromium        # idempotent — installs the browser binary
+```
+If `npx playwright install` can't reach the CDN (restricted network), say so and stop.
 
-6. **Compliance gate.** If a finding touches advice/recommendations, payments, capital-raising / securities, credit, or bank-data — **read `docs/strategy/REGULATORY-AVOID-LIST.md` first**. Those escalators are never-autonomous (Tier E): surface them, never "fix" by building or un-gating.
+---
 
-7. **Report + act.** Write a dated report to `bots/reports/ai-journey-<YYYY-MM-DD>.md` (plain-English: what ran, confirmed vs rejected, what's healthy). For real, unambiguous, in-scope bugs, fix per `docs/audits/MERGE_AUTHORIZATION.md` tiers and open a **draft PR**. For ambiguous / product / compliance decisions, ask the founder with `AskUserQuestion`.
+## Step 2 — Target
 
-8. **Summarise** to the user in plain English — the report path, key findings, and any screenshots worth surfacing via the file-send tool.
+Default `JOURNEY_BASE=https://lambent-sawine-17c3dd.netlify.app` (the Netlify preview mirror). The harness sets `ignoreHTTPSErrors` for sandbox TLS-MITM. Confirm the target is reachable first.
 
-Known limitation: the link-crawler follows **links**; full multi-step form completion (`ai-form.cjs`) needs a real network — in this sandbox the TLS-MITM proxy drops the quiz's async fetches, so point `FORM_BASE` at the Vercel deploy to run a flow to a result.
+**Important:** the sandbox TLS-MITM proxy drops async API fetches, so the quiz's `/api/get-matched/start` and `/resolve` will time out in the sandbox. For a complete form run, trigger the **GitHub Actions workflow** instead (see Step 5) — it runs on a clean GitHub runner with no proxy.
+
+---
+
+## Step 3 — Run (in-session, sandbox)
+
+**Link crawler** for a single persona:
+```bash
+NODE_PATH=node_modules \
+  JOURNEY_NAME=advice-seeker JOURNEY_START=/advisors \
+  JOURNEY_GOAL="Find a financial adviser near retirement" \
+  JOURNEY_KEYWORDS="adviser,retirement,super,contact" \
+  JOURNEY_VIEWPORT=desktop JOURNEY_STEPS=12 \
+  JOURNEY_OUT=/tmp/journey \
+  node bots/journey/ai-journey.cjs
+```
+
+Or load a persona from `personas.cjs`:
+```bash
+node -e "
+  const { getPersona } = require('./bots/journey/personas.cjs');
+  const p = getPersona('advice-seeker');
+  require('child_process').spawnSync('node', ['bots/journey/ai-journey.cjs'], {
+    env: { ...process.env, JOURNEY_NAME: p.name, JOURNEY_START: p.startPath,
+           JOURNEY_GOAL: p.goal, JOURNEY_KEYWORDS: p.keywords.join(','),
+           JOURNEY_VIEWPORT: p.viewport, JOURNEY_STEPS: String(p.steps),
+           JOURNEY_OUT: '/tmp/journey', NODE_PATH: 'node_modules' },
+    stdio: 'inherit',
+  });
+"
+```
+
+**Form driver** (works on sandbox for navigation, but quiz fetches may fail — use GHA for full run):
+```bash
+NODE_PATH=node_modules \
+  FORM_NAME=get-matched FORM_START=/get-matched \
+  FORM_GOAL="Complete the quiz as a long-term growth investor" \
+  FORM_KEYWORDS="long-term,growth,shares,etf,balanced,yes,high" \
+  FORM_VIEWPORT=desktop FORM_OUT=/tmp/journey \
+  node bots/journey/ai-form.cjs
+```
+
+**Lead flows** (all four: quiz + adviser enquiry + broker comparison + account signup):
+```bash
+NODE_PATH=node_modules LEAD_OUT=/tmp/journey node bots/journey/lead-flows.cjs
+```
+
+The side-effect firewall is built in: on any **live/protected** target every payment, affiliate `/go/`, lead, Supabase auth, and account write is **mocked**. Never disable it against a real target.
+
+---
+
+## Step 4 — Read it back and judge
+
+Open `/tmp/journey/<name>.json` and the per-step screenshots. Walk the journey as the persona:
+- Flag confusing flows, dead-ends, broken links, missing fee/risk disclosures
+- Check `tapViolationCount` on mobile runs (< 44 px is a real usability failure)
+- Check `a11y.imgsNoAlt`, `btnsNoName`, `inputsNoLabel` totals
+- Check `pagesWithoutCanonical`, `pagesWithoutMetaDesc` for SEO gaps
+- For lead flows: verify `advisorEnquiryWellFormed: true` in the summary
+
+---
+
+## Step 5 — Full run on GitHub Actions (bypasses TLS-MITM proxy)
+
+The **AI journey** workflow (`.github/workflows/ai-journey.yml`) runs the full suite on a clean GitHub runner — this is the only way to complete the quiz end-to-end in automation. Trigger it:
+
+- **Manual:** Actions → "AI journey" → "Run workflow" — pick target, flows, persona
+- **Automatic:** Fridays 16:00 UTC (weekly)
+
+Artifact `ai-journey-<run-id>` contains all JSON reports + screenshots. Download it and read with Claude.
+
+---
+
+## Step 6 — Verify before reporting (critical)
+
+The sandbox network is flaky — a one-off 403/503/000 is usually transient. For every candidate finding, re-probe with 4–5 retries (`request.newContext({ ignoreHTTPSErrors: true })`) and only call it real if the status is **consistent**. Discard transients.
+
+---
+
+## Step 7 — Compliance gate
+
+If a finding touches advice/recommendations, payments, capital-raising/securities, credit, or bank-data — **read `docs/strategy/REGULATORY-AVOID-LIST.md` first**. Those escalators are never-autonomous (Tier E): surface them, never fix by building or un-gating.
+
+---
+
+## Step 8 — Report + act
+
+Write a dated report to `bots/reports/ai-journey-<YYYY-MM-DD>.md`. For real, unambiguous, in-scope bugs, fix per `docs/audits/MERGE_AUTHORIZATION.md` tiers and open a **draft PR**. For ambiguous / product / compliance decisions, ask the founder.
+
+---
+
+## Personas
+
+| Name | Start | Viewport | Steps |
+|------|-------|----------|-------|
+| `new-investor` | `/` | desktop | 15 |
+| `advice-seeker` | `/advisors` | desktop | 12 |
+| `quiz-taker` | `/get-matched` | desktop | 14 |
+| `mobile-shopper` | `/` | mobile | 10 |
+| `first-home-buyer` | `/invest/property` | desktop | 12 |
+| `startup-investor` | `/invest/startups` | desktop | 12 |
+
+Full definitions: `bots/journey/personas.cjs`.

--- a/.github/workflows/ai-journey.yml
+++ b/.github/workflows/ai-journey.yml
@@ -1,0 +1,195 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# AI Journey workflow — runs the full in-session journey suite on a real GitHub
+# runner (clean network, no TLS-MITM proxy), which enables:
+#   • Full quiz completion — /api/get-matched start/answer/resolve go through
+#   • Multi-step form driving to a confirmed result screen
+#   • Lead payload capture and well-formedness verification
+#   • Broker comparison table rendering
+#   • Account signup flow detection
+#
+# Cost model: ZERO Anthropic spend — all journey scripts are deterministic
+# heuristic crawlers. Claude judges the JSON + screenshots in-session after
+# downloading the artifact. No API key required.
+#
+# Side-effect firewall is ALWAYS active: payments, Stripe, affiliate /go/,
+# lead writes, Supabase auth, and all non-functional API writes are mocked.
+# The quiz's own compute endpoints are allowed (they create only anonymous
+# session rows, no PII/payment).
+#
+# Schedules:
+#   • Weekly: Fridays 16:00 UTC (~02:00 AEST Saturday) — full suite
+#   • Manual: workflow_dispatch with target, flows, and persona overrides
+# ──────────────────────────────────────────────────────────────────────────────
+
+name: AI journey
+
+on:
+  schedule:
+    - cron: "0 16 * * 5"    # Fridays 16:00 UTC
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Target base URL (leave blank for Netlify preview)"
+        required: false
+      flows:
+        description: "Flows to run: all | journey | forms | leads"
+        required: false
+        default: "all"
+      persona:
+        description: "Single persona name to run (blank = run all)"
+        required: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ai-journey
+  cancel-in-progress: false
+
+jobs:
+  journey:
+    name: AI journey suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      # Resolve target: input → repo var → Netlify default
+      JOURNEY_BASE: ${{ github.event.inputs.target || vars.BOTS_TARGET_URL || 'https://lambent-sawine-17c3dd.netlify.app' }}
+      LEAD_BASE:    ${{ github.event.inputs.target || vars.BOTS_TARGET_URL || 'https://lambent-sawine-17c3dd.netlify.app' }}
+      FORM_BASE:    ${{ github.event.inputs.target || vars.BOTS_TARGET_URL || 'https://lambent-sawine-17c3dd.netlify.app' }}
+      JOURNEY_OUT:  /tmp/journey
+      LEAD_OUT:     /tmp/journey
+      FORM_OUT:     /tmp/journey
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Confirm target is reachable
+        run: |
+          TARGET="${{ github.event.inputs.target || vars.BOTS_TARGET_URL || 'https://lambent-sawine-17c3dd.netlify.app' }}"
+          echo "::notice::AI journey target: $TARGET"
+          curl -sf --max-time 15 "$TARGET" -o /dev/null \
+            && echo "::notice::Target reachable ✓" \
+            || echo "::warning::Target did not return 200 — journey will still run but results may show errors"
+
+      # ── A) Link crawler — one step per persona ──────────────────────────────
+
+      - name: Journey — new-investor (desktop)
+        if: >-
+          (github.event_name == 'schedule' ||
+           !inputs.flows || inputs.flows == 'all' || inputs.flows == 'journey') &&
+          (!inputs.persona || inputs.persona == 'new-investor')
+        continue-on-error: true
+        env:
+          JOURNEY_NAME: new-investor
+          JOURNEY_START: /
+          JOURNEY_GOAL: "Find and compare investment platforms suitable for a beginner and reach the point of opening an account. Flag anything confusing, broken, or missing fees/risk disclosures."
+          JOURNEY_KEYWORDS: compare,broker,shares,etf,fees,open account
+          JOURNEY_VIEWPORT: desktop
+          JOURNEY_STEPS: "15"
+        run: NODE_PATH=node_modules node bots/journey/ai-journey.cjs
+
+      - name: Journey — advice-seeker (desktop)
+        if: >-
+          (github.event_name == 'schedule' ||
+           !inputs.flows || inputs.flows == 'all' || inputs.flows == 'journey') &&
+          (!inputs.persona || inputs.persona == 'advice-seeker')
+        continue-on-error: true
+        env:
+          JOURNEY_NAME: advice-seeker
+          JOURNEY_START: /advisors
+          JOURNEY_GOAL: "Find a financial adviser who suits someone near retirement. Reach a point where I could make contact. Flag dead ends, confusing steps, or missing AFSL/fee disclosures."
+          JOURNEY_KEYWORDS: adviser,retirement,super,plan,contact,enquire
+          JOURNEY_VIEWPORT: desktop
+          JOURNEY_STEPS: "12"
+        run: NODE_PATH=node_modules node bots/journey/ai-journey.cjs
+
+      - name: Journey — quiz-taker (desktop)
+        if: >-
+          (github.event_name == 'schedule' ||
+           !inputs.flows || inputs.flows == 'all' || inputs.flows == 'journey') &&
+          (!inputs.persona || inputs.persona == 'quiz-taker')
+        continue-on-error: true
+        env:
+          JOURNEY_NAME: quiz-taker
+          JOURNEY_START: /get-matched
+          JOURNEY_GOAL: "Complete the get-matched quiz as a long-term growth investor and reach a personalised action plan. Judge whether the result is clear and trustworthy."
+          JOURNEY_KEYWORDS: long-term,growth,shares,etf,balanced,yes,high
+          JOURNEY_VIEWPORT: desktop
+          JOURNEY_STEPS: "14"
+        run: NODE_PATH=node_modules node bots/journey/ai-journey.cjs
+
+      - name: Journey — mobile-shopper (iPhone)
+        if: >-
+          (github.event_name == 'schedule' ||
+           !inputs.flows || inputs.flows == 'all' || inputs.flows == 'journey') &&
+          (!inputs.persona || inputs.persona == 'mobile-shopper')
+        continue-on-error: true
+        env:
+          JOURNEY_NAME: mobile-shopper
+          JOURNEY_START: /
+          JOURNEY_GOAL: "Compare investment platforms on mobile. Flag tap targets < 44 px, horizontal overflow, or anything hard to use on a phone."
+          JOURNEY_KEYWORDS: compare,broker,fees,account,open
+          JOURNEY_VIEWPORT: mobile
+          JOURNEY_STEPS: "10"
+        run: NODE_PATH=node_modules node bots/journey/ai-journey.cjs
+
+      # ── B) Form driver — get-matched quiz to result ─────────────────────────
+
+      - name: Form — get-matched quiz (desktop)
+        if: >-
+          github.event_name == 'schedule' ||
+          !inputs.flows || inputs.flows == 'all' || inputs.flows == 'forms'
+        continue-on-error: true
+        env:
+          FORM_NAME: get-matched-desktop
+          FORM_START: /get-matched
+          FORM_GOAL: "Complete the get-matched quiz as a long-term growth investor and reach a personalised action plan."
+          FORM_KEYWORDS: long-term,growth,shares,etf,balanced,yes,high
+          FORM_VIEWPORT: desktop
+          FORM_STEPS: "14"
+        run: NODE_PATH=node_modules node bots/journey/ai-form.cjs
+
+      - name: Form — get-matched quiz (mobile)
+        if: >-
+          github.event_name == 'schedule' ||
+          !inputs.flows || inputs.flows == 'all' || inputs.flows == 'forms'
+        continue-on-error: true
+        env:
+          FORM_NAME: get-matched-mobile
+          FORM_START: /get-matched
+          FORM_GOAL: "Complete the get-matched quiz on a mobile device and reach a result. Flag any tap-target issues or mobile layout problems."
+          FORM_KEYWORDS: long-term,growth,shares,etf,balanced
+          FORM_VIEWPORT: mobile
+          FORM_STEPS: "14"
+        run: NODE_PATH=node_modules node bots/journey/ai-form.cjs
+
+      # ── C) Lead flows — quiz + adviser enquiry + comparison + signup ─────────
+
+      - name: Lead flows (all four)
+        if: >-
+          github.event_name == 'schedule' ||
+          !inputs.flows || inputs.flows == 'all' || inputs.flows == 'leads'
+        continue-on-error: true
+        run: NODE_PATH=node_modules node bots/journey/lead-flows.cjs
+
+      # ── Upload all reports + screenshots ────────────────────────────────────
+
+      - name: Upload journey artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ai-journey-${{ github.run_id }}
+          path: /tmp/journey/**
+          if-no-files-found: warn
+          retention-days: 14

--- a/__tests__/integration/o-iter6.rls.int.test.ts
+++ b/__tests__/integration/o-iter6.rls.int.test.ts
@@ -37,7 +37,7 @@ import path from "node:path";
 
 const MIGRATION_PATH = path.join(
   process.cwd(),
-  "supabase/migrations/20260429_o_iter6_rls_forum.sql",
+  "supabase/migrations/archive/20260429_o_iter6_rls_forum.sql",
 );
 
 const FORUM_TABLES = [

--- a/__tests__/integration/o-iter7.rls.int.test.ts
+++ b/__tests__/integration/o-iter7.rls.int.test.ts
@@ -30,7 +30,7 @@ import path from "node:path";
 
 const MIGRATION_PATH = path.resolve(
   __dirname,
-  "../../supabase/migrations/20260429_o_iter7_rls_editorial_obs_secrets.sql",
+  "../../supabase/migrations/archive/20260429_o_iter7_rls_editorial_obs_secrets.sql",
 );
 const SQL = readFileSync(MIGRATION_PATH, "utf8");
 

--- a/__tests__/integration/o-iter8.rls.int.test.ts
+++ b/__tests__/integration/o-iter8.rls.int.test.ts
@@ -26,7 +26,7 @@ import path from "node:path";
 
 const MIGRATION_PATH = path.resolve(
   __dirname,
-  "../../supabase/migrations/20260501_o_iter8_rls_observability.sql",
+  "../../supabase/migrations/archive/20260501_o_iter8_rls_observability.sql",
 );
 const SQL = readFileSync(MIGRATION_PATH, "utf8");
 

--- a/__tests__/integration/quarterly-reports-rls.int.test.ts
+++ b/__tests__/integration/quarterly-reports-rls.int.test.ts
@@ -27,7 +27,7 @@ import path from "node:path";
 
 const MIGRATION_PATH = path.resolve(
   __dirname,
-  "../../supabase/migrations/20260501_c05b_quarterly_reports_rls.sql",
+  "../../supabase/migrations/archive/20260501_c05b_quarterly_reports_rls.sql",
 );
 const SQL = readFileSync(MIGRATION_PATH, "utf8");
 

--- a/bots/journey/ai-form.cjs
+++ b/bots/journey/ai-form.cjs
@@ -1,87 +1,162 @@
 /* eslint-disable */
 /**
- * Interactive form-journey driver (AI journey, phase 2).
+ * Interactive form-journey driver v2.
  *
- * The link-crawler (`ai-journey.cjs`) follows links; it cannot *drive* a
- * multi-step form. This driver completes a guided flow like the get-matched
- * quiz: at each step it answers the visible question (selecting an option /
- * filling an input), advances, and judges whether it reached a clear result —
- * all behind the side-effect firewall (leads / payments / affiliate / account
- * writes mocked, so no junk lead is created). Claude reads the captured steps +
- * screenshots and judges the result. In-session on the Max plan, no API key.
+ * Drives any multi-step form on the site to completion. At each step it
+ * observes the visible controls, answers the current question, advances,
+ * and judges whether it reached a clear result — all behind the side-effect
+ * firewall. Lead/enquiry POSTs are mocked AND their bodies captured so the
+ * payload can be verified without creating real records.
+ *
+ * Improvements over v1:
+ *   - Mobile / tablet / desktop viewport (FORM_VIEWPORT)
+ *   - Lead payload capture: intercepts + logs lead/enquiry POSTs
+ *   - Supabase auth endpoint mock (for signup/login flows)
+ *   - Modal + cookie-banner dismissal between every step
+ *   - Stagnation detection on URL + heading hash (not heading alone)
+ *   - Waits for network idle after advance clicks
+ *   - Console errors captured throughout
+ *
+ * Env vars:
+ *   FORM_BASE       Target origin (default: Netlify preview)
+ *   FORM_START      Start path (default: /get-matched)
+ *   FORM_NAME       Name used in output filenames
+ *   FORM_GOAL       Plain-text goal for the report
+ *   FORM_KEYWORDS   Comma-separated choice-alignment words
+ *   FORM_STEPS      Max steps before giving up (default: 14)
+ *   FORM_VIEWPORT   mobile | tablet | desktop (default: desktop)
+ *   FORM_OUT        Output directory (default: /tmp/journey)
  */
 const { chromium } = require("@playwright/test");
 const fs = require("fs");
 
-const BASE = process.env.FORM_BASE || "https://lambent-sawine-17c3dd.netlify.app";
-const START = process.env.FORM_START || "/get-matched";
-const NAME = process.env.FORM_NAME || "form";
-const GOAL = process.env.FORM_GOAL || "";
+const BASE     = process.env.FORM_BASE     || "https://lambent-sawine-17c3dd.netlify.app";
+const START    = process.env.FORM_START    || "/get-matched";
+const NAME     = process.env.FORM_NAME     || "form";
+const GOAL     = process.env.FORM_GOAL     || "";
 const KEYWORDS = (process.env.FORM_KEYWORDS || "long-term,growth,shares,etf,balanced")
   .split(",").map((s) => s.trim().toLowerCase()).filter(Boolean);
 const MAX_STEPS = parseInt(process.env.FORM_STEPS || "14", 10);
-const OUT = process.env.FORM_OUT || "/tmp/journey";
+const OUT      = process.env.FORM_OUT      || "/tmp/journey";
 fs.mkdirSync(OUT, { recursive: true });
 
-// Firewall — faithful to bots/safety/money-paths.ts (protected target).
-function shouldMock(url, method) {
-  let path; try { path = new URL(url, BASE).pathname; } catch { return false; }
-  const m = method.toUpperCase();
-  const WRITE = m === "POST" || m === "PUT" || m === "PATCH" || m === "DELETE";
-  if (/^\/go\//.test(path)) return "affiliate";
-  if (/^\/api\/(affiliate\/click|track-click|ab-track|drip-click|attribution\/touch|form-event|track-event)\b/.test(path)) return "affiliate";
-  if (/^\/api\/stripe\//.test(path) || /billing/i.test(path) || /checkout/i.test(path)) return "payment";
-  if (/^\/api\/(account\/holdings\/sharesight|org-auth\/stripe-connect|webhooks\/)/.test(path)) return "external";
-  if (/^\/api\/account\/(delete|documents)\b/.test(path)) return "destructive";
-  // Allow the feature-under-test's OWN functional endpoints — you can't drive a
-  // quiz whose start/answer/resolve calls you mock. These create only anonymous
-  // session/compute rows (no payment, no affiliate, no PII-lead); the final
-  // account "save" needs auth and 401s for our anon bot anyway.
-  if (/^\/api\/(get-matched|calculator|score|hub-quiz)\b/.test(path)) return false;
-  if (WRITE && /^\/api\//.test(path)) return "write";
-  return false;
+// ── Viewports ─────────────────────────────────────────────────────────────────
+const VIEWPORTS = {
+  mobile:  { width: 390,  height: 844,  isMobile: true,  hasTouch: true,
+             ua: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1" },
+  tablet:  { width: 820,  height: 1180, isMobile: true,  hasTouch: true,
+             ua: "Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1" },
+  desktop: { width: 1366, height: 900,  isMobile: false, hasTouch: false,
+             ua: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36" },
+};
+const VP = VIEWPORTS[(process.env.FORM_VIEWPORT || "desktop").toLowerCase()] || VIEWPORTS.desktop;
+
+// ── Side-effect firewall + lead capture ───────────────────────────────────────
+// Lead/enquiry/booking writes — mock AND capture the payload.
+const LEAD_WRITE = /^\/api\/(advisor-enquiry|advisor-lead|advisor-booking|sponsored-booking|booking|quiz-lead|submit-lead|lead-outcome|report-leads|developer-leads|answers\/ask|newsletter[\w/-]*|exit-intent-log)\b/;
+// Feature-under-test's own functional endpoints — allow through (real compute).
+const ALLOW = /^\/api\/(get-matched|calculator|score|hub-quiz|advisors?\/(search|filter))\b/;
+
+function classify(url, method) {
+  let path; try { path = new URL(url, BASE).pathname; } catch { return null; }
+  const WRITE = ["POST", "PUT", "PATCH", "DELETE"].includes(method.toUpperCase());
+  if (/^\/go\//.test(path)) return { cat: "affiliate" };
+  if (/^\/api\/(affiliate\/click|track-click|ab-track|drip-click|attribution\/touch|form-event|track-event)\b/.test(path)) return { cat: "affiliate" };
+  if (/^\/api\/stripe\//.test(path) || /billing/i.test(path) || /checkout/i.test(path)) return { cat: "payment" };
+  // Supabase auth — mock signup/login so no real account is created.
+  if (/supabase\.co\/auth\//.test(url)) return { cat: "auth", capture: WRITE };
+  if (LEAD_WRITE.test(path)) return { cat: "lead", capture: true, path };
+  if (ALLOW.test(path)) return null;
+  if (WRITE && /^\/api\//.test(path)) return { cat: "write" };
+  return null;
 }
 
-// Buttons that ADVANCE the flow (vs. answer it).
-const ADVANCE = /\b(next|continue|see (my )?results?|get (matched|started|my)|show (my )?|reveal|view (my )?plan|finish|submit|done|let'?s go|start|build (my )?plan|find)\b/i;
-// Things we must never click mid-quiz.
-const AVOID = /\b(back|previous|skip|cancel|close|log ?in|sign ?in|sign ?up|logout|home)\b/i;
+// ── Advance / avoid heuristics ────────────────────────────────────────────────
+const ADVANCE = /\b(next|continue|see (my )?results?|get (matched|started|my plan)|show (my )?|reveal|view (my )?plan|finish|submit|done|let'?s go|start|build (my )?plan|find (my )?match|send|confirm)\b/i;
+const AVOID   = /\b(back|previous|skip|cancel|close|log ?in|sign ?in|sign ?up|logout|home|dismiss|no thanks|maybe later)\b/i;
 
+// ── Observer (runs in browser context) ───────────────────────────────────────
 const observeFn = () => {
-  const vis = (el) => { const r = el.getBoundingClientRect(); const s = getComputedStyle(el); return r.width > 1 && r.height > 1 && s.visibility !== "hidden" && s.display !== "none" && s.opacity !== "0"; };
+  const vis = (el) => {
+    const r = el.getBoundingClientRect();
+    const s = getComputedStyle(el);
+    return r.width > 1 && r.height > 1 && s.visibility !== "hidden" && s.display !== "none" && s.opacity !== "0";
+  };
   const txt = (el) => (el && el.textContent || "").replace(/\s+/g, " ").trim();
-  const headings = [...document.querySelectorAll("h1,h2,h3,legend,[role=heading],[class*=question],[class*=step-title]")].filter(vis).map((h) => txt(h)).filter(Boolean).slice(0, 8);
+  const navAnc = (el) => !!el.closest("header,nav,footer,[role=navigation],[role=banner],[role=contentinfo]");
+
+  const headings = [...document.querySelectorAll("h1,h2,h3,legend,[role=heading],[class*=question],[class*=step-title]")]
+    .filter(vis).map((h) => txt(h)).filter(Boolean).slice(0, 8);
   const radios = [...document.querySelectorAll("input[type=radio],input[type=checkbox]")].filter(vis).length;
-  const choiceButtons = [...document.querySelectorAll("button,[role=button],[role=radio],[role=option],label")].filter(vis)
+  const choiceButtons = [...document.querySelectorAll("button,[role=button],[role=radio],[role=option],label")]
+    .filter(vis).filter((el) => !navAnc(el))
     .map((el) => txt(el) || el.getAttribute("aria-label") || "").filter(Boolean)
-    .filter((t) => !ADVANCE.test(t) && !AVOID.test(t)).slice(0, 14);
-  const advanceButtons = [...document.querySelectorAll("button,[role=button],a[role=button]")].filter(vis)
-    .map((el) => txt(el) || el.getAttribute("aria-label") || "").filter((t) => ADVANCE.test(t)).slice(0, 6);
+    .filter((t) => !/\b(next|continue|see (my )?results?|get (matched|started)|show|reveal|view|finish|submit|done|let'?s go|start|build|find|send|confirm)\b/i.test(t))
+    .filter((t) => !/\b(back|previous|skip|cancel|close|log ?in|sign ?in|sign ?up|logout|home|dismiss)\b/i.test(t))
+    .slice(0, 14);
+  const advanceButtons = [...document.querySelectorAll("button,[role=button],a[role=button]")]
+    .filter(vis).filter((el) => !navAnc(el))
+    .map((el) => txt(el) || el.getAttribute("aria-label") || "")
+    .filter((t) => /\b(next|continue|see (my )?results?|get (matched|started)|show|reveal|view|finish|submit|done|let'?s go|start|build|find|send|confirm)\b/i.test(t))
+    .slice(0, 6);
   const textInputs = [...document.querySelectorAll("input,select,textarea")].filter(vis)
     .filter((el) => !["radio", "checkbox", "hidden", "submit", "button"].includes((el.getAttribute("type") || el.tagName.toLowerCase())))
-    .map((el) => ({ type: el.getAttribute("type") || el.tagName.toLowerCase(), name: el.getAttribute("name") || el.id || "", ph: el.getAttribute("placeholder") || "" })).slice(0, 10);
+    .map((el) => ({ type: el.getAttribute("type") || el.tagName.toLowerCase(), name: el.getAttribute("name") || el.id || "", ph: el.getAttribute("placeholder") || "" }))
+    .slice(0, 10);
   const body = txt(document.body);
-  const isResult = /your (result|plan|match|score|recommendation)|recommended for you|based on your answers|action plan|personalised plan|here'?s what|your matches/i.test(body);
-  // Interactive controls that live in the MAIN content (not the global nav /
-  // header / footer) — so we don't mistake the site chrome for a form.
-  const navAncestor = (el) => el.closest("header,nav,footer,[role=navigation],[role=banner],[role=contentinfo]") !== null;
-  const contentControls = [...document.querySelectorAll("button,[role=button],[role=radio],[role=option],input[type=radio],input[type=checkbox],input[type=text],input[type=email],input[type=number],select,textarea")].filter(vis).filter((el) => !navAncestor(el)).length;
-  // A degraded / fallback / error state means there is no quiz to drive here.
+  const isResult = /your (result|plan|match|score|recommendation)|recommended for you|based on your answers|action plan|personalised plan|here.?s what|your matches|matched you with|get started with/i.test(body);
+  const contentControls = [...document.querySelectorAll("button,[role=button],[role=radio],[role=option],input[type=radio],input[type=checkbox],input[type=text],input[type=email],input[type=number],select,textarea")]
+    .filter(vis).filter((el) => !navAnc(el)).length;
   const errorState = /ran into a problem|failed to start|not sure where to start|no accounts matched|browse comparisons instead|something went wrong|please try again/i.test(body);
-  return { url: location.href, title: document.title, headings, radios, choiceButtons, advanceButtons, textInputs, bodyLen: body.length, isResult, contentControls, errorState, bodySample: body.slice(0, 600) };
+  // Detect modal/overlay that might need dismissal.
+  const hasModal = !!document.querySelector("[role=dialog],[aria-modal=true],[class*=modal],[class*=overlay],[class*=sheet]");
+  // OTP / verification prompt.
+  const hasOtp = /verify your email|check your email|confirmation code|enter the code|sent you a code/i.test(body);
+  return { url: location.href, title: document.title, headings, radios, choiceButtons, advanceButtons, textInputs, bodyLen: body.length, isResult, contentControls, errorState, hasModal, hasOtp, bodySample: body.slice(0, 600) };
 };
 
-async function fillTextInputs(page, kw) {
+// ── Modal dismissal ───────────────────────────────────────────────────────────
+async function dismissModals(page) {
+  // Cookie / consent banner — decline or close.
+  for (const sel of [
+    'button:has-text("Accept")', 'button:has-text("Decline")',
+    'button:has-text("Got it")', 'button:has-text("OK")',
+    '[aria-label*="close" i]', '[aria-label*="dismiss" i]',
+    'button:has-text("No thanks")', 'button:has-text("Maybe later")',
+  ]) {
+    const el = page.locator(sel).first();
+    if (await el.count().catch(() => 0) > 0) {
+      await el.click({ timeout: 2000 }).catch(() => {});
+      await page.waitForTimeout(400);
+    }
+  }
+}
+
+// ── Fill visible text / number / select inputs ─────────────────────────────
+async function fillTextInputs(page, keywords) {
   const inputs = page.locator("input:visible, textarea:visible, select:visible");
   const n = await inputs.count().catch(() => 0);
   let filled = 0;
   for (let i = 0; i < n; i++) {
     const el = inputs.nth(i);
-    const type = (await el.getAttribute("type").catch(() => "")) || (await el.evaluate((e) => e.tagName.toLowerCase()).catch(() => ""));
+    const type = (await el.getAttribute("type").catch(() => "")) ||
+      (await el.evaluate((e) => e.tagName.toLowerCase()).catch(() => ""));
     if (["radio", "checkbox", "hidden", "submit", "button"].includes(type)) continue;
     try {
-      if (type === "select" || type === "select-one") { await el.selectOption({ index: 1 }).catch(() => {}); filled++; continue; }
-      const val = type === "email" ? "qa-bot@example.com" : type === "number" ? "50000" : type === "tel" ? "0400000000" : "Test";
+      if (type === "select" || type === "select-one") {
+        await el.selectOption({ index: 1 }).catch(() => {});
+        filled++;
+        continue;
+      }
+      const ph = (await el.getAttribute("placeholder").catch(() => "")) || "";
+      const nm = (await el.getAttribute("name").catch(() => "")) || (await el.getAttribute("id").catch(() => "")) || "";
+      const val =
+        type === "email"  ? "qa-bot@example.com" :
+        type === "number" ? "50000" :
+        type === "tel"    ? "0400000000" :
+        /password/i.test(nm) ? "TestPass123!" :
+        /name|full/i.test(nm + ph) ? "QA Bot" :
+        keywords.length > 0 ? "Build long-term wealth" : "Test";
       const cur = await el.inputValue().catch(() => "");
       if (!cur) { await el.fill(val).catch(() => {}); filled++; }
     } catch {}
@@ -91,33 +166,66 @@ async function fillTextInputs(page, kw) {
 
 (async () => {
   const browser = await chromium.launch({ args: ["--no-sandbox"] });
-  const ctx = await browser.newContext({ ignoreHTTPSErrors: true, viewport: { width: 1366, height: 1000 } });
-  await ctx.addInitScript(() => { try { localStorage.setItem("user_onboarding_seen", "true"); localStorage.setItem("cookie-consent", "declined"); localStorage.setItem("inv_cookie_consent", "declined"); } catch {} });
-  const mocked = [];
+  const ctx = await browser.newContext({
+    ignoreHTTPSErrors: true,
+    viewport: { width: VP.width, height: VP.height },
+    isMobile: VP.isMobile,
+    hasTouch: VP.hasTouch,
+    userAgent: VP.ua,
+  });
+  await ctx.addInitScript(() => {
+    try {
+      localStorage.setItem("user_onboarding_seen", "true");
+      ["cookie-consent", "inv_cookie_consent", "cookie_consent"].forEach((k) => localStorage.setItem(k, "declined"));
+    } catch {}
+  });
+
+  const leads = [];
+  const mocked = {};
   await ctx.route("**/*", (route) => {
     const req = route.request();
-    const cat = shouldMock(req.url(), req.method());
-    if (cat) {
-      let p = "?"; try { p = new URL(req.url(), BASE).pathname; } catch {}
-      mocked.push({ category: cat, method: req.method(), path: p });
-      if (cat === "affiliate" && req.method() === "GET") return route.fulfill({ status: 200, contentType: "text/html", body: "<!doctype html><title>Mocked</title>" });
-      return route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, mocked: true }) });
+    const c = classify(req.url(), req.method());
+    if (!c) return route.continue();
+    mocked[c.cat] = (mocked[c.cat] || 0) + 1;
+    if (c.capture) {
+      let body = null;
+      try { body = JSON.parse(req.postData() || "null"); } catch { body = (req.postData() || "").slice(0, 400); }
+      leads.push({ cat: c.cat, path: c.path || req.url(), method: req.method(), body });
     }
-    return route.continue();
+    if (c.cat === "auth") {
+      return route.fulfill({
+        status: 200, contentType: "application/json",
+        body: JSON.stringify({ access_token: "mock-token", token_type: "bearer", expires_in: 3600, refresh_token: "mock-refresh",
+          user: { id: "mock-user-id", email: "qa-bot@example.com", email_confirmed_at: new Date().toISOString() } }),
+      });
+    }
+    if (c.cat === "affiliate" && req.method() === "GET") {
+      return route.fulfill({ status: 200, contentType: "text/html", body: "<!doctype html><title>Mocked</title>" });
+    }
+    return route.fulfill({ status: 200, contentType: "application/json",
+      body: JSON.stringify({ ok: true, id: "mock-" + (leads.length || mocked[c.cat]), mocked: true }) });
   });
+
   const page = await ctx.newPage();
   const consoleErrors = [];
-  page.on("console", (m) => { if (m.type() === "error" && !/SSL certificate|ERR_CERT|net::ERR/i.test(m.text())) consoleErrors.push(m.text().slice(0, 160)); });
+  page.on("console", (m) => {
+    if (m.type() === "error" && !/SSL certificate|ERR_CERT|net::ERR/i.test(m.text()))
+      consoleErrors.push(m.text().slice(0, 160));
+  });
 
   await page.goto(BASE + START, { waitUntil: "domcontentloaded", timeout: 30000 }).catch(() => {});
   await page.waitForTimeout(1800);
+  await dismissModals(page);
 
   const steps = [];
   let prevSig = "";
   let stagnant = 0;
 
   for (let i = 0; i < MAX_STEPS; i++) {
-    let obs; try { obs = await page.evaluate(observeFn); } catch { obs = { url: page.url(), headings: [], choiceButtons: [], advanceButtons: [], textInputs: [], radios: 0 }; }
+    let obs;
+    try { obs = await page.evaluate(observeFn); }
+    catch { obs = { url: page.url(), headings: [], choiceButtons: [], advanceButtons: [], textInputs: [], radios: 0, hasModal: false, hasOtp: false }; }
+
     const shot = `${OUT}/${NAME}-step-${i}.png`;
     try { await page.screenshot({ path: shot, fullPage: true }); } catch {}
 
@@ -125,32 +233,44 @@ async function fillTextInputs(page, kw) {
     if (sig === prevSig) stagnant++; else stagnant = 0;
     prevSig = sig;
 
-    // No drivable form here (error/fallback/degraded, or only site-chrome
-    // controls)? Record it and stop — don't spin clicking the global nav.
-    if (!obs.isResult && (obs.errorState || (obs.contentControls || 0) === 0)) {
-      steps.push({ step: i, url: obs.url, headings: obs.headings, errorState: obs.errorState, contentControls: obs.contentControls, isResult: false, note: "no drivable interactive form (error/fallback/nav-only) — stopped", bodySample: obs.bodySample, screenshot: shot });
+    // OTP / email-verification wall — can't proceed without real credentials.
+    if (obs.hasOtp) {
+      steps.push({ step: i, url: obs.url, headings: obs.headings, isResult: false,
+        note: "OTP / email-verification prompt — cannot proceed (mocked auth, no real email)", screenshot: shot });
       console.log(`\n── step ${i}  ${obs.url}`);
-      console.log(`   Q: ${(obs.headings || [])[0] || "(no heading)"}`);
-      console.log(`   ⏹ no drivable form here (errorState=${obs.errorState}, contentControls=${obs.contentControls}) — stopping cleanly`);
+      console.log("   ⏹ OTP verification wall — stopping cleanly");
       break;
     }
 
-    // ── Decide + act ──────────────────────────────────────────────────────
+    // No drivable form (error/fallback/nav-only).
+    if (!obs.isResult && (obs.errorState || (obs.contentControls || 0) === 0)) {
+      steps.push({ step: i, url: obs.url, headings: obs.headings, errorState: obs.errorState,
+        contentControls: obs.contentControls, isResult: false,
+        note: "no drivable interactive form (error/fallback/nav-only) — stopped", bodySample: obs.bodySample, screenshot: shot });
+      console.log(`\n── step ${i}  ${obs.url}`);
+      console.log(`   ⏹ no drivable form (errorState=${obs.errorState}, contentControls=${obs.contentControls}) — stopping`);
+      break;
+    }
+
+    // ── Decide + act ─────────────────────────────────────────────────────────
     const actions = [];
-    // 1) fill any text inputs (email/number/etc.)
+
+    // 1) Dismiss any modal that appeared.
+    if (obs.hasModal) { await dismissModals(page); actions.push("dismissed modal"); }
+
+    // 2) Fill text / number / select inputs.
     const filled = await fillTextInputs(page, KEYWORDS);
     if (filled) actions.push(`filled ${filled} input(s)`);
 
-    // 2) answer: prefer a goal-aligned choice, else the first choice (radio/option/label/button).
+    // 3) Answer: prefer goal-aligned choice, else first choice.
     let answered = false;
     const radioCount = await page.locator("input[type=radio]:visible").count().catch(() => 0);
     if (radioCount > 0) {
-      // check the first not-yet-checked radio (one question group per step is the common case)
       const r = page.locator("input[type=radio]:visible").first();
       await r.check({ force: true, timeout: 3000 }).catch(() => {});
-      answered = true; actions.push("checked a radio option");
+      answered = true;
+      actions.push("checked first radio");
     } else {
-      // option-style: clickable elements that are NOT advance/avoid buttons
       const opts = page.locator("button:visible, [role=radio]:visible, [role=option]:visible, label:visible");
       const oc = await opts.count().catch(() => 0);
       let pick = -1, fallback = -1;
@@ -161,21 +281,36 @@ async function fillTextInputs(page, kw) {
         if (KEYWORDS.some((kw) => t.toLowerCase().includes(kw))) { pick = k; break; }
       }
       const idx = pick >= 0 ? pick : fallback;
-      if (idx >= 0) { const t = ((await opts.nth(idx).innerText().catch(() => "")) || "").replace(/\s+/g, " ").trim(); await opts.nth(idx).click({ timeout: 3000 }).catch(() => {}); answered = true; actions.push(`picked option "${t.slice(0, 40)}"`); }
+      if (idx >= 0) {
+        const t = ((await opts.nth(idx).innerText().catch(() => "")) || "").replace(/\s+/g, " ").trim();
+        await opts.nth(idx).click({ timeout: 3000 }).catch(() => {});
+        answered = true;
+        actions.push(`picked option "${t.slice(0, 40)}"`);
+      }
     }
 
     await page.waitForTimeout(600);
 
-    // 3) advance
+    // 4) Advance.
     let advanced = false;
     const adv = page.getByRole("button", { name: ADVANCE }).filter({ hasNotText: AVOID });
     if (await adv.count().catch(() => 0) > 0) {
       await adv.first().click({ timeout: 3000 }).catch(() => {});
-      advanced = true; actions.push("clicked advance");
+      advanced = true;
+      actions.push("clicked advance");
     }
-    await page.waitForTimeout(1500);
 
-    steps.push({ step: i, url: obs.url, headings: obs.headings, radios: obs.radios, choiceButtons: obs.choiceButtons, advanceButtons: obs.advanceButtons, textInputs: obs.textInputs, isResult: obs.isResult, bodyLen: obs.bodyLen, bodySample: obs.bodySample, actions, screenshot: shot });
+    // Wait for network settle (up to 2.5 s) then a short fixed pause.
+    await page.waitForLoadState("networkidle", { timeout: 2500 }).catch(() => {});
+    await page.waitForTimeout(800);
+
+    steps.push({
+      step: i, url: obs.url, headings: obs.headings,
+      radios: obs.radios, choiceButtons: obs.choiceButtons,
+      advanceButtons: obs.advanceButtons, textInputs: obs.textInputs,
+      isResult: obs.isResult, bodyLen: obs.bodyLen, bodySample: obs.bodySample,
+      actions, screenshot: shot,
+    });
 
     console.log(`\n── step ${i}  ${obs.url}`);
     console.log(`   Q: ${(obs.headings || [])[0] || "(no heading)"}`);
@@ -187,8 +322,21 @@ async function fillTextInputs(page, kw) {
   }
 
   await browser.close();
-  const summary = { name: NAME, goal: GOAL, base: BASE, start: START, steps: steps.length, reachedResult: steps.some((s) => s.isResult), consoleErrors: [...new Set(consoleErrors)], mockedTotal: mocked.length, mockedByCategory: mocked.reduce((a, m) => ((a[m.category] = (a[m.category] || 0) + 1), a), {}) };
+
+  const summary = {
+    name: NAME,
+    goal: GOAL,
+    base: BASE,
+    start: START,
+    viewport: process.env.FORM_VIEWPORT || "desktop",
+    steps: steps.length,
+    reachedResult: steps.some((s) => s.isResult),
+    consoleErrors: [...new Set(consoleErrors)],
+    leadsCapture: { total: leads.length, byCategory: leads.reduce((a, l) => ((a[l.cat] = (a[l.cat] || 0) + 1), a), {}), samples: leads.slice(0, 3) },
+    mockedByCategory: mocked,
+  };
+
   fs.writeFileSync(`${OUT}/${NAME}.json`, JSON.stringify({ summary, steps }, null, 2));
-  console.log(`\n=== FORM JOURNEY COMPLETE: ${NAME} — ${steps.length} steps, reachedResult=${summary.reachedResult} ===`);
+  console.log(`\n=== FORM JOURNEY v2 COMPLETE: ${NAME} — ${steps.length} steps, reachedResult=${summary.reachedResult} ===`);
   console.log(JSON.stringify(summary, null, 2));
 })().catch((e) => { console.error("FATAL", e); process.exit(1); });

--- a/bots/journey/ai-journey.cjs
+++ b/bots/journey/ai-journey.cjs
@@ -1,55 +1,81 @@
 /* eslint-disable */
 /**
- * In-session AI journey harness (v3 — resilient best-first crawl).
+ * In-session AI journey harness (v4 — full-signal best-first crawl).
  *
- * Drives a real browser against the live (PROTECTED) site as a persona, with the
- * money-path firewall mocking every side-effecting request (payments, affiliate
- * /go/ redirects, leads, emails, account writes). Goal-directed best-first crawl
- * with retry-on-transient + backtracking, so flaky-proxy hiccups and dead-ends
- * don't derail the walk. Captures observations + screenshots + interceptions to
- * disk; Claude (in-session, on Max) reads it back and judges it like a real user.
- * No Anthropic API key, no separate bill.
+ * Drives a real browser against the live site as a persona. Captures:
+ *   - UX observations (headings, CTAs, forms, buttons)
+ *   - Tap-target size violations (< 44 px on mobile)
+ *   - SEO/meta signals (canonical, og:title, description, JSON-LD presence)
+ *   - Performance (navigation timing: TTFB, DOMContentLoaded, load)
+ *   - A11y quick-scan (images without alt, buttons without accessible name)
+ *   - Broken images (naturalWidth === 0 after load)
+ *   - Cookie banner detection
+ *   - Console errors + failed API responses
+ *
+ * Goal-directed best-first crawl with retry-on-transient + backtracking.
+ * Claude (in-session, on Max plan) reads the JSON + screenshots and judges
+ * like a real user. No Anthropic API key. No separate bill.
+ *
+ * Env vars:
+ *   JOURNEY_BASE       Target origin (default: Netlify preview)
+ *   JOURNEY_START      Start path (default: /)
+ *   JOURNEY_NAME       Persona name used in output filenames
+ *   JOURNEY_GOAL       Plain-text goal for the report
+ *   JOURNEY_KEYWORDS   Comma-separated terms that score links higher
+ *   JOURNEY_STEPS      Max pages to visit (default: 15)
+ *   JOURNEY_VIEWPORT   mobile | tablet | desktop (default: desktop)
+ *   JOURNEY_OUT        Output directory (default: /tmp/journey)
+ *   JOURNEY_ALLOW_WRITES  Set to "1" to allow non-payment API writes
+ *                         (use against a sandbox deploy, not production)
  */
 const { chromium } = require("@playwright/test");
 const fs = require("fs");
 
-const BASE = process.env.JOURNEY_BASE || "https://lambent-sawine-17c3dd.netlify.app";
-const START = process.env.JOURNEY_START || "/";
-const NAME = process.env.JOURNEY_NAME || "persona";
-const GOAL = process.env.JOURNEY_GOAL || "";
-const KEYWORDS = (process.env.JOURNEY_KEYWORDS || "")
+const BASE        = process.env.JOURNEY_BASE     || "https://lambent-sawine-17c3dd.netlify.app";
+const START       = process.env.JOURNEY_START    || "/";
+const NAME        = process.env.JOURNEY_NAME     || "persona";
+const GOAL        = process.env.JOURNEY_GOAL     || "";
+const KEYWORDS    = (process.env.JOURNEY_KEYWORDS || "")
   .split(",").map((s) => s.trim().toLowerCase()).filter(Boolean);
-const MAX_STEPS = parseInt(process.env.JOURNEY_STEPS || "10", 10);
-const OUT = process.env.JOURNEY_OUT || "/tmp/journey";
+const MAX_STEPS   = parseInt(process.env.JOURNEY_STEPS || "15", 10);
+const ALLOW_WRITES = process.env.JOURNEY_ALLOW_WRITES === "1";
+const OUT         = process.env.JOURNEY_OUT      || "/tmp/journey";
 fs.mkdirSync(OUT, { recursive: true });
 
-// ── Viewport: JOURNEY_VIEWPORT=mobile|tablet|desktop (default desktop). Lets the
-// UX/UI pass exercise responsive layouts (nav collapse, tap targets, reflow).
+// ── Viewports ────────────────────────────────────────────────────────────────
 const VIEWPORTS = {
-  mobile: { width: 390, height: 844, ua: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1", isMobile: true },
-  tablet: { width: 820, height: 1180, ua: "Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1", isMobile: true },
-  desktop: { width: 1366, height: 900, ua: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36", isMobile: false },
+  mobile:  { width: 390,  height: 844,  isMobile: true,  hasTouch: true,
+             ua: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1" },
+  tablet:  { width: 820,  height: 1180, isMobile: true,  hasTouch: true,
+             ua: "Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1" },
+  desktop: { width: 1366, height: 900,  isMobile: false, hasTouch: false,
+             ua: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36" },
 };
 const VP = VIEWPORTS[(process.env.JOURNEY_VIEWPORT || "desktop").toLowerCase()] || VIEWPORTS.desktop;
+const IS_MOBILE = VP.isMobile;
 
-// ── Protective firewall (PROTECTED target). Faithful to bots/safety/money-paths.ts.
+// ── Side-effect firewall ─────────────────────────────────────────────────────
 function shouldMock(url, method) {
-  let path;
-  try { path = new URL(url, BASE).pathname; } catch { return false; }
+  let path; try { path = new URL(url, BASE).pathname; } catch { return false; }
   const m = method.toUpperCase();
   const WRITE = m === "POST" || m === "PUT" || m === "PATCH" || m === "DELETE";
+  // Always mock — regardless of allow-writes mode.
   if (/^\/go\//.test(path)) return "affiliate";
   if (/^\/api\/(affiliate\/click|track-click|ab-track|drip-click|attribution\/touch|form-event|track-event)\b/.test(path)) return "affiliate";
   if (/^\/api\/stripe\//.test(path) || /billing/i.test(path) || /checkout/i.test(path)) return "payment";
   if (/^\/api\/(account\/holdings\/sharesight|org-auth\/stripe-connect|webhooks\/)/.test(path)) return "external";
   if (/^\/api\/account\/(delete|documents)\b/.test(path)) return "destructive";
-  if (WRITE && /^\/api\//.test(path)) return "write";
+  // Conditionally allow writes when JOURNEY_ALLOW_WRITES=1 (sandbox target).
+  if (WRITE && /^\/api\//.test(path)) return ALLOW_WRITES ? false : "write";
   return false;
 }
 
-const SKIP_LINK = /(\/go\/|logout|sign[-\s]?out|signout|\/auth\/|delete|unsubscribe|mailto:|tel:|\.pdf$|^#|^javascript:)/i;
+// ── Helpers ──────────────────────────────────────────────────────────────────
+const SKIP_LINK  = /(\/go\/|logout|sign[-\s]?out|signout|\/auth\/|delete|unsubscribe|mailto:|tel:|\.pdf$|^#|^javascript:)/i;
 const PROXY_NOISE = /SSL certificate|ERR_CERT|net::ERR|Failed to load resource.*(net::|status of 4)|chrome-error/i;
-const CTA = ["compare", "get started", "get matched", "find", "match", "open account", "open an account", "book", "view", "see all", "browse", "start", "calculate", "quiz", "next", "continue", "apply", "join", "explore", "learn more", "choose", "review"];
+const CTA = ["compare","get started","get matched","find","match","open account","book","view","see all",
+             "browse","start","calculate","quiz","next","continue","apply","join","explore","learn more",
+             "choose","review","connect","contact","enquire","send"];
 
 function sameOrigin(href) {
   if (!href) return false;
@@ -68,17 +94,19 @@ function scoreLink(l) {
   return s;
 }
 
-const observeFn = () => {
+// ── Full-signal page observer (runs in browser context) ───────────────────────
+const observeFn = (isMobile) => {
   const txt = (el) => (el && el.textContent || "").replace(/\s+/g, " ").trim();
   const vis = (el) => {
     const r = el.getBoundingClientRect();
     const s = getComputedStyle(el);
     return r.width > 1 && r.height > 1 && s.visibility !== "hidden" && s.display !== "none" && s.opacity !== "0";
   };
+
+  // ── Core UX ────────────────────────────────────────────────────────────────
   const headings = [...document.querySelectorAll("h1,h2")].filter(vis).map((h) => h.tagName + ": " + txt(h)).slice(0, 30);
   const links = [...document.querySelectorAll("a[href]")].filter(vis)
-    .map((a) => ({ text: txt(a).slice(0, 80), href: a.getAttribute("href") }))
-    .filter((l) => l.text && l.href);
+    .map((a) => ({ text: txt(a).slice(0, 80), href: a.getAttribute("href") })).filter((l) => l.text && l.href);
   const buttons = [...document.querySelectorAll("button,[role=button],input[type=submit]")].filter(vis)
     .map((b) => txt(b) || b.getAttribute("aria-label") || "").filter(Boolean).slice(0, 30);
   const fields = [...document.querySelectorAll("input,select,textarea")].filter(vis)
@@ -86,20 +114,79 @@ const observeFn = () => {
   const conversionCtas = links.filter((l) => /^\/go\//.test(l.href)).map((l) => ({ text: l.text, href: l.href })).slice(0, 20);
   const h1 = txt(document.querySelector("h1"));
   const bodyText = txt(document.body);
-  const notFound = /404|page not found/i.test(document.title) || /404|page not found|doesn.?t exist|no longer available/i.test(h1);
-  const emptyish = bodyText.length < 350;
+  const notFound   = /404|page not found/i.test(document.title) || /404|page not found|doesn.?t exist|no longer available/i.test(h1);
+  const emptyish   = bodyText.length < 350;
   const mentionsFees = /\bfees?\b|\bbrokerage\b|\$\s?\d|per trade|monthly fee|management fee/i.test(bodyText);
   const mentionsRisk = /\brisk\b|capital at risk|may lose|not (financial|personal) advice|general (advice|information)/i.test(bodyText);
-  return { url: location.href, title: document.title, h1, headings, links, buttons, fields, conversionCtas, notFound, emptyish, mentionsFees, mentionsRisk, bodyLen: bodyText.length, bodyTextSample: bodyText.slice(0, 1200) };
+
+  // ── Tap-target size check (mobile only) ───────────────────────────────────
+  const TAP_MIN = 44;
+  const tapViolations = isMobile
+    ? [...document.querySelectorAll("a,button,[role=button],[role=link]")].filter(vis).reduce((acc, el) => {
+        const r = el.getBoundingClientRect();
+        if (r.width < TAP_MIN || r.height < TAP_MIN) {
+          const label = (txt(el) || el.getAttribute("aria-label") || el.tagName).slice(0, 60);
+          acc.push({ label, w: Math.round(r.width), h: Math.round(r.height) });
+        }
+        return acc;
+      }, []).slice(0, 20)
+    : [];
+
+  // ── SEO / meta ─────────────────────────────────────────────────────────────
+  const canonical    = (document.querySelector('link[rel=canonical]') || {}).href || null;
+  const ogTitle      = (document.querySelector('meta[property="og:title"]') || {}).content || null;
+  const metaDesc     = (document.querySelector('meta[name=description]') || {}).content || null;
+  const hasJsonLd    = document.querySelectorAll('script[type="application/ld+json"]').length;
+  const robotsMeta   = (document.querySelector('meta[name=robots]') || {}).content || null;
+
+  // ── Performance timing ────────────────────────────────────────────────────
+  let perf = null;
+  try {
+    const t = performance.timing;
+    perf = {
+      ttfb:  t.responseStart - t.navigationStart,
+      domCL: t.domContentLoadedEventEnd - t.navigationStart,
+      load:  t.loadEventEnd - t.navigationStart,
+    };
+  } catch {}
+
+  // ── A11y quick-scan ────────────────────────────────────────────────────────
+  const imgsNoAlt = [...document.querySelectorAll("img")].filter(vis)
+    .filter((img) => !img.getAttribute("alt") && !img.getAttribute("aria-label") && !img.getAttribute("role"))
+    .map((img) => (img.getAttribute("src") || "").split("/").pop().slice(0, 60)).slice(0, 10);
+  const btnsNoName = [...document.querySelectorAll("button,[role=button]")].filter(vis)
+    .filter((b) => !txt(b) && !b.getAttribute("aria-label") && !b.getAttribute("title"))
+    .length;
+  const inputsNoLabel = [...document.querySelectorAll("input:not([type=hidden]):not([type=submit]):not([type=button]),select,textarea")].filter(vis)
+    .filter((el) => {
+      const id = el.id;
+      return !el.getAttribute("aria-label") && !el.getAttribute("aria-labelledby") && !(id && document.querySelector(`label[for="${id}"]`));
+    }).length;
+
+  // ── Broken images ─────────────────────────────────────────────────────────
+  const brokenImgs = [...document.querySelectorAll("img")].filter(vis)
+    .filter((img) => img.complete && img.naturalWidth === 0)
+    .map((img) => (img.getAttribute("src") || "").slice(0, 80)).slice(0, 10);
+
+  // ── Cookie banner ─────────────────────────────────────────────────────────
+  const hasCookieBanner = !!document.querySelector('[id*=cookie],[class*=cookie],[id*=consent],[class*=consent],[id*=gdpr],[class*=gdpr]');
+
+  return {
+    url: location.href, title: document.title, h1, headings, links, buttons, fields,
+    conversionCtas, notFound, emptyish, mentionsFees, mentionsRisk,
+    bodyLen: bodyText.length, bodyTextSample: bodyText.slice(0, 2000),
+    tapViolations, canonical, ogTitle, metaDesc, hasJsonLd, robotsMeta, perf,
+    imgsNoAlt, btnsNoName, inputsNoLabel, brokenImgs, hasCookieBanner,
+  };
 };
 
+// ── Navigation with retry ─────────────────────────────────────────────────────
 async function gotoWithRetry(page, url) {
   let last = { status: 0, error: "" };
   for (let attempt = 1; attempt <= 3; attempt++) {
     try {
       const resp = await page.goto(url, { waitUntil: "domcontentloaded", timeout: 30000 });
       const status = resp ? resp.status() : 0;
-      // 403/429/5xx through the sandbox proxy are usually transient rate-limits — retry.
       if (status === 403 || status === 429 || status >= 500) {
         last = { status, error: "http " + status };
         await page.waitForTimeout(1500 * attempt);
@@ -114,20 +201,24 @@ async function gotoWithRetry(page, url) {
   return { status: last.status, ok: false, error: last.error, attempts: 3 };
 }
 
+// ── Main ─────────────────────────────────────────────────────────────────────
 (async () => {
   const browser = await chromium.launch({ args: ["--no-sandbox"] });
   const ctx = await browser.newContext({
     ignoreHTTPSErrors: true,
-    viewport: { width: VP.width, height: VP.height },
-    userAgent: VP.ua,
-    isMobile: VP.isMobile,
-    hasTouch: VP.isMobile,
+    viewport:   { width: VP.width, height: VP.height },
+    userAgent:  VP.ua,
+    isMobile:   VP.isMobile,
+    hasTouch:   VP.isMobile,
   });
+
+  // Pre-dismiss cookie/onboarding overlays so they don't block taps.
   await ctx.addInitScript(() => {
     try {
       localStorage.setItem("user_onboarding_seen", "true");
       localStorage.setItem("cookie-consent", "declined");
       localStorage.setItem("inv_cookie_consent", "declined");
+      localStorage.setItem("cookie_consent", "declined");
     } catch {}
     try { sessionStorage.setItem("inv_newsletter_exit_intent_shown", "1"); } catch {}
   });
@@ -140,7 +231,7 @@ async function gotoWithRetry(page, url) {
       let p = "?"; try { p = new URL(req.url(), BASE).pathname; } catch {}
       mocked.push({ category: cat, method: req.method(), path: p });
       if (cat === "affiliate" && req.method() === "GET") {
-        return route.fulfill({ status: 200, contentType: "text/html", body: "<!doctype html><title>Mocked affiliate redirect</title><p>Outbound affiliate click intercepted by safety firewall.</p>" });
+        return route.fulfill({ status: 200, contentType: "text/html", body: "<!doctype html><title>Mocked affiliate redirect</title><p>Outbound affiliate click intercepted.</p>" });
       }
       return route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, mocked: true }) });
     }
@@ -150,13 +241,27 @@ async function gotoWithRetry(page, url) {
   const page = await ctx.newPage();
   const consoleErrors = [], proxyNoise = [], failedResponses = [], externalFailures = [];
   const baseOrigin = new URL(BASE).origin;
-  page.on("console", (m) => { if (m.type() !== "error") return; const t = m.text().slice(0, 200); (PROXY_NOISE.test(t) ? proxyNoise : consoleErrors).push(t); });
-  page.on("response", (r) => { if (r.status() < 400) return; try { const u = new URL(r.url(), BASE); const line = r.status() + " " + u.pathname; (u.origin === baseOrigin ? failedResponses : externalFailures).push(line); } catch {} });
-  page.on("pageerror", (e) => { const t = "pageerror: " + (e.message || "").slice(0, 200); (PROXY_NOISE.test(t) ? proxyNoise : consoleErrors).push(t); });
+  page.on("console", (m) => {
+    if (m.type() !== "error") return;
+    const t = m.text().slice(0, 200);
+    (PROXY_NOISE.test(t) ? proxyNoise : consoleErrors).push(t);
+  });
+  page.on("response", (r) => {
+    if (r.status() < 400) return;
+    try {
+      const u = new URL(r.url(), BASE);
+      const line = r.status() + " " + u.pathname;
+      (u.origin === baseOrigin ? failedResponses : externalFailures).push(line);
+    } catch {}
+  });
+  page.on("pageerror", (e) => {
+    const t = "pageerror: " + (e.message || "").slice(0, 200);
+    (PROXY_NOISE.test(t) ? proxyNoise : consoleErrors).push(t);
+  });
 
   // ── Goal-directed best-first crawl ────────────────────────────────────────
-  const visited = new Set();
-  const steps = [];
+  const visited  = new Set();
+  const steps    = [];
   const frontier = [{ href: START, score: 999, fromText: null, fromUrl: null, depth: 0 }];
 
   while (frontier.length && steps.length < MAX_STEPS) {
@@ -172,15 +277,18 @@ async function gotoWithRetry(page, url) {
     const url = item.href.startsWith("http") ? item.href : BASE + item.href;
 
     const nav = await gotoWithRetry(page, url);
-    await page.waitForTimeout(1600);
+    // Brief settle — enough for JS hydration without being slow.
+    await page.waitForTimeout(1400);
 
     let obs;
-    try { obs = await page.evaluate(observeFn); } catch (e) { obs = { url: page.url(), links: [], evalError: (e.message || "").slice(0, 160) }; }
+    try { obs = await page.evaluate(observeFn, IS_MOBILE); }
+    catch (e) { obs = { url: page.url(), links: [], evalError: (e.message || "").slice(0, 160) }; }
+
     const shot = `${OUT}/${NAME}-step-${i}.png`;
-    try { await page.screenshot({ path: shot, fullPage: true }); } catch { try { await page.screenshot({ path: shot }); } catch {} }
+    try { await page.screenshot({ path: shot, fullPage: true }); }
+    catch { try { await page.screenshot({ path: shot }); } catch {} }
 
     const realDeadEnd = !nav.ok || obs.notFound;
-    // Enqueue children (unless this page was a real dead-end after retries).
     let enqueued = 0;
     if (nav.ok && obs.links) {
       for (const l of obs.links) {
@@ -198,18 +306,34 @@ async function gotoWithRetry(page, url) {
       url: obs.url, title: obs.title, h1: obs.h1,
       notFound: obs.notFound, emptyish: obs.emptyish, realDeadEnd, bodyLen: obs.bodyLen,
       mentionsFees: obs.mentionsFees, mentionsRisk: obs.mentionsRisk,
-      headings: obs.headings, links: (obs.links || []).slice(0, 50), buttons: obs.buttons, fields: obs.fields,
-      conversionCtas: obs.conversionCtas, bodyTextSample: obs.bodyTextSample,
-      consoleErrors: consoleErrors.slice(eS), failedResponses: failedResponses.slice(fS),
-      externalFailures: externalFailures.slice(xS), proxyNoise: proxyNoise.slice(pS),
-      mocked: mocked.slice(mS), screenshot: shot,
+      headings: obs.headings, links: (obs.links || []).slice(0, 50),
+      buttons: obs.buttons, fields: obs.fields, conversionCtas: obs.conversionCtas,
+      // Full-signal extras
+      tapViolations: obs.tapViolations || [],
+      seo: { canonical: obs.canonical, ogTitle: obs.ogTitle, metaDesc: obs.metaDesc, hasJsonLd: obs.hasJsonLd, robotsMeta: obs.robotsMeta },
+      perf: obs.perf,
+      a11y: { imgsNoAlt: obs.imgsNoAlt || [], btnsNoName: obs.btnsNoName || 0, inputsNoLabel: obs.inputsNoLabel || 0 },
+      brokenImgs: obs.brokenImgs || [],
+      hasCookieBanner: obs.hasCookieBanner || false,
+      bodyTextSample: obs.bodyTextSample,
+      consoleErrors:     consoleErrors.slice(eS),
+      failedResponses:   failedResponses.slice(fS),
+      externalFailures:  externalFailures.slice(xS),
+      proxyNoise:        proxyNoise.slice(pS),
+      mocked:            mocked.slice(mS),
+      screenshot:        shot,
     });
 
+    // ── Console output ───────────────────────────────────────────────────────
     console.log(`\n── step ${i} (depth ${item.depth}) · ${action}`);
     console.log(`   ${obs.url}`);
-    console.log(`   title: ${obs.title}`);
-    console.log(`   h1: ${obs.h1 || "(none)"}  status:${nav.status}${nav.attempts > 1 ? " (after " + nav.attempts + " tries)" : ""}${obs.notFound ? "  [!! NOT FOUND]" : ""}${realDeadEnd ? "  [DEAD-END]" : ""}`);
+    console.log(`   title: ${obs.title}  status:${nav.status}${nav.attempts > 1 ? " (after " + nav.attempts + " tries)" : ""}${obs.notFound ? "  [!! NOT FOUND]" : ""}${realDeadEnd ? "  [DEAD-END]" : ""}`);
     console.log(`   links:${(obs.links || []).length} buttons:${(obs.buttons || []).length} fields:${(obs.fields || []).length}  fees:${obs.mentionsFees ? "Y" : "·"} risk:${obs.mentionsRisk ? "Y" : "·"}  +${enqueued} queued`);
+    if (obs.perf) console.log(`   perf: TTFB ${obs.perf.ttfb}ms  DCL ${obs.perf.domCL}ms  load ${obs.perf.load}ms`);
+    if ((obs.tapViolations || []).length) console.log(`   !! tap targets < 44px: ${obs.tapViolations.length} — e.g. "${(obs.tapViolations[0] || {}).label}" ${(obs.tapViolations[0] || {}).w}×${(obs.tapViolations[0] || {}).h}px`);
+    if ((obs.brokenImgs || []).length) console.log(`   !! broken images: ${obs.brokenImgs.length}`);
+    if ((obs.imgsNoAlt || []).length) console.log(`   !! images without alt: ${obs.imgsNoAlt.length}`);
+    if (obs.btnsNoName) console.log(`   !! buttons without accessible name: ${obs.btnsNoName}`);
     if (obs.conversionCtas && obs.conversionCtas.length) console.log(`   conversion CTAs: ${obs.conversionCtas.length} (e.g. "${obs.conversionCtas[0].text}" → ${obs.conversionCtas[0].href})`);
     const sc = consoleErrors.slice(eS), sf = failedResponses.slice(fS), sm = mocked.slice(mS);
     if (sc.length) console.log(`   !! console errors: ${sc.length} — ${sc[0]}`);
@@ -221,16 +345,37 @@ async function gotoWithRetry(page, url) {
   await browser.close();
 
   const dedupe = (a) => [...new Set(a)];
+  const allTapViolations = steps.flatMap((s) => s.tapViolations || []);
+  const allBrokenImgs    = dedupe(steps.flatMap((s) => s.brokenImgs || []));
   const summary = {
-    persona: NAME, goal: GOAL, base: BASE, start: START, stepsVisited: steps.length,
+    persona: NAME, goal: GOAL, base: BASE, start: START, viewport: process.env.JOURNEY_VIEWPORT || "desktop",
+    stepsVisited: steps.length,
     pagesVisited: steps.map((s) => normPath(s.url)),
-    totalMocked: mocked.length, mockedByCategory: mocked.reduce((a, m) => ((a[m.category] = (a[m.category] || 0) + 1), a), {}),
-    realConsoleErrors: dedupe(consoleErrors), realInternalFailures: dedupe(failedResponses),
-    sandboxProxyNoise: proxyNoise.length, externalFailures: dedupe(externalFailures).length,
-    pagesWithFees: steps.filter((s) => s.mentionsFees).length, pagesWithRisk: steps.filter((s) => s.mentionsRisk).length,
-    conversionCtasSeen: dedupe(steps.flatMap((s) => (s.conversionCtas || []).map((c) => c.href))),
-    realDeadEnds: steps.filter((s) => s.realDeadEnd).map((s) => ({ url: normPath(s.url), status: s.navStatus, from: s.action })),
+    totalMocked: mocked.length,
+    mockedByCategory: mocked.reduce((a, m) => ((a[m.category] = (a[m.category] || 0) + 1), a), {}),
+    realConsoleErrors:    dedupe(consoleErrors),
+    realInternalFailures: dedupe(failedResponses),
+    sandboxProxyNoise:    proxyNoise.length,
+    externalFailures:     dedupe(externalFailures).length,
+    pagesWithFees:        steps.filter((s) => s.mentionsFees).length,
+    pagesWithRisk:        steps.filter((s) => s.mentionsRisk).length,
+    conversionCtasSeen:   dedupe(steps.flatMap((s) => (s.conversionCtas || []).map((c) => c.href))),
+    realDeadEnds:         steps.filter((s) => s.realDeadEnd).map((s) => ({ url: normPath(s.url), status: s.navStatus, from: s.action })),
+    // Full-signal extras
+    tapViolationCount:  allTapViolations.length,
+    tapViolationSample: allTapViolations.slice(0, 5),
+    brokenImages:       allBrokenImgs,
+    a11y: {
+      totalImgsNoAlt:      steps.reduce((n, s) => n + (s.a11y?.imgsNoAlt?.length || 0), 0),
+      totalBtnsNoName:     steps.reduce((n, s) => n + (s.a11y?.btnsNoName || 0), 0),
+      totalInputsNoLabel:  steps.reduce((n, s) => n + (s.a11y?.inputsNoLabel || 0), 0),
+    },
+    perfSummary: steps.filter((s) => s.perf).map((s) => ({ url: normPath(s.url), ...s.perf })),
+    pagesWithoutCanonical: steps.filter((s) => !s.seo?.canonical).map((s) => normPath(s.url)),
+    pagesWithoutMetaDesc:  steps.filter((s) => !s.seo?.metaDesc).map((s) => normPath(s.url)),
+    pagesWithoutJsonLd:    steps.filter((s) => !s.seo?.hasJsonLd).map((s) => normPath(s.url)),
   };
+
   fs.writeFileSync(`${OUT}/${NAME}.json`, JSON.stringify({ summary, steps }, null, 2));
   console.log(`\n=== JOURNEY COMPLETE: ${NAME} — ${steps.length} pages ===`);
   console.log(JSON.stringify(summary, null, 2));

--- a/bots/journey/lead-flows.cjs
+++ b/bots/journey/lead-flows.cjs
@@ -1,29 +1,32 @@
 /* eslint-disable */
 /**
- * Launch-readiness test #3 — lead/revenue flows, end-to-end.
+ * Lead/revenue flow driver v2 — end-to-end.
  *
- *   A) get-matched quiz:  /get-matched → answer every QuestionCard
- *      (role=radio auto-advances; multiselect/text/number use "Continue")
- *      → reach the result/plan screen.
- *   B) adviser enquiry:   /advisors → an adviser profile → fill the Contact
- *      form (name/email/phone/message) → "Send Enquiry" → "Enquiry Sent!".
+ * Runs four flows and verifies that each reaches a confirmed end-state:
  *
- * Side-effect firewall with PAYLOAD CAPTURE: lead/enquiry/booking writes are
- * mocked locally (no real lead created) but their request bodies are captured
- * so we can VERIFY the lead would be well-formed (has email + the right ids).
- * The feature-under-test's own compute endpoints (/api/get-matched/*) are
- * ALLOWED — you can't drive a quiz whose start/answer/resolve you mock.
+ *   A) get-matched quiz   — /get-matched → answer all QuestionCards → result screen.
+ *   B) adviser enquiry    — /advisors → profile → fill Contact form → "Enquiry Sent!".
+ *   C) broker comparison  — /compare → add two brokers → comparison table renders.
+ *   D) account signup     — /login → detect signup link/tab → fill form → mock auth
+ *                           → detect success state (dashboard redirect or email-verify).
  *
- * Runs best-effort in the sandbox (the enquiry submit is mocked locally so it
- * works here; the quiz's start/answer calls go through the flaky TLS-MITM proxy,
- * so full quiz completion is reliable only against a real network — point
- * LEAD_BASE at the Vercel deploy). In-session on the Max plan, no API key.
+ * Side-effect firewall with PAYLOAD CAPTURE: lead/enquiry/booking and Supabase
+ * auth writes are mocked locally (no real lead or account created) but their
+ * request bodies are captured so we can VERIFY the payload is well-formed.
+ *
+ * The quiz's own compute endpoints (/api/get-matched/*) are ALLOWED — you
+ * can't drive a quiz whose start/answer/resolve you mock.
+ *
+ * Env vars:
+ *   LEAD_BASE    Target origin (default: Netlify preview)
+ *   LEAD_OUT     Output directory (default: /tmp/journey)
+ *   LEAD_STEPS   Max steps for the quiz flow (default: 18)
  */
 const { chromium } = require("@playwright/test");
 const fs = require("fs");
 
-const BASE = process.env.LEAD_BASE || "https://lambent-sawine-17c3dd.netlify.app";
-const OUT = process.env.LEAD_OUT || "/tmp/journey";
+const BASE  = process.env.LEAD_BASE  || "https://lambent-sawine-17c3dd.netlify.app";
+const OUT   = process.env.LEAD_OUT   || "/tmp/journey";
 const STEPS = parseInt(process.env.LEAD_STEPS || "18", 10);
 fs.mkdirSync(OUT, { recursive: true });
 
@@ -37,15 +40,41 @@ function classify(url, method) {
   const WRITE = ["POST", "PUT", "PATCH", "DELETE"].includes(method.toUpperCase());
   if (/^\/go\//.test(path)) return { cat: "affiliate" };
   if (/^\/api\/stripe\//.test(path) || /checkout|billing/i.test(path)) return { cat: "payment" };
+  // Supabase auth — mock so no real account is created; capture the payload.
+  if (/supabase\.co\/auth\//.test(url)) return { cat: "auth", capture: WRITE, path: "/supabase/auth" };
   if (LEAD_WRITE.test(path)) return { cat: "lead", capture: true, path };
-  if (ALLOW.test(path)) return null;            // allow through (real compute)
+  if (ALLOW.test(path)) return null;           // allow through (real compute)
   if (WRITE && /^\/api\//.test(path)) return { cat: "write" };
-  return null;                                   // GET / asset → allow
+  return null;                                  // GET / asset → allow
 }
 
-const txtFn = () => {};
+// ── Shared route handler setup ────────────────────────────────────────────────
+async function installFirewall(ctx, leads, mockedOther) {
+  await ctx.route("**/*", (route) => {
+    const req = route.request();
+    const c = classify(req.url(), req.method());
+    if (!c) return route.continue();
+    if (c.capture) {
+      let body = null;
+      try { body = JSON.parse(req.postData() || "null"); } catch { body = (req.postData() || "").slice(0, 400); }
+      leads.push({ path: c.path, cat: c.cat, method: req.method(), body });
+    }
+    mockedOther[c.cat] = (mockedOther[c.cat] || 0) + 1;
+    if (c.cat === "auth") {
+      return route.fulfill({ status: 200, contentType: "application/json",
+        body: JSON.stringify({ access_token: "mock-token", token_type: "bearer", expires_in: 3600, refresh_token: "mock-refresh",
+          user: { id: "mock-user-id", email: "qa-bot@example.com", email_confirmed_at: new Date().toISOString() } }) });
+    }
+    if (c.cat === "affiliate" && req.method() === "GET") {
+      return route.fulfill({ status: 200, contentType: "text/html", body: "<!doctype html><title>Mocked</title>" });
+    }
+    return route.fulfill({ status: 200, contentType: "application/json",
+      body: JSON.stringify({ ok: true, id: "mock-" + leads.length, mocked: true }) });
+  });
+}
 
-async function runGetMatched(page, leads) {
+// ── Flow A: get-matched quiz ──────────────────────────────────────────────────
+async function runGetMatched(page) {
   const r = { name: "get-matched quiz", url: BASE + "/get-matched", steps: [], reachedResult: false, note: null };
   await page.goto(BASE + "/get-matched", { waitUntil: "domcontentloaded", timeout: 30000 }).catch(() => {});
   await page.waitForTimeout(2800);
@@ -58,47 +87,43 @@ async function runGetMatched(page, leads) {
       const prompt = t(document.querySelector("article h1")) || "";
       const radios = [...document.querySelectorAll("[role=radiogroup] [role=radio], article [role=radio]")].map((b) => t(b)).filter(Boolean);
       const hasContinue = [...document.querySelectorAll("article button")].some((b) => /continue/i.test(t(b)));
-      const textInput = !!document.querySelector("article input[type=text], article textarea");
+      const textInput  = !!document.querySelector("article input[type=text], article textarea");
       const numberInput = !!document.querySelector("article input[type=number]");
-      const multiBtns = [...document.querySelectorAll("article button")].filter((b) => !/continue/i.test(t(b)) && t(b)).length;
-      // A QuestionCard is on screen iff there's a prompt h1 + at least one input control.
+      const multiBtns  = [...document.querySelectorAll("article button")].filter((b) => !/continue/i.test(t(b)) && t(b)).length;
       const isQuestion = !!prompt && (radios.length > 0 || textInput || numberInput || multiBtns > 0);
-      // The AnalyzingScreen interstitial (its exact copy) while /resolve runs.
-      const analyzing = /building your action plan|personalising your action plan|matching your goals|checking platforms, advisors|finding your match|analy(s|z)ing|crunching/i.test(body);
-      // Markers UNIQUE to the final result screen (the restart button + top matches).
+      const analyzing  = /building your action plan|personalising your action plan|matching your goals|checking platforms|finding your match|analy(s|z)ing|crunching/i.test(body);
       const resultText = /start over|different answers|your top match|view all matches|recommended next step|book a (call|consult)|contact (this|an|your) advis|no (strong )?match for/i.test(body);
       const errorState = /ran into a problem|failed to start|something went wrong/i.test(body);
-      const noStart = /not sure where to start/i.test(body);
-      const result = resultText && !isQuestion && !analyzing;
-      return { prompt, radios, hasContinue, textInput, numberInput, multiBtns, isQuestion, result, analyzing, errorState, noStart };
+      const noStart    = /not sure where to start/i.test(body);
+      return { prompt, radios, hasContinue, textInput, numberInput, multiBtns, isQuestion, result: resultText && !isQuestion && !analyzing, analyzing, errorState, noStart };
     }).catch(() => ({}));
 
-    const shot = `${OUT}/getmatched-step-${i}.png`;
+    const shot = `${OUT}/flow-a-step-${i}.png`;
     await page.screenshot({ path: shot, fullPage: true }).catch(() => {});
     r.steps.push({ i, prompt: s.prompt || "", options: (s.radios || []).length, result: !!s.result, analyzing: !!s.analyzing, error: !!s.errorState, screenshot: shot });
-    console.log(`  [get-matched] step ${i}: ${s.result ? "RESULT" : s.analyzing ? "analyzing…" : s.errorState ? "ERROR" : s.noStart ? "fallback(not-sure-where-to-start)" : (s.prompt || "(no question)").slice(0, 64)}  · options:${(s.radios || []).length}`);
+    console.log(`  [get-matched] step ${i}: ${s.result ? "RESULT" : s.analyzing ? "analyzing…" : s.errorState ? "ERROR" : s.noStart ? "fallback(not-sure-where-to-start)" : (s.prompt || "(no question)").slice(0, 64)}  · opts:${(s.radios || []).length}`);
 
     if (s.result) { r.reachedResult = true; r.note = "reached result/plan screen"; break; }
-    if (s.errorState || s.noStart) { r.note = "quiz did not render questions (error/fallback — in the sandbox this is the TLS-MITM proxy dropping the start fetch; expected to work on a real network / Vercel)"; break; }
+    if (s.errorState || s.noStart) { r.note = "quiz did not render questions (TLS-MITM proxy in sandbox — works on real network/Vercel)"; break; }
     if (s.analyzing) {
       analyzingRounds++;
-      if (analyzingRounds > 5) { r.note = "stuck on 'Building your action plan' — /resolve didn't return (in the sandbox this is the TLS-MITM proxy dropping the resolve fetch; expected to complete on a real network / Vercel)"; break; }
-      await page.waitForTimeout(2200); continue;
+      if (analyzingRounds > 5) { r.note = "stuck on 'Building your action plan' — /resolve timed out (expected on sandbox proxy)"; break; }
+      await page.waitForTimeout(2200);
+      continue;
     }
     analyzingRounds = 0;
     if (!s.prompt && (s.radios || []).length === 0 && !s.textInput && !s.numberInput) { r.note = "no question card detected — stopping"; break; }
 
-    // ── Answer the current question ─────────────────────────────
-    const article = page.locator("article").first();
-    const radioLoc = page.locator("[role=radiogroup] [role=radio], article [role=radio]");
-    const rc = await radioLoc.count().catch(() => 0);
+    const article    = page.locator("article").first();
+    const radioLoc   = page.locator("[role=radiogroup] [role=radio], article [role=radio]");
+    const rc         = await radioLoc.count().catch(() => 0);
     if (rc > 0) {
       let idx = 0;
       for (let k = 0; k < rc; k++) {
         const tt = ((await radioLoc.nth(k).innerText().catch(() => "")) || "").toLowerCase();
         if (/long|growth|wealth|retire|confident|experienc|shares|etf|balanced|\byes\b|high|grow/.test(tt)) { idx = k; break; }
       }
-      await radioLoc.nth(idx).click({ timeout: 4000 }).catch(() => {});   // select auto-advances
+      await radioLoc.nth(idx).click({ timeout: 4000 }).catch(() => {});
     } else if (s.textInput) {
       await article.locator("input[type=text], textarea").first().fill("Build long-term wealth").catch(() => {});
     } else if (s.numberInput) {
@@ -106,7 +131,6 @@ async function runGetMatched(page, leads) {
     } else if (s.multiBtns > 0) {
       await article.locator("button").filter({ hasNotText: /continue/i }).first().click({ timeout: 4000 }).catch(() => {});
     }
-    // Continue button (multiselect/text/number)
     const cont = article.getByRole("button", { name: /continue/i });
     if (await cont.count().catch(() => 0) > 0) await cont.first().click({ timeout: 4000 }).catch(() => {});
     await page.waitForTimeout(1900);
@@ -114,7 +138,8 @@ async function runGetMatched(page, leads) {
   return r;
 }
 
-async function runAdviserEnquiry(page, leads) {
+// ── Flow B: adviser enquiry ───────────────────────────────────────────────────
+async function runAdviserEnquiry(page) {
   const r = { name: "adviser enquiry", profileUrl: null, submitted: false, confirmation: false, note: null };
   await page.goto(BASE + "/advisors", { waitUntil: "domcontentloaded", timeout: 30000 }).catch(() => {});
   await page.waitForTimeout(2200);
@@ -129,21 +154,24 @@ async function runAdviserEnquiry(page, leads) {
 
   await page.goto(profile, { waitUntil: "domcontentloaded", timeout: 30000 }).catch(() => {});
   await page.waitForTimeout(2200);
-  await page.screenshot({ path: `${OUT}/enquiry-profile.png`, fullPage: true }).catch(() => {});
+  await page.screenshot({ path: `${OUT}/flow-b-profile.png`, fullPage: true }).catch(() => {});
 
+  // Some profiles hide the form behind an "Enquire" button.
   const nameI = page.locator('input[placeholder="Full name"]');
   if (await nameI.count().catch(() => 0) === 0) {
-    // Some profiles surface the form behind an "Enquire" / "Contact" button — try to open it.
     const opener = page.getByRole("button", { name: /enquire|contact|get in touch|send enquiry/i });
-    if (await opener.count().catch(() => 0) > 0) { await opener.first().click({ timeout: 4000 }).catch(() => {}); await page.waitForTimeout(1200); }
+    if (await opener.count().catch(() => 0) > 0) {
+      await opener.first().click({ timeout: 4000 }).catch(() => {});
+      await page.waitForTimeout(1200);
+    }
   }
-  if (await nameI.count().catch(() => 0) === 0) { r.note = "contact form not found on this profile"; return r; }
+  if (await nameI.count().catch(() => 0) === 0) { r.note = "contact form not found on profile"; return r; }
 
   await nameI.first().fill("QA Bot (pre-launch test)").catch(() => {});
   await page.locator('input[placeholder="your@email.com"], input[type=email]').first().fill("qa-bot@example.com").catch(() => {});
   const phone = page.locator('input[placeholder="04XX XXX XXX"], input[type=tel]');
   if (await phone.count().catch(() => 0) > 0) await phone.first().fill("0400000000").catch(() => {});
-  const msg = page.locator('textarea');
+  const msg = page.locator("textarea");
   if (await msg.count().catch(() => 0) > 0) await msg.first().fill("Automated pre-launch QA enquiry — please ignore.").catch(() => {});
 
   const send = page.getByRole("button", { name: /send enquiry/i });
@@ -151,54 +179,161 @@ async function runAdviserEnquiry(page, leads) {
   await send.first().click({ timeout: 5000 }).catch(() => {});
   r.submitted = true;
   await page.waitForTimeout(2500);
-  await page.screenshot({ path: `${OUT}/enquiry-result.png`, fullPage: true }).catch(() => {});
-  r.confirmation = await page.evaluate(() => /enquiry sent|typically respond within 24|reviews your request/i.test(document.body.textContent || "")).catch(() => false);
+  await page.screenshot({ path: `${OUT}/flow-b-result.png`, fullPage: true }).catch(() => {});
+  r.confirmation = await page.evaluate(() =>
+    /enquiry sent|typically respond within 24|reviews your request/i.test(document.body.textContent || "")
+  ).catch(() => false);
   return r;
 }
 
+// ── Flow C: broker comparison ─────────────────────────────────────────────────
+async function runBrokerComparison(page) {
+  const r = { name: "broker comparison", url: BASE + "/compare", added: 0, tableRendered: false, note: null };
+  await page.goto(BASE + "/compare", { waitUntil: "domcontentloaded", timeout: 30000 }).catch(() => {});
+  await page.waitForTimeout(2500);
+  await page.screenshot({ path: `${OUT}/flow-c-before.png`, fullPage: true }).catch(() => {});
+
+  // Try to add up to 2 brokers via any "Add to compare" / "Compare" button.
+  const addBtns = page.getByRole("button", { name: /add to compare|compare|add/i })
+    .filter({ hasNotText: /remove|clear|reset/i });
+  const totalAdd = await addBtns.count().catch(() => 0);
+  for (let k = 0; k < Math.min(totalAdd, 2); k++) {
+    await addBtns.nth(k).click({ timeout: 3000 }).catch(() => {});
+    await page.waitForTimeout(800);
+    r.added++;
+  }
+
+  // Alternatively, some UIs auto-select brokers on the /compare page already.
+  // Check if a comparison table / panel is present.
+  await page.waitForTimeout(1500);
+  await page.screenshot({ path: `${OUT}/flow-c-after.png`, fullPage: true }).catch(() => {});
+
+  r.tableRendered = await page.evaluate(() => {
+    const body = (document.body.textContent || "").replace(/\s+/g, " ");
+    // Comparison table markers: column headers for two+ brokers, fee rows, etc.
+    return /brokerage|management fee|CHESS|min\. deposit|trading fee/i.test(body) &&
+      (document.querySelector("table,thead,[class*=compare-table],[class*=comparison]") !== null ||
+       document.querySelectorAll("[class*=broker-card],[class*=BrokerCard]").length >= 2);
+  }).catch(() => false);
+
+  if (!r.tableRendered && r.added === 0) {
+    // No "Add to compare" buttons — check if this page is already a table.
+    r.tableRendered = await page.evaluate(() =>
+      /brokerage|management fee|CHESS/i.test(document.body.textContent || "") &&
+      document.querySelector("table,thead") !== null
+    ).catch(() => false);
+    r.note = "no 'Add to compare' buttons found — checked for pre-populated table";
+  }
+
+  return r;
+}
+
+// ── Flow D: account signup detection ─────────────────────────────────────────
+async function runAccountSignup(page) {
+  const r = { name: "account signup", formFound: false, submitted: false, successState: false, note: null };
+  // Try /login first (often has a "Sign up" tab or link) then /signup.
+  for (const path of ["/login", "/signup", "/register"]) {
+    await page.goto(BASE + path, { waitUntil: "domcontentloaded", timeout: 20000 }).catch(() => {});
+    await page.waitForTimeout(1800);
+    const hasForm = await page.evaluate(() => {
+      return document.querySelector('input[type=email], input[placeholder*="email" i]') !== null;
+    }).catch(() => false);
+    if (hasForm) { r.note = `form found at ${path}`; break; }
+  }
+  await page.screenshot({ path: `${OUT}/flow-d-form.png`, fullPage: true }).catch(() => {});
+
+  // Switch to signup tab/link if we're on the login page.
+  const signupLink = page.getByRole("link", { name: /sign ?up|create account|register|join/i })
+    .or(page.getByRole("tab", { name: /sign ?up|register/i }))
+    .first();
+  if (await signupLink.count().catch(() => 0) > 0) {
+    await signupLink.click({ timeout: 3000 }).catch(() => {});
+    await page.waitForTimeout(1200);
+  }
+
+  const emailInput = page.locator('input[type=email], input[placeholder*="email" i]').first();
+  if (await emailInput.count().catch(() => 0) === 0) {
+    r.note = r.note ? r.note + " — but email field not found after tab switch" : "no email field found on login/signup/register pages";
+    return r;
+  }
+  r.formFound = true;
+
+  await emailInput.fill("qa-bot@example.com").catch(() => {});
+  const pwField = page.locator('input[type=password]').first();
+  if (await pwField.count().catch(() => 0) > 0) await pwField.fill("TestPass123!").catch(() => {});
+  const nameField = page.locator('input[placeholder*="name" i], input[name*="name" i]').first();
+  if (await nameField.count().catch(() => 0) > 0) await nameField.fill("QA Bot").catch(() => {});
+
+  const submitBtn = page.getByRole("button", { name: /sign ?up|create account|register|get started|continue|next/i }).first();
+  if (await submitBtn.count().catch(() => 0) === 0) { r.note = "submit button not found"; return r; }
+  await submitBtn.click({ timeout: 5000 }).catch(() => {});
+  r.submitted = true;
+  await page.waitForLoadState("networkidle", { timeout: 3000 }).catch(() => {});
+  await page.waitForTimeout(2000);
+  await page.screenshot({ path: `${OUT}/flow-d-result.png`, fullPage: true }).catch(() => {});
+
+  r.successState = await page.evaluate(() => {
+    const body = (document.body.textContent || "").replace(/\s+/g, " ");
+    // Success: redirect to /account/dashboard, or verify-email message, or welcome copy.
+    return /verify your email|check your email|account created|welcome|dashboard|get started/i.test(body) ||
+      /\/account(\/dashboard)?/.test(location.pathname);
+  }).catch(() => false);
+  return r;
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
 (async () => {
   const browser = await chromium.launch({ args: ["--no-sandbox"] });
-  const ctx = await browser.newContext({ ignoreHTTPSErrors: true, viewport: { width: 1366, height: 1000 } });
-  await ctx.addInitScript(() => { try { ["user_onboarding_seen"].forEach((k) => localStorage.setItem(k, "true")); ["cookie-consent", "inv_cookie_consent", "cookie_consent"].forEach((k) => localStorage.setItem(k, "declined")); } catch {} });
+  const ctx = await browser.newContext({
+    ignoreHTTPSErrors: true,
+    viewport: { width: 1366, height: 1000 },
+  });
+  await ctx.addInitScript(() => {
+    try {
+      ["user_onboarding_seen"].forEach((k) => localStorage.setItem(k, "true"));
+      ["cookie-consent", "inv_cookie_consent", "cookie_consent"].forEach((k) => localStorage.setItem(k, "declined"));
+    } catch {}
+  });
+
   const leads = [];
   const mockedOther = {};
-  await ctx.route("**/*", (route) => {
-    const req = route.request();
-    const c = classify(req.url(), req.method());
-    if (!c) return route.continue();
-    if (c.capture) {
-      let body = null; try { body = JSON.parse(req.postData() || "null"); } catch { body = (req.postData() || "").slice(0, 400); }
-      leads.push({ path: c.path, method: req.method(), body });
-      return route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, id: "mock-lead-" + leads.length, mocked: true }) });
-    }
-    mockedOther[c.cat] = (mockedOther[c.cat] || 0) + 1;
-    if (c.cat === "affiliate" && req.method() === "GET") return route.fulfill({ status: 200, contentType: "text/html", body: "<!doctype html><title>Mocked</title>" });
-    return route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ ok: true, mocked: true }) });
-  });
+  await installFirewall(ctx, leads, mockedOther);
   const page = await ctx.newPage();
 
-  console.log(`\n=== Lead-flow E2E vs ${BASE} ===`);
-  const getMatched = await runGetMatched(page, leads);
-  const adviserEnquiry = await runAdviserEnquiry(page, leads);
+  console.log(`\n=== Lead-flow E2E v2 vs ${BASE} ===`);
+  const flowA = await runGetMatched(page, leads);
+  const flowB = await runAdviserEnquiry(page);
+  const flowC = await runBrokerComparison(page);
+  const flowD = await runAccountSignup(page);
   await browser.close();
 
-  // ── Verify lead capture is well-formed ──────────────────────
-  const enquiry = leads.find((l) => /advisor-enquiry/.test(l.path));
-  const enquiryValid = !!(enquiry && enquiry.body && enquiry.body.user_email && (enquiry.body.professional_id !== undefined));
+  // ── Verify lead capture is well-formed ────────────────────────────────────
+  const enquiry      = leads.find((l) => /advisor-enquiry/.test(l.path));
+  const enquiryValid = !!(enquiry && enquiry.body && enquiry.body.user_email && enquiry.body.professional_id !== undefined);
+  const authCapture  = leads.find((l) => l.cat === "auth");
 
   const summary = {
     base: BASE,
-    getMatched: { reachedResult: getMatched.reachedResult, steps: getMatched.steps.length, note: getMatched.note },
-    adviserEnquiry: { submitted: adviserEnquiry.submitted, confirmationShown: adviserEnquiry.confirmation, profile: adviserEnquiry.profileUrl, note: adviserEnquiry.note },
+    flowA_getMatched:      { reachedResult: flowA.reachedResult, steps: flowA.steps.length, note: flowA.note },
+    flowB_adviserEnquiry:  { submitted: flowB.submitted, confirmationShown: flowB.confirmation, profile: flowB.profileUrl, note: flowB.note },
+    flowC_brokerComparison: { added: flowC.added, tableRendered: flowC.tableRendered, note: flowC.note },
+    flowD_accountSignup:   { formFound: flowD.formFound, submitted: flowD.submitted, successState: flowD.successState, note: flowD.note },
     leadCapture: {
       total: leads.length,
       advisorEnquiryCaptured: !!enquiry,
       advisorEnquiryWellFormed: enquiryValid,
-      sample: enquiry ? { path: enquiry.path, keys: enquiry.body && typeof enquiry.body === "object" ? Object.keys(enquiry.body) : null, user_email: enquiry.body?.user_email, professional_id: enquiry.body?.professional_id } : null,
+      authCallMocked: !!authCapture,
+      sample: enquiry ? {
+        path: enquiry.path,
+        keys: enquiry.body && typeof enquiry.body === "object" ? Object.keys(enquiry.body) : null,
+        user_email: enquiry.body?.user_email,
+        professional_id: enquiry.body?.professional_id,
+      } : null,
     },
     otherSideEffectsMocked: mockedOther,
   };
-  fs.writeFileSync(`${OUT}/lead-flows.json`, JSON.stringify({ summary, getMatched, adviserEnquiry, capturedLeads: leads }, null, 2));
+
+  fs.writeFileSync(`${OUT}/lead-flows.json`, JSON.stringify({ summary, flowA, flowB, flowC, flowD, capturedLeads: leads }, null, 2));
   console.log("\n=== SUMMARY ===");
   console.log(JSON.stringify(summary, null, 2));
 })().catch((e) => { console.error("FATAL", e); process.exit(1); });

--- a/bots/journey/personas.cjs
+++ b/bots/journey/personas.cjs
@@ -1,0 +1,76 @@
+/* eslint-disable */
+/**
+ * Standard journey personas (CommonJS) — shared by ai-journey.cjs,
+ * ai-form.cjs, lead-flows.cjs, and .github/workflows/ai-journey.yml.
+ *
+ * Each persona: { name, description, startPath, goal, keywords[],
+ *   viewport, steps, formStart, formGoal }
+ */
+
+const PERSONAS = [
+  {
+    name: "new-investor",
+    description: "Complete beginner comparing investment platforms for the first time.",
+    startPath: "/",
+    goal: "Find and compare investment platforms suitable for a beginner, and get to the point where I could open an account. Note anything confusing, broken, or any missing fees/risk disclosures.",
+    keywords: ["compare", "broker", "shares", "etf", "fees", "open account"],
+    viewport: "desktop",
+    steps: 15,
+    formStart: "/get-matched",
+    formGoal: "Complete the get-matched quiz as a new investor and reach a personalised action plan.",
+  },
+  {
+    name: "advice-seeker",
+    description: "Pre-retiree looking for a financial adviser.",
+    startPath: "/advisors",
+    goal: "Find a financial adviser who suits someone near retirement, and reach a point where I could make contact or book a consultation. Flag dead ends, confusing steps, or missing disclosures.",
+    keywords: ["adviser", "retirement", "super", "plan", "contact", "enquire"],
+    viewport: "desktop",
+    steps: 12,
+  },
+  {
+    name: "quiz-taker",
+    description: "Visitor using the guided get-matched quiz.",
+    startPath: "/get-matched",
+    goal: "Complete the get-matched quiz as a long-term growth investor and reach a personalised action plan. Judge whether the result is clear and trustworthy.",
+    keywords: ["long-term", "growth", "shares", "etf", "balanced", "yes", "high"],
+    viewport: "desktop",
+    steps: 14,
+    formStart: "/get-matched",
+    formGoal: "Complete the get-matched quiz as a long-term growth investor and reach a result screen.",
+  },
+  {
+    name: "mobile-shopper",
+    description: "Mobile user comparing brokers on an iPhone.",
+    startPath: "/",
+    goal: "Find and compare investment platforms on mobile. Flag tap targets that are too small, overflow issues, or anything hard to use on a phone.",
+    keywords: ["compare", "broker", "fees", "account", "open"],
+    viewport: "mobile",
+    steps: 10,
+  },
+  {
+    name: "first-home-buyer",
+    description: "First home buyer researching property investment options.",
+    startPath: "/invest/property",
+    goal: "Research property investment options and find a financial adviser who specialises in property. Note confusing flows or missing disclosures.",
+    keywords: ["property", "investment", "adviser", "financial", "plan", "home"],
+    viewport: "desktop",
+    steps: 12,
+  },
+  {
+    name: "startup-investor",
+    description: "Angel investor exploring startup investment platforms.",
+    startPath: "/invest/startups",
+    goal: "Find startup investment platforms and opportunities. Note required accreditation disclosures, risk warnings, and any auth-gate that appears.",
+    keywords: ["startup", "angel", "invest", "platform", "risk", "accredited"],
+    viewport: "desktop",
+    steps: 12,
+  },
+];
+
+/** Lookup by name. Returns undefined if not found. */
+function getPersona(name) {
+  return PERSONAS.find((p) => p.name === name);
+}
+
+module.exports = { PERSONAS, getPersona };


### PR DESCRIPTION
## Summary

Upgrades the entire AI journey bot suite to capture more signal, complete real forms end-to-end on GitHub Actions (no TLS-MITM proxy), and cover four revenue-critical flows with payload verification.

### What changed

**`bots/journey/ai-journey.cjs` → v4** (link crawler)
- Tap-target violation detection (< 44 px, mobile-only) with sample output
- SEO/meta signals per page: canonical, og:title, metaDesc presence, JSON-LD, robots meta
- Performance timing via Navigation Timing API: TTFB, DOMContentLoaded, load
- A11y quick-scan: images without alt, buttons without accessible name, inputs without label
- Broken image detection (naturalWidth === 0 after load)
- Cookie-banner detection
- `JOURNEY_ALLOW_WRITES` env var for sandbox targets
- Body text sample extended to 2 000 chars; MAX_STEPS default raised to 15

**`bots/journey/ai-form.cjs` → v2** (multi-step form driver)
- Mobile / tablet / desktop viewport via `FORM_VIEWPORT`
- Lead payload capture: intercepts `LEAD_WRITE` POSTs, mocks + logs bodies
- Supabase auth endpoint mock (no real accounts created)
- Modal / cookie-banner dismissal between steps
- Stagnation detection on URL + heading hash (was heading-only)
- Network-idle wait after advance clicks

**`bots/journey/lead-flows.cjs` → v2** (revenue flow driver)
- Four flows: get-matched quiz, adviser enquiry, **broker comparison** (new), **account signup detection** (new)
- Shared `installFirewall()` helper
- Auth POSTs captured and logged alongside lead POSTs
- Flow C checks for "Add to compare" buttons and verifies comparison table renders
- Flow D fills login/signup form, mocks Supabase auth, detects success state

**`bots/journey/personas.cjs`** (new)
- Standard persona definitions as a CJS module
- `getPersona(name)` returns all env vars needed by any journey script
- 6 personas: new-investor, advice-seeker, quiz-taker, mobile-shopper, first-home-buyer, startup-investor

**`.github/workflows/ai-journey.yml`** (new)
- Weekly schedule: Fridays 16:00 UTC
- `workflow_dispatch` with `target`, `flows`, and `persona` inputs
- Runs on a clean GitHub runner — **no TLS-MITM proxy**, so quiz fetches complete end-to-end
- 4 link-crawler personas + 2 form runs (desktop + mobile) + lead flows
- All steps `continue-on-error: true` (advisory, never a merge gate)
- Uploads all JSON reports + screenshots as a 14-day artifact

**`.claude/commands/ai-journey.md`** (updated)
- Script reference table
- Persona table with start path / viewport / steps
- Step-by-step run instructions for sandbox vs GitHub Actions
- Note about TLS-MITM proxy limitation in sandbox

## How to use

**In-session (sandbox):** `/ai-journey advice-seeker` — link crawler works; quiz fetch may time out

**Full run:** Actions → "AI journey" → Run workflow → download `ai-journey-<run-id>` artifact → read JSON + screenshots with Claude

https://claude.ai/code/session_01QqCyz6TKBmdqQitiwua9Xn

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqCyz6TKBmdqQitiwua9Xn)_