### PR TITLE
fix(invest): register MM-V01b discovery verticals + rescue 69 orphaned test files

### DIFF
--- a/__tests__/api/account-holdings-handoff-token.test.ts
+++ b/__tests__/api/account-holdings-handoff-token.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for GET /api/account/holdings/handoff/[token]
+ *
+ * Auth: PUBLIC — the token IS the auth factor (random opaque UUID, 14-day TTL,
+ * single-consumption). No session required.
+ * Delegates to lib/investor-handoff.ts → getHandoff().
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+const mockGetHandoff = vi.fn(
+  async (_token: unknown): Promise<{
+    intent: string;
+    holdings: unknown[];
+    created_at: string;
+  } | null> => null,
+);
+
+vi.mock("@/lib/investor-handoff", () => ({
+  getHandoff: (...args: unknown[]) => mockGetHandoff(args[0]),
+}));
+
+import { GET } from "@/app/api/account/holdings/handoff/[token]/route";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const validToken = "550e8400-e29b-41d4-a716-446655440000";
+
+function makeReq(token: string): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/account/holdings/handoff/${token}`,
+    { method: "GET" },
+  );
+}
+
+function makeParams(token: string): { params: Promise<{ token: string }> } {
+  return { params: Promise.resolve({ token }) };
+}
+
+const mockHandoffResult = {
+  intent: "tax-prep",
+  holdings: [
+    {
+      ticker: "VAS",
+      exchange: "ASX",
+      shares: 100,
+      cost_basis_per_share_cents: 9500,
+      acquired_at: "2024-01-15",
+      broker_slug: "selfwealth",
+      notes: null,
+    },
+  ],
+  created_at: "2026-05-01T00:00:00Z",
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("GET /api/account/holdings/handoff/[token]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetHandoff.mockResolvedValue(null);
+  });
+
+  it("returns 400 when token is empty string", async () => {
+    const res = await GET(makeReq(""), makeParams(""));
+    expect(res.status).toBe(400);
+    const json = await res.json() as { error: string };
+    expect(json.error).toBe("invalid_token");
+  });
+
+  it("returns 400 when token exceeds 200 characters", async () => {
+    const longToken = "x".repeat(201);
+    const res = await GET(makeReq(longToken), makeParams(longToken));
+    expect(res.status).toBe(400);
+    const json = await res.json() as { error: string };
+    expect(json.error).toBe("invalid_token");
+  });
+
+  it("returns 404 when handoff is not found / expired / consumed", async () => {
+    mockGetHandoff.mockResolvedValue(null);
+    const res = await GET(makeReq(validToken), makeParams(validToken));
+    expect(res.status).toBe(404);
+    const json = await res.json() as { error: string };
+    expect(json.error).toBe("not_found");
+  });
+
+  it("calls getHandoff with the resolved token from params", async () => {
+    mockGetHandoff.mockResolvedValue(null);
+    await GET(makeReq(validToken), makeParams(validToken));
+    expect(mockGetHandoff).toHaveBeenCalledWith(validToken);
+  });
+
+  it("returns 200 with holdings snapshot when token is valid", async () => {
+    mockGetHandoff.mockResolvedValue(mockHandoffResult);
+    const res = await GET(makeReq(validToken), makeParams(validToken));
+    expect(res.status).toBe(200);
+    const json = await res.json() as typeof mockHandoffResult;
+    expect(json).toHaveProperty("intent", "tax-prep");
+    expect(json).toHaveProperty("holdings");
+    expect(Array.isArray(json.holdings)).toBe(true);
+    expect(json.holdings).toHaveLength(1);
+    expect(json).toHaveProperty("created_at", "2026-05-01T00:00:00Z");
+  });
+
+  it("sets Cache-Control: private, no-store on successful response", async () => {
+    mockGetHandoff.mockResolvedValue(mockHandoffResult);
+    const res = await GET(makeReq(validToken), makeParams(validToken));
+    expect(res.headers.get("cache-control")).toBe("private, no-store");
+  });
+
+  it("returns holdings details correctly (ticker, exchange, shares, etc.)", async () => {
+    mockGetHandoff.mockResolvedValue(mockHandoffResult);
+    const res = await GET(makeReq(validToken), makeParams(validToken));
+    const json = await res.json() as { holdings: Array<{ ticker: string; shares: number }> };
+    const holding = json.holdings[0];
+    expect(holding).toBeDefined();
+    expect(holding?.ticker).toBe("VAS");
+    expect(holding?.shares).toBe(100);
+  });
+
+  it("does NOT require auth — no supabase client mocking needed", async () => {
+    // The route has no supabase import; this confirms that by simply running
+    // without any supabase mock and still getting a 404 (not 401/500)
+    mockGetHandoff.mockResolvedValue(null);
+    const res = await GET(makeReq(validToken), makeParams(validToken));
+    expect(res.status).toBe(404); // Not 401 — auth is not checked
+  });
+
+  it("returns 400 for token exactly at 200 chars boundary (exactly 200 chars is valid)", async () => {
+    // 200 chars is the max allowed length, should pass token validation
+    // and proceed to getHandoff (which returns null → 404)
+    const borderToken = "a".repeat(200);
+    mockGetHandoff.mockResolvedValue(null);
+    const res = await GET(makeReq(borderToken), makeParams(borderToken));
+    // 200-char token passes the guard; getHandoff returns null → 404
+    expect(res.status).toBe(404);
+  });
+});

--- a/__tests__/api/account-profile-share-token.test.ts
+++ b/__tests__/api/account-profile-share-token.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for GET /api/account/profile-share/[token]
+ *
+ * Auth: PUBLIC — the token IS the auth factor. No session required.
+ * Rate-limit: 60/min/IP via isAllowed().
+ * Delegates data fetching to lib/profile-share.ts → getProfileShare().
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockGetProfileShare = vi.fn(
+  async (_token: unknown): Promise<{
+    snapshot: Record<string, unknown>;
+    wasConsumedPreviously: boolean;
+    expiresAt: string;
+  } | null> => null,
+);
+
+vi.mock("@/lib/profile-share", () => ({
+  getProfileShare: (...args: unknown[]) => mockGetProfileShare(args[0]),
+}));
+
+const mockIsAllowed = vi.fn(async (): Promise<boolean> => true);
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: (..._a: unknown[]) => mockIsAllowed(),
+  ipKey: () => "test-ip",
+}));
+
+import { GET } from "@/app/api/account/profile-share/[token]/route";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeReq(token: string): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/account/profile-share/${token}`,
+    {
+      method: "GET",
+      headers: { "x-forwarded-for": "1.2.3.4" },
+    },
+  );
+}
+
+function makeParams(token: string): { params: Promise<{ token: string }> } {
+  return { params: Promise.resolve({ token }) };
+}
+
+const validToken = "a".repeat(48); // 24-byte hex token
+
+const mockSnapshot = {
+  goals: { is_fhb: true, is_pre_retiree: false, is_business_owner: false,
+           is_cross_border: false, is_hnw: false, budget_band: null,
+           experience_level: null, primary_vertical: null, display_name: null },
+  quiz: null,
+  watchlist: [],
+  health: null,
+  created_at: "2026-01-01T00:00:00Z",
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("GET /api/account/profile-share/[token]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+    mockGetProfileShare.mockResolvedValue(null);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsAllowed.mockResolvedValue(false);
+    const res = await GET(makeReq(validToken), makeParams(validToken));
+    expect(res.status).toBe(429);
+    const json = await res.json() as { error: string };
+    expect(json.error).toMatch(/too many/i);
+  });
+
+  it("returns 404 when token not found / expired / revoked", async () => {
+    mockGetProfileShare.mockResolvedValue(null);
+    const res = await GET(makeReq(validToken), makeParams(validToken));
+    expect(res.status).toBe(404);
+    const json = await res.json() as { error: string };
+    expect(json.error).toMatch(/not found|expired|revoked/i);
+  });
+
+  it("returns 200 with snapshot when token is valid (first read)", async () => {
+    mockGetProfileShare.mockResolvedValue({
+      snapshot: mockSnapshot,
+      wasConsumedPreviously: false,
+      expiresAt: "2026-06-01T00:00:00Z",
+    });
+    const res = await GET(makeReq(validToken), makeParams(validToken));
+    expect(res.status).toBe(200);
+    const json = await res.json() as {
+      snapshot: unknown;
+      was_consumed_previously: boolean;
+      expires_at: string;
+    };
+    expect(json).toHaveProperty("snapshot");
+    expect(json.was_consumed_previously).toBe(false);
+    expect(json.expires_at).toBe("2026-06-01T00:00:00Z");
+  });
+
+  it("returns was_consumed_previously=true on subsequent reads", async () => {
+    mockGetProfileShare.mockResolvedValue({
+      snapshot: mockSnapshot,
+      wasConsumedPreviously: true,
+      expiresAt: "2026-06-01T00:00:00Z",
+    });
+    const res = await GET(makeReq(validToken), makeParams(validToken));
+    expect(res.status).toBe(200);
+    const json = await res.json() as { was_consumed_previously: boolean };
+    expect(json.was_consumed_previously).toBe(true);
+  });
+
+  it("calls getProfileShare with the resolved token from params", async () => {
+    const token = "b".repeat(48);
+    mockGetProfileShare.mockResolvedValue({
+      snapshot: mockSnapshot,
+      wasConsumedPreviously: false,
+      expiresAt: "2026-06-01T00:00:00Z",
+    });
+    await GET(makeReq(token), makeParams(token));
+    expect(mockGetProfileShare).toHaveBeenCalledWith(token);
+  });
+
+  it("returns snapshot contents including goals and watchlist", async () => {
+    const snapshot = {
+      ...mockSnapshot,
+      goals: { is_fhb: true, is_pre_retiree: false, is_business_owner: false,
+               is_cross_border: false, is_hnw: true, budget_band: "1m",
+               experience_level: "advanced", primary_vertical: "etf", display_name: "Bob" },
+      watchlist: [{ item_type: "etf", item_slug: "vas", display_name: "VAS" }],
+    };
+    mockGetProfileShare.mockResolvedValue({
+      snapshot,
+      wasConsumedPreviously: false,
+      expiresAt: "2026-06-01T00:00:00Z",
+    });
+    const res = await GET(makeReq(validToken), makeParams(validToken));
+    expect(res.status).toBe(200);
+    const json = await res.json() as { snapshot: typeof snapshot };
+    expect(json.snapshot.goals).toMatchObject({ is_fhb: true, is_hnw: true, display_name: "Bob" });
+    expect(json.snapshot.watchlist).toHaveLength(1);
+  });
+});

--- a/__tests__/api/account-user-lists-id-items.test.ts
+++ b/__tests__/api/account-user-lists-id-items.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Tests for GET/POST/DELETE /api/account/user-lists/[id]/items
+ *
+ * Auth: GET is accessible to list owner or when is_public=true (no user required).
+ *       POST and DELETE require an authenticated user who owns the list.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+const mockGetUser = vi.fn(
+  async (): Promise<{ data: { user: { id: string; email?: string } | null }; error: unknown }> => ({
+    data: { user: { id: "u1", email: "u@e.com" } },
+    error: null,
+  }),
+);
+
+function makeBuilder(
+  data: unknown = [],
+  error: unknown = null,
+): Record<string, unknown> {
+  const c: Record<string, unknown> = {
+    then: (r: (v: { data: unknown; error: unknown }) => unknown) =>
+      Promise.resolve(r({ data, error })),
+  };
+  for (const m of [
+    "select", "insert", "update", "upsert", "delete", "eq", "neq", "gt",
+    "gte", "lt", "lte", "in", "is", "not", "or", "order", "limit", "range",
+    "single", "maybeSingle", "filter", "contains", "overlaps",
+  ]) {
+    c[m] = vi.fn((..._a: unknown[]) => c);
+  }
+  return c;
+}
+
+const mockFrom = vi.fn((..._a: unknown[]) => makeBuilder());
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    from: mockFrom,
+    auth: { getUser: mockGetUser },
+  })),
+}));
+
+import { GET, POST, DELETE } from "@/app/api/account/user-lists/[id]/items/route";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeReq(method: string, body?: unknown, listId = "5"): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/account/user-lists/${listId}/items`,
+    {
+      method,
+      ...(body !== undefined
+        ? { body: JSON.stringify(body), headers: { "content-type": "application/json" } }
+        : {}),
+    },
+  );
+}
+
+const validItem = {
+  item_type: "broker",
+  item_ref: "stake",
+  label: "Stake",
+  notes: "Good broker",
+};
+
+// ── GET ───────────────────────────────────────────────────────────────────────
+
+describe("GET /api/account/user-lists/[id]/items", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } }, error: null });
+  });
+
+  it("returns 400 when listId is not a valid integer", async () => {
+    const res = await GET(makeReq("GET", undefined, "abc"));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("invalid_id");
+  });
+
+  it("returns 404 when list does not exist", async () => {
+    // First from() call is user_lists single → null
+    mockFrom.mockImplementationOnce(() => makeBuilder(null));
+    const res = await GET(makeReq("GET"));
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json.error).toBe("not_found");
+  });
+
+  it("returns 403 when list is private and user is not owner", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "other-user" } }, error: null });
+    // List exists but owned by u1, not public
+    mockFrom.mockImplementationOnce(() =>
+      makeBuilder({ id: 5, owner_user_id: "u1", is_public: false }),
+    );
+    const res = await GET(makeReq("GET"));
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.error).toBe("forbidden");
+  });
+
+  it("returns 403 when unauthenticated user requests private list", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+    mockFrom.mockImplementationOnce(() =>
+      makeBuilder({ id: 5, owner_user_id: "u1", is_public: false }),
+    );
+    const res = await GET(makeReq("GET"));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns items for the owner of a private list", async () => {
+    mockFrom
+      .mockImplementationOnce(() =>
+        makeBuilder({ id: 5, owner_user_id: "u1", is_public: false }),
+      )
+      .mockImplementationOnce(() =>
+        makeBuilder([{ id: 1, item_type: "broker", item_ref: "stake", label: "", notes: "", added_at: "2026-01-01" }]),
+      );
+    const res = await GET(makeReq("GET"));
+    expect(res.status).toBe(200);
+    const json = await res.json() as { items: unknown[] };
+    expect(json).toHaveProperty("items");
+    expect(Array.isArray(json.items)).toBe(true);
+    expect(json.items).toHaveLength(1);
+  });
+
+  it("returns items for a public list even when unauthenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+    mockFrom
+      .mockImplementationOnce(() =>
+        makeBuilder({ id: 5, owner_user_id: "u1", is_public: true }),
+      )
+      .mockImplementationOnce(() => makeBuilder([]));
+    const res = await GET(makeReq("GET"));
+    expect(res.status).toBe(200);
+    const json = await res.json() as { items: unknown[] };
+    expect(json.items).toEqual([]);
+  });
+
+  it("returns 500 when items query fails", async () => {
+    mockFrom
+      .mockImplementationOnce(() =>
+        makeBuilder({ id: 5, owner_user_id: "u1", is_public: true }),
+      )
+      .mockImplementationOnce(() => makeBuilder(null, { message: "db error", code: "XXXXX" }));
+    const res = await GET(makeReq("GET"));
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toBe("fetch_failed");
+  });
+});
+
+// ── POST ──────────────────────────────────────────────────────────────────────
+
+describe("POST /api/account/user-lists/[id]/items", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } }, error: null });
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+    const res = await POST(makeReq("POST", validItem));
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error).toBe("unauthorized");
+  });
+
+  it("returns 400 when item_type is invalid", async () => {
+    const res = await POST(makeReq("POST", { ...validItem, item_type: "unknown_type" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when item_ref is missing", async () => {
+    const res = await POST(makeReq("POST", { item_type: "broker" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when body is invalid JSON", async () => {
+    const req = new NextRequest("http://localhost/api/account/user-lists/5/items", {
+      method: "POST",
+      body: "not-json{",
+      headers: { "content-type": "application/json" },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid listId", async () => {
+    const res = await POST(makeReq("POST", validItem, "0"));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("invalid_id");
+  });
+
+  it("returns 404 when user does not own the list", async () => {
+    // ownership check returns null (not found for this user)
+    mockFrom.mockImplementationOnce(() => makeBuilder(null));
+    const res = await POST(makeReq("POST", validItem));
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json.error).toBe("not_found");
+  });
+
+  it("returns 409 on duplicate item (unique constraint violation)", async () => {
+    mockFrom
+      .mockImplementationOnce(() => makeBuilder({ id: 5, owner_user_id: "u1" }))
+      .mockImplementationOnce(() => makeBuilder(null, { code: "23505", message: "dup" }));
+    const res = await POST(makeReq("POST", validItem));
+    expect(res.status).toBe(409);
+    const json = await res.json();
+    expect(json.error).toBe("already_in_list");
+  });
+
+  it("returns 500 on other insert errors", async () => {
+    mockFrom
+      .mockImplementationOnce(() => makeBuilder({ id: 5, owner_user_id: "u1" }))
+      .mockImplementationOnce(() => makeBuilder(null, { code: "XXXXX", message: "db fail" }));
+    const res = await POST(makeReq("POST", validItem));
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toBe("insert_failed");
+  });
+
+  it("returns 201 with item on success", async () => {
+    const newItem = { id: 99, ...validItem, added_at: "2026-05-01T00:00:00Z" };
+    mockFrom
+      .mockImplementationOnce(() => makeBuilder({ id: 5, owner_user_id: "u1" }))
+      .mockImplementationOnce(() => makeBuilder(newItem));
+    const res = await POST(makeReq("POST", validItem));
+    expect(res.status).toBe(201);
+    const json = await res.json() as { item: typeof newItem };
+    expect(json).toHaveProperty("item");
+    expect(json.item.item_ref).toBe("stake");
+  });
+});
+
+// ── DELETE ────────────────────────────────────────────────────────────────────
+
+describe("DELETE /api/account/user-lists/[id]/items", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } }, error: null });
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+    const res = await DELETE(makeReq("DELETE", { item_type: "broker", item_ref: "stake" }));
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error).toBe("unauthorized");
+  });
+
+  it("returns 400 for invalid listId", async () => {
+    const res = await DELETE(makeReq("DELETE", { item_type: "broker", item_ref: "stake" }, "nan"));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("invalid_id");
+  });
+
+  it("returns 400 when item_type is missing", async () => {
+    const res = await DELETE(makeReq("DELETE", { item_ref: "stake" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when item_ref is missing", async () => {
+    const res = await DELETE(makeReq("DELETE", { item_type: "broker" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 500 when delete query fails", async () => {
+    mockFrom.mockImplementationOnce(() => makeBuilder(null, { message: "delete error" }));
+    const res = await DELETE(makeReq("DELETE", { item_type: "broker", item_ref: "stake" }));
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toBe("delete_failed");
+  });
+
+  it("returns 200 ok on successful delete", async () => {
+    mockFrom.mockImplementationOnce(() => makeBuilder(null, null));
+    const res = await DELETE(makeReq("DELETE", { item_type: "broker", item_ref: "stake" }));
+    expect(res.status).toBe(200);
+    const json = await res.json() as { ok: boolean };
+    expect(json.ok).toBe(true);
+  });
+});

--- a/__tests__/api/admin-ab-tests.test.ts
+++ b/__tests__/api/admin-ab-tests.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+const mockRequireAdmin = vi.fn();
+vi.mock("@/lib/require-admin", () => ({
+  requireAdmin: (..._a: unknown[]) => mockRequireAdmin(),
+}));
+
+function makeBuilder(data: unknown = [], error: unknown = null) {
+  const c: Record<string, unknown> = {
+    then: (r: (v: { data: unknown; error: unknown }) => unknown) =>
+      Promise.resolve(r({ data, error })),
+  };
+  for (const m of [
+    "select", "insert", "update", "upsert", "delete", "eq", "neq", "gt", "gte",
+    "lt", "lte", "in", "is", "not", "or", "order", "limit", "range", "single",
+    "maybeSingle", "filter",
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  return c;
+}
+
+const mockFrom = vi.fn((..._a: unknown[]) => makeBuilder());
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+import { GET, POST, PATCH } from "@/app/api/admin/ab-tests/route";
+
+function makeReq(method = "GET", body?: unknown): NextRequest {
+  return new Request("http://localhost/api/admin/ab-tests", {
+    method,
+    ...(body !== undefined
+      ? { body: JSON.stringify(body), headers: { "content-type": "application/json" } }
+      : {}),
+  }) as unknown as NextRequest;
+}
+
+const adminOk = { ok: true, email: "admin@invest.com.au", userId: "u1" };
+const adminDenied = {
+  ok: false,
+  response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+};
+const adminForbidden = {
+  ok: false,
+  response: NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+};
+
+const validCreateBody = {
+  name: "Hero CTA test",
+  test_type: "cta",
+  page: "/brokers",
+  variant_a: { label: "Open Account" },
+  variant_b: { label: "Start Free" },
+  traffic_split: 0.5,
+};
+
+describe("GET /api/admin/ab-tests", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdmin.mockResolvedValue(adminOk);
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder([], null));
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockRequireAdmin.mockResolvedValue(adminDenied);
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for non-admin email", async () => {
+    mockRequireAdmin.mockResolvedValue(adminForbidden);
+    const res = await GET();
+    expect(res.status).toBe(403);
+  });
+
+  it("returns tests list when admin", async () => {
+    const tests = [{ id: 1, name: "Hero test", status: "draft" }];
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder(tests, null));
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.tests).toHaveLength(1);
+    expect(json.tests[0].name).toBe("Hero test");
+  });
+
+  it("returns empty array when table is empty", async () => {
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder(null, null));
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.tests).toEqual([]);
+  });
+
+  it("returns 500 on DB error", async () => {
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder(null, { message: "connection lost" }));
+    const res = await GET();
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toBe("connection lost");
+  });
+});
+
+describe("POST /api/admin/ab-tests", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdmin.mockResolvedValue(adminOk);
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder(null, null));
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockRequireAdmin.mockResolvedValue(adminDenied);
+    const res = await POST(makeReq("POST", validCreateBody));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    const req = new Request("http://localhost/api/admin/ab-tests", {
+      method: "POST",
+      body: "not-json{",
+      headers: { "content-type": "application/json" },
+    }) as unknown as NextRequest;
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/invalid json/i);
+  });
+
+  it("returns 400 when required field is missing (name)", async () => {
+    const { name: _n, ...noName } = validCreateBody;
+    const res = await POST(makeReq("POST", noName));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when traffic_split is missing", async () => {
+    const { traffic_split: _ts, ...noSplit } = validCreateBody;
+    const res = await POST(makeReq("POST", noSplit));
+    expect(res.status).toBe(400);
+  });
+
+  it("creates a test and returns 200", async () => {
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder(null, null));
+    const res = await POST(makeReq("POST", validCreateBody));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+  });
+
+  it("returns 500 on DB insert error", async () => {
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder(null, { message: "db error" }));
+    const res = await POST(makeReq("POST", validCreateBody));
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toBe("db error");
+  });
+});
+
+describe("PATCH /api/admin/ab-tests", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdmin.mockResolvedValue(adminOk);
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder(null, null));
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockRequireAdmin.mockResolvedValue(adminDenied);
+    const res = await PATCH(makeReq("PATCH", { id: 1, status: "running" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    const req = new Request("http://localhost/api/admin/ab-tests", {
+      method: "PATCH",
+      body: "bad{",
+      headers: { "content-type": "application/json" },
+    }) as unknown as NextRequest;
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when id is missing", async () => {
+    const res = await PATCH(makeReq("PATCH", { status: "running" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when no update fields provided (only id)", async () => {
+    const res = await PATCH(makeReq("PATCH", { id: 1 }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("no_updates");
+  });
+
+  it("returns 400 when winner is not a or b", async () => {
+    const res = await PATCH(makeReq("PATCH", { id: 1, winner: "c" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("updates status and returns 200", async () => {
+    const res = await PATCH(makeReq("PATCH", { id: 1, status: "running" }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+  });
+
+  it("updates winner and returns 200", async () => {
+    const res = await PATCH(makeReq("PATCH", { id: 1, winner: "a", status: "concluded" }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+  });
+
+  it("updates start_date and end_date fields", async () => {
+    const res = await PATCH(
+      makeReq("PATCH", { id: 2, start_date: "2026-01-01", end_date: "2026-02-01", updated_at: "2026-01-01T00:00:00Z" }),
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 500 on DB update error", async () => {
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder(null, { message: "write failed" }));
+    const res = await PATCH(makeReq("PATCH", { id: 1, status: "paused" }));
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toBe("write failed");
+  });
+});

--- a/__tests__/api/admin-affiliate-dashboard.test.ts
+++ b/__tests__/api/admin-affiliate-dashboard.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+const mockRequireAdmin = vi.fn();
+vi.mock("@/lib/require-admin", () => ({
+  requireAdmin: (..._a: unknown[]) => mockRequireAdmin(),
+}));
+
+function makeBuilder(data: unknown = [], error: unknown = null) {
+  const c: Record<string, unknown> = {
+    then: (r: (v: { data: unknown; error: unknown }) => unknown) =>
+      Promise.resolve(r({ data, error })),
+  };
+  for (const m of [
+    "select", "insert", "update", "upsert", "delete", "eq", "neq", "gt", "gte",
+    "lt", "lte", "in", "is", "not", "or", "order", "limit", "range", "single",
+    "maybeSingle", "filter",
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  return c;
+}
+
+const mockFrom = vi.fn((..._a: unknown[]) => makeBuilder());
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+import { GET } from "@/app/api/admin/affiliate-dashboard/route";
+
+function makeReq(period?: string): NextRequest {
+  const url = period
+    ? `http://localhost/api/admin/affiliate-dashboard?period=${period}`
+    : "http://localhost/api/admin/affiliate-dashboard";
+  return new Request(url, { method: "GET" }) as unknown as NextRequest;
+}
+
+const adminOk = { ok: true, email: "admin@invest.com.au", userId: "u1" };
+const adminDenied = {
+  ok: false,
+  response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+};
+const adminForbidden = {
+  ok: false,
+  response: NextResponse.json({ error: "Forbidden" }, { status: 403 }),
+};
+
+const sampleClicks = [
+  { broker_slug: "broker-a", broker_name: "Broker A", created_at: "2026-05-01T00:00:00Z" },
+];
+const sampleSignups = [
+  { id: "s1", broker_slug: "broker-a", click_id: "c1", signup_date: "2026-05-10", revenue_cents: 5000, status: "confirmed", source: "organic", external_ref: null, utm_source: null, utm_campaign: null },
+];
+const sampleReports = [
+  { id: "r1", month: "2026-05", revenue_cents: 10000 },
+];
+
+describe("GET /api/admin/affiliate-dashboard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdmin.mockResolvedValue(adminOk);
+    // Default: all queries succeed with sample data
+    let callCount = 0;
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      callCount++;
+      if (callCount === 1) return makeBuilder(sampleClicks, null);
+      if (callCount === 2) return makeBuilder(sampleSignups, null);
+      return makeBuilder(sampleReports, null);
+    });
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockRequireAdmin.mockResolvedValue(adminDenied);
+    const res = await GET(makeReq());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for non-admin user", async () => {
+    mockRequireAdmin.mockResolvedValue(adminForbidden);
+    const res = await GET(makeReq());
+    expect(res.status).toBe(403);
+  });
+
+  it("returns clicks, signups, and monthlyReports for default period (30d)", async () => {
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.clicks).toHaveLength(1);
+    expect(json.signups).toHaveLength(1);
+    expect(json.monthlyReports).toHaveLength(1);
+  });
+
+  it("accepts period=7d without error", async () => {
+    const res = await GET(makeReq("7d"));
+    expect(res.status).toBe(200);
+  });
+
+  it("accepts period=30d without error", async () => {
+    const res = await GET(makeReq("30d"));
+    expect(res.status).toBe(200);
+  });
+
+  it("accepts period=90d without error", async () => {
+    const res = await GET(makeReq("90d"));
+    expect(res.status).toBe(200);
+  });
+
+  it("accepts period=all without error", async () => {
+    const res = await GET(makeReq("all"));
+    expect(res.status).toBe(200);
+  });
+
+  it("falls back to 30d for unrecognised period parameter", async () => {
+    const res = await GET(makeReq("99y"));
+    expect(res.status).toBe(200);
+  });
+
+  it("returns empty arrays when tables are empty (null data)", async () => {
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder(null, null));
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.clicks).toEqual([]);
+    expect(json.signups).toEqual([]);
+    expect(json.monthlyReports).toEqual([]);
+  });
+
+  it("returns 500 when clicks query fails", async () => {
+    let callCount = 0;
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      callCount++;
+      if (callCount === 1) return makeBuilder(null, { message: "clicks error" });
+      if (callCount === 2) return makeBuilder(sampleSignups, null);
+      return makeBuilder(sampleReports, null);
+    });
+    const res = await GET(makeReq());
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toMatch(/failed to load/i);
+  });
+
+  it("returns 500 when signups query fails", async () => {
+    let callCount = 0;
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      callCount++;
+      if (callCount === 1) return makeBuilder(sampleClicks, null);
+      if (callCount === 2) return makeBuilder(null, { message: "signups error" });
+      return makeBuilder(sampleReports, null);
+    });
+    const res = await GET(makeReq());
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 500 when monthly reports query fails", async () => {
+    let callCount = 0;
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      callCount++;
+      if (callCount === 1) return makeBuilder(sampleClicks, null);
+      if (callCount === 2) return makeBuilder(sampleSignups, null);
+      return makeBuilder(null, { message: "reports error" });
+    });
+    const res = await GET(makeReq());
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/admin-article-scorecard.test.ts
+++ b/__tests__/api/admin-article-scorecard.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockRequireAdmin = vi.fn();
+vi.mock("@/lib/require-admin", () => ({
+  requireAdmin: () => mockRequireAdmin(),
+}));
+
+const mockFrom = vi.fn();
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+const mockRunScorecard = vi.fn();
+vi.mock("@/lib/article-scorecard", () => ({
+  runScorecard: (...args: unknown[]) => mockRunScorecard(...args),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() })),
+}));
+
+import { POST, GET } from "@/app/api/admin/article-scorecard/route";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const ADMIN_GUARD = { ok: true, email: "admin@test.com", userId: "uid-1" } as const;
+const DENY_GUARD = {
+  ok: false,
+  response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+} as const;
+
+const SCORECARD_RESULT = {
+  score: 85,
+  grade: "B",
+  passedChecks: ["word_count", "has_excerpt"],
+  failedChecks: ["no_perf_guarantee"],
+  remediation: [{ check: "no_perf_guarantee", severity: "soft", message: "Remove performance guarantees" }],
+};
+
+function makePost(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/admin/article-scorecard", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeGet(params: Record<string, string> = {}): NextRequest {
+  const url = new URL("http://localhost/api/admin/article-scorecard");
+  Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  return new NextRequest(url);
+}
+
+function setupFromMock(maybySingleData: unknown = null, insertError: { message: string } | null = null) {
+  mockFrom.mockImplementation((table: string) => {
+    if (table === "article_scorecard_runs") {
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        order: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockReturnThis(),
+        insert: vi.fn().mockResolvedValue({ error: insertError }),
+        maybeSingle: vi.fn().mockResolvedValue({ data: maybySingleData }),
+      };
+    }
+    if (table === "admin_audit_log") {
+      return { insert: vi.fn().mockResolvedValue({ error: null }) };
+    }
+    return {};
+  });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("POST /api/admin/article-scorecard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdmin.mockResolvedValue(ADMIN_GUARD);
+    mockRunScorecard.mockReturnValue(SCORECARD_RESULT);
+    setupFromMock();
+  });
+
+  it("returns 401 when not admin", async () => {
+    mockRequireAdmin.mockResolvedValue(DENY_GUARD);
+    const res = await POST(makePost({ slug: "test", title: "T", body: "B" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when slug is missing", async () => {
+    const res = await POST(makePost({ title: "Test Article", body: "Some body text" }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/slug/);
+  });
+
+  it("returns 400 when title is missing", async () => {
+    const res = await POST(makePost({ slug: "test-slug", body: "Some body text" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when body is missing", async () => {
+    const res = await POST(makePost({ slug: "test-slug", title: "Test Article" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 200 with scorecard result", async () => {
+    const res = await POST(makePost({ slug: "test", title: "Test Article", body: "Body text" }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.score).toBe(85);
+    expect(json.grade).toBe("B");
+    expect(json.passed_checks).toEqual(["word_count", "has_excerpt"]);
+    expect(json.failed_checks).toEqual(["no_perf_guarantee"]);
+  });
+
+  it("calls runScorecard with correct input fields", async () => {
+    await POST(makePost({
+      slug: "test",
+      title: "T",
+      body: "B",
+      excerpt: "Exc",
+      category: "investing",
+      tags: ["smsf"],
+      template_slug: "review",
+      min_words: 500,
+    }));
+    expect(mockRunScorecard).toHaveBeenCalledWith(expect.objectContaining({
+      title: "T",
+      body: "B",
+      excerpt: "Exc",
+      category: "investing",
+      tags: ["smsf"],
+      templateSlug: "review",
+      minWords: 500,
+    }));
+  });
+
+  it("persists to article_scorecard_runs when persist=true", async () => {
+    let insertCalled = false;
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "article_scorecard_runs") {
+        return {
+          insert: vi.fn().mockImplementation(() => {
+            insertCalled = true;
+            return Promise.resolve({ error: null });
+          }),
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          order: vi.fn().mockReturnThis(),
+          limit: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({ data: null }),
+        };
+      }
+      if (table === "admin_audit_log") {
+        return { insert: vi.fn().mockResolvedValue({ error: null }) };
+      }
+      return {};
+    });
+    await POST(makePost({ slug: "my-slug", title: "T", body: "B", persist: true }));
+    expect(insertCalled).toBe(true);
+  });
+
+  it("does not persist when persist is not set", async () => {
+    let insertCalled = false;
+    mockFrom.mockImplementation(() => ({
+      insert: vi.fn().mockImplementation(() => {
+        insertCalled = true;
+        return Promise.resolve({ error: null });
+      }),
+    }));
+    await POST(makePost({ slug: "my-slug", title: "T", body: "B" }));
+    expect(insertCalled).toBe(false);
+  });
+});
+
+describe("GET /api/admin/article-scorecard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdmin.mockResolvedValue(ADMIN_GUARD);
+    setupFromMock();
+  });
+
+  it("returns 401 when not admin", async () => {
+    mockRequireAdmin.mockResolvedValue(DENY_GUARD);
+    const res = await GET(makeGet({ slug: "test" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when slug param is missing", async () => {
+    const res = await GET(makeGet());
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/Missing slug/);
+  });
+
+  it("returns 200 with null item when no run found", async () => {
+    setupFromMock(null);
+    const res = await GET(makeGet({ slug: "new-article" }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.item).toBeNull();
+  });
+
+  it("returns 200 with run data when found", async () => {
+    setupFromMock({ score: 90, grade: "A", article_slug: "found-article" });
+    const res = await GET(makeGet({ slug: "found-article" }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.item).toMatchObject({ score: 90, grade: "A" });
+  });
+});

--- a/__tests__/api/admin-articles-editor-save.test.ts
+++ b/__tests__/api/admin-articles-editor-save.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+const mockRequireAdmin = vi.fn();
+vi.mock("@/lib/require-admin", () => ({
+  requireAdmin: () => mockRequireAdmin(),
+}));
+
+const mockFrom = vi.fn();
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+const mockRunScorecard = vi.fn();
+vi.mock("@/lib/article-scorecard", () => ({
+  runScorecard: (...args: unknown[]) => mockRunScorecard(...args),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/admin/articles-editor/save/route";
+
+const ADMIN_GUARD_OK = { ok: true as const, email: "admin@test.com", response: undefined };
+const GOOD_SCORECARD = { grade: "A", score: 90, passedChecks: [], failedChecks: [], remediation: [] };
+const FAIL_SCORECARD = { grade: "F", score: 10, passedChecks: [], failedChecks: ["too short"], remediation: [] };
+
+function makeReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/admin/articles-editor/save", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRequireAdmin.mockResolvedValue(ADMIN_GUARD_OK);
+  mockRunScorecard.mockReturnValue(GOOD_SCORECARD);
+  mockFrom.mockImplementation((table: string) => {
+    if (table === "articles") {
+      return { upsert: vi.fn().mockResolvedValue({ data: null, error: null }) };
+    }
+    return { insert: vi.fn().mockResolvedValue({ data: null, error: null }) };
+  });
+});
+
+describe("POST /api/admin/articles-editor/save", () => {
+  it("returns 401 when requireAdmin denies", async () => {
+    mockRequireAdmin.mockResolvedValueOnce({ ok: false as const, response: new NextResponse(null, { status: 401 }) });
+    const res = await POST(makeReq({ slug: "my-slug", title: "My Article Title", content: "body" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when slug is invalid (uppercase / spaces)", async () => {
+    const res = await POST(makeReq({ slug: "Bad Slug!", title: "My Article Title", content: "body" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/slug/i);
+  });
+
+  it("returns 400 when title is too short", async () => {
+    const res = await POST(makeReq({ slug: "my-slug", title: "Hi", content: "body" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/title/i);
+  });
+
+  it("returns 400 when content is missing", async () => {
+    const res = await POST(makeReq({ slug: "my-slug", title: "My Article Title" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/content/i);
+  });
+
+  it("returns 400 when publishing with grade F scorecard", async () => {
+    mockRunScorecard.mockReturnValueOnce(FAIL_SCORECARD);
+    const res = await POST(makeReq({ slug: "my-slug", title: "My Article Title", content: "body", status: "published" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/grade is F/i);
+    expect(Array.isArray(body.failed_checks)).toBe(true);
+  });
+
+  it("saves draft with grade F without error", async () => {
+    mockRunScorecard.mockReturnValueOnce(FAIL_SCORECARD);
+    const res = await POST(makeReq({ slug: "my-slug", title: "My Article Title", content: "body", status: "draft" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.grade).toBe("F");
+    expect(body.status).toBe("draft");
+  });
+
+  it("returns 200 with ok, grade, score on success", async () => {
+    const res = await POST(makeReq({ slug: "my-slug", title: "My Article Title", content: "body" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.grade).toBe("A");
+    expect(body.score).toBe(90);
+  });
+
+  it("returns 500 when DB upsert fails", async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "articles") {
+        return { upsert: vi.fn().mockResolvedValue({ data: null, error: { message: "constraint violation" } }) };
+      }
+      return { insert: vi.fn().mockResolvedValue({ data: null, error: null }) };
+    });
+    const res = await POST(makeReq({ slug: "my-slug", title: "My Article Title", content: "body" }));
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/admin-content-generate-draft.test.ts
+++ b/__tests__/api/admin-content-generate-draft.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockAdminFrom = vi.fn();
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+// ── Import ────────────────────────────────────────────────────────────────────
+
+import { POST } from "@/app/api/admin/content/generate-draft/route";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makePost(body: unknown, authHeader?: string): NextRequest {
+  return new NextRequest("http://localhost/api/admin/content/generate-draft", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      authorization: authHeader ?? `Bearer test-cron-secret`,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeChain(result: unknown) {
+  const self: Record<string, (...a: unknown[]) => unknown> = {};
+  ["select", "eq", "update", "insert", "order", "limit", "filter"].forEach((k) => {
+    self[k] = () => self;
+  });
+  self["single"] = () => Promise.resolve(result);
+  self["maybeSingle"] = () => Promise.resolve(result);
+  self["then"] = (...a: unknown[]) =>
+    Promise.resolve(result).then(a[0] as Parameters<Promise<unknown>["then"]>[0]);
+  return self;
+}
+
+const CALENDAR_ITEM = {
+  id: 1,
+  title: "Best ETF Brokers in Australia",
+  article_type: "article",
+  category: "brokers",
+  target_keyword: "best etf brokers",
+  secondary_keywords: ["cheap etfs", "asx etfs"],
+  brief: "Compare ETF broker fees.",
+  related_tools: ["/fee-impact"],
+  related_brokers: ["commsec", "selfwealth"],
+  assigned_author_id: null,
+  assigned_reviewer_id: null,
+};
+
+const ARTICLE_BODY = {
+  title: "Best ETF Brokers",
+  content: "Full article body here.",
+  excerpt: "Compare ETF brokers.",
+  meta_title: "Best ETF Brokers AU",
+  meta_description: "Find the best ETF broker for you.",
+  sections: [],
+  tags: ["etfs", "brokers"],
+  read_time: 7,
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("POST /api/admin/content/generate-draft", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = "test-cron-secret";
+    process.env.ANTHROPIC_API_KEY = "test-api-key";
+  });
+
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+    delete process.env.ANTHROPIC_API_KEY;
+  });
+
+  it("returns 401 when authorization header is wrong", async () => {
+    const res = await POST(makePost({ calendarId: 1 }, "Bearer wrong-secret"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 500 when ANTHROPIC_API_KEY not configured", async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    const res = await POST(makePost({ calendarId: 1 }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toMatch(/ANTHROPIC_API_KEY/);
+  });
+
+  it("returns 400 when calendarId missing", async () => {
+    const res = await POST(makePost({}));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/calendarId/);
+  });
+
+  it("returns 404 when calendar item not found", async () => {
+    mockAdminFrom.mockReturnValue(makeChain({ data: null, error: { message: "not found" } }));
+    const res = await POST(makePost({ calendarId: 999 }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 502 when Anthropic API returns non-ok response", async () => {
+    let callCount = 0;
+    mockAdminFrom.mockImplementation(() => {
+      callCount++;
+      // First call: calendar item lookup succeeds
+      // Subsequent: brokers, articles, update status
+      if (callCount === 1) {
+        return makeChain({ data: CALENDAR_ITEM, error: null });
+      }
+      return makeChain({ data: [], error: null });
+    });
+    mockFetch.mockResolvedValue({
+      ok: false,
+      text: () => Promise.resolve("Internal server error"),
+    });
+    const res = await POST(makePost({ calendarId: 1 }));
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.error).toMatch(/Anthropic/i);
+  });
+
+  it("returns 500 when article insert fails", async () => {
+    let callCount = 0;
+    mockAdminFrom.mockImplementation(() => {
+      callCount++;
+      // 1=calendar item, 2=brokers, 3=articles, 4=update drafting status, 5=articles insert
+      if (callCount === 1) return makeChain({ data: CALENDAR_ITEM, error: null });
+      if (callCount === 5) return makeChain({ data: null, error: { message: "slug conflict" } });
+      return makeChain({ data: [], error: null });
+    });
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          content: [{ text: JSON.stringify(ARTICLE_BODY) }],
+        }),
+    });
+    const res = await POST(makePost({ calendarId: 1 }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toMatch(/draft/i);
+  });
+
+  it("returns 200 success with articleId when Anthropic responds with valid JSON", async () => {
+    let callCount = 0;
+    mockAdminFrom.mockImplementation(() => {
+      callCount++;
+      // 1=calendar, 2=brokers, 3=existing-articles, 4=update-drafting, 5=insert-article, 6=update-draft-ready
+      if (callCount === 1) return makeChain({ data: CALENDAR_ITEM, error: null });
+      if (callCount === 5) return makeChain({ data: { id: 42 }, error: null });
+      return makeChain({ data: [], error: null });
+    });
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          content: [{ text: JSON.stringify(ARTICLE_BODY) }],
+        }),
+    });
+    const res = await POST(makePost({ calendarId: 1 }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.articleId).toBe(42);
+    expect(typeof body.slug).toBe("string");
+  });
+
+  it("handles raw non-JSON AI response gracefully (fallback to raw content)", async () => {
+    let callCount = 0;
+    mockAdminFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return makeChain({ data: CALENDAR_ITEM, error: null });
+      if (callCount === 5) return makeChain({ data: { id: 99 }, error: null });
+      return makeChain({ data: [], error: null });
+    });
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          content: [{ text: "This is plain text, not JSON." }],
+        }),
+    });
+    const res = await POST(makePost({ calendarId: 1 }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+  });
+});

--- a/__tests__/api/admin-fi-revalidate.test.ts
+++ b/__tests__/api/admin-fi-revalidate.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockRevalidateTag = vi.fn();
+vi.mock("next/cache", () => ({
+  revalidateTag: (...args: unknown[]) => mockRevalidateTag(...args),
+}));
+
+const mockGetAdminEmails = vi.fn<() => string[]>(() => ["admin@invest.com.au"]);
+vi.mock("@/lib/admin", () => ({
+  getAdminEmails: () => mockGetAdminEmails(),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/admin/foreign-investment/revalidate/route";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const INTERNAL_KEY = "test-internal-key";
+
+function makePost(
+  body: unknown = { adminEmail: "admin@invest.com.au" },
+  key = INTERNAL_KEY
+): NextRequest {
+  return new NextRequest("http://localhost/api/admin/foreign-investment/revalidate", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${key}`,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("POST /api/admin/foreign-investment/revalidate", () => {
+  beforeEach(() => {
+    process.env.INTERNAL_API_KEY = INTERNAL_KEY;
+  });
+  afterEach(() => {
+    vi.resetAllMocks();
+    delete process.env.INTERNAL_API_KEY;
+  });
+
+  it("returns 401 when no authorization header provided", async () => {
+    const req = new NextRequest("http://localhost/api/admin/foreign-investment/revalidate", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ adminEmail: "admin@invest.com.au" }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when wrong bearer token", async () => {
+    const res = await POST(makePost({ adminEmail: "admin@invest.com.au" }, "wrong-key"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when INTERNAL_API_KEY env is not set", async () => {
+    delete process.env.INTERNAL_API_KEY;
+    const res = await POST(makePost());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 on invalid JSON", async () => {
+    const req = new NextRequest("http://localhost/api/admin/foreign-investment/revalidate", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${INTERNAL_KEY}`,
+      },
+      body: "not-json",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 403 when adminEmail is not in admin list", async () => {
+    mockGetAdminEmails.mockReturnValue(["admin@invest.com.au"]);
+    const res = await POST(makePost({ adminEmail: "outsider@example.com" }));
+    expect(res.status).toBe(403);
+  });
+
+  it("calls revalidateTag for all 9 FI cache tags", async () => {
+    mockGetAdminEmails.mockReturnValue(["admin@invest.com.au"]);
+    const res = await POST(makePost());
+    expect(res.status).toBe(200);
+
+    const expectedTags = [
+      "fi-data",
+      "fi-data-categories",
+      "fi-tax-non-resident",
+      "fi-tax-resident",
+      "fi-dta-countries",
+      "fi-dasp-rates",
+      "fi-withholding-rates",
+      "fi-property-rules",
+      "fi-change-log",
+    ];
+    expect(mockRevalidateTag).toHaveBeenCalledTimes(9);
+    for (const tag of expectedTags) {
+      expect(mockRevalidateTag).toHaveBeenCalledWith(tag, expect.anything());
+    }
+  });
+
+  it("returns {ok: true, busted: [...]} with all 9 tags", async () => {
+    mockGetAdminEmails.mockReturnValue(["admin@invest.com.au"]);
+    const res = await POST(makePost());
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(Array.isArray(json.busted)).toBe(true);
+    expect(json.busted).toHaveLength(9);
+    expect(json.busted).toContain("fi-data");
+    expect(json.busted).toContain("fi-change-log");
+  });
+});

--- a/__tests__/api/admin-fin-objection-id.test.ts
+++ b/__tests__/api/admin-fin-objection-id.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockGetUser = vi.fn();
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() => ({ auth: { getUser: () => mockGetUser() } })),
+}));
+
+const mockFrom = vi.fn();
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+vi.mock("@/lib/admin", () => ({
+  getFinObjectionEmails: () => ["fin@test.com"],
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+import { POST } from "@/app/api/admin/fin-objection/[id]/route";
+
+const FIN_USER = { email: "fin@test.com" };
+
+function makeReq(id: string): [NextRequest, { params: Promise<{ id: string }> }] {
+  const req = new NextRequest(`http://localhost/api/admin/fin-objection/${id}`, {
+    method: "POST",
+  });
+  return [req, { params: Promise.resolve({ id }) }];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("POST /api/admin/fin-objection/[id]", () => {
+  it("returns 401 when no session", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const [req, ctx] = makeReq("art-1");
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when email not in fin-objection allowlist", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { email: "admin@other.com" } } });
+    const [req, ctx] = makeReq("art-1");
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toMatch(/fin-objection/i);
+  });
+
+  it("stamps fin_objection_at and writes audit log on success", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: FIN_USER } });
+    const articleData = { id: "art-1", fin_objection_at: new Date().toISOString(), status: "review_passed" };
+    let call = 0;
+    mockFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) {
+        // update editorial_articles
+        return {
+          update: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          select: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: articleData, error: null }),
+        };
+      }
+      // admin_audit_log insert
+      return { insert: vi.fn().mockResolvedValue({ data: null, error: null }) };
+    });
+    const [req, ctx] = makeReq("art-1");
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.id).toBe("art-1");
+    expect(body.fin_objection_at).toBeDefined();
+  });
+
+  it("returns 404 when article not found or not in review_passed state", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: FIN_USER } });
+    mockFrom.mockReturnValue({
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: null, error: null }),
+    });
+    const [req, ctx] = makeReq("not-found");
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 500 when DB update returns error", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: FIN_USER } });
+    mockFrom.mockReturnValue({
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: null, error: { message: "constraint violation" } }),
+    });
+    const [req, ctx] = makeReq("art-err");
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/admin-rba-polls-id-reveal.test.ts
+++ b/__tests__/api/admin-rba-polls-id-reveal.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { NextRequest } from "next/server";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+const mockGetUser = vi.fn(
+  async (): Promise<{ data: { user: { id: string; email?: string } | null }; error: unknown }> => ({
+    data: { user: { id: "u1", email: "admin@invest.com.au" } },
+    error: null,
+  }),
+);
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: mockGetUser },
+  })),
+}));
+
+function makeBuilder(data: unknown = null, error: unknown = null) {
+  const c: Record<string, unknown> = {
+    then: (r: (v: { data: unknown; error: unknown }) => unknown) =>
+      Promise.resolve(r({ data, error })),
+  };
+  for (const m of [
+    "select", "insert", "update", "upsert", "delete", "eq", "neq", "gt", "gte",
+    "lt", "lte", "in", "is", "not", "or", "order", "limit", "range", "single",
+    "maybeSingle", "filter",
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  return c;
+}
+
+const mockFrom = vi.fn((..._a: unknown[]) => makeBuilder());
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+import { POST } from "@/app/api/admin/rba-polls/[id]/reveal/route";
+
+// The route uses withValidatedBody so the exported POST is the wrapper.
+// It extracts the poll id from req.url path segments.
+function makeReq(pollId: string, body: unknown): NextRequest {
+  return new Request(`http://localhost/api/admin/rba-polls/${pollId}/reveal`, {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  }) as unknown as NextRequest;
+}
+
+// The route reads ADMIN_EMAILS from process.env, not from @/lib/admin.
+const ORIGINAL_ENV = process.env.ADMIN_EMAILS;
+
+describe("POST /api/admin/rba-polls/[id]/reveal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.ADMIN_EMAILS = "admin@invest.com.au";
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "u1", email: "admin@invest.com.au" } },
+      error: null,
+    });
+    mockFrom.mockImplementation((..._a: unknown[]) =>
+      makeBuilder({ id: 1, meeting_date: "2026-06-03", outcome: 0, change_bps: null, decided_at: "2026-06-03T00:00:00Z" }, null),
+    );
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_ENV === undefined) {
+      delete process.env.ADMIN_EMAILS;
+    } else {
+      process.env.ADMIN_EMAILS = ORIGINAL_ENV;
+    }
+  });
+
+  it("returns 401 when user is not authenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+    const res = await POST(makeReq("1", { outcome: 0 }));
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error).toBe("unauthorized");
+  });
+
+  it("returns 403 when user email is not in ADMIN_EMAILS", async () => {
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "u2", email: "regular@example.com" } },
+      error: null,
+    });
+    const res = await POST(makeReq("1", { outcome: 0 }));
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.error).toBe("forbidden");
+  });
+
+  it("returns 400 when body is invalid JSON", async () => {
+    const req = new Request("http://localhost/api/admin/rba-polls/1/reveal", {
+      method: "POST",
+      body: "bad-json{",
+      headers: { "content-type": "application/json" },
+    }) as unknown as NextRequest;
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when outcome is not -1, 0, or 1", async () => {
+    const res = await POST(makeReq("1", { outcome: 2 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when outcome is missing", async () => {
+    const res = await POST(makeReq("1", {}));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when poll id is not a valid integer", async () => {
+    const res = await POST(makeReq("not-a-number", { outcome: 0 }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("invalid_poll_id");
+  });
+
+  it("returns 400 when poll id is zero", async () => {
+    const res = await POST(makeReq("0", { outcome: 1 }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("invalid_poll_id");
+  });
+
+  it("reveals a hold outcome (0) and returns poll data", async () => {
+    const pollData = { id: 5, meeting_date: "2026-06-03", outcome: 0, change_bps: null, decided_at: "2026-06-03T00:00:00Z" };
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder(pollData, null));
+    const res = await POST(makeReq("5", { outcome: 0 }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(json.poll.outcome).toBe(0);
+  });
+
+  it("reveals a hike outcome (1) with change_bps", async () => {
+    const pollData = { id: 3, meeting_date: "2026-06-03", outcome: 1, change_bps: 25, decided_at: "2026-06-03T00:00:00Z" };
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder(pollData, null));
+    const res = await POST(makeReq("3", { outcome: 1, change_bps: 25 }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.poll.change_bps).toBe(25);
+  });
+
+  it("reveals a cut outcome (-1) with change_bps", async () => {
+    const pollData = { id: 4, meeting_date: "2026-06-03", outcome: -1, change_bps: -25, decided_at: "2026-06-03T00:00:00Z" };
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder(pollData, null));
+    const res = await POST(makeReq("4", { outcome: -1, change_bps: -25 }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.poll.outcome).toBe(-1);
+  });
+
+  it("returns 500 when DB update fails", async () => {
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder(null, { message: "db failure" }));
+    const res = await POST(makeReq("1", { outcome: 0 }));
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toBe("update_failed");
+  });
+
+  it("returns 404 when poll is not found (null data, no error)", async () => {
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder(null, null));
+    const res = await POST(makeReq("99", { outcome: 0 }));
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json.error).toBe("poll_not_found");
+  });
+});

--- a/__tests__/api/advisor-auth-analytics-export.test.ts
+++ b/__tests__/api/advisor-auth-analytics-export.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Hoisted mock refs ─────────────────────────────────────────────────────────
+
+const { mockRequireAdvisorSession, mockIsRateLimited, mockAdminFrom } = vi.hoisted(() => ({
+  mockRequireAdvisorSession: vi.fn<(...args: unknown[]) => Promise<unknown>>(async () => 7),
+  mockIsRateLimited: vi.fn<(...args: unknown[]) => Promise<boolean>>(async () => false),
+  mockAdminFrom: vi.fn<(...args: unknown[]) => unknown>(),
+}));
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: (...args: unknown[]) => mockRequireAdvisorSession(...args),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: (...args: unknown[]) => mockIsRateLimited(...args),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+// ── Route under test ──────────────────────────────────────────────────────────
+
+import { GET } from "@/app/api/advisor-auth/analytics/export/route";
+
+// ── Builder helper ────────────────────────────────────────────────────────────
+
+function makeBuilder(data: unknown = null, error: unknown = null) {
+  const c: Record<string, unknown> = {
+    then: (r: (v: { data: unknown; error: unknown }) => unknown) =>
+      Promise.resolve(r({ data, error })),
+  };
+  for (const m of [
+    "select", "insert", "update", "upsert", "delete", "eq", "neq", "gt", "gte",
+    "lt", "lte", "in", "is", "not", "or", "order", "limit", "range", "single",
+    "maybeSingle", "filter", "contains", "overlaps",
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  return c;
+}
+
+function makeGet(searchParams = "") {
+  return new NextRequest(
+    `http://localhost/api/advisor-auth/analytics/export${searchParams ? `?${searchParams}` : ""}`,
+    { method: "GET" },
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("GET /api/advisor-auth/analytics/export — auth + rate-limit", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+    mockRequireAdvisorSession.mockResolvedValue(7);
+  });
+
+  it("returns 401 when requireAdvisorSession returns null", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce(null);
+    const res = await GET(makeGet());
+    expect(res.status).toBe(401);
+    const body = await res.json() as { error: string };
+    expect(body.error).toMatch(/not authenticated/i);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsRateLimited.mockResolvedValueOnce(true);
+    const res = await GET(makeGet());
+    expect(res.status).toBe(429);
+    const body = await res.json() as { error: string };
+    expect(body.error).toMatch(/too many requests/i);
+  });
+});
+
+describe("GET /api/advisor-auth/analytics/export — DB error", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+    mockRequireAdvisorSession.mockResolvedValue(7);
+  });
+
+  it("returns 500 when DB query fails", async () => {
+    mockAdminFrom.mockReturnValue(makeBuilder(null, { message: "db error" }));
+    const res = await GET(makeGet());
+    expect(res.status).toBe(500);
+    const body = await res.json() as { error: string };
+    expect(body.error).toMatch(/failed to fetch/i);
+  });
+});
+
+describe("GET /api/advisor-auth/analytics/export — CSV output", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+    mockRequireAdvisorSession.mockResolvedValue(7);
+  });
+
+  it("returns 200 with text/csv content-type when no leads exist", async () => {
+    mockAdminFrom.mockReturnValue(makeBuilder([], null));
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("text/csv");
+    expect(res.headers.get("Content-Disposition")).toContain("attachment");
+    const text = await res.text();
+    expect(text).toContain("Date,Client,Source,Status,Billed (AUD),Notes");
+  });
+
+  it("includes one data row per lead with masked client name", async () => {
+    mockAdminFrom.mockReturnValue(
+      makeBuilder(
+        [
+          {
+            created_at: "2025-03-15T10:00:00.000Z",
+            user_name: "John Smith",
+            source_page: "/brokers",
+            status: "contacted",
+            bill_amount_cents: 4900,
+            advisor_notes: "Interested",
+          },
+        ],
+        null,
+      ),
+    );
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    const lines = text.split("\r\n");
+    // Header + 1 data row
+    expect(lines.length).toBeGreaterThanOrEqual(2);
+    const dataLine = lines[1] ?? "";
+    // Date should be present
+    expect(dataLine).toContain("2025-03-15");
+    // Client name masked: "J. S****"
+    expect(dataLine).toContain("J. S****");
+    // Billed as dollars
+    expect(dataLine).toContain("49.00");
+    // Status
+    expect(dataLine).toContain("contacted");
+  });
+
+  it("uses filename with 'all-time' label when period=all", async () => {
+    mockAdminFrom.mockReturnValue(makeBuilder([], null));
+    const res = await GET(makeGet("period=all"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Disposition")).toContain("all-time");
+  });
+
+  it("uses filename with '90d' label when period=90d", async () => {
+    mockAdminFrom.mockReturnValue(makeBuilder([], null));
+    const res = await GET(makeGet("period=90d"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Disposition")).toContain("90d");
+  });
+
+  it("applies gte filter for 30d period and not for all period", async () => {
+    const builder = makeBuilder([], null);
+    mockAdminFrom.mockReturnValue(builder);
+
+    await GET(makeGet("period=30d"));
+    // gte should have been called (cutoff set for 30d)
+    expect(builder.gte).toHaveBeenCalled();
+  });
+
+  it("does not apply gte filter for all period", async () => {
+    const builder = makeBuilder([], null);
+    mockAdminFrom.mockReturnValue(builder);
+
+    await GET(makeGet("period=all"));
+    // gte should NOT have been called (no cutoff for 'all')
+    expect(builder.gte).not.toHaveBeenCalled();
+  });
+
+  it("sets Cache-Control: no-store", async () => {
+    mockAdminFrom.mockReturnValue(makeBuilder([], null));
+    const res = await GET(makeGet());
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("CSV-escapes cells that contain commas", async () => {
+    mockAdminFrom.mockReturnValue(
+      makeBuilder(
+        [
+          {
+            created_at: "2025-01-01T00:00:00.000Z",
+            user_name: "Alice",
+            source_page: null,
+            status: "new",
+            bill_amount_cents: 0,
+            advisor_notes: "Fee: $1,000",
+          },
+        ],
+        null,
+      ),
+    );
+    const res = await GET(makeGet());
+    const text = await res.text();
+    // The note with a comma must be wrapped in quotes
+    expect(text).toContain('"Fee: $1,000"');
+  });
+
+  it("masks a single-name client correctly (no last name)", async () => {
+    mockAdminFrom.mockReturnValue(
+      makeBuilder(
+        [
+          {
+            created_at: "2025-01-01T00:00:00.000Z",
+            user_name: "Madonna",
+            source_page: null,
+            status: "new",
+            bill_amount_cents: 0,
+            advisor_notes: null,
+          },
+        ],
+        null,
+      ),
+    );
+    const res = await GET(makeGet());
+    const text = await res.text();
+    // Single name → "M****"
+    expect(text).toContain("M****");
+  });
+});

--- a/__tests__/api/advisor-auth-benchmarks.test.ts
+++ b/__tests__/api/advisor-auth-benchmarks.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const { mockRequireAdvisorSession } = vi.hoisted(() => ({
+  mockRequireAdvisorSession: vi.fn<() => Promise<number | null>>(),
+}));
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: (...args: unknown[]) =>
+    mockRequireAdvisorSession(...(args as [])),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: vi.fn(async () => false),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+// ── Supabase admin builder ────────────────────────────────────────────────────
+
+function makeBuilder(data: unknown = null, error: unknown = null) {
+  const c: Record<string, unknown> = {
+    then: (r: (v: { data: unknown; error: unknown }) => unknown) =>
+      Promise.resolve(r({ data, error })),
+  };
+  for (const m of [
+    "select", "insert", "update", "upsert", "delete",
+    "eq", "neq", "gt", "gte", "lt", "lte", "in", "is", "not", "or",
+    "order", "limit", "range", "filter",
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  c.single = vi.fn(() => Promise.resolve({ data, error }));
+  c.maybeSingle = vi.fn(() => Promise.resolve({ data, error }));
+  return c;
+}
+
+const mockFrom = vi.fn((..._a: unknown[]) => makeBuilder());
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+// ── Route under test ──────────────────────────────────────────────────────────
+
+import { GET } from "@/app/api/advisor-auth/benchmarks/route";
+import { isRateLimited } from "@/lib/rate-limit";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const ADVISOR_ID = 66;
+
+function makeGet(): NextRequest {
+  return new NextRequest("http://localhost/api/advisor-auth/benchmarks", {
+    method: "GET",
+    headers: { "x-forwarded-for": "1.2.3.4" },
+  });
+}
+
+const selfProfile = {
+  type: "financial_planner",
+  location_state: "NSW",
+  avg_response_minutes: 60,
+  rating: 4.8,
+  review_count: 12,
+};
+
+const peerRows = [
+  { id: 101, avg_response_minutes: 30, rating: 4.5, review_count: 8 },
+  { id: 102, avg_response_minutes: 90, rating: 4.2, review_count: 3 },
+  { id: 103, avg_response_minutes: 45, rating: 4.9, review_count: 25 },
+];
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("GET /api/advisor-auth/benchmarks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdvisorSession.mockResolvedValue(ADVISOR_ID);
+    (isRateLimited as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+
+    let call = 0;
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      call++;
+      if (call === 1) {
+        // professionals.maybeSingle — self
+        const b = makeBuilder(selfProfile, null);
+        (b.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({ data: selfProfile, error: null });
+        return b;
+      }
+      if (call === 2) {
+        // professional_leads — self leads
+        return makeBuilder(
+          [
+            { status: "accepted" },
+            { status: "accepted" },
+            { status: "rejected" },
+          ],
+          null,
+        );
+      }
+      // professionals peers query
+      return makeBuilder(peerRows, null);
+    });
+  });
+
+  it("returns 429 when rate limited", async () => {
+    (isRateLimited as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+    const res = await GET(makeGet());
+    expect(res.status).toBe(429);
+    const json = await res.json();
+    expect(json.error).toMatch(/Too many requests/i);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockRequireAdvisorSession.mockResolvedValue(null);
+    const res = await GET(makeGet());
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error).toMatch(/Not authenticated/i);
+  });
+
+  it("returns 404 when advisor profile not found", async () => {
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      const b = makeBuilder(null, null);
+      (b.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({ data: null, error: null });
+      return b;
+    });
+    const res = await GET(makeGet());
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json.error).toMatch(/Advisor not found/i);
+  });
+
+  it("returns 200 with correct response shape", async () => {
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(typeof json.cohortSize).toBe("number");
+    expect(json.yours).toBeDefined();
+    expect(json.peerMedian).toBeDefined();
+    expect(json.peerTop25).toBeDefined();
+  });
+
+  it("includes yours metrics from the self profile", async () => {
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.yours.rating).toBe(selfProfile.rating);
+    expect(json.yours.reviewCount).toBe(selfProfile.review_count);
+    expect(json.yours.avgResponseMinutes).toBe(selfProfile.avg_response_minutes);
+  });
+
+  it("computes accept rate from self leads", async () => {
+    // 2 accepted out of 3 total = 66.7%
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.yours.acceptRate).toBeCloseTo(66.7, 0);
+  });
+
+  it("returns null acceptRate when advisor has no leads", async () => {
+    let call = 0;
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      call++;
+      if (call === 1) {
+        const b = makeBuilder(selfProfile, null);
+        (b.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({ data: selfProfile, error: null });
+        return b;
+      }
+      if (call === 2) {
+        return makeBuilder([], null);
+      }
+      return makeBuilder(peerRows, null);
+    });
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.yours.acceptRate).toBeNull();
+  });
+
+  it("returns peerMedian with computed stats from peer rows", async () => {
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    // Median of [30, 45, 90] = 45
+    expect(json.peerMedian.avgResponseMinutes).toBe(45);
+    // Median of [4.2, 4.5, 4.9] = 4.5
+    expect(json.peerMedian.rating).toBe(4.5);
+    // Median of [3, 8, 25] = 8
+    expect(json.peerMedian.reviewCount).toBe(8);
+    // Peer acceptRate is null (not computed)
+    expect(json.peerMedian.acceptRate).toBeNull();
+  });
+
+  it("returns peerTop25 with 25th-pct response time and 75th-pct for rating/reviews", async () => {
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    // 25th pct of [30, 45, 90] (idx=0) = 30
+    expect(json.peerTop25.avgResponseMinutes).toBe(30);
+    // 75th pct of [4.2, 4.5, 4.9]: idx = floor(0.75 * 2) = 1 → 4.5
+    expect(json.peerTop25.rating).toBe(4.5);
+  });
+
+  it("returns cohortSize matching the number of peer rows", async () => {
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.cohortSize).toBe(peerRows.length);
+  });
+
+  it("returns nulls in peerMedian/peerTop25 when there are no peers", async () => {
+    let call = 0;
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      call++;
+      if (call === 1) {
+        const b = makeBuilder(selfProfile, null);
+        (b.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({ data: selfProfile, error: null });
+        return b;
+      }
+      if (call === 2) {
+        return makeBuilder([], null);
+      }
+      // peers empty
+      return makeBuilder([], null);
+    });
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.cohortSize).toBe(0);
+    expect(json.peerMedian.avgResponseMinutes).toBeNull();
+    expect(json.peerMedian.rating).toBeNull();
+    expect(json.peerMedian.reviewCount).toBeNull();
+    expect(json.peerTop25.avgResponseMinutes).toBeNull();
+    expect(json.peerTop25.rating).toBeNull();
+  });
+
+  it("applies state filter when advisor has a location_state set", async () => {
+    await GET(makeGet());
+    // The third call to mockFrom is for the peer query which should have chained .eq calls
+    expect(mockFrom).toHaveBeenCalled();
+  });
+
+  it("skips state filter when advisor has no location_state", async () => {
+    const noStateProfile = { ...selfProfile, location_state: null };
+    let call = 0;
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      call++;
+      if (call === 1) {
+        const b = makeBuilder(noStateProfile, null);
+        (b.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+          data: noStateProfile,
+          error: null,
+        });
+        return b;
+      }
+      if (call === 2) {
+        return makeBuilder([], null);
+      }
+      return makeBuilder(peerRows, null);
+    });
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.cohortSize).toBe(peerRows.length);
+  });
+});

--- a/__tests__/api/advisor-auth-case-studies-id.test.ts
+++ b/__tests__/api/advisor-auth-case-studies-id.test.ts
@@ -1,0 +1,357 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── withValidatedBody real Zod mock ───────────────────────────────────────────
+
+vi.mock("@/lib/validation/withValidatedBody", () => ({
+  withValidatedBody:
+    (
+      schema: {
+        safeParse: (v: unknown) => {
+          success: boolean;
+          data?: unknown;
+          error?: { issues: unknown[] };
+        };
+      },
+      handler: (req: NextRequest, body: unknown, ctx?: unknown) => unknown,
+    ) =>
+    async (req: NextRequest, ctx?: unknown) => {
+      let raw: unknown;
+      try {
+        raw = await req.json();
+      } catch {
+        return new Response(
+          JSON.stringify({ error: "Invalid JSON body" }),
+          { status: 400 },
+        );
+      }
+      const parsed = schema.safeParse(raw);
+      if (!parsed.success) {
+        const issues = parsed.error!.issues as Array<{
+          path?: string[];
+          message?: string;
+        }>;
+        const first = issues[0];
+        const path = first?.path?.join(".") ?? "";
+        const message = first?.message ?? "Invalid request body";
+        return new Response(
+          JSON.stringify({
+            error: path ? `${path}: ${message}` : message,
+            code: "validation_error",
+            issues,
+          }),
+          { status: 400 },
+        );
+      }
+      return handler(req, parsed.data, ctx);
+    },
+}));
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const { mockRequireAdvisorSession } = vi.hoisted(() => ({
+  mockRequireAdvisorSession: vi.fn<() => Promise<number | null>>(),
+}));
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: (...args: unknown[]) =>
+    mockRequireAdvisorSession(...(args as [])),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: vi.fn(async () => false),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+// ── Supabase admin builder ────────────────────────────────────────────────────
+
+function makeBuilder(data: unknown = null, error: unknown = null) {
+  const c: Record<string, unknown> = {
+    then: (r: (v: { data: unknown; error: unknown }) => unknown) =>
+      Promise.resolve(r({ data, error })),
+  };
+  for (const m of [
+    "select", "insert", "update", "upsert", "delete",
+    "eq", "neq", "gt", "gte", "lt", "lte", "in", "is", "not", "or",
+    "order", "limit", "range", "filter",
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  c.single = vi.fn(() => Promise.resolve({ data, error }));
+  c.maybeSingle = vi.fn(() => Promise.resolve({ data, error }));
+  return c;
+}
+
+const mockFrom = vi.fn((..._a: unknown[]) => makeBuilder());
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+// ── Route under test ──────────────────────────────────────────────────────────
+
+import {
+  PATCH as _PATCH,
+  DELETE,
+} from "@/app/api/advisor-auth/case-studies/[caseStudyId]/route";
+import { isRateLimited } from "@/lib/rate-limit";
+
+// The real withValidatedBody returns (req) => ... but the inner handler accepts
+// context as a third arg passed through Next.js. Our mock forwards ctx, so we
+// cast to the two-arg form for tests.
+type PatchFn = (req: NextRequest, ctx: RouteContext) => Promise<Response>;
+const PATCH = _PATCH as unknown as PatchFn;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const ADVISOR_ID = 22;
+const CASE_STUDY_ID = 4;
+
+type RouteContext = { params: Promise<{ caseStudyId: string }> };
+
+function makeContext(id: string = String(CASE_STUDY_ID)): RouteContext {
+  return { params: Promise.resolve({ caseStudyId: id }) };
+}
+
+function makePatch(body: unknown, caseStudyId: string = String(CASE_STUDY_ID)): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/advisor-auth/case-studies/${caseStudyId}`,
+    {
+      method: "PATCH",
+      body: JSON.stringify(body),
+      headers: { "Content-Type": "application/json", "x-forwarded-for": "1.2.3.4" },
+    },
+  );
+}
+
+function makeDeleteReq(caseStudyId: string = String(CASE_STUDY_ID)): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/advisor-auth/case-studies/${caseStudyId}`,
+    { method: "DELETE", headers: { "x-forwarded-for": "1.2.3.4" } },
+  );
+}
+
+const existingRow = { id: CASE_STUDY_ID };
+
+const mockCaseStudy = {
+  id: CASE_STUDY_ID,
+  title: "How we saved $50k in taxes",
+  situation: "Client had a complex tax situation from multiple income sources.",
+  approach: "We restructured their portfolio using a trust structure.",
+  outcome: "Client saved $50,000 annually in tax.",
+  client_type: "individual",
+  outcome_type: "tax_saving",
+  status: "draft",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+const validPatchBody = {
+  title: "Updated Case Study Title Here",
+  status: "published",
+};
+
+// ── Tests: PATCH ──────────────────────────────────────────────────────────────
+
+describe("PATCH /api/advisor-auth/case-studies/[caseStudyId]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdvisorSession.mockResolvedValue(ADVISOR_ID);
+    (isRateLimited as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+
+    let call = 0;
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      call++;
+      if (call === 1) {
+        // ownership check
+        const b = makeBuilder(existingRow, null);
+        (b.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({ data: existingRow, error: null });
+        return b;
+      }
+      // update query
+      const b = makeBuilder(mockCaseStudy, null);
+      (b.single as ReturnType<typeof vi.fn>).mockResolvedValue({ data: mockCaseStudy, error: null });
+      return b;
+    });
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockRequireAdvisorSession.mockResolvedValue(null);
+    const res = await PATCH(makePatch(validPatchBody), makeContext());
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error).toMatch(/Not authenticated/i);
+  });
+
+  it("returns 429 when rate limited", async () => {
+    (isRateLimited as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+    const res = await PATCH(makePatch(validPatchBody), makeContext());
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 400 when title is too short (under 5 chars)", async () => {
+    const res = await PATCH(makePatch({ title: "Hi" }), makeContext());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when client_type is invalid", async () => {
+    const res = await PATCH(makePatch({ client_type: "corporation" }), makeContext());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when outcome_type is invalid", async () => {
+    const res = await PATCH(makePatch({ outcome_type: "lottery_win" }), makeContext());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when status is invalid", async () => {
+    const res = await PATCH(makePatch({ status: "archived" }), makeContext());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when caseStudyId is not a number", async () => {
+    const res = await PATCH(makePatch(validPatchBody, "abc"), makeContext("abc"));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/Invalid case study ID/i);
+  });
+
+  it("returns 404 when case study not found or not owned", async () => {
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      const b = makeBuilder(null, null);
+      (b.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({ data: null, error: null });
+      return b;
+    });
+    const res = await PATCH(makePatch(validPatchBody), makeContext());
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json.error).toMatch(/Case study not found/i);
+  });
+
+  it("updates case study and returns 200 with caseStudy data", async () => {
+    const res = await PATCH(makePatch(validPatchBody), makeContext());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.caseStudy).toBeDefined();
+  });
+
+  it("allows updating all valid optional fields at once", async () => {
+    const fullPatch = {
+      title: "Complete Case Study Update",
+      situation: "The client faced significant financial challenges over two decades.",
+      approach: "We took a holistic approach to restructure their entire portfolio.",
+      outcome: "Client achieved financial independence five years early.",
+      client_type: "family",
+      outcome_type: "retirement_planning",
+      status: "published",
+    };
+    const res = await PATCH(makePatch(fullPatch), makeContext());
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 500 when DB update fails", async () => {
+    let call = 0;
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      call++;
+      if (call === 1) {
+        const b = makeBuilder(existingRow, null);
+        (b.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({ data: existingRow, error: null });
+        return b;
+      }
+      const b = makeBuilder(null, { message: "update failed" });
+      (b.single as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: null,
+        error: { message: "update failed" },
+      });
+      return b;
+    });
+    const res = await PATCH(makePatch(validPatchBody), makeContext());
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toMatch(/Failed to update case study/i);
+  });
+});
+
+// ── Tests: DELETE ─────────────────────────────────────────────────────────────
+
+describe("DELETE /api/advisor-auth/case-studies/[caseStudyId]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdvisorSession.mockResolvedValue(ADVISOR_ID);
+    (isRateLimited as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+
+    let call = 0;
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      call++;
+      if (call === 1) {
+        const b = makeBuilder(existingRow, null);
+        (b.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({ data: existingRow, error: null });
+        return b;
+      }
+      return makeBuilder(null, null);
+    });
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockRequireAdvisorSession.mockResolvedValue(null);
+    const res = await DELETE(makeDeleteReq(), makeContext());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 429 when rate limited", async () => {
+    (isRateLimited as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+    const res = await DELETE(makeDeleteReq(), makeContext());
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 400 when caseStudyId is not a number", async () => {
+    const res = await DELETE(makeDeleteReq("nope"), makeContext("nope"));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/Invalid case study ID/i);
+  });
+
+  it("returns 404 when case study not found or not owned", async () => {
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      const b = makeBuilder(null, null);
+      (b.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({ data: null, error: null });
+      return b;
+    });
+    const res = await DELETE(makeDeleteReq(), makeContext());
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json.error).toMatch(/Case study not found/i);
+  });
+
+  it("soft-deletes case study (sets status=draft) and returns success", async () => {
+    const res = await DELETE(makeDeleteReq(), makeContext());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+  });
+
+  it("returns 500 when DB update fails", async () => {
+    let call = 0;
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      call++;
+      if (call === 1) {
+        const b = makeBuilder(existingRow, null);
+        (b.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({ data: existingRow, error: null });
+        return b;
+      }
+      return makeBuilder(null, { message: "delete failed" });
+    });
+    const res = await DELETE(makeDeleteReq(), makeContext());
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toMatch(/Failed to delete case study/i);
+  });
+});

--- a/__tests__/api/advisor-auth-events-rsvps.test.ts
+++ b/__tests__/api/advisor-auth-events-rsvps.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const { mockRequireAdvisorSession } = vi.hoisted(() => ({
+  mockRequireAdvisorSession: vi.fn<() => Promise<number | null>>(),
+}));
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: (...args: unknown[]) =>
+    mockRequireAdvisorSession(...(args as [])),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: vi.fn(async () => false),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+// ── Supabase admin builder ────────────────────────────────────────────────────
+
+function makeBuilder(data: unknown = null, error: unknown = null, count: number | null = null) {
+  const c: Record<string, unknown> = {
+    then: (r: (v: { data: unknown; error: unknown; count: number | null }) => unknown) =>
+      Promise.resolve(r({ data, error, count })),
+  };
+  for (const m of [
+    "select", "insert", "update", "upsert", "delete",
+    "eq", "neq", "gt", "gte", "lt", "lte", "in", "is", "not", "or",
+    "order", "limit", "range", "filter",
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  c.single = vi.fn(() => Promise.resolve({ data, error }));
+  c.maybeSingle = vi.fn(() => Promise.resolve({ data, error }));
+  return c;
+}
+
+const mockFrom = vi.fn((..._a: unknown[]) => makeBuilder());
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+// ── Route under test ──────────────────────────────────────────────────────────
+
+import { GET, DELETE } from "@/app/api/advisor-auth/events/[eventId]/rsvps/route";
+import { isRateLimited } from "@/lib/rate-limit";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const ADVISOR_ID = 33;
+const EVENT_ID = 5;
+
+function makeGet(eventId: string = String(EVENT_ID)): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/advisor-auth/events/${eventId}/rsvps`,
+    { method: "GET" },
+  );
+}
+
+function makeDelete(eventId: string = String(EVENT_ID), body: unknown = { rsvpId: 1 }): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/advisor-auth/events/${eventId}/rsvps`,
+    {
+      method: "DELETE",
+      body: JSON.stringify(body),
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+}
+
+const mockRsvp = {
+  id: 1,
+  event_id: EVENT_ID,
+  user_id: "user-abc",
+  status: "confirmed",
+  created_at: "2026-01-01T00:00:00Z",
+};
+
+const mockEventRow = { id: EVENT_ID };
+
+// ── Tests: GET ────────────────────────────────────────────────────────────────
+
+describe("GET /api/advisor-auth/events/[eventId]/rsvps", () => {
+  const eventParams = { params: Promise.resolve({ eventId: String(EVENT_ID) }) };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdvisorSession.mockResolvedValue(ADVISOR_ID);
+    (isRateLimited as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+
+    let call = 0;
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      call++;
+      if (call === 1) {
+        // ownership check → advisor_events
+        const b = makeBuilder(mockEventRow, null);
+        (b.single as ReturnType<typeof vi.fn>).mockResolvedValue({ data: mockEventRow, error: null });
+        return b;
+      }
+      // rsvps query — terminal via .then
+      return makeBuilder([mockRsvp], null, 1);
+    });
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockRequireAdvisorSession.mockResolvedValue(null);
+    const res = await GET(makeGet(), eventParams);
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error).toMatch(/Not authenticated/i);
+  });
+
+  it("returns 429 when rate limited", async () => {
+    (isRateLimited as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+    const res = await GET(makeGet(), eventParams);
+    expect(res.status).toBe(429);
+    const json = await res.json();
+    expect(json.error).toMatch(/Too many requests/i);
+  });
+
+  it("returns 400 when eventId is not a number", async () => {
+    const params = { params: Promise.resolve({ eventId: "not-a-number" }) };
+    const res = await GET(makeGet("not-a-number"), params);
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/Invalid event ID/i);
+  });
+
+  it("returns 404 when event not found or not owned by advisor", async () => {
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      const b = makeBuilder(null, null);
+      (b.single as ReturnType<typeof vi.fn>).mockResolvedValue({ data: null, error: null });
+      return b;
+    });
+    const res = await GET(makeGet(), eventParams);
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json.error).toMatch(/Event not found/i);
+  });
+
+  it("returns 200 with rsvps array and count on success", async () => {
+    const res = await GET(makeGet(), eventParams);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(Array.isArray(json.rsvps)).toBe(true);
+    expect(typeof json.count).toBe("number");
+  });
+
+  it("returns empty rsvps when event has no attendees", async () => {
+    let call = 0;
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      call++;
+      if (call === 1) {
+        const b = makeBuilder(mockEventRow, null);
+        (b.single as ReturnType<typeof vi.fn>).mockResolvedValue({ data: mockEventRow, error: null });
+        return b;
+      }
+      return makeBuilder([], null, 0);
+    });
+    const res = await GET(makeGet(), eventParams);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.rsvps).toEqual([]);
+    expect(json.count).toBe(0);
+  });
+
+  it("returns 500 when rsvps DB query fails", async () => {
+    let call = 0;
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      call++;
+      if (call === 1) {
+        const b = makeBuilder(mockEventRow, null);
+        (b.single as ReturnType<typeof vi.fn>).mockResolvedValue({ data: mockEventRow, error: null });
+        return b;
+      }
+      return makeBuilder(null, { message: "db error" }, null);
+    });
+    const res = await GET(makeGet(), eventParams);
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toMatch(/Failed to fetch RSVPs/i);
+  });
+});
+
+// ── Tests: DELETE ─────────────────────────────────────────────────────────────
+
+describe("DELETE /api/advisor-auth/events/[eventId]/rsvps", () => {
+  const eventParams = { params: Promise.resolve({ eventId: String(EVENT_ID) }) };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdvisorSession.mockResolvedValue(ADVISOR_ID);
+    (isRateLimited as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+
+    let call = 0;
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      call++;
+      if (call === 1) {
+        // ownership check
+        const b = makeBuilder(mockEventRow, null);
+        (b.single as ReturnType<typeof vi.fn>).mockResolvedValue({ data: mockEventRow, error: null });
+        return b;
+      }
+      if (call === 2) {
+        // rsvp delete — resolves via .then
+        return makeBuilder(null, null);
+      }
+      if (call === 3) {
+        // rsvp_count select
+        const b = makeBuilder({ rsvp_count: 3 }, null);
+        (b.single as ReturnType<typeof vi.fn>).mockResolvedValue({ data: { rsvp_count: 3 }, error: null });
+        return b;
+      }
+      // update rsvp_count
+      return makeBuilder(null, null);
+    });
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockRequireAdvisorSession.mockResolvedValue(null);
+    const res = await DELETE(makeDelete(), eventParams);
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error).toMatch(/Not authenticated/i);
+  });
+
+  it("returns 400 when eventId is not a number", async () => {
+    const params = { params: Promise.resolve({ eventId: "bad" }) };
+    const res = await DELETE(makeDelete("bad"), params);
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/Invalid event ID/i);
+  });
+
+  it("returns 400 when body is invalid JSON", async () => {
+    const req = new NextRequest(
+      `http://localhost/api/advisor-auth/events/${EVENT_ID}/rsvps`,
+      { method: "DELETE", body: "{{bad}}", headers: { "Content-Type": "application/json" } },
+    );
+    const res = await DELETE(req, eventParams);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when rsvpId is missing from body", async () => {
+    const res = await DELETE(makeDelete(String(EVENT_ID), {}), eventParams);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when event not found or not owned by advisor", async () => {
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      const b = makeBuilder(null, null);
+      (b.single as ReturnType<typeof vi.fn>).mockResolvedValue({ data: null, error: null });
+      return b;
+    });
+    const res = await DELETE(makeDelete(), eventParams);
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json.error).toMatch(/Event not found/i);
+  });
+
+  it("deletes RSVP and returns success", async () => {
+    const res = await DELETE(makeDelete(), eventParams);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+  });
+
+  it("returns 500 when RSVP delete fails", async () => {
+    let call = 0;
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      call++;
+      if (call === 1) {
+        const b = makeBuilder(mockEventRow, null);
+        (b.single as ReturnType<typeof vi.fn>).mockResolvedValue({ data: mockEventRow, error: null });
+        return b;
+      }
+      // rsvp delete fails
+      return makeBuilder(null, { message: "delete error" });
+    });
+    const res = await DELETE(makeDelete(), eventParams);
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toMatch(/Failed to delete RSVP/i);
+  });
+});

--- a/__tests__/api/advisor-auth-feed.test.ts
+++ b/__tests__/api/advisor-auth-feed.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Hoisted mocks ──────────────────────────────────────────────────────────────
+
+const { mockRequireAdvisorSession, mockGetUser } = vi.hoisted(() => ({
+  mockRequireAdvisorSession: vi.fn<() => Promise<number | null>>(),
+  mockGetUser: vi.fn<() => Promise<{ data: { user: { id: string } | null } }>>(),
+}));
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: (...args: unknown[]) =>
+    mockRequireAdvisorSession(...(args as [])),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: mockGetUser },
+  })),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: vi.fn(async () => false),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+// ── Supabase admin builder ────────────────────────────────────────────────────
+
+function makeBuilder(data: unknown = null, error: unknown = null) {
+  const c: Record<string, unknown> = {
+    then: (r: (v: { data: unknown; error: unknown }) => unknown) =>
+      Promise.resolve(r({ data, error })),
+  };
+  for (const m of [
+    "select", "insert", "update", "upsert", "delete",
+    "eq", "neq", "gt", "gte", "lt", "lte", "in", "is", "not", "or",
+    "order", "limit", "range", "filter",
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  c.single = vi.fn(() => Promise.resolve({ data, error }));
+  c.maybeSingle = vi.fn(() => Promise.resolve({ data, error }));
+  return c;
+}
+
+const mockFrom = vi.fn((..._a: unknown[]) => makeBuilder());
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+// ── Route under test ──────────────────────────────────────────────────────────
+
+import { GET } from "@/app/api/advisor-auth/feed/route";
+import { isRateLimited } from "@/lib/rate-limit";
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const ADVISOR_ID = 55;
+const USER_ID = "auth-uuid-99";
+
+const MOCK_POSTS = [
+  {
+    id: 1,
+    professional_id: ADVISOR_ID,
+    status: "published",
+    content: "Great market update!",
+    created_at: "2026-05-01T10:00:00Z",
+    professional: { id: ADVISOR_ID, name: "Jane Advisor", firm_name: "Acme Wealth", photo_url: null, slug: "jane-advisor" },
+  },
+  {
+    id: 2,
+    professional_id: 10,
+    status: "published",
+    content: "Diversification matters.",
+    created_at: "2026-04-30T09:00:00Z",
+    professional: { id: 10, name: "Bob Finance", firm_name: "Finance Co", photo_url: null, slug: "bob-finance" },
+  },
+];
+
+function makeGet(): NextRequest {
+  return new NextRequest("http://localhost/api/advisor-auth/feed", {
+    method: "GET",
+    headers: { "x-forwarded-for": "2.3.4.5" },
+  });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("GET /api/advisor-auth/feed", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdvisorSession.mockResolvedValue(ADVISOR_ID);
+    mockGetUser.mockResolvedValue({ data: { user: { id: USER_ID } } });
+    (isRateLimited as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+
+    // Default: follows (empty) + posts
+    let call = 0;
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      call++;
+      if (call === 1) {
+        // advisor_follows
+        return makeBuilder([], null);
+      }
+      // advisor_posts
+      return makeBuilder(MOCK_POSTS, null);
+    });
+  });
+
+  // ── 429 rate limiting ─────────────────────────────────────────────────────
+
+  it("returns 429 when rate limited", async () => {
+    (isRateLimited as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+    const res = await GET(makeGet());
+    expect(res.status).toBe(429);
+    const json = await res.json();
+    expect(json.error).toMatch(/too many requests/i);
+  });
+
+  // ── 401 advisor session not found ─────────────────────────────────────────
+
+  it("returns 401 when requireAdvisorSession returns null", async () => {
+    mockRequireAdvisorSession.mockResolvedValue(null);
+    const res = await GET(makeGet());
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error).toMatch(/not authenticated/i);
+  });
+
+  // ── 401 auth user not found ───────────────────────────────────────────────
+
+  it("returns 401 when auth user is null", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const res = await GET(makeGet());
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error).toMatch(/not authenticated/i);
+  });
+
+  // ── 200 with posts ────────────────────────────────────────────────────────
+
+  it("returns 200 with posts array", async () => {
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.posts).toHaveLength(2);
+    expect(json.posts[0]).toMatchObject({ status: "published" });
+  });
+
+  // ── 200 with empty posts when no follows and no own posts ─────────────────
+
+  it("returns 200 with empty posts array when no posts exist", async () => {
+    let call = 0;
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      call++;
+      if (call === 1) {
+        return makeBuilder([], null);
+      }
+      return makeBuilder(null, null);
+    });
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.posts).toEqual([]);
+  });
+
+  // ── own professional_id always included in feed ───────────────────────────
+
+  it("includes own professional_id in the followed IDs list", async () => {
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    // The .in() call on advisor_posts should include ADVISOR_ID
+    const postsBuilder = mockFrom.mock.results[1]?.value as Record<string, ReturnType<typeof vi.fn>>;
+    expect(postsBuilder).toBeDefined();
+    const inCall = (postsBuilder.in as ReturnType<typeof vi.fn>).mock.calls[0] as unknown[];
+    // inCall[1] is the array of IDs passed to .in()
+    expect(Array.isArray(inCall[1])).toBe(true);
+    expect((inCall[1] as number[]).includes(ADVISOR_ID)).toBe(true);
+  });
+
+  // ── 500 when posts query fails ────────────────────────────────────────────
+
+  it("returns 500 when posts DB query fails", async () => {
+    let call = 0;
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      call++;
+      if (call === 1) {
+        return makeBuilder([], null);
+      }
+      return makeBuilder(null, { message: "query failed" });
+    });
+    const res = await GET(makeGet());
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toMatch(/failed to fetch feed/i);
+  });
+
+  // ── follows merged into ID list ───────────────────────────────────────────
+
+  it("merges followed professional IDs into the posts query", async () => {
+    const followedId = 99;
+    let call = 0;
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      call++;
+      if (call === 1) {
+        return makeBuilder([{ following_professional_id: followedId }], null);
+      }
+      return makeBuilder(MOCK_POSTS, null);
+    });
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const postsBuilder = mockFrom.mock.results[1]?.value as Record<string, ReturnType<typeof vi.fn>>;
+    const inCall = (postsBuilder.in as ReturnType<typeof vi.fn>).mock.calls[0] as unknown[];
+    const ids = inCall[1] as number[];
+    expect(ids).toContain(followedId);
+    expect(ids).toContain(ADVISOR_ID);
+  });
+});

--- a/__tests__/api/advisor-auth-follow.test.ts
+++ b/__tests__/api/advisor-auth-follow.test.ts
@@ -1,0 +1,323 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── withValidatedBody real Zod mock ───────────────────────────────────────────
+
+vi.mock("@/lib/validation/withValidatedBody", () => ({
+  withValidatedBody:
+    (
+      schema: {
+        safeParse: (v: unknown) => {
+          success: boolean;
+          data?: unknown;
+          error?: { issues: unknown[] };
+        };
+      },
+      handler: (req: NextRequest, body: unknown) => unknown,
+    ) =>
+    async (req: NextRequest) => {
+      let raw: unknown;
+      try {
+        raw = await req.json();
+      } catch {
+        return new Response(
+          JSON.stringify({ error: "Invalid JSON body" }),
+          { status: 400 },
+        );
+      }
+      const parsed = schema.safeParse(raw);
+      if (!parsed.success) {
+        const issues = parsed.error!.issues as Array<{
+          path?: string[];
+          message?: string;
+        }>;
+        const first = issues[0];
+        const path = first?.path?.join(".") ?? "";
+        const message = first?.message ?? "Invalid request body";
+        return new Response(
+          JSON.stringify({
+            error: path ? `${path}: ${message}` : message,
+            code: "validation_error",
+            issues,
+          }),
+          { status: 400 },
+        );
+      }
+      return handler(req, parsed.data);
+    },
+}));
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const { mockRequireAdvisorSession, mockGetUser } = vi.hoisted(() => ({
+  mockRequireAdvisorSession: vi.fn<() => Promise<number | null>>(),
+  mockGetUser: vi.fn(),
+}));
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: (...args: unknown[]) =>
+    mockRequireAdvisorSession(...(args as [])),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: mockGetUser },
+  })),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: vi.fn(async () => false),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+// ── Supabase admin builder ────────────────────────────────────────────────────
+
+function makeBuilder(data: unknown = null, error: unknown = null) {
+  const c: Record<string, unknown> = {
+    then: (r: (v: { data: unknown; error: unknown }) => unknown) =>
+      Promise.resolve(r({ data, error })),
+  };
+  for (const m of [
+    "select", "insert", "update", "upsert", "delete",
+    "eq", "neq", "gt", "gte", "lt", "lte", "in", "is", "not", "or",
+    "order", "limit", "range", "filter",
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  c.single = vi.fn(() => Promise.resolve({ data, error }));
+  c.maybeSingle = vi.fn(() => Promise.resolve({ data, error }));
+  return c;
+}
+
+const mockFrom = vi.fn((..._a: unknown[]) => makeBuilder());
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+// ── Route under test ──────────────────────────────────────────────────────────
+
+import { POST, DELETE } from "@/app/api/advisor-auth/follow/route";
+import { isRateLimited } from "@/lib/rate-limit";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const ADVISOR_ID = 11;
+const TARGET_ID = 77;
+const USER_ID = "auth-user-uuid-123";
+
+function makePost(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/advisor-auth/follow", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json", "x-forwarded-for": "1.2.3.4" },
+  });
+}
+
+function makeDeleteReq(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/advisor-auth/follow", {
+    method: "DELETE",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json", "x-forwarded-for": "1.2.3.4" },
+  });
+}
+
+const validBody = { professionalId: TARGET_ID };
+
+// ── Tests: POST ───────────────────────────────────────────────────────────────
+
+describe("POST /api/advisor-auth/follow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdvisorSession.mockResolvedValue(ADVISOR_ID);
+    (isRateLimited as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+    mockGetUser.mockResolvedValue({ data: { user: { id: USER_ID } } });
+
+    let call = 0;
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      call++;
+      if (call === 1) {
+        // advisor_follows insert — success
+        return makeBuilder(null, null);
+      }
+      if (call === 2) {
+        // professionals follower_count select
+        const b = makeBuilder({ follower_count: 5 }, null);
+        (b.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+          data: { follower_count: 5 },
+          error: null,
+        });
+        return b;
+      }
+      // professionals update
+      return makeBuilder(null, null);
+    });
+  });
+
+  it("returns 429 when rate limited", async () => {
+    (isRateLimited as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+    const res = await POST(makePost(validBody));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when advisor session is not found", async () => {
+    mockRequireAdvisorSession.mockResolvedValue(null);
+    const res = await POST(makePost(validBody));
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error).toMatch(/Not authenticated/i);
+  });
+
+  it("returns 401 when auth user is not found", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const res = await POST(makePost(validBody));
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error).toMatch(/Not authenticated/i);
+  });
+
+  it("returns 400 when professionalId is missing", async () => {
+    const res = await POST(makePost({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when professionalId is not a positive integer", async () => {
+    const res = await POST(makePost({ professionalId: -5 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("follows advisor and returns 200 success", async () => {
+    const res = await POST(makePost(validBody));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+  });
+
+  it("returns success (idempotent) when already following (unique_violation 23505)", async () => {
+    mockFrom.mockImplementation((..._a: unknown[]) =>
+      makeBuilder(null, { code: "23505", message: "duplicate key" }),
+    );
+    const res = await POST(makePost(validBody));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+  });
+
+  it("returns 500 when DB insert fails with non-duplicate error", async () => {
+    mockFrom.mockImplementation((..._a: unknown[]) =>
+      makeBuilder(null, { code: "PGRST0", message: "connection error" }),
+    );
+    const res = await POST(makePost(validBody));
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toMatch(/Failed to follow advisor/i);
+  });
+
+  it("increments follower_count after successful follow", async () => {
+    const res = await POST(makePost(validBody));
+    expect(res.status).toBe(200);
+    // At least 3 mockFrom calls: insert + select + update
+    expect(mockFrom.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ── Tests: DELETE ─────────────────────────────────────────────────────────────
+
+describe("DELETE /api/advisor-auth/follow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdvisorSession.mockResolvedValue(ADVISOR_ID);
+    (isRateLimited as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+    mockGetUser.mockResolvedValue({ data: { user: { id: USER_ID } } });
+
+    let call = 0;
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      call++;
+      if (call === 1) {
+        // advisor_follows delete — success
+        return makeBuilder(null, null);
+      }
+      if (call === 2) {
+        // professionals follower_count select
+        const b = makeBuilder({ follower_count: 5 }, null);
+        (b.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+          data: { follower_count: 5 },
+          error: null,
+        });
+        return b;
+      }
+      // professionals update
+      return makeBuilder(null, null);
+    });
+  });
+
+  it("returns 429 when rate limited", async () => {
+    (isRateLimited as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+    const res = await DELETE(makeDeleteReq(validBody));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when advisor session is not found", async () => {
+    mockRequireAdvisorSession.mockResolvedValue(null);
+    const res = await DELETE(makeDeleteReq(validBody));
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error).toMatch(/Not authenticated/i);
+  });
+
+  it("returns 401 when auth user is not found", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const res = await DELETE(makeDeleteReq(validBody));
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error).toMatch(/Not authenticated/i);
+  });
+
+  it("returns 400 when body is invalid JSON", async () => {
+    const req = new NextRequest("http://localhost/api/advisor-auth/follow", {
+      method: "DELETE",
+      body: "bad-json",
+      headers: { "Content-Type": "application/json", "x-forwarded-for": "1.2.3.4" },
+    });
+    const res = await DELETE(req);
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/Invalid JSON/i);
+  });
+
+  it("returns 400 when professionalId is missing", async () => {
+    const res = await DELETE(makeDeleteReq({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("unfollows advisor and returns 200 success", async () => {
+    const res = await DELETE(makeDeleteReq(validBody));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+  });
+
+  it("returns 500 when DB delete fails", async () => {
+    mockFrom.mockImplementation((..._a: unknown[]) =>
+      makeBuilder(null, { message: "delete failed" }),
+    );
+    const res = await DELETE(makeDeleteReq(validBody));
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toMatch(/Failed to unfollow advisor/i);
+  });
+
+  it("decrements follower_count after successful unfollow", async () => {
+    const res = await DELETE(makeDeleteReq(validBody));
+    expect(res.status).toBe(200);
+    expect(mockFrom.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/__tests__/api/advisor-auth-leaderboard.test.ts
+++ b/__tests__/api/advisor-auth-leaderboard.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Hoisted mocks ──────────────────────────────────────────────────────────────
+
+const { mockRequireAdvisorSession } = vi.hoisted(() => ({
+  mockRequireAdvisorSession: vi.fn<() => Promise<number | null>>(),
+}));
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: (...args: unknown[]) =>
+    mockRequireAdvisorSession(...(args as [])),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: vi.fn(async () => false),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+// ── Supabase admin builder ────────────────────────────────────────────────────
+
+function makeBuilder(data: unknown = null, error: unknown = null, count: number | null = null) {
+  const c: Record<string, unknown> = {
+    then: (r: (v: { data: unknown; error: unknown; count: number | null }) => unknown) =>
+      Promise.resolve(r({ data, error, count })),
+    count,
+  };
+  for (const m of [
+    "select", "insert", "update", "upsert", "delete",
+    "eq", "neq", "gt", "gte", "lt", "lte", "in", "is", "not", "or",
+    "order", "limit", "range", "filter",
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  c.single = vi.fn(() => Promise.resolve({ data, error, count }));
+  c.maybeSingle = vi.fn(() => Promise.resolve({ data, error, count }));
+  return c;
+}
+
+const mockFrom = vi.fn((..._a: unknown[]) => makeBuilder());
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+// ── Route under test ──────────────────────────────────────────────────────────
+
+import { GET } from "@/app/api/advisor-auth/leaderboard/route";
+import { isRateLimited } from "@/lib/rate-limit";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const ADVISOR_ID = 42;
+
+function makeGet(): NextRequest {
+  return new NextRequest("http://localhost/api/advisor-auth/leaderboard", {
+    method: "GET",
+    headers: { "x-forwarded-for": "1.2.3.4" },
+  });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("GET /api/advisor-auth/leaderboard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdvisorSession.mockResolvedValue(ADVISOR_ID);
+    (isRateLimited as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+
+    // Default: advisor has a rank row + total 100 advisors
+    let call = 0;
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      call++;
+      if (call === 1) {
+        // advisor's own rank row
+        const b = makeBuilder({ rank: 10, score: 850 }, null);
+        (b.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+          data: { rank: 10, score: 850 },
+          error: null,
+          count: null,
+        });
+        return b;
+      }
+      // count query — return count via the builder
+      const b = makeBuilder(null, null, 100);
+      return b;
+    });
+  });
+
+  // ── 429 rate limiting ─────────────────────────────────────────────────────
+
+  it("returns 429 when rate limited", async () => {
+    (isRateLimited as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+    const res = await GET(makeGet());
+    expect(res.status).toBe(429);
+    const json = await res.json();
+    expect(json.error).toMatch(/too many requests/i);
+  });
+
+  // ── 401 unauthenticated ───────────────────────────────────────────────────
+
+  it("returns 401 when advisor session is not found", async () => {
+    mockRequireAdvisorSession.mockResolvedValue(null);
+    const res = await GET(makeGet());
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error).toMatch(/not authenticated/i);
+  });
+
+  // ── rank: null when advisor has no leaderboard row ────────────────────────
+
+  it("returns { rank: null } when advisor is not on the leaderboard", async () => {
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      const b = makeBuilder(null, null);
+      (b.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: null,
+        error: null,
+        count: null,
+      });
+      return b;
+    });
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.rank).toBeNull();
+  });
+
+  // ── happy path: rank + score + total + percentile ─────────────────────────
+
+  it("returns rank, score, total and percentile when advisor is on leaderboard", async () => {
+    // Already set in beforeEach (rank=10, total=100)
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.rank).toBe(10);
+    expect(json.score).toBe(850);
+    expect(json.total).toBe(100);
+    // percentile = Math.round(((100 - 10) / 100) * 100) = 90
+    expect(json.percentile).toBe(90);
+  });
+
+  // ── percentile is null when total is 0 ───────────────────────────────────
+
+  it("returns percentile: null when total leaderboard count is 0", async () => {
+    let call = 0;
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      call++;
+      if (call === 1) {
+        const b = makeBuilder({ rank: 1, score: 100 }, null);
+        (b.maybeSingle as ReturnType<typeof vi.fn>).mockResolvedValue({
+          data: { rank: 1, score: 100 },
+          error: null,
+          count: null,
+        });
+        return b;
+      }
+      // count = 0
+      return makeBuilder(null, null, 0);
+    });
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.percentile).toBeNull();
+  });
+
+  // ── 500 on unexpected error ───────────────────────────────────────────────
+
+  it("returns 500 when an unexpected error is thrown", async () => {
+    mockFrom.mockImplementation(() => {
+      throw new Error("DB connection refused");
+    });
+    const res = await GET(makeGet());
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toMatch(/failed to fetch rank/i);
+  });
+});

--- a/__tests__/api/advisor-auth-posts-react.test.ts
+++ b/__tests__/api/advisor-auth-posts-react.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Hoisted mock refs ─────────────────────────────────────────────────────────
+
+const {
+  mockRequireAdvisorSession,
+  mockIsRateLimited,
+  mockAdminFrom,
+  mockGetUser,
+} = vi.hoisted(() => ({
+  mockRequireAdvisorSession: vi.fn<(...args: unknown[]) => Promise<unknown>>(async () => 10),
+  mockIsRateLimited: vi.fn<(...args: unknown[]) => Promise<boolean>>(async () => false),
+  mockAdminFrom: vi.fn<(...args: unknown[]) => unknown>(),
+  mockGetUser: vi.fn<(...args: unknown[]) => Promise<unknown>>(async () => ({
+    data: { user: { id: "uuid-user-1" } },
+  })),
+}));
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: (...args: unknown[]) => mockRequireAdvisorSession(...args),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: (...args: unknown[]) => mockIsRateLimited(...args),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: mockGetUser },
+  })),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() })),
+}));
+
+// ── Route under test ──────────────────────────────────────────────────────────
+
+import { POST } from "@/app/api/advisor-auth/posts/[postId]/react/route";
+
+// ── Builder helper ────────────────────────────────────────────────────────────
+
+function makeBuilder(
+  data: unknown = null,
+  error: unknown = null,
+  count: number | null = null,
+) {
+  const c: Record<string, unknown> = {
+    then: (r: (v: { data: unknown; error: unknown; count: number | null }) => unknown) =>
+      Promise.resolve(r({ data, error, count })),
+  };
+  for (const m of [
+    "select", "insert", "update", "upsert", "delete", "eq", "neq", "gt", "gte",
+    "lt", "lte", "in", "is", "not", "or", "order", "limit", "range", "single",
+    "maybeSingle", "filter", "contains", "overlaps",
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  return c;
+}
+
+// Helper that resolves to { error, count } to satisfy the select+head=true pattern
+function makeCountBuilder(count: number | null = 3, error: unknown = null) {
+  const c: Record<string, unknown> = {
+    then: (r: (v: { data: null; error: unknown; count: number | null }) => unknown) =>
+      Promise.resolve(r({ data: null, error, count })),
+  };
+  for (const m of [
+    "select", "insert", "update", "upsert", "delete", "eq", "neq", "gt", "gte",
+    "lt", "lte", "in", "is", "not", "or", "order", "limit", "range", "single",
+    "maybeSingle", "filter", "contains", "overlaps",
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  return c;
+}
+
+function makePost(postId: string, body: unknown) {
+  return new NextRequest(
+    `http://localhost/api/advisor-auth/posts/${postId}/react`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-forwarded-for": "1.2.3.4",
+      },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+function makeParams(postId: string) {
+  return { params: Promise.resolve({ postId }) };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("POST /api/advisor-auth/posts/[postId]/react — auth + rate-limit", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+    mockRequireAdvisorSession.mockResolvedValue(10);
+    mockGetUser.mockResolvedValue({ data: { user: { id: "uuid-user-1" } } });
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsRateLimited.mockResolvedValueOnce(true);
+    const res = await POST(
+      makePost("42", { reaction_type: "like" }),
+      makeParams("42"),
+    );
+    expect(res.status).toBe(429);
+    const body = await res.json() as { error: string };
+    expect(body.error).toMatch(/too many requests/i);
+  });
+
+  it("returns 401 when requireAdvisorSession returns null", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce(null);
+    const res = await POST(
+      makePost("42", { reaction_type: "like" }),
+      makeParams("42"),
+    );
+    expect(res.status).toBe(401);
+    const body = await res.json() as { error: string };
+    expect(body.error).toMatch(/not authenticated/i);
+  });
+
+  it("returns 401 when supabase getUser returns null user", async () => {
+    mockGetUser.mockResolvedValueOnce({ data: { user: null } });
+    const res = await POST(
+      makePost("42", { reaction_type: "like" }),
+      makeParams("42"),
+    );
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("POST /api/advisor-auth/posts/[postId]/react — validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+    mockRequireAdvisorSession.mockResolvedValue(10);
+    mockGetUser.mockResolvedValue({ data: { user: { id: "uuid-user-1" } } });
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    const req = new NextRequest(
+      "http://localhost/api/advisor-auth/posts/42/react",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "x-forwarded-for": "1.2.3.4" },
+        body: "not json{",
+      },
+    );
+    const res = await POST(req, makeParams("42"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for an invalid reaction_type", async () => {
+    const res = await POST(
+      makePost("42", { reaction_type: "laugh" }),
+      makeParams("42"),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for a non-numeric postId", async () => {
+    const res = await POST(
+      makePost("abc", { reaction_type: "like" }),
+      makeParams("abc"),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toMatch(/invalid post/i);
+  });
+
+  it("returns 400 for postId = 0", async () => {
+    const res = await POST(
+      makePost("0", { reaction_type: "like" }),
+      makeParams("0"),
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /api/advisor-auth/posts/[postId]/react — DB paths", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+    mockRequireAdvisorSession.mockResolvedValue(10);
+    mockGetUser.mockResolvedValue({ data: { user: { id: "uuid-user-1" } } });
+  });
+
+  it("returns 500 when upsert fails", async () => {
+    mockAdminFrom.mockReturnValue(makeBuilder(null, { message: "upsert boom" }));
+    const res = await POST(
+      makePost("42", { reaction_type: "like" }),
+      makeParams("42"),
+    );
+    expect(res.status).toBe(500);
+    const body = await res.json() as { error: string };
+    expect(body.error).toMatch(/failed to react/i);
+  });
+
+  it("returns 500 when count query fails", async () => {
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      call += 1;
+      if (call === 1) return makeBuilder(null, null); // upsert succeeds
+      return makeCountBuilder(null, { message: "count boom" }); // count fails
+    });
+    const res = await POST(
+      makePost("42", { reaction_type: "insightful" }),
+      makeParams("42"),
+    );
+    expect(res.status).toBe(500);
+    const body = await res.json() as { error: string };
+    expect(body.error).toMatch(/failed to update count/i);
+  });
+
+  it("returns 200 with success + reaction_count on happy path", async () => {
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      call += 1;
+      if (call === 1) return makeBuilder(null, null); // upsert
+      if (call === 2) return makeCountBuilder(5, null); // count query
+      return makeBuilder(null, null); // advisor_posts update
+    });
+    const res = await POST(
+      makePost("42", { reaction_type: "celebrate" }),
+      makeParams("42"),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as { success: boolean; reaction_count: number };
+    expect(body.success).toBe(true);
+    expect(body.reaction_count).toBe(5);
+  });
+
+  it("uses reaction_count 0 when count is null", async () => {
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      call += 1;
+      if (call === 1) return makeBuilder(null, null);
+      if (call === 2) return makeCountBuilder(null, null); // null count
+      return makeBuilder(null, null);
+    });
+    const res = await POST(
+      makePost("55", { reaction_type: "like" }),
+      makeParams("55"),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json() as { reaction_count: number };
+    expect(body.reaction_count).toBe(0);
+  });
+});

--- a/__tests__/api/advisor-auth-profile-details.test.ts
+++ b/__tests__/api/advisor-auth-profile-details.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Hoisted mock refs ─────────────────────────────────────────────────────────
+
+const { mockRequireAdvisorSession, mockIsRateLimited, mockAdminFrom } = vi.hoisted(() => ({
+  mockRequireAdvisorSession: vi.fn<(...args: unknown[]) => Promise<unknown>>(async () => 20),
+  mockIsRateLimited: vi.fn<(...args: unknown[]) => Promise<boolean>>(async () => false),
+  mockAdminFrom: vi.fn<(...args: unknown[]) => unknown>(),
+}));
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: (...args: unknown[]) => mockRequireAdvisorSession(...args),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: (...args: unknown[]) => mockIsRateLimited(...args),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() })),
+}));
+
+// ── Route under test ──────────────────────────────────────────────────────────
+
+import { GET, PATCH } from "@/app/api/advisor-auth/profile-details/route";
+
+// ── Builder helper ────────────────────────────────────────────────────────────
+
+function makeBuilder(data: unknown = null, error: unknown = null) {
+  const c: Record<string, unknown> = {
+    then: (r: (v: { data: unknown; error: unknown }) => unknown) =>
+      Promise.resolve(r({ data, error })),
+  };
+  for (const m of [
+    "select", "insert", "update", "upsert", "delete", "eq", "neq", "gt", "gte",
+    "lt", "lte", "in", "is", "not", "or", "order", "limit", "range", "single",
+    "maybeSingle", "filter", "contains", "overlaps",
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  return c;
+}
+
+function makeGet() {
+  return new NextRequest(
+    "http://localhost/api/advisor-auth/profile-details",
+    { method: "GET" },
+  );
+}
+
+function makePatch(body: unknown) {
+  return new NextRequest(
+    "http://localhost/api/advisor-auth/profile-details",
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json", "x-forwarded-for": "1.2.3.4" },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+// ── GET Tests ─────────────────────────────────────────────────────────────────
+
+describe("GET /api/advisor-auth/profile-details — auth", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdvisorSession.mockResolvedValue(20);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce(null);
+    const res = await GET(makeGet());
+    expect(res.status).toBe(401);
+    const body = await res.json() as { error: string };
+    expect(body.error).toMatch(/not authenticated/i);
+  });
+});
+
+describe("GET /api/advisor-auth/profile-details — success", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdvisorSession.mockResolvedValue(20);
+  });
+
+  it("returns services and certifications for the advisor", async () => {
+    const services = [{ id: 1, name: "SMSF" }];
+    const certs = [{ id: 9, name: "CFP" }];
+
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      call += 1;
+      if (call === 1) return makeBuilder(services, null); // advisor_services
+      return makeBuilder(certs, null); // advisor_certifications
+    });
+
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const body = await res.json() as { services: unknown[]; certifications: unknown[] };
+    expect(body.services).toEqual(services);
+    expect(body.certifications).toEqual(certs);
+  });
+
+  it("returns empty arrays when both queries return null", async () => {
+    mockAdminFrom.mockReturnValue(makeBuilder(null, null));
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const body = await res.json() as { services: unknown[]; certifications: unknown[] };
+    expect(body.services).toEqual([]);
+    expect(body.certifications).toEqual([]);
+  });
+});
+
+// ── PATCH Tests ───────────────────────────────────────────────────────────────
+
+describe("PATCH /api/advisor-auth/profile-details — auth + rate-limit", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+    mockRequireAdvisorSession.mockResolvedValue(20);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsRateLimited.mockResolvedValueOnce(true);
+    const res = await PATCH(makePatch({ languages_spoken: ["English"] }));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce(null);
+    const res = await PATCH(makePatch({ languages_spoken: ["English"] }));
+    expect(res.status).toBe(401);
+    const body = await res.json() as { error: string };
+    expect(body.error).toMatch(/not authenticated/i);
+  });
+});
+
+describe("PATCH /api/advisor-auth/profile-details — validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+    mockRequireAdvisorSession.mockResolvedValue(20);
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    const req = new NextRequest(
+      "http://localhost/api/advisor-auth/profile-details",
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json", "x-forwarded-for": "1.2.3.4" },
+        body: "not json{",
+      },
+    );
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toMatch(/invalid json/i);
+  });
+
+  it("returns 400 for invalid min_client_assets_band value", async () => {
+    const res = await PATCH(makePatch({ min_client_assets_band: "notvalid" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when a language string exceeds 50 chars", async () => {
+    const longLang = "a".repeat(51);
+    const res = await PATCH(makePatch({ languages_spoken: [longLang] }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when specializations array exceeds 20 items", async () => {
+    const specs = Array.from({ length: 21 }, (_, i) => `Spec${i}`);
+    const res = await PATCH(makePatch({ specializations: specs }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 200 with success:true when body has no recognizable fields (no-op update)", async () => {
+    // Empty object → no fields to update → early success
+    const res = await PATCH(makePatch({}));
+    expect(res.status).toBe(200);
+    const body = await res.json() as { success: boolean };
+    expect(body.success).toBe(true);
+  });
+});
+
+describe("PATCH /api/advisor-auth/profile-details — DB paths", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+    mockRequireAdvisorSession.mockResolvedValue(20);
+  });
+
+  it("returns 200 when update succeeds", async () => {
+    mockAdminFrom.mockReturnValue(makeBuilder(null, null));
+    const res = await PATCH(makePatch({ languages_spoken: ["English", "Mandarin"] }));
+    expect(res.status).toBe(200);
+    const body = await res.json() as { success: boolean };
+    expect(body.success).toBe(true);
+  });
+
+  it("returns 500 when DB update fails", async () => {
+    mockAdminFrom.mockReturnValue(makeBuilder(null, { message: "db error" }));
+    const res = await PATCH(
+      makePatch({ min_client_assets_band: "250k" }),
+    );
+    expect(res.status).toBe(500);
+    const body = await res.json() as { error: string };
+    expect(body.error).toMatch(/update failed/i);
+  });
+
+  it("accepts null for min_client_assets_band (nullable field)", async () => {
+    mockAdminFrom.mockReturnValue(makeBuilder(null, null));
+    const res = await PATCH(makePatch({ min_client_assets_band: null }));
+    expect(res.status).toBe(200);
+  });
+
+  it("accepts a valid min_client_assets_band enum value", async () => {
+    mockAdminFrom.mockReturnValue(makeBuilder(null, null));
+    const res = await PATCH(makePatch({ min_client_assets_band: "1m" }));
+    expect(res.status).toBe(200);
+    const body = await res.json() as { success: boolean };
+    expect(body.success).toBe(true);
+  });
+});

--- a/__tests__/api/advisor-auth-profile-score.test.ts
+++ b/__tests__/api/advisor-auth-profile-score.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const { mockRequireAdvisorSession } = vi.hoisted(() => ({
+  mockRequireAdvisorSession: vi.fn<() => Promise<number | null>>(),
+}));
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: (...args: unknown[]) =>
+    mockRequireAdvisorSession(...(args as [])),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: vi.fn(async () => false),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+// ── Supabase admin builder ────────────────────────────────────────────────────
+
+function makeBuilder(data: unknown = null, error: unknown = null, count: number | null = null) {
+  const c: Record<string, unknown> = {
+    then: (r: (v: { data: unknown; error: unknown; count: number | null }) => unknown) =>
+      Promise.resolve(r({ data, error, count })),
+  };
+  for (const m of [
+    "select", "insert", "update", "upsert", "delete",
+    "eq", "neq", "gt", "gte", "lt", "lte", "in", "is", "not", "or",
+    "order", "limit", "range", "filter", "contains", "overlaps",
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  c.single = vi.fn(() => Promise.resolve({ data, error }));
+  c.maybeSingle = vi.fn(() => Promise.resolve({ data, error }));
+  return c;
+}
+
+const mockFrom = vi.fn((..._a: unknown[]) => makeBuilder());
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+// ── Route under test ──────────────────────────────────────────────────────────
+
+import { GET } from "@/app/api/advisor-auth/profile-score/route";
+import { isRateLimited } from "@/lib/rate-limit";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const ADVISOR_ID = 7;
+
+function makeGet(): NextRequest {
+  return new NextRequest("http://localhost/api/advisor-auth/profile-score", {
+    method: "GET",
+  });
+}
+
+const fullProfile = {
+  photo_url: "https://cdn.example.com/photo.jpg",
+  bio: "A".repeat(110),
+  specialties: ["SMSF", "Retirement"],
+  booking_link: "https://cal.com/advisor",
+  review_count: 10,
+  rating: 4.5,
+  website: "https://advisor.com.au",
+  afsl_number: "123456",
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("GET /api/advisor-auth/profile-score", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdvisorSession.mockResolvedValue(ADVISOR_ID);
+    (isRateLimited as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockRequireAdvisorSession.mockResolvedValue(null);
+    const res = await GET(makeGet());
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error).toMatch(/Not authenticated/i);
+  });
+
+  it("returns 429 when rate limited", async () => {
+    (isRateLimited as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+    const res = await GET(makeGet());
+    expect(res.status).toBe(429);
+    const json = await res.json();
+    expect(json.error).toMatch(/Too many requests/i);
+  });
+
+  it("returns 404 when advisor profile not found", async () => {
+    let call = 0;
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      call++;
+      // professionals → maybeSingle null; services and certs → count 0
+      if (call === 1) return makeBuilder(null, null);
+      return makeBuilder(null, null, 0);
+    });
+    const res = await GET(makeGet());
+    expect(res.status).toBe(404);
+    const json = await res.json();
+    expect(json.error).toMatch(/Advisor not found/i);
+  });
+
+  it("returns full 100 score for a complete profile", async () => {
+    let call = 0;
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      call++;
+      if (call === 1) return makeBuilder(fullProfile, null);
+      // services count = 2, certs count = 1
+      if (call === 2) return makeBuilder(null, null, 2);
+      return makeBuilder(null, null, 1);
+    });
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.score).toBe(100);
+    expect(json.maxScore).toBe(100);
+    expect(Array.isArray(json.breakdown)).toBe(true);
+    expect(json.breakdown).toHaveLength(10);
+    expect(json.breakdown.every((b: { earned: boolean }) => b.earned)).toBe(true);
+  });
+
+  it("returns score 0 for an empty profile", async () => {
+    const emptyProfile = {
+      photo_url: null,
+      bio: null,
+      specialties: null,
+      booking_link: null,
+      review_count: 0,
+      rating: 0,
+      website: null,
+      afsl_number: null,
+    };
+    let call = 0;
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      call++;
+      if (call === 1) return makeBuilder(emptyProfile, null);
+      return makeBuilder(null, null, 0);
+    });
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.score).toBe(0);
+    expect(json.breakdown.every((b: { earned: boolean }) => !b.earned)).toBe(true);
+  });
+
+  it("excludes ui-avatars placeholder from photo score", async () => {
+    const profile = { ...fullProfile, photo_url: "https://ui-avatars.com/api/?name=Test" };
+    let call = 0;
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      call++;
+      if (call === 1) return makeBuilder(profile, null);
+      if (call === 2) return makeBuilder(null, null, 2);
+      return makeBuilder(null, null, 1);
+    });
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    // photo_url is a placeholder — 15 pts not earned
+    expect(json.score).toBe(85);
+    const photoItem = json.breakdown.find((b: { label: string }) => b.label === "Profile photo");
+    expect(photoItem?.earned).toBe(false);
+  });
+
+  it("earns bio points only when bio > 100 chars", async () => {
+    const shortBio = { ...fullProfile, bio: "Short bio" };
+    let call = 0;
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      call++;
+      if (call === 1) return makeBuilder(shortBio, null);
+      if (call === 2) return makeBuilder(null, null, 1);
+      return makeBuilder(null, null, 1);
+    });
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    const bioItem = json.breakdown.find((b: { label: string }) => b.label === "Bio (100+ characters)");
+    expect(bioItem?.earned).toBe(false);
+  });
+
+  it("returns each breakdown item with label, points, earned, tip fields", async () => {
+    let call = 0;
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      call++;
+      if (call === 1) return makeBuilder(fullProfile, null);
+      if (call === 2) return makeBuilder(null, null, 1);
+      return makeBuilder(null, null, 1);
+    });
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    for (const item of json.breakdown) {
+      expect(typeof item.label).toBe("string");
+      expect(typeof item.points).toBe("number");
+      expect(typeof item.earned).toBe("boolean");
+      expect(typeof item.tip).toBe("string");
+    }
+  });
+
+  it("earns review points only when review_count >= 5", async () => {
+    const fewReviews = { ...fullProfile, review_count: 4 };
+    let call = 0;
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      call++;
+      if (call === 1) return makeBuilder(fewReviews, null);
+      if (call === 2) return makeBuilder(null, null, 1);
+      return makeBuilder(null, null, 1);
+    });
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    const reviewItem = json.breakdown.find((b: { label: string }) => b.label === "5+ reviews");
+    expect(reviewItem?.earned).toBe(false);
+  });
+});

--- a/__tests__/api/advisor-auth-reviews-invite.test.ts
+++ b/__tests__/api/advisor-auth-reviews-invite.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── withValidatedBody: real Zod pass-through ──────────────────────────────────
+
+vi.mock("@/lib/validation/withValidatedBody", () => ({
+  withValidatedBody:
+    (
+      schema: {
+        safeParse: (v: unknown) => {
+          success: boolean;
+          data?: unknown;
+          error?: { issues: unknown[] };
+        };
+      },
+      handler: (req: NextRequest, body: unknown) => unknown,
+    ) =>
+    async (req: NextRequest) => {
+      let raw: unknown;
+      try {
+        raw = await req.json();
+      } catch {
+        return new Response(
+          JSON.stringify({ error: "Invalid JSON body" }),
+          { status: 400 },
+        );
+      }
+      const parsed = schema.safeParse(raw);
+      if (!parsed.success) {
+        const issues = parsed.error!.issues as Array<{
+          path?: string[];
+          message?: string;
+        }>;
+        const first = issues[0];
+        const path = first?.path?.join(".") ?? "";
+        const message = first?.message ?? "Invalid request body";
+        return new Response(
+          JSON.stringify({
+            error: path ? `${path}: ${message}` : message,
+            code: "validation_error",
+            issues,
+          }),
+          { status: 400 },
+        );
+      }
+      return handler(req, parsed.data);
+    },
+}));
+
+// ── Hoisted mocks ──────────────────────────────────────────────────────────────
+
+const { mockRequireAdvisorSession, mockSendReviewRequest } = vi.hoisted(() => ({
+  mockRequireAdvisorSession: vi.fn<() => Promise<number | null>>(),
+  mockSendReviewRequest: vi.fn<() => Promise<boolean>>(),
+}));
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: (...args: unknown[]) =>
+    mockRequireAdvisorSession(...(args as [])),
+}));
+
+vi.mock("@/lib/advisor-emails", () => ({
+  sendReviewRequest: (..._args: unknown[]) => mockSendReviewRequest(),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: vi.fn(async () => false),
+}));
+
+// ── Supabase admin builder ────────────────────────────────────────────────────
+
+function makeBuilder(data: unknown = null, error: unknown = null) {
+  const c: Record<string, unknown> = {
+    then: (r: (v: { data: unknown; error: unknown }) => unknown) =>
+      Promise.resolve(r({ data, error })),
+  };
+  for (const m of [
+    "select", "insert", "update", "upsert", "delete",
+    "eq", "neq", "gt", "gte", "lt", "lte", "in", "is", "not", "or",
+    "order", "limit", "range", "filter",
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  c.single = vi.fn(() => Promise.resolve({ data, error }));
+  c.maybeSingle = vi.fn(() => Promise.resolve({ data, error }));
+  return c;
+}
+
+const mockFrom = vi.fn((..._a: unknown[]) => makeBuilder());
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+// ── Route under test ──────────────────────────────────────────────────────────
+
+import { POST } from "@/app/api/advisor-auth/reviews/invite/route";
+import { isRateLimited } from "@/lib/rate-limit";
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const ADVISOR_ID = 88;
+
+const MOCK_ADVISOR = {
+  name: "Sarah Wealth",
+  slug: "sarah-wealth",
+};
+
+const VALID_BODY = {
+  email: "client@example.com",
+  name: "John Client",
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makePost(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/advisor-auth/reviews/invite", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: {
+      "Content-Type": "application/json",
+      "x-forwarded-for": "9.8.7.6",
+    },
+  });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("POST /api/advisor-auth/reviews/invite", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdvisorSession.mockResolvedValue(ADVISOR_ID);
+    (isRateLimited as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+    mockSendReviewRequest.mockResolvedValue(true);
+
+    // Default: advisor lookup succeeds
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      const b = makeBuilder(MOCK_ADVISOR, null);
+      (b.single as ReturnType<typeof vi.fn>).mockResolvedValue({
+        data: MOCK_ADVISOR,
+        error: null,
+      });
+      return b;
+    });
+  });
+
+  // ── 429 rate limiting ─────────────────────────────────────────────────────
+
+  it("returns 429 when rate limited", async () => {
+    (isRateLimited as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+    const res = await POST(makePost(VALID_BODY));
+    expect(res.status).toBe(429);
+    const json = await res.json();
+    expect(json.error).toMatch(/too many requests/i);
+  });
+
+  // ── 401 unauthenticated ───────────────────────────────────────────────────
+
+  it("returns 401 when advisor session is not found", async () => {
+    mockRequireAdvisorSession.mockResolvedValue(null);
+    const res = await POST(makePost(VALID_BODY));
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error).toMatch(/not authenticated/i);
+  });
+
+  // ── 400 validation: missing email ────────────────────────────────────────
+
+  it("returns 400 when email is missing", async () => {
+    const res = await POST(makePost({ name: "Client" }));
+    expect(res.status).toBe(400);
+  });
+
+  // ── 400 validation: invalid email ────────────────────────────────────────
+
+  it("returns 400 when email is not a valid email address", async () => {
+    const res = await POST(makePost({ email: "not-an-email", name: "Client" }));
+    expect(res.status).toBe(400);
+  });
+
+  // ── 400 validation: missing name ─────────────────────────────────────────
+
+  it("returns 400 when client name is missing", async () => {
+    const res = await POST(makePost({ email: "client@example.com" }));
+    expect(res.status).toBe(400);
+  });
+
+  // ── 400 validation: empty name ────────────────────────────────────────────
+
+  it("returns 400 when client name is empty string", async () => {
+    const res = await POST(makePost({ email: "client@example.com", name: "" }));
+    expect(res.status).toBe(400);
+  });
+
+  // ── 400 validation: name exceeds max length ───────────────────────────────
+
+  it("returns 400 when client name exceeds 200 characters", async () => {
+    const res = await POST(makePost({ email: "client@example.com", name: "A".repeat(201) }));
+    expect(res.status).toBe(400);
+  });
+
+  // ── 400 invalid JSON ─────────────────────────────────────────────────────
+
+  it("returns 400 on invalid JSON body", async () => {
+    const req = new NextRequest("http://localhost/api/advisor-auth/reviews/invite", {
+      method: "POST",
+      body: "not-json{{",
+      headers: { "Content-Type": "application/json", "x-forwarded-for": "9.8.7.6" },
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  // ── 500 advisor not found in DB ───────────────────────────────────────────
+
+  it("returns 500 when advisor row is not found in professionals table", async () => {
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      const b = makeBuilder(null, null);
+      (b.single as ReturnType<typeof vi.fn>).mockResolvedValue({ data: null, error: null });
+      return b;
+    });
+    const res = await POST(makePost(VALID_BODY));
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toMatch(/advisor not found/i);
+  });
+
+  // ── 500 email send fails ──────────────────────────────────────────────────
+
+  it("returns 500 when sendReviewRequest returns false", async () => {
+    mockSendReviewRequest.mockResolvedValue(false);
+    const res = await POST(makePost(VALID_BODY));
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toMatch(/failed to send invitation email/i);
+  });
+
+  // ── 200 success ───────────────────────────────────────────────────────────
+
+  it("returns 200 with success:true when invitation is sent", async () => {
+    const res = await POST(makePost(VALID_BODY));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+  });
+
+  // ── sendReviewRequest called with correct args ─────────────────────────────
+
+  it("calls sendReviewRequest with client email, client name, advisor name, advisor slug", async () => {
+    await POST(makePost(VALID_BODY));
+    expect(mockSendReviewRequest).toHaveBeenCalledTimes(1);
+  });
+});

--- a/__tests__/api/advisor-auth-trust-score.test.ts
+++ b/__tests__/api/advisor-auth-trust-score.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Hoisted mock refs ─────────────────────────────────────────────────────────
+
+const { mockRequireAdvisorSession, mockAdminFrom } = vi.hoisted(() => ({
+  mockRequireAdvisorSession: vi.fn<(...args: unknown[]) => Promise<unknown>>(async () => 77),
+  mockAdminFrom: vi.fn<(...args: unknown[]) => unknown>(),
+}));
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: (...args: unknown[]) => mockRequireAdvisorSession(...args),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+// ── Route under test ──────────────────────────────────────────────────────────
+
+import { GET } from "@/app/api/advisor-auth/trust-score/route";
+
+// ── Builder helper ────────────────────────────────────────────────────────────
+
+function makeBuilder(data: unknown = null, error: unknown = null) {
+  const c: Record<string, unknown> = {
+    then: (r: (v: { data: unknown; error: unknown }) => unknown) =>
+      Promise.resolve(r({ data, error })),
+  };
+  for (const m of [
+    "select", "insert", "update", "upsert", "delete", "eq", "neq", "gt", "gte",
+    "lt", "lte", "in", "is", "not", "or", "order", "limit", "range", "single",
+    "maybeSingle", "filter", "contains", "overlaps",
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  return c;
+}
+
+type ProfRow = {
+  id: number;
+  verified: boolean | null;
+  afsl_number: string | null;
+  registration_number: string | null;
+  verified_at: string | null;
+  created_at: string | null;
+  years_experience: number | null;
+  bio: string | null;
+  photo_url: string | null;
+  qualifications: unknown[] | null;
+  education: unknown[] | null;
+  memberships: unknown[] | null;
+  fee_structure: string | null;
+  fee_description: string | null;
+  linkedin_url: string | null;
+  website: string | null;
+  languages: unknown[] | null;
+  rating: number | null;
+  review_count: number | null;
+  trust_score_overall: number | null;
+  trust_score_updated_at: string | null;
+  trust_score_version: number | null;
+};
+
+const EMPTY_ROW: ProfRow = {
+  id: 77,
+  verified: null,
+  afsl_number: null,
+  registration_number: null,
+  verified_at: null,
+  created_at: null,
+  years_experience: null,
+  bio: null,
+  photo_url: null,
+  qualifications: null,
+  education: null,
+  memberships: null,
+  fee_structure: null,
+  fee_description: null,
+  linkedin_url: null,
+  website: null,
+  languages: null,
+  rating: null,
+  review_count: null,
+  trust_score_overall: null,
+  trust_score_updated_at: null,
+  trust_score_version: null,
+};
+
+const FULL_ROW: ProfRow = {
+  ...EMPTY_ROW,
+  verified: true,
+  afsl_number: "123456",
+  registration_number: "AR-789",
+  verified_at: new Date(Date.now() - 30 * 86400000).toISOString(), // 30 days ago (recent)
+  created_at: new Date(Date.now() - 15 * 365 * 86400000).toISOString(), // 15 years ago
+  years_experience: 15,
+  bio: "I am a highly experienced financial advisor with decades of expertise.",
+  photo_url: "https://example.com/photo.jpg",
+  qualifications: [{ name: "CFP" }],
+  education: [{ degree: "BCom" }],
+  memberships: [{ org: "FPA" }],
+  fee_structure: "fee-for-service",
+  fee_description: "Flat fee for comprehensive advice.",
+  linkedin_url: "https://linkedin.com/in/advisor",
+  website: "https://advisor.com",
+  languages: ["English", "Mandarin"],
+  rating: 4.8,
+  review_count: 25,
+  trust_score_overall: 95,
+  trust_score_updated_at: "2025-01-01T00:00:00Z",
+  trust_score_version: 2,
+};
+
+function makeGet() {
+  return new NextRequest(
+    "http://localhost/api/advisor-auth/trust-score",
+    { method: "GET" },
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("GET /api/advisor-auth/trust-score — auth", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdvisorSession.mockResolvedValue(77);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockRequireAdvisorSession.mockResolvedValueOnce(null);
+    const res = await GET(makeGet());
+    expect(res.status).toBe(401);
+    const body = await res.json() as { error: string };
+    expect(body.error).toMatch(/unauthorized/i);
+  });
+});
+
+describe("GET /api/advisor-auth/trust-score — DB error + not found", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdvisorSession.mockResolvedValue(77);
+  });
+
+  it("returns 404 when professional row is not found (null data)", async () => {
+    mockAdminFrom.mockReturnValue(makeBuilder(null, null));
+    const res = await GET(makeGet());
+    expect(res.status).toBe(404);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe("not_found");
+  });
+
+  it("returns 404 when DB returns an error", async () => {
+    mockAdminFrom.mockReturnValue(makeBuilder(null, { message: "row not found" }));
+    const res = await GET(makeGet());
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("GET /api/advisor-auth/trust-score — success: score structure", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdvisorSession.mockResolvedValue(77);
+  });
+
+  it("returns score object with required shape", async () => {
+    mockAdminFrom.mockReturnValue(makeBuilder(FULL_ROW, null));
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const body = await res.json() as {
+      score: {
+        overall: number;
+        label: string;
+        labelColor: string;
+        dimensions: unknown[];
+        computedAt: string;
+      };
+      cached_overall: number | null;
+      cached_updated_at: string | null;
+      cached_version: number;
+    };
+
+    expect(typeof body.score.overall).toBe("number");
+    expect(body.score.overall).toBeGreaterThanOrEqual(0);
+    expect(body.score.overall).toBeLessThanOrEqual(100);
+    expect(typeof body.score.label).toBe("string");
+    expect(typeof body.score.labelColor).toBe("string");
+    expect(Array.isArray(body.score.dimensions)).toBe(true);
+    expect(body.score.dimensions).toHaveLength(4);
+    expect(typeof body.score.computedAt).toBe("string");
+
+    expect(body.cached_overall).toBe(95);
+    expect(body.cached_updated_at).toBe("2025-01-01T00:00:00Z");
+    expect(body.cached_version).toBe(2);
+  });
+
+  it("returns null for cached fields when they are null in DB", async () => {
+    mockAdminFrom.mockReturnValue(makeBuilder(EMPTY_ROW, null));
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const body = await res.json() as {
+      cached_overall: unknown;
+      cached_updated_at: unknown;
+      cached_version: number;
+    };
+    expect(body.cached_overall).toBeNull();
+    expect(body.cached_updated_at).toBeNull();
+    expect(body.cached_version).toBe(0);
+  });
+
+  it("computes a high overall score for a fully-populated profile", async () => {
+    mockAdminFrom.mockReturnValue(makeBuilder(FULL_ROW, null));
+    const res = await GET(makeGet());
+    const body = await res.json() as { score: { overall: number; label: string } };
+    // Full profile with verification, 15yr experience, all fields, 25 reviews → should be high
+    expect(body.score.overall).toBeGreaterThan(80);
+    expect(body.score.label).toBe("Strong");
+  });
+
+  it("computes a low overall score for a bare profile", async () => {
+    mockAdminFrom.mockReturnValue(makeBuilder(EMPTY_ROW, null));
+    const res = await GET(makeGet());
+    const body = await res.json() as { score: { overall: number; label: string } };
+    // No signals → should be low
+    expect(body.score.overall).toBeLessThan(50);
+  });
+
+  it("returns 4 dimension keys: verification, track_record, transparency, client_feedback", async () => {
+    mockAdminFrom.mockReturnValue(makeBuilder(EMPTY_ROW, null));
+    const res = await GET(makeGet());
+    const body = await res.json() as {
+      score: { dimensions: Array<{ key: string }> };
+    };
+    const keys = body.score.dimensions.map((d) => d.key);
+    expect(keys).toContain("verification");
+    expect(keys).toContain("track_record");
+    expect(keys).toContain("transparency");
+    expect(keys).toContain("client_feedback");
+  });
+
+  it("score is always fresh (computed, not relying on cached_overall)", async () => {
+    // Provide a row with cached_overall=10 but full profile that scores much higher
+    const rowWithStaleCache: ProfRow = {
+      ...FULL_ROW,
+      trust_score_overall: 10, // stale low score
+    };
+    mockAdminFrom.mockReturnValue(makeBuilder(rowWithStaleCache, null));
+    const res = await GET(makeGet());
+    const body = await res.json() as {
+      score: { overall: number };
+      cached_overall: number | null;
+    };
+    // Fresh computed score should differ from the stale cache
+    expect(body.score.overall).toBeGreaterThan(80);
+    expect(body.cached_overall).toBe(10); // stale value echoed as-is
+    expect(body.score.overall).not.toBe(body.cached_overall);
+  });
+});

--- a/__tests__/api/advisor-portal-ideal-client.test.ts
+++ b/__tests__/api/advisor-portal-ideal-client.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for GET + PUT /api/advisor-portal/ideal-client
+ *
+ * Auth: requireAdvisorSession
+ * GET branches: 401, 500 (db error), 200 (existing criteria), 200 (null criteria + meta)
+ * PUT (withValidatedBody): 400 (bad body), 401, 500 (db error), 200
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const { mockRequireAdvisorSession, mockAdminFrom } = vi.hoisted(() => ({
+  mockRequireAdvisorSession: vi.fn<() => Promise<number | null>>().mockResolvedValue(7),
+  mockAdminFrom: vi.fn(),
+}));
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: (..._args: unknown[]) => mockRequireAdvisorSession(),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() })),
+}));
+
+// ── Route under test ──────────────────────────────────────────────────────────
+
+import { GET, PUT } from "@/app/api/advisor-portal/ideal-client/route";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeBuilder(data: unknown, error: unknown = null) {
+  const b: Record<string, unknown> = {};
+  for (const m of [
+    "select", "update", "upsert", "eq", "order", "limit", "single", "maybeSingle",
+  ]) {
+    b[m] = vi.fn(() => b);
+  }
+  b.then = (resolve: (v: unknown) => unknown) =>
+    Promise.resolve(resolve({ data, error }));
+  return b;
+}
+
+function makeGet(): NextRequest {
+  return new NextRequest("http://localhost/api/advisor-portal/ideal-client", { method: "GET" });
+}
+
+function makePut(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/advisor-portal/ideal-client", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// ── GET tests ─────────────────────────────────────────────────────────────────
+
+describe("GET /api/advisor-portal/ideal-client", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdvisorSession.mockResolvedValue(7);
+  });
+
+  it("returns 401 when requireAdvisorSession returns null", async () => {
+    mockRequireAdvisorSession.mockResolvedValue(null);
+    const res = await GET(makeGet());
+    expect(res.status).toBe(401);
+    expect((await res.json() as Record<string, unknown>).error).toMatch(/unauthorized/i);
+  });
+
+  it("returns 500 when the DB query fails", async () => {
+    mockAdminFrom.mockReturnValue(makeBuilder(null, { message: "db error" }));
+    const res = await GET(makeGet());
+    expect(res.status).toBe(500);
+    expect((await res.json() as Record<string, unknown>).error).toBe("fetch_failed");
+  });
+
+  it("returns 200 with null criteria when no record exists", async () => {
+    mockAdminFrom.mockReturnValue(makeBuilder(null));
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.criteria).toBeNull();
+    expect(body.updated_at).toBeNull();
+    // meta should include all valid enums
+    const meta = body.meta as Record<string, unknown>;
+    expect(Array.isArray(meta.valid_verticals)).toBe(true);
+    expect(Array.isArray(meta.valid_budget_bands)).toBe(true);
+    expect(Array.isArray(meta.valid_archetypes)).toBe(true);
+    expect(Array.isArray(meta.valid_experience_levels)).toBe(true);
+  });
+
+  it("returns 200 with existing criteria and metadata", async () => {
+    const criteria = {
+      verticals: ["etf", "shares"],
+      budget_bands: ["100k_250k"],
+      archetypes: ["hnw"],
+      experience_levels: ["intermediate"],
+    };
+    mockAdminFrom.mockReturnValue(
+      makeBuilder({ criteria, updated_at: "2026-05-01T10:00:00Z" }),
+    );
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.criteria).toEqual(criteria);
+    expect(body.updated_at).toBe("2026-05-01T10:00:00Z");
+  });
+});
+
+// ── PUT tests ─────────────────────────────────────────────────────────────────
+
+describe("PUT /api/advisor-portal/ideal-client", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdvisorSession.mockResolvedValue(7);
+  });
+
+  it("returns 400 when body is invalid JSON", async () => {
+    const req = new NextRequest("http://localhost/api/advisor-portal/ideal-client", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: "{bad-json",
+    });
+    const res = await PUT(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when verticals contains an invalid enum value", async () => {
+    const res = await PUT(makePut({ verticals: ["not_valid_vertical"] }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when budget_bands exceeds the max count of 6", async () => {
+    const bands = ["under_100k", "100k_250k", "250k_500k", "500k_1m", "1m_5m", "5m_plus", "under_100k"];
+    const res = await PUT(makePut({ budget_bands: bands }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when description exceeds 500 characters", async () => {
+    const res = await PUT(makePut({ description: "x".repeat(501) }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 401 when requireAdvisorSession returns null", async () => {
+    mockRequireAdvisorSession.mockResolvedValue(null);
+    const res = await PUT(makePut({ verticals: ["etf"] }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 500 when upsert fails", async () => {
+    mockAdminFrom.mockReturnValue(makeBuilder(null, { message: "upsert error" }));
+    const res = await PUT(makePut({ verticals: ["etf"] }));
+    expect(res.status).toBe(500);
+    expect((await res.json() as Record<string, unknown>).error).toBe("upsert_failed");
+  });
+
+  it("returns 200 with success and criteria on successful upsert", async () => {
+    mockAdminFrom.mockReturnValue(makeBuilder(null)); // upsert success (no error)
+    const criteria = {
+      verticals: ["etf", "shares"],
+      budget_bands: ["100k_250k", "250k_500k"],
+      archetypes: ["hnw", "pre_retiree"],
+      experience_levels: ["intermediate", "advanced"],
+      description: "Looking for HNW investors",
+    };
+    const res = await PUT(makePut(criteria));
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.success).toBe(true);
+    expect(body.criteria).toEqual(criteria);
+  });
+
+  it("accepts empty object body (all fields optional)", async () => {
+    mockAdminFrom.mockReturnValue(makeBuilder(null));
+    const res = await PUT(makePut({}));
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.success).toBe(true);
+  });
+});

--- a/__tests__/api/advisor-portal-office-hours-id-questions-qid.test.ts
+++ b/__tests__/api/advisor-portal-office-hours-id-questions-qid.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Tests for PATCH /api/advisor-portal/office-hours/[id]/questions/[qid]
+ *
+ * Auth: requireAdvisorSession
+ * Branches: 400 (bad sessionId), 400 (bad questionId), 400 (bad body),
+ *           401, 404 (session not found), 404 (question not found),
+ *           500 (db error), 200 (answer set), 200 (is_removed set)
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const { mockRequireAdvisorSession, mockAdminFrom } = vi.hoisted(() => ({
+  mockRequireAdvisorSession: vi.fn<() => Promise<number | null>>().mockResolvedValue(42),
+  mockAdminFrom: vi.fn(),
+}));
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: (..._args: unknown[]) => mockRequireAdvisorSession(),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() })),
+}));
+
+// ── Route under test ──────────────────────────────────────────────────────────
+
+import { PATCH } from "@/app/api/advisor-portal/office-hours/[id]/questions/[qid]/route";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeBuilder(data: unknown, error: unknown = null) {
+  const b: Record<string, unknown> = {};
+  for (const m of [
+    "select", "update", "eq", "order", "limit", "single", "maybeSingle",
+  ]) {
+    b[m] = vi.fn(() => b);
+  }
+  b.then = (resolve: (v: unknown) => unknown) =>
+    Promise.resolve(resolve({ data, error }));
+  return b;
+}
+
+function makePatch(sessionId: number | string, questionId: number | string, body: unknown): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/advisor-portal/office-hours/${sessionId}/questions/${questionId}`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    },
+  );
+}
+
+const SESSION = { id: 7, advisor_id: 42 };
+const QUESTION = { id: 3, session_id: 7 };
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("PATCH /api/advisor-portal/office-hours/[id]/questions/[qid]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdvisorSession.mockResolvedValue(42);
+  });
+
+  it("returns 400 when session id in URL is not a valid integer", async () => {
+    const res = await PATCH(makePatch("not-id", 3, { answer: "Great question!" }));
+    expect(res.status).toBe(400);
+    expect((await res.json() as Record<string, unknown>).error).toMatch(/invalid session id/i);
+  });
+
+  it("returns 400 when question id in URL is not a valid integer", async () => {
+    const res = await PATCH(makePatch(7, "not-qid", { answer: "Hello" }));
+    expect(res.status).toBe(400);
+    expect((await res.json() as Record<string, unknown>).error).toMatch(/invalid question id/i);
+  });
+
+  it("returns 400 when body is invalid JSON", async () => {
+    const req = new NextRequest(
+      "http://localhost/api/advisor-portal/office-hours/7/questions/3",
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: "{bad json",
+      },
+    );
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when answer exceeds max length (2000 chars)", async () => {
+    const longAnswer = "x".repeat(2001);
+    const res = await PATCH(makePatch(7, 3, { answer: longAnswer }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 401 when requireAdvisorSession returns null", async () => {
+    mockRequireAdvisorSession.mockResolvedValue(null);
+    mockAdminFrom.mockReturnValue(makeBuilder(SESSION));
+    const res = await PATCH(makePatch(7, 3, { answer: "My answer" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when session does not belong to this advisor", async () => {
+    mockAdminFrom.mockReturnValue(makeBuilder(null));
+    const res = await PATCH(makePatch(7, 3, { answer: "My answer" }));
+    expect(res.status).toBe(404);
+    expect((await res.json() as Record<string, unknown>).error).toMatch(/session not found/i);
+  });
+
+  it("returns 404 when question does not belong to this session", async () => {
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) return makeBuilder(SESSION); // session
+      return makeBuilder(null);                    // question not found
+    });
+    const res = await PATCH(makePatch(7, 3, { answer: "My answer" }));
+    expect(res.status).toBe(404);
+    expect((await res.json() as Record<string, unknown>).error).toMatch(/question not found/i);
+  });
+
+  it("returns 500 when the update query fails", async () => {
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) return makeBuilder(SESSION);
+      if (call === 2) return makeBuilder(QUESTION);
+      return makeBuilder(null, { message: "db error" });
+    });
+    const res = await PATCH(makePatch(7, 3, { answer: "My answer" }));
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 200 with updated question when answer is set", async () => {
+    const updated = {
+      id: 3,
+      question: "What about ETFs?",
+      answer: "They are great.",
+      answered_at: "2026-05-01T10:00:00Z",
+      is_removed: false,
+    };
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) return makeBuilder(SESSION);
+      if (call === 2) return makeBuilder(QUESTION);
+      return makeBuilder(updated);
+    });
+    const res = await PATCH(makePatch(7, 3, { answer: "They are great." }));
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.id).toBe(3);
+    expect(body.answer).toBe("They are great.");
+    expect(body.answered_at).not.toBeNull();
+  });
+
+  it("returns 200 when is_removed is set to true", async () => {
+    const updated = {
+      id: 3,
+      question: "Off-topic question",
+      answer: null,
+      answered_at: null,
+      is_removed: true,
+    };
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) return makeBuilder(SESSION);
+      if (call === 2) return makeBuilder(QUESTION);
+      return makeBuilder(updated);
+    });
+    const res = await PATCH(makePatch(7, 3, { is_removed: true }));
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.is_removed).toBe(true);
+  });
+
+  it("returns 200 when both answer and is_removed are updated together", async () => {
+    const updated = {
+      id: 3,
+      question: "Test",
+      answer: "Yes",
+      answered_at: "2026-05-01T10:00:00Z",
+      is_removed: false,
+    };
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) return makeBuilder(SESSION);
+      if (call === 2) return makeBuilder(QUESTION);
+      return makeBuilder(updated);
+    });
+    const res = await PATCH(makePatch(7, 3, { answer: "Yes", is_removed: false }));
+    expect(res.status).toBe(200);
+  });
+});

--- a/__tests__/api/advisor-portal-office-hours-id.test.ts
+++ b/__tests__/api/advisor-portal-office-hours-id.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Tests for PATCH + DELETE /api/advisor-portal/office-hours/[id]
+ *
+ * Auth: requireAdvisorSession
+ * PATCH (withValidatedBody):
+ *   400 (bad id), 400 (bad body), 401, 404 (session not found),
+ *   409 (ended session without transcript transition), 500 (db error), 200
+ * DELETE:
+ *   400 (bad id), 401, 404 (not found), 409 (not draft), 200
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const { mockRequireAdvisorSession, mockAdminFrom } = vi.hoisted(() => ({
+  mockRequireAdvisorSession: vi.fn<() => Promise<number | null>>().mockResolvedValue(42),
+  mockAdminFrom: vi.fn(),
+}));
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: (..._args: unknown[]) => mockRequireAdvisorSession(),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() })),
+}));
+
+// ── Route under test ──────────────────────────────────────────────────────────
+
+import { PATCH, DELETE } from "@/app/api/advisor-portal/office-hours/[id]/route";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeBuilder(data: unknown, error: unknown = null) {
+  const b: Record<string, unknown> = {};
+  for (const m of [
+    "select", "insert", "update", "delete", "upsert",
+    "eq", "neq", "in", "order", "limit", "single", "maybeSingle",
+  ]) {
+    b[m] = vi.fn(() => b);
+  }
+  b.then = (resolve: (v: unknown) => unknown) =>
+    Promise.resolve(resolve({ data, error }));
+  return b;
+}
+
+function makePatch(sessionId: number | string, body: unknown): NextRequest {
+  return new NextRequest(`http://localhost/api/advisor-portal/office-hours/${sessionId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeDelete(sessionId: number | string): NextRequest {
+  return new NextRequest(`http://localhost/api/advisor-portal/office-hours/${sessionId}`, {
+    method: "DELETE",
+  });
+}
+
+const EXISTING_SESSION = { id: 7, advisor_id: 42, status: "upcoming" };
+
+// ── PATCH tests ───────────────────────────────────────────────────────────────
+
+describe("PATCH /api/advisor-portal/office-hours/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdvisorSession.mockResolvedValue(42);
+  });
+
+  it("returns 400 when session id in URL is not a valid integer", async () => {
+    const res = await PATCH(makePatch("not-a-number", { title: "My Session" }));
+    expect(res.status).toBe(400);
+    expect((await res.json() as Record<string, unknown>).error).toMatch(/invalid session id/i);
+  });
+
+  it("returns 400 when body fails Zod validation (title too short)", async () => {
+    const res = await PATCH(makePatch(7, { title: "AB" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when body is invalid JSON", async () => {
+    const req = new NextRequest("http://localhost/api/advisor-portal/office-hours/7", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: "{bad json",
+    });
+    const res = await PATCH(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 401 when requireAdvisorSession returns null", async () => {
+    mockRequireAdvisorSession.mockResolvedValue(null);
+    mockAdminFrom.mockReturnValue(makeBuilder(EXISTING_SESSION));
+    const res = await PATCH(makePatch(7, { status: "live" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when session not found for this advisor", async () => {
+    mockAdminFrom.mockReturnValue(makeBuilder(null));
+    const res = await PATCH(makePatch(7, { status: "live" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 409 when trying to edit an ended session without transitioning to transcript", async () => {
+    mockAdminFrom.mockReturnValue(makeBuilder({ ...EXISTING_SESSION, status: "ended" }));
+    const res = await PATCH(makePatch(7, { title: "Updated Title 1234" }));
+    expect(res.status).toBe(409);
+    expect((await res.json() as Record<string, unknown>).error).toMatch(/cannot edit ended/i);
+  });
+
+  it("allows updating ended session status to transcript", async () => {
+    const updatedSession = { id: 7, title: "Session", status: "transcript", is_published: false, updated_at: "now" };
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) return makeBuilder({ ...EXISTING_SESSION, status: "ended" });
+      return makeBuilder(updatedSession);
+    });
+    const res = await PATCH(makePatch(7, { status: "transcript" }));
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.status).toBe("transcript");
+  });
+
+  it("returns 500 when update DB query fails", async () => {
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) return makeBuilder(EXISTING_SESSION);
+      return makeBuilder(null, { message: "db error" });
+    });
+    const res = await PATCH(makePatch(7, { status: "live" }));
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 200 with updated session data on success", async () => {
+    const updatedSession = { id: 7, title: "My Great Session", status: "upcoming", is_published: true, updated_at: "now" };
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) return makeBuilder(EXISTING_SESSION);
+      return makeBuilder(updatedSession);
+    });
+    const res = await PATCH(makePatch(7, { title: "My Great Session", is_published: true }));
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.id).toBe(7);
+    expect(body.title).toBe("My Great Session");
+    expect(body.is_published).toBe(true);
+  });
+
+  it("returns 400 for invalid status enum value", async () => {
+    const res = await PATCH(makePatch(7, { status: "invalid_status" }));
+    expect(res.status).toBe(400);
+  });
+});
+
+// ── DELETE tests ──────────────────────────────────────────────────────────────
+
+describe("DELETE /api/advisor-portal/office-hours/[id]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdvisorSession.mockResolvedValue(42);
+  });
+
+  it("returns 400 when session id is not a valid integer", async () => {
+    const res = await DELETE(makeDelete("abc"), { params: Promise.resolve({ id: "abc" }) });
+    expect(res.status).toBe(400);
+    expect((await res.json() as Record<string, unknown>).error).toMatch(/invalid session id/i);
+  });
+
+  it("returns 401 when advisor session is not found", async () => {
+    mockRequireAdvisorSession.mockResolvedValue(null);
+    const res = await DELETE(makeDelete(7), { params: Promise.resolve({ id: "7" }) });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when session does not belong to this advisor", async () => {
+    mockAdminFrom.mockReturnValue(makeBuilder(null));
+    const res = await DELETE(makeDelete(7), { params: Promise.resolve({ id: "7" }) });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 409 when session is not in draft status", async () => {
+    mockAdminFrom.mockReturnValue(makeBuilder({ id: 7, advisor_id: 42, status: "upcoming" }));
+    const res = await DELETE(makeDelete(7), { params: Promise.resolve({ id: "7" }) });
+    expect(res.status).toBe(409);
+    expect((await res.json() as Record<string, unknown>).error).toMatch(/draft sessions/i);
+  });
+
+  it("returns 200 when draft session is successfully deleted", async () => {
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) return makeBuilder({ id: 7, advisor_id: 42, status: "draft" });
+      return makeBuilder(null); // delete
+    });
+    const res = await DELETE(makeDelete(7), { params: Promise.resolve({ id: "7" }) });
+    expect(res.status).toBe(200);
+    expect((await res.json() as Record<string, unknown>).success).toBe(true);
+  });
+});

--- a/__tests__/api/advisor-portal-office-hours.test.ts
+++ b/__tests__/api/advisor-portal-office-hours.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Tests for GET + POST /api/advisor-portal/office-hours
+ *
+ * Auth: requireAdvisorSession
+ * GET branches: 401, 500 (db error), 200 (empty list), 200 (list with sessions)
+ * POST (withValidatedBody): 400 (bad body), 401, 500 (db error), 201 (created)
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const { mockRequireAdvisorSession, mockAdminFrom } = vi.hoisted(() => ({
+  mockRequireAdvisorSession: vi.fn<() => Promise<number | null>>().mockResolvedValue(42),
+  mockAdminFrom: vi.fn(),
+}));
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: (..._args: unknown[]) => mockRequireAdvisorSession(),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() })),
+}));
+
+// ── Route under test ──────────────────────────────────────────────────────────
+
+import { GET, POST } from "@/app/api/advisor-portal/office-hours/route";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeBuilder(data: unknown, error: unknown = null) {
+  const b: Record<string, unknown> = {};
+  for (const m of [
+    "select", "insert", "update", "upsert", "delete",
+    "eq", "order", "limit", "single", "maybeSingle",
+  ]) {
+    b[m] = vi.fn(() => b);
+  }
+  b.then = (resolve: (v: unknown) => unknown) =>
+    Promise.resolve(resolve({ data, error }));
+  return b;
+}
+
+function makeGet(): NextRequest {
+  return new NextRequest("http://localhost/api/advisor-portal/office-hours", { method: "GET" });
+}
+
+function makePost(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/advisor-portal/office-hours", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const VALID_BODY = {
+  title: "AMA: ETF Investing Basics",
+  scheduled_at: "2026-06-15T10:00:00Z",
+};
+
+const SESSION_ROW = {
+  id: 1,
+  title: "AMA: ETF Investing Basics",
+  scheduled_at: "2026-06-15T10:00:00Z",
+  status: "upcoming",
+  max_questions: 20,
+  is_published: false,
+};
+
+// ── GET tests ─────────────────────────────────────────────────────────────────
+
+describe("GET /api/advisor-portal/office-hours", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdvisorSession.mockResolvedValue(42);
+  });
+
+  it("returns 401 when requireAdvisorSession returns null", async () => {
+    mockRequireAdvisorSession.mockResolvedValue(null);
+    const res = await GET(makeGet());
+    expect(res.status).toBe(401);
+    expect((await res.json() as Record<string, unknown>).error).toMatch(/unauthorized/i);
+  });
+
+  it("returns 500 when the DB query fails", async () => {
+    mockAdminFrom.mockReturnValue(makeBuilder(null, { message: "db error" }));
+    const res = await GET(makeGet());
+    expect(res.status).toBe(500);
+    expect((await res.json() as Record<string, unknown>).error).toBe("fetch_failed");
+  });
+
+  it("returns 200 with empty sessions array when advisor has no sessions", async () => {
+    mockAdminFrom.mockReturnValue(makeBuilder(null));
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.sessions).toEqual([]);
+  });
+
+  it("returns 200 with sessions list", async () => {
+    const sessions = [
+      { ...SESSION_ROW, id: 1 },
+      { ...SESSION_ROW, id: 2, title: "Q&A: Property Investment" },
+    ];
+    mockAdminFrom.mockReturnValue(makeBuilder(sessions));
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect((body.sessions as unknown[]).length).toBe(2);
+    expect(((body.sessions as Array<Record<string, unknown>>)[0]).id).toBe(1);
+  });
+});
+
+// ── POST tests ────────────────────────────────────────────────────────────────
+
+describe("POST /api/advisor-portal/office-hours", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdvisorSession.mockResolvedValue(42);
+  });
+
+  it("returns 400 when body is invalid JSON", async () => {
+    const req = new NextRequest("http://localhost/api/advisor-portal/office-hours", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{invalid-json",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when title is too short (less than 5 chars)", async () => {
+    const res = await POST(makePost({ title: "AB", scheduled_at: "2026-06-15T10:00:00Z" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when scheduled_at is not a valid datetime", async () => {
+    const res = await POST(makePost({ title: "Valid Title Here", scheduled_at: "not-a-date" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when scheduled_at is missing", async () => {
+    const res = await POST(makePost({ title: "Valid Title Here" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when max_questions exceeds 100", async () => {
+    const res = await POST(makePost({ ...VALID_BODY, max_questions: 101 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 401 when requireAdvisorSession returns null", async () => {
+    mockRequireAdvisorSession.mockResolvedValue(null);
+    const res = await POST(makePost(VALID_BODY));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 500 when insert fails", async () => {
+    mockAdminFrom.mockReturnValue(makeBuilder(null, { message: "insert error" }));
+    const res = await POST(makePost(VALID_BODY));
+    expect(res.status).toBe(500);
+    expect((await res.json() as Record<string, unknown>).error).toBe("insert_failed");
+  });
+
+  it("returns 201 with created session on success", async () => {
+    mockAdminFrom.mockReturnValue(makeBuilder(SESSION_ROW));
+    const res = await POST(makePost(VALID_BODY));
+    expect(res.status).toBe(201);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.id).toBe(1);
+    expect(body.title).toBe("AMA: ETF Investing Basics");
+    expect(body.status).toBe("upcoming");
+    expect(body.max_questions).toBe(20);
+    expect(body.is_published).toBe(false);
+  });
+
+  it("creates session with optional fields when provided", async () => {
+    const fullBody = {
+      ...VALID_BODY,
+      description: "A session about ETF basics for beginners.",
+      ends_at: "2026-06-15T11:00:00Z",
+      max_questions: 50,
+      is_published: true,
+    };
+    const fullSession = { ...SESSION_ROW, description: fullBody.description, max_questions: 50, is_published: true };
+    mockAdminFrom.mockReturnValue(makeBuilder(fullSession));
+    const res = await POST(makePost(fullBody));
+    expect(res.status).toBe(201);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.max_questions).toBe(50);
+    expect(body.is_published).toBe(true);
+  });
+});

--- a/__tests__/api/advisor-portal-session-pricing.test.ts
+++ b/__tests__/api/advisor-portal-session-pricing.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Tests for GET + PUT /api/advisor-portal/session-pricing
+ *
+ * Auth: Supabase server client (auth.getUser) + admin client for advisor lookup
+ * GET branches: 401 (no user), 404 (advisor not found), 200 (returns pricing)
+ * PUT branches: 429, 401, 400 (bad body), 404 (advisor not found), 500 (db error),
+ *               200 (sets price), 200 (null/0 = free)
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const { mockIsRateLimited, mockGetUser, mockAdminFrom } = vi.hoisted(() => ({
+  mockIsRateLimited: vi.fn<() => Promise<boolean>>().mockResolvedValue(false),
+  mockGetUser: vi.fn<() => Promise<{ data: { user: { email: string } | null } }>>().mockResolvedValue({
+    data: { user: { email: "advisor@example.com" } },
+  }),
+  mockAdminFrom: vi.fn(),
+}));
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: (..._args: unknown[]) => mockIsRateLimited(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() =>
+    Promise.resolve({ auth: { getUser: mockGetUser } }),
+  ),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() })),
+}));
+
+// ── Route under test ──────────────────────────────────────────────────────────
+
+import { GET, PUT } from "@/app/api/advisor-portal/session-pricing/route";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeBuilder(data: unknown, error: unknown = null) {
+  const b: Record<string, unknown> = {};
+  for (const m of [
+    "select", "update", "eq", "order", "limit", "single", "maybeSingle",
+  ]) {
+    b[m] = vi.fn(() => b);
+  }
+  b.then = (resolve: (v: unknown) => unknown) =>
+    Promise.resolve(resolve({ data, error }));
+  return b;
+}
+
+function makeGet(): NextRequest {
+  return new NextRequest("http://localhost/api/advisor-portal/session-pricing", {
+    method: "GET",
+    headers: { "x-forwarded-for": "1.2.3.4" },
+  });
+}
+
+function makePut(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/advisor-portal/session-pricing", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json", "x-forwarded-for": "1.2.3.4" },
+    body: JSON.stringify(body),
+  });
+}
+
+// ── GET tests ─────────────────────────────────────────────────────────────────
+
+describe("GET /api/advisor-portal/session-pricing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+    mockGetUser.mockResolvedValue({ data: { user: { email: "advisor@example.com" } } });
+  });
+
+  it("returns 401 when user is not authenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const res = await GET(makeGet());
+    expect(res.status).toBe(401);
+    expect((await res.json() as Record<string, unknown>).error).toMatch(/authentication required/i);
+  });
+
+  it("returns 404 when advisor is not found in professionals table", async () => {
+    mockAdminFrom.mockReturnValue(makeBuilder(null));
+    const res = await GET(makeGet());
+    expect(res.status).toBe(404);
+    expect((await res.json() as Record<string, unknown>).error).toMatch(/advisor not found/i);
+  });
+
+  it("returns 200 with sessionPriceCents and priceInDollars when price is set", async () => {
+    mockAdminFrom.mockReturnValue(makeBuilder({ session_price_cents: 15000 }));
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.sessionPriceCents).toBe(15000);
+    expect(body.priceInDollars).toBe(150);
+  });
+
+  it("returns 200 with null prices when advisor has no session price", async () => {
+    mockAdminFrom.mockReturnValue(makeBuilder({ session_price_cents: null }));
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.sessionPriceCents).toBeNull();
+    expect(body.priceInDollars).toBeNull();
+  });
+});
+
+// ── PUT tests ─────────────────────────────────────────────────────────────────
+
+describe("PUT /api/advisor-portal/session-pricing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+    mockGetUser.mockResolvedValue({ data: { user: { email: "advisor@example.com" } } });
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsRateLimited.mockResolvedValue(true);
+    const res = await PUT(makePut({ priceInDollars: 150 }));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when user is not authenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const res = await PUT(makePut({ priceInDollars: 150 }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when body is invalid JSON", async () => {
+    const req = new NextRequest("http://localhost/api/advisor-portal/session-pricing", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", "x-forwarded-for": "1.2.3.4" },
+      body: "{bad-json",
+    });
+    const res = await PUT(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when priceInDollars exceeds max (10000)", async () => {
+    const res = await PUT(makePut({ priceInDollars: 99999 }));
+    expect(res.status).toBe(400);
+    expect((await res.json() as Record<string, unknown>).error).toMatch(/invalid request/i);
+  });
+
+  it("returns 400 when priceInDollars is negative", async () => {
+    const res = await PUT(makePut({ priceInDollars: -1 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when advisor is not found", async () => {
+    // maybeSingle returns null for getAdvisorId lookup
+    mockAdminFrom.mockReturnValue(makeBuilder(null));
+    const res = await PUT(makePut({ priceInDollars: 150 }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 500 when update fails", async () => {
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) return makeBuilder({ id: 7 }); // getAdvisorId
+      return makeBuilder(null, { message: "update error" }); // update
+    });
+    const res = await PUT(makePut({ priceInDollars: 150 }));
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 200 with sessionPriceCents set to dollars*100", async () => {
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) return makeBuilder({ id: 7 });
+      return makeBuilder(null); // update success
+    });
+    const res = await PUT(makePut({ priceInDollars: 200 }));
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.ok).toBe(true);
+    expect(body.sessionPriceCents).toBe(20000);
+  });
+
+  it("returns 200 with null sessionPriceCents when priceInDollars is null (free)", async () => {
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) return makeBuilder({ id: 7 });
+      return makeBuilder(null);
+    });
+    const res = await PUT(makePut({ priceInDollars: null }));
+    expect(res.status).toBe(200);
+    expect((await res.json() as Record<string, unknown>).sessionPriceCents).toBeNull();
+  });
+
+  it("returns 200 with null sessionPriceCents when priceInDollars is 0 (free)", async () => {
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) return makeBuilder({ id: 7 });
+      return makeBuilder(null);
+    });
+    const res = await PUT(makePut({ priceInDollars: 0 }));
+    expect(res.status).toBe(200);
+    expect((await res.json() as Record<string, unknown>).sessionPriceCents).toBeNull();
+  });
+});

--- a/__tests__/api/answers-id-vote.test.ts
+++ b/__tests__/api/answers-id-vote.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() })),
+}));
+
+const mockIsRateLimited = vi.fn();
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: (...a: unknown[]) => mockIsRateLimited(...a),
+}));
+
+const mockAdminFrom = vi.fn();
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+import { POST } from "@/app/api/answers/[id]/vote/route";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function makeReq(id: string, body: unknown, ip = "1.2.3.4"): [NextRequest, { params: Promise<{ id: string }> }] {
+  const req = new NextRequest(`http://localhost/api/answers/${id}/vote`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-forwarded-for": ip },
+    body: JSON.stringify(body),
+  });
+  return [req, { params: Promise.resolve({ id }) }];
+}
+
+function mockChain(result: { data: unknown; error?: { message: string } | null }) {
+  const c: Record<string, unknown> = {};
+  for (const m of ["select", "eq", "update", "insert", "not"]) {
+    c[m] = vi.fn(() => c);
+  }
+  c.single = vi.fn().mockResolvedValue(result);
+  c.then = (resolve: (v: typeof result) => unknown) => Promise.resolve(resolve(result));
+  return c;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe("POST /api/answers/[id]/vote", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockIsRateLimited.mockResolvedValue(true);
+    const [req, ctx] = makeReq("1", { vote: 1 });
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 400 when id is not a number", async () => {
+    const [req, ctx] = makeReq("abc", { vote: 1 });
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toMatch(/invalid answer id/i);
+  });
+
+  it("returns 400 when vote is not 1 or -1", async () => {
+    const [req, ctx] = makeReq("5", { vote: 2 });
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toMatch(/vote must be 1 or -1/i);
+  });
+
+  it("returns 404 when answer not found", async () => {
+    mockAdminFrom.mockReturnValue(mockChain({ data: null, error: { message: "Not found" } }));
+    const [req, ctx] = makeReq("99", { vote: 1 });
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns current counts unchanged when same vote already cast", async () => {
+    const answer = { id: 1, vote_count: 5, helpful_count: 3 };
+    const existingVote = { id: 10, vote_value: 1 };
+    let callCount = 0;
+    mockAdminFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return mockChain({ data: answer });
+      return mockChain({ data: existingVote });
+    });
+    const [req, ctx] = makeReq("1", { vote: 1 });
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { vote_count: number; helpful_count: number };
+    expect(body.vote_count).toBe(5);
+    expect(body.helpful_count).toBe(3);
+  });
+
+  it("inserts new vote and returns updated counts", async () => {
+    const answer = { id: 2, vote_count: 4, helpful_count: 2 };
+    let callCount = 0;
+    const insertChain = {
+      insert: vi.fn().mockResolvedValue({ error: null }),
+    };
+    const updateChain = {
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockResolvedValue({ error: null }),
+    };
+    mockAdminFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return mockChain({ data: answer });
+      if (callCount === 2) return mockChain({ data: null }); // no existing vote
+      if (callCount === 3) return insertChain;
+      return updateChain;
+    });
+    const [req, ctx] = makeReq("2", { vote: 1 });
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { vote_count: number; helpful_count: number };
+    expect(body.vote_count).toBe(5); // 4 + 1
+    expect(body.helpful_count).toBe(3); // 2 + 1
+  });
+
+  it("changes vote direction and adjusts helpful_count", async () => {
+    const answer = { id: 3, vote_count: 2, helpful_count: 1 };
+    const existingVote = { id: 20, vote_value: 1 }; // previously upvoted
+    let callCount = 0;
+    const updateVoteChain = {
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockResolvedValue({ error: null }),
+    };
+    const updateCountChain = {
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockResolvedValue({ error: null }),
+    };
+    mockAdminFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return mockChain({ data: answer });
+      if (callCount === 2) return mockChain({ data: existingVote });
+      if (callCount === 3) return updateVoteChain;
+      return updateCountChain;
+    });
+    const [req, ctx] = makeReq("3", { vote: -1 }); // flipping to downvote
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { vote_count: number; helpful_count: number };
+    // voteDelta = -1 - 1 = -2; helpfulDelta = -1 (losing upvote)
+    expect(body.vote_count).toBe(0); // 2 + (-2)
+    expect(body.helpful_count).toBe(0); // max(0, 1 + (-1))
+  });
+
+  it("returns 500 when vote count update fails", async () => {
+    const answer = { id: 4, vote_count: 0, helpful_count: 0 };
+    let callCount = 0;
+    const insertChain = {
+      insert: vi.fn().mockResolvedValue({ error: null }),
+    };
+    const failUpdateChain = {
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockResolvedValue({ error: { message: "DB error" } }),
+    };
+    mockAdminFrom.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) return mockChain({ data: answer });
+      if (callCount === 2) return mockChain({ data: null });
+      if (callCount === 3) return insertChain;
+      return failUpdateChain;
+    });
+    const [req, ctx] = makeReq("4", { vote: 1 });
+    const res = await POST(req, ctx);
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/booking-slot-checkout.test.ts
+++ b/__tests__/api/booking-slot-checkout.test.ts
@@ -1,0 +1,370 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const { mockServerFrom, mockGetUser } = vi.hoisted(() => ({
+  mockServerFrom: vi.fn(),
+  mockGetUser: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    from: mockServerFrom,
+    auth: { getUser: mockGetUser },
+  })),
+}));
+
+const { mockAdminFrom } = vi.hoisted(() => ({ mockAdminFrom: vi.fn() }));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+const { mockIsRateLimited } = vi.hoisted(() => ({ mockIsRateLimited: vi.fn() }));
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: (...args: unknown[]) => mockIsRateLimited(...args),
+}));
+
+const { mockCreateBookingCheckout } = vi.hoisted(() => ({ mockCreateBookingCheckout: vi.fn() }));
+vi.mock("@/lib/stripe-connect", () => ({
+  createBookingCheckout: (...args: unknown[]) => mockCreateBookingCheckout(...args),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() })),
+}));
+
+vi.mock("@/lib/url", () => ({
+  getSiteUrl: (_host: unknown) => "https://invest.com.au",
+}));
+
+import { POST } from "@/app/api/booking/[slotId]/checkout/route";
+
+// ─── Builder helper ───────────────────────────────────────────────────────────
+
+function makeBuilder(data: unknown = null, error: unknown = null) {
+  const c: Record<string, unknown> = {
+    then: (r: (v: { data: unknown; error: unknown }) => unknown) =>
+      Promise.resolve(r({ data, error })),
+  };
+  for (const m of [
+    "select", "insert", "update", "upsert", "delete",
+    "eq", "maybeSingle", "single",
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  return c;
+}
+
+// The route awaits params as a Promise (Next.js dynamic route convention)
+type RouteParams = { params: Promise<{ slotId: string }> };
+
+function makeParams(slotId: string): RouteParams {
+  return { params: Promise.resolve({ slotId }) };
+}
+
+const FUTURE_DATE = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+
+const OPEN_SLOT = {
+  id: 42,
+  professional_id: 7,
+  starts_at: FUTURE_DATE,
+  ends_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000 + 3600_000).toISOString(),
+  status: "open",
+};
+
+const ADVISOR_ROW = {
+  id: 7,
+  name: "Jane Smith CFP",
+  slug: "jane-smith-cfp",
+  session_price_cents: 15000,
+  stripe_connect_account_id: "acct_test123",
+  stripe_connect_charges_enabled: true,
+};
+
+function makePost(body: unknown, slotId = "42"): [NextRequest, RouteParams] {
+  const req = new NextRequest(`http://localhost/api/booking/${slotId}/checkout`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-forwarded-for": "1.2.3.4" },
+    body: JSON.stringify(body),
+  });
+  return [req, makeParams(slotId)];
+}
+
+const VALID_BODY = {
+  consumerName: "Alice Investor",
+  consumerEmail: "alice@example.com",
+  topic: "Retirement planning",
+};
+
+// ─── Rate limiting ────────────────────────────────────────────────────────────
+
+describe("POST /api/booking/[slotId]/checkout — rate limiting", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 429 when rate limited", async () => {
+    mockIsRateLimited.mockResolvedValue(true);
+    const [req, params] = makePost(VALID_BODY);
+    const res = await POST(req, params);
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toMatch(/too many/i);
+  });
+});
+
+// ─── slotId validation ────────────────────────────────────────────────────────
+
+describe("POST /api/booking/[slotId]/checkout — slotId validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+  });
+
+  it("returns 400 for a non-numeric slotId", async () => {
+    const [req, params] = makePost(VALID_BODY, "not-a-number");
+    const res = await POST(req, params);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/invalid slot/i);
+  });
+
+  it("returns 400 for slotId=0", async () => {
+    const [req, params] = makePost(VALID_BODY, "0");
+    const res = await POST(req, params);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for negative slotId", async () => {
+    const [req, params] = makePost(VALID_BODY, "-5");
+    const res = await POST(req, params);
+    expect(res.status).toBe(400);
+  });
+});
+
+// ─── Body validation ──────────────────────────────────────────────────────────
+
+describe("POST /api/booking/[slotId]/checkout — body validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+  });
+
+  it("returns 400 on invalid JSON body", async () => {
+    const req = new NextRequest("http://localhost/api/booking/42/checkout", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "x-forwarded-for": "1.2.3.4" },
+      body: "{bad json",
+    });
+    const res = await POST(req, makeParams("42"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when consumerName is missing", async () => {
+    const [req, params] = makePost({ consumerEmail: "a@b.com" });
+    const res = await POST(req, params);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/invalid/i);
+  });
+
+  it("returns 400 when consumerEmail is not a valid email", async () => {
+    const [req, params] = makePost({ consumerName: "Alice", consumerEmail: "not-email" });
+    const res = await POST(req, params);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when topic exceeds 500 chars", async () => {
+    const [req, params] = makePost({
+      consumerName: "Alice",
+      consumerEmail: "alice@example.com",
+      topic: "x".repeat(501),
+    });
+    const res = await POST(req, params);
+    expect(res.status).toBe(400);
+  });
+});
+
+// ─── Slot lookups ─────────────────────────────────────────────────────────────
+
+describe("POST /api/booking/[slotId]/checkout — slot state checks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+  });
+
+  it("returns 404 when slot not found", async () => {
+    mockAdminFrom.mockReturnValue(makeBuilder(null));
+    const [req, params] = makePost(VALID_BODY);
+    const res = await POST(req, params);
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toMatch(/not found/i);
+  });
+
+  it("returns 409 when slot status is not open", async () => {
+    mockAdminFrom.mockReturnValue(makeBuilder({ ...OPEN_SLOT, status: "booked" }));
+    const [req, params] = makePost(VALID_BODY);
+    const res = await POST(req, params);
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toMatch(/no longer available/i);
+  });
+
+  it("returns 409 when slot has already passed", async () => {
+    const pastDate = new Date(Date.now() - 3600_000).toISOString();
+    mockAdminFrom.mockReturnValue(makeBuilder({ ...OPEN_SLOT, starts_at: pastDate }));
+    const [req, params] = makePost(VALID_BODY);
+    const res = await POST(req, params);
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toMatch(/passed/i);
+  });
+});
+
+// ─── Advisor lookups ──────────────────────────────────────────────────────────
+
+describe("POST /api/booking/[slotId]/checkout — advisor checks", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+  });
+
+  it("returns 404 when advisor not found", async () => {
+    mockAdminFrom
+      .mockReturnValueOnce(makeBuilder(OPEN_SLOT))
+      .mockReturnValueOnce(makeBuilder(null));
+    const [req, params] = makePost(VALID_BODY);
+    const res = await POST(req, params);
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toMatch(/advisor not found/i);
+  });
+
+  it("returns 422 when session_price_cents is null or zero", async () => {
+    mockAdminFrom
+      .mockReturnValueOnce(makeBuilder(OPEN_SLOT))
+      .mockReturnValueOnce(makeBuilder({ ...ADVISOR_ROW, session_price_cents: null }));
+    const [req, params] = makePost(VALID_BODY);
+    const res = await POST(req, params);
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body.error).toMatch(/payment/i);
+  });
+
+  it("returns 422 when session_price_cents is 0", async () => {
+    mockAdminFrom
+      .mockReturnValueOnce(makeBuilder(OPEN_SLOT))
+      .mockReturnValueOnce(makeBuilder({ ...ADVISOR_ROW, session_price_cents: 0 }));
+    const [req, params] = makePost(VALID_BODY);
+    const res = await POST(req, params);
+    expect(res.status).toBe(422);
+  });
+});
+
+// ─── Checkout creation ────────────────────────────────────────────────────────
+
+describe("POST /api/booking/[slotId]/checkout — Stripe checkout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+    mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } });
+    mockAdminFrom
+      .mockReturnValueOnce(makeBuilder(OPEN_SLOT))
+      .mockReturnValueOnce(makeBuilder(ADVISOR_ROW));
+  });
+
+  it("returns { checkoutUrl } on successful checkout creation", async () => {
+    mockCreateBookingCheckout.mockResolvedValue({ checkoutUrl: "https://checkout.stripe.com/pay/cs_test_123" });
+    const [req, params] = makePost(VALID_BODY);
+    const res = await POST(req, params);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.checkoutUrl).toBe("https://checkout.stripe.com/pay/cs_test_123");
+  });
+
+  it("passes correct fields to createBookingCheckout", async () => {
+    mockCreateBookingCheckout.mockResolvedValue({ checkoutUrl: "https://checkout.stripe.com/pay/cs_test_456" });
+    const [req, params] = makePost(VALID_BODY);
+    await POST(req, params);
+    expect(mockCreateBookingCheckout).toHaveBeenCalledWith(
+      expect.objectContaining({
+        slotId: 42,
+        professionalId: 7,
+        advisorSlug: "jane-smith-cfp",
+        advisorName: "Jane Smith CFP",
+        consumerEmail: "alice@example.com",
+        amountCents: 15000,
+      }),
+    );
+  });
+
+  it("includes consumerUserId when user is authenticated", async () => {
+    mockCreateBookingCheckout.mockResolvedValue({ checkoutUrl: "https://checkout.stripe.com/pay/cs_test_789" });
+    const [req, params] = makePost(VALID_BODY);
+    await POST(req, params);
+    expect(mockCreateBookingCheckout).toHaveBeenCalledWith(
+      expect.objectContaining({ consumerUserId: "user-1" }),
+    );
+  });
+
+  it("sets consumerUserId=null when user is not authenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    // Re-setup admin mocks after clearAllMocks above
+    mockAdminFrom
+      .mockReturnValueOnce(makeBuilder(OPEN_SLOT))
+      .mockReturnValueOnce(makeBuilder(ADVISOR_ROW));
+    mockCreateBookingCheckout.mockResolvedValue({ checkoutUrl: "https://checkout.stripe.com/pay/cs_test_abc" });
+    const [req, params] = makePost(VALID_BODY);
+    await POST(req, params);
+    expect(mockCreateBookingCheckout).toHaveBeenCalledWith(
+      expect.objectContaining({ consumerUserId: null }),
+    );
+  });
+
+  it("returns 422 when advisor is not connected to Stripe (pro_not_connected)", async () => {
+    mockCreateBookingCheckout.mockResolvedValue({
+      checkoutUrl: null,
+      unavailable: "pro_not_connected",
+    });
+    const [req, params] = makePost(VALID_BODY);
+    const res = await POST(req, params);
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body.error).toMatch(/payment is not set up/i);
+  });
+
+  it("returns 503 for any other checkout failure", async () => {
+    mockCreateBookingCheckout.mockResolvedValue({
+      checkoutUrl: null,
+      unavailable: "stripe_error",
+    });
+    const [req, params] = makePost(VALID_BODY);
+    const res = await POST(req, params);
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toMatch(/unavailable/i);
+  });
+});
+
+describe("POST /api/booking/[slotId]/checkout — optional topic field", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    mockAdminFrom
+      .mockReturnValueOnce(makeBuilder(OPEN_SLOT))
+      .mockReturnValueOnce(makeBuilder(ADVISOR_ROW));
+    mockCreateBookingCheckout.mockResolvedValue({ checkoutUrl: "https://checkout.stripe.com/pay/cs_test_no_topic" });
+  });
+
+  it("accepts a body without topic field", async () => {
+    const [req, params] = makePost({ consumerName: "Alice", consumerEmail: "alice@example.com" });
+    const res = await POST(req, params);
+    expect(res.status).toBe(200);
+  });
+});

--- a/__tests__/api/checkin.test.ts
+++ b/__tests__/api/checkin.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Hoisted mock refs ─────────────────────────────────────────────────────────
+
+const { mockIsRateLimited, mockGetUser, mockFrom } = vi.hoisted(() => ({
+  mockIsRateLimited: vi.fn<(...args: unknown[]) => Promise<boolean>>(async () => false),
+  mockGetUser: vi.fn<
+    () => Promise<{ data: { user: { id: string; email?: string } | null }; error: unknown }>
+  >(async () => ({ data: { user: { id: "u1", email: "u@e.com" } }, error: null })),
+  mockFrom: vi.fn(() => makeChain()),
+}));
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: (...args: unknown[]) => mockIsRateLimited(...args),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: mockGetUser },
+    from: mockFrom,
+  })),
+}));
+
+/**
+ * withValidatedBody mock — parses with the real Zod schema from the route.
+ */
+vi.mock("@/lib/validation/withValidatedBody", () => ({
+  withValidatedBody: (
+    schema: {
+      safeParse: (
+        v: unknown,
+      ) => { success: boolean; data?: unknown; error?: { issues: Array<{ message: string }> } };
+    },
+    handler: (req: NextRequest, body: unknown) => unknown,
+  ) =>
+    async (req: NextRequest) => {
+      let rawBody: unknown;
+      try {
+        rawBody = await req.json();
+      } catch {
+        const { NextResponse } = await import("next/server");
+        return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+      }
+      const parsed = schema.safeParse(rawBody);
+      if (!parsed.success) {
+        const { NextResponse } = await import("next/server");
+        const firstMsg = parsed.error?.issues[0]?.message ?? "Validation error";
+        return NextResponse.json(
+          { error: firstMsg, code: "validation_error", issues: parsed.error?.issues ?? [] },
+          { status: 400 },
+        );
+      }
+      return handler(req, parsed.data);
+    },
+}));
+
+vi.mock("@/lib/streak", () => ({
+  computeNewStreakCount: vi.fn(
+    (existing: { check_in_date: string; streak_count: number }[], _today: string) => {
+      if (existing.length === 0) return 1;
+      return existing[0]!.streak_count + 1;
+    },
+  ),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeChain(res: { data?: unknown; error?: unknown } = {}) {
+  const chain: Record<string, unknown> = {};
+  for (const m of [
+    "select", "insert", "update", "delete", "upsert",
+    "eq", "neq", "lt", "lte", "gte", "is", "in", "not", "or",
+    "order", "limit", "range", "maybeSingle", "single", "filter",
+  ]) {
+    chain[m] = vi.fn(() => chain);
+  }
+  chain.then = (resolve: (v: unknown) => unknown) =>
+    Promise.resolve(resolve({ data: res.data ?? null, error: res.error ?? null }));
+  chain.catch = () => chain;
+  return chain;
+}
+
+const TODAY = new Date().toISOString().slice(0, 10);
+const YESTERDAY = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
+
+function makePostReq(body?: unknown, ip = "1.2.3.4"): NextRequest {
+  return new NextRequest("http://localhost/api/checkin", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-forwarded-for": ip },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+function makeGetReq(ip = "1.2.3.4"): NextRequest {
+  return new NextRequest("http://localhost/api/checkin", {
+    method: "GET",
+    headers: { "x-forwarded-for": ip },
+  });
+}
+
+// ── Route under test (imported after all mocks) ───────────────────────────────
+import { POST, GET } from "@/app/api/checkin/route";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// POST /api/checkin
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("POST /api/checkin", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } }, error: null });
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsRateLimited.mockResolvedValue(true);
+    const res = await POST(makePostReq({ source: "article_read" }));
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toMatch(/too many requests/i);
+  });
+
+  it("passes the correct rate-limit key", async () => {
+    // Rate limited short-circuits before auth — just check key format
+    mockIsRateLimited.mockResolvedValue(true);
+    await POST(makePostReq({ source: "article_read" }, "5.5.5.5"));
+    expect(mockIsRateLimited).toHaveBeenCalledWith("checkin:5.5.5.5", 20, 60);
+  });
+
+  it("returns 401 when user is not authenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+    // No existing checkins needed — unauthenticated returns early
+    mockFrom.mockReturnValue(makeChain({ data: [], error: null }));
+    const res = await POST(makePostReq({ source: "article_read" }));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toMatch(/unauthenticated/i);
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    const req = new NextRequest("http://localhost/api/checkin", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "not-json{{",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid source enum", async () => {
+    const res = await POST(makePostReq({ source: "invalid_source" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("uses default source 'article_read' when source is omitted", async () => {
+    // No existing checkins → new checkin branch
+    let callNum = 0;
+    const upsertCalls: unknown[] = [];
+    mockFrom.mockImplementation(() => {
+      callNum++;
+      const chain = makeChain({ data: [], error: null });
+      if (callNum === 2) {
+        // Second call is the upsert
+        const upsertFn = chain.upsert as ReturnType<typeof vi.fn>;
+        upsertFn.mockImplementation((v: unknown) => {
+          upsertCalls.push(v);
+          return chain;
+        });
+      }
+      return chain;
+    });
+    await POST(makePostReq({}));
+    const upserted = upsertCalls[0] as Record<string, unknown>;
+    expect(upserted?.source).toBe("article_read");
+  });
+
+  it("returns 200 with isNew=false when already checked in today", async () => {
+    // Simulate existing checkin today
+    mockFrom.mockReturnValue(
+      makeChain({
+        data: [{ check_in_date: TODAY, streak_count: 3 }],
+        error: null,
+      }),
+    );
+    const res = await POST(makePostReq({ source: "article_read" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.isNew).toBe(false);
+    expect(body.streak).toBe(3);
+  });
+
+  it("returns 500 when upsert fails", async () => {
+    let call = 0;
+    mockFrom.mockImplementation(() => {
+      call++;
+      // First call: fetch existing (no checkins today)
+      if (call === 1) return makeChain({ data: [{ check_in_date: YESTERDAY, streak_count: 2 }], error: null });
+      // Second call: upsert fails
+      return makeChain({ data: null, error: { message: "upsert boom" } });
+    });
+    const res = await POST(makePostReq({ source: "calculator" }));
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 200 with isNew=true on first ever checkin", async () => {
+    let call = 0;
+    mockFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) return makeChain({ data: [], error: null }); // no prior checkins
+      return makeChain({ data: null, error: null }); // upsert success
+    });
+    const res = await POST(makePostReq({ source: "watchlist" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.isNew).toBe(true);
+    expect(body.streak).toBe(1);
+  });
+
+  it("returns 200 with extended streak when previous checkin was yesterday", async () => {
+    let call = 0;
+    mockFrom.mockImplementation(() => {
+      call++;
+      if (call === 1)
+        return makeChain({
+          data: [{ check_in_date: YESTERDAY, streak_count: 4 }],
+          error: null,
+        });
+      return makeChain({ data: null, error: null });
+    });
+    const res = await POST(makePostReq({ source: "quiz" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.isNew).toBe(true);
+    expect(body.streak).toBe(5); // mock computeNewStreakCount returns existing.streak_count + 1
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// GET /api/checkin
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("GET /api/checkin", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } }, error: null });
+  });
+
+  it("returns { streak: 0 } when rate-limited (no error status)", async () => {
+    mockIsRateLimited.mockResolvedValue(true);
+    const res = await GET(makeGetReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.streak).toBe(0);
+  });
+
+  it("returns { streak: 0 } when user is not authenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+    const res = await GET(makeGetReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.streak).toBe(0);
+  });
+
+  it("returns { streak: 0 } when user has no checkins", async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: null }));
+    const res = await GET(makeGetReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.streak).toBe(0);
+  });
+
+  it("returns active streak when last checkin was today", async () => {
+    mockFrom.mockReturnValue(makeChain({ data: { check_in_date: TODAY, streak_count: 7 }, error: null }));
+    const res = await GET(makeGetReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.streak).toBe(7);
+  });
+
+  it("returns active streak when last checkin was yesterday", async () => {
+    mockFrom.mockReturnValue(makeChain({ data: { check_in_date: YESTERDAY, streak_count: 5 }, error: null }));
+    const res = await GET(makeGetReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.streak).toBe(5);
+  });
+
+  it("returns { streak: 0 } when last checkin was more than 1 day ago (streak broken)", async () => {
+    const twoDaysAgo = new Date(Date.now() - 2 * 86_400_000).toISOString().slice(0, 10);
+    mockFrom.mockReturnValue(makeChain({ data: { check_in_date: twoDaysAgo, streak_count: 10 }, error: null }));
+    const res = await GET(makeGetReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.streak).toBe(0);
+  });
+});

--- a/__tests__/api/clubs-clubId-route.test.ts
+++ b/__tests__/api/clubs-clubId-route.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for GET /api/clubs/[clubId]
+ *
+ * Auth: Supabase server client (auth.getUser) + admin client for benchmark
+ * Branches: 429, 401, 403 (not_member), 404 (club not found), 200 (full detail + benchmark)
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const { mockIsAllowed, mockGetUser, mockFrom, mockAdminFrom } = vi.hoisted(() => ({
+  mockIsAllowed: vi.fn<() => Promise<boolean>>().mockResolvedValue(true),
+  mockGetUser: vi.fn<() => Promise<{ data: { user: { id: string } | null } }>>().mockResolvedValue({
+    data: { user: { id: "user-1" } },
+  }),
+  mockFrom: vi.fn(),
+  mockAdminFrom: vi.fn(),
+}));
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: (..._args: unknown[]) => mockIsAllowed(),
+  ipKey: () => "ip:test",
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() =>
+    Promise.resolve({ auth: { getUser: mockGetUser }, from: mockFrom }),
+  ),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() })),
+}));
+
+// ── Route under test ──────────────────────────────────────────────────────────
+
+import { GET } from "@/app/api/clubs/[clubId]/route";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeBuilder(data: unknown, error: unknown = null) {
+  const b: Record<string, unknown> = {};
+  for (const m of [
+    "select", "insert", "update", "delete",
+    "eq", "neq", "in", "order", "limit", "single", "maybeSingle",
+  ]) {
+    b[m] = vi.fn(() => b);
+  }
+  b.then = (resolve: (v: unknown) => unknown) =>
+    Promise.resolve(resolve({ data, error }));
+  return b;
+}
+
+const CLUB_ID = "club-xyz";
+const PARAMS = { params: Promise.resolve({ clubId: CLUB_ID }) };
+
+function makeGet(clubId = CLUB_ID): NextRequest {
+  return new NextRequest(`http://localhost/api/clubs/${clubId}`, { method: "GET" });
+}
+
+const MEMBERSHIP = { id: "mem-1", role: "member", display_name: "Alex" };
+const CLUB_DATA = {
+  id: CLUB_ID,
+  name: "ETF Club",
+  slug: "etf-club-123",
+  description: null,
+  member_limit: 20,
+  created_by: "user-1",
+  created_at: "2026-05-01T00:00:00Z",
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("GET /api/clubs/[clubId]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+    mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } });
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsAllowed.mockResolvedValue(false);
+    const res = await GET(makeGet(), PARAMS);
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const res = await GET(makeGet(), PARAMS);
+    expect(res.status).toBe(401);
+    expect((await res.json() as Record<string, unknown>).error).toMatch(/unauthorized/i);
+  });
+
+  it("returns 403 when user is not a club member", async () => {
+    // membership query returns null
+    mockFrom.mockReturnValue(makeBuilder(null));
+    const res = await GET(makeGet(), PARAMS);
+    expect(res.status).toBe(403);
+    expect((await res.json() as Record<string, unknown>).error).toBe("not_member");
+  });
+
+  it("returns 404 when club data is null", async () => {
+    let call = 0;
+    // call 1: membership → found; calls 2-5: Promise.all returns club as null, rest as []
+    mockFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) return makeBuilder(MEMBERSHIP);
+      // club
+      if (call === 2) return makeBuilder(null);
+      return makeBuilder([]);
+    });
+    // Admin queries for benchmark (best-effort, may or may not run)
+    mockAdminFrom.mockReturnValue(makeBuilder([]));
+    const res = await GET(makeGet(), PARAMS);
+    expect(res.status).toBe(404);
+    expect((await res.json() as Record<string, unknown>).error).toBe("not_found");
+  });
+
+  it("returns 200 with full club detail when user is a member", async () => {
+    const members = [
+      { id: "mem-1", role: "member", display_name: "Alex", joined_at: "2026-05-01T00:00:00Z" },
+    ];
+    const watchlist = [
+      { id: "wl-1", broker_id: 5, notes: "Good fees", created_at: "2026-05-02T00:00:00Z", brokers: { name: "CommSec", slug: "commsec", logo_url: null, rating: 4.5, asx_fee: 10 } },
+    ];
+    const messages = [
+      { id: "msg-1", body: "Hello", created_at: "2026-05-03T00:00:00Z", club_members: { display_name: "Alex", role: "member" } },
+    ];
+
+    let call = 0;
+    mockFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) return makeBuilder(MEMBERSHIP); // membership check
+      if (call === 2) return makeBuilder(CLUB_DATA);   // club
+      if (call === 3) return makeBuilder(members);     // members
+      if (call === 4) return makeBuilder(watchlist);   // watchlist
+      return makeBuilder(messages);                    // messages
+    });
+
+    // Admin benchmark queries
+    mockAdminFrom.mockReturnValueOnce(
+      makeBuilder([{ user_id: "user-1", display_name: "Alex" }]),
+    ).mockReturnValueOnce(
+      makeBuilder([{ user_id: "user-1", broker_slug: "commsec" }]),
+    );
+
+    const res = await GET(makeGet(), PARAMS);
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect((body.club as Record<string, unknown>).id).toBe(CLUB_ID);
+    expect((body.myMembership as Record<string, unknown>).role).toBe("member");
+    expect((body.members as unknown[]).length).toBe(1);
+    expect((body.watchlist as unknown[]).length).toBe(1);
+    expect((body.messages as unknown[]).length).toBe(1);
+    // benchmark should be populated
+    expect(Array.isArray(body.benchmark)).toBe(true);
+  });
+
+  it("returns 200 with empty benchmark when admin query fails (non-fatal)", async () => {
+    let call = 0;
+    mockFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) return makeBuilder(MEMBERSHIP);
+      if (call === 2) return makeBuilder(CLUB_DATA);
+      if (call === 3) return makeBuilder([]);
+      if (call === 4) return makeBuilder([]);
+      return makeBuilder([]);
+    });
+
+    // Admin throws error — benchmark should degrade gracefully
+    mockAdminFrom.mockImplementation(() => {
+      throw new Error("admin unavailable");
+    });
+
+    const res = await GET(makeGet(), PARAMS);
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.benchmark).toEqual([]);
+  });
+});

--- a/__tests__/api/clubs-clubId-watchlist.test.ts
+++ b/__tests__/api/clubs-clubId-watchlist.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Tests for POST + DELETE /api/clubs/[clubId]/watchlist
+ *
+ * Auth: Supabase server client (auth.getUser)
+ * POST (withValidatedBody, ctx-forwarded):
+ *   429, 400 (bad body), 401, 403 (not_member), 409 (duplicate), 500 (db error), 200
+ * DELETE:
+ *   429, 401, 400 (missing itemId), 403 (not_member),
+ *   404 (item not found), 403 (not owner + not adder), 500 (db error), 200
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const { mockIsAllowed, mockGetUser, mockFrom } = vi.hoisted(() => ({
+  mockIsAllowed: vi.fn<() => Promise<boolean>>().mockResolvedValue(true),
+  mockGetUser: vi.fn<() => Promise<{ data: { user: { id: string } | null } }>>().mockResolvedValue({
+    data: { user: { id: "user-1" } },
+  }),
+  mockFrom: vi.fn(),
+}));
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: (..._args: unknown[]) => mockIsAllowed(),
+  ipKey: () => "ip:test",
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() =>
+    Promise.resolve({ auth: { getUser: mockGetUser }, from: mockFrom }),
+  ),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() })),
+}));
+
+// ── Route under test ──────────────────────────────────────────────────────────
+// Uses the real withValidatedBody, which forwards the Next.js route context
+// ({ params }) to the handler as its 3rd arg — so the tests call POST(req, ctx).
+
+import { POST, DELETE } from "@/app/api/clubs/[clubId]/watchlist/route";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeBuilder(data: unknown, error: unknown = null) {
+  const b: Record<string, unknown> = {};
+  for (const m of [
+    "select", "insert", "update", "delete", "upsert",
+    "eq", "neq", "in", "is", "order", "limit", "single", "maybeSingle",
+  ]) {
+    b[m] = vi.fn(() => b);
+  }
+  b.then = (resolve: (v: unknown) => unknown) =>
+    Promise.resolve(resolve({ data, error }));
+  return b;
+}
+
+const CLUB_ID = "club-wl";
+const PARAMS = { params: Promise.resolve({ clubId: CLUB_ID }) };
+
+function makePost(body: unknown): NextRequest {
+  return new NextRequest(`http://localhost/api/clubs/${CLUB_ID}/watchlist`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeDelete(itemId?: string): NextRequest {
+  const url = new URL(`http://localhost/api/clubs/${CLUB_ID}/watchlist`);
+  if (itemId) url.searchParams.set("itemId", itemId);
+  return new NextRequest(url.toString(), { method: "DELETE" });
+}
+
+// ── POST tests ────────────────────────────────────────────────────────────────
+
+describe("POST /api/clubs/[clubId]/watchlist", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+    mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } });
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsAllowed.mockResolvedValue(false);
+    const res = await POST(makePost({ brokerId: 1 }), PARAMS);
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 400 when body is invalid JSON", async () => {
+    const req = new NextRequest(`http://localhost/api/clubs/${CLUB_ID}/watchlist`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    const res = await POST(req, PARAMS);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when brokerId is missing from body", async () => {
+    const res = await POST(makePost({ notes: "hello" }), PARAMS);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const res = await POST(makePost({ brokerId: 5 }), PARAMS);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when user is not a club member", async () => {
+    mockFrom.mockReturnValue(makeBuilder(null));
+    const res = await POST(makePost({ brokerId: 5 }), PARAMS);
+    expect(res.status).toBe(403);
+    expect((await res.json() as Record<string, unknown>).error).toBe("not_member");
+  });
+
+  it("returns 409 when broker is already on watchlist (unique constraint)", async () => {
+    let call = 0;
+    mockFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) return makeBuilder({ id: "mem-1" }); // membership
+      return makeBuilder(null, { code: "23505", message: "duplicate" }); // insert
+    });
+    const res = await POST(makePost({ brokerId: 5 }), PARAMS);
+    expect(res.status).toBe(409);
+    expect((await res.json() as Record<string, unknown>).error).toMatch(/already on watchlist/i);
+  });
+
+  it("returns 500 when insert fails with non-duplicate error", async () => {
+    let call = 0;
+    mockFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) return makeBuilder({ id: "mem-1" });
+      return makeBuilder(null, { code: "500", message: "db error" });
+    });
+    const res = await POST(makePost({ brokerId: 5 }), PARAMS);
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 200 on successful watchlist add", async () => {
+    let call = 0;
+    mockFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) return makeBuilder({ id: "mem-1" });
+      return makeBuilder(null); // insert success (no error)
+    });
+    const res = await POST(makePost({ brokerId: 5, notes: "Good broker" }), PARAMS);
+    expect(res.status).toBe(200);
+    expect((await res.json() as Record<string, unknown>).ok).toBe(true);
+  });
+});
+
+// ── DELETE tests ──────────────────────────────────────────────────────────────
+
+describe("DELETE /api/clubs/[clubId]/watchlist", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+    mockGetUser.mockResolvedValue({ data: { user: { id: "user-1" } } });
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsAllowed.mockResolvedValue(false);
+    const res = await DELETE(makeDelete("item-1"), PARAMS);
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const res = await DELETE(makeDelete("item-1"), PARAMS);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when itemId query param is missing", async () => {
+    const res = await DELETE(makeDelete(), PARAMS);
+    expect(res.status).toBe(400);
+    expect((await res.json() as Record<string, unknown>).error).toMatch(/itemId is required/i);
+  });
+
+  it("returns 403 when user is not a club member", async () => {
+    mockFrom.mockReturnValue(makeBuilder(null));
+    const res = await DELETE(makeDelete("item-1"), PARAMS);
+    expect(res.status).toBe(403);
+    expect((await res.json() as Record<string, unknown>).error).toBe("not_member");
+  });
+
+  it("returns 404 when item is not found", async () => {
+    let call = 0;
+    mockFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) return makeBuilder({ id: "mem-1", role: "member" }); // membership
+      return makeBuilder(null); // item not found
+    });
+    const res = await DELETE(makeDelete("missing-item"), PARAMS);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when non-owner tries to remove another member's item", async () => {
+    let call = 0;
+    mockFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) return makeBuilder({ id: "mem-1", role: "member" });
+      // item was added by different member
+      return makeBuilder({ id: "item-1", added_by_member_id: "mem-other" });
+    });
+    const res = await DELETE(makeDelete("item-1"), PARAMS);
+    expect(res.status).toBe(403);
+    expect((await res.json() as Record<string, unknown>).error).toBe("forbidden");
+  });
+
+  it("returns 200 when owner removes another member's item", async () => {
+    let call = 0;
+    mockFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) return makeBuilder({ id: "mem-1", role: "owner" });
+      if (call === 2) return makeBuilder({ id: "item-1", added_by_member_id: "mem-other" });
+      return makeBuilder(null); // delete succeeds
+    });
+    const res = await DELETE(makeDelete("item-1"), PARAMS);
+    expect(res.status).toBe(200);
+    expect((await res.json() as Record<string, unknown>).ok).toBe(true);
+  });
+
+  it("returns 200 when member removes their own item", async () => {
+    let call = 0;
+    mockFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) return makeBuilder({ id: "mem-1", role: "member" });
+      if (call === 2) return makeBuilder({ id: "item-1", added_by_member_id: "mem-1" });
+      return makeBuilder(null); // delete
+    });
+    const res = await DELETE(makeDelete("item-1"), PARAMS);
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 500 when delete query fails", async () => {
+    let call = 0;
+    mockFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) return makeBuilder({ id: "mem-1", role: "owner" });
+      if (call === 2) return makeBuilder({ id: "item-1", added_by_member_id: "mem-other" });
+      return makeBuilder(null, { message: "db error" });
+    });
+    const res = await DELETE(makeDelete("item-1"), PARAMS);
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/cron-advisor-auto-topup.test.ts
+++ b/__tests__/api/cron-advisor-auto-topup.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NextRequest } from "next/server";
+
+// ── Mocks — must appear before route import ──────────────────────────────────
+
+const mockRequireCronAuth = vi.fn();
+const mockRecordLedgerEntry = vi.fn();
+const mockGetStripe = vi.fn();
+const { mockAdminFrom } = vi.hoisted(() => ({ mockAdminFrom: vi.fn() }));
+
+vi.mock("@/lib/cron-auth", () => ({
+  requireCronAuth: (...args: unknown[]) => mockRequireCronAuth(...args),
+}));
+
+vi.mock("@/lib/cron-run-log", () => ({
+  wrapCronHandler: (_name: string, h: unknown) => h,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn() })),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+vi.mock("@/lib/stripe", () => ({
+  getStripe: (...args: unknown[]) => mockGetStripe(...args),
+}));
+
+vi.mock("@/lib/advisor-credit-ledger", () => ({
+  recordLedgerEntry: (...args: unknown[]) => mockRecordLedgerEntry(...args),
+}));
+
+import { GET, AUTO_TOPUP_MAX_CENTS, AUTO_TOPUP_COOLDOWN_MS } from "@/app/api/cron/advisor-auto-topup/route";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeReq() {
+  return new Request("http://localhost/api/cron/advisor-auto-topup") as unknown as NextRequest;
+}
+
+function makeSelectChain(data: unknown, error: unknown = null) {
+  const chain: Record<string, unknown> = {};
+  for (const m of ["select", "eq", "gte", "order", "limit", "filter"]) {
+    chain[m] = vi.fn(() => chain);
+  }
+  chain.then = (cb: (v: unknown) => unknown) => Promise.resolve(cb({ data, error }));
+  return chain;
+}
+
+const mockStripe = {
+  customers: { retrieve: vi.fn() },
+  paymentIntents: { create: vi.fn() },
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("GET /api/cron/advisor-auto-topup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireCronAuth.mockReturnValue(null);
+    mockGetStripe.mockReturnValue(mockStripe);
+    mockRecordLedgerEntry.mockResolvedValue(undefined);
+  });
+
+  it("returns 401 when cron auth fails", async () => {
+    const { NextResponse } = await import("next/server");
+    mockRequireCronAuth.mockReturnValue(
+      NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    );
+    const res = await GET(makeReq());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 500 when professionals DB query fails", async () => {
+    mockAdminFrom.mockReturnValue(
+      makeSelectChain(null, { message: "connection refused" }),
+    );
+    const res = await GET(makeReq());
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toBeTruthy();
+  });
+
+  it("returns ok:true with no outcomes when no candidates exist", async () => {
+    mockAdminFrom.mockReturnValue(makeSelectChain([]));
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(json.eligible_count).toBe(0);
+    expect(json.outcomes).toHaveLength(0);
+  });
+
+  it("filters out candidates whose balance is at or above threshold", async () => {
+    const aboveThreshold = {
+      id: 1,
+      credit_balance_cents: 5000,
+      auto_topup_threshold_cents: 5000, // balance === threshold → not eligible
+      auto_topup_amount_cents: 15000,
+      stripe_customer_id: "cus_test",
+    };
+    mockAdminFrom.mockReturnValue(makeSelectChain([aboveThreshold]));
+    const res = await GET(makeReq());
+    const json = await res.json();
+    expect(json.eligible_count).toBe(0);
+    expect(json.candidate_count).toBe(1);
+  });
+
+  it("skips advisor with no stripe_customer_id", async () => {
+    const noStripe = {
+      id: 2,
+      credit_balance_cents: 1000,
+      auto_topup_threshold_cents: 3000,
+      auto_topup_amount_cents: 15000,
+      stripe_customer_id: null,
+    };
+    mockAdminFrom.mockReturnValue(makeSelectChain([noStripe]));
+    const res = await GET(makeReq());
+    const json = await res.json();
+    expect(json.eligible_count).toBe(1);
+    expect(json.skipped_count).toBe(1);
+    const outcome = json.outcomes[0];
+    expect(outcome.status).toBe("skipped");
+    expect(outcome.reason).toBe("no_stripe_customer");
+  });
+
+  it("skips advisor in 24h cooldown (recent auto-topup ledger entry)", async () => {
+    const pro = {
+      id: 3,
+      credit_balance_cents: 1000,
+      auto_topup_threshold_cents: 3000,
+      auto_topup_amount_cents: 15000,
+      stripe_customer_id: "cus_abc",
+    };
+
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      if (call++ === 0) return makeSelectChain([pro]); // professionals
+      return makeSelectChain([{ id: 1, created_at: new Date().toISOString(), metadata: { auto_topup: true } }]); // recent ledger entry
+    });
+
+    const res = await GET(makeReq());
+    const json = await res.json();
+    expect(json.skipped_count).toBe(1);
+    expect(json.outcomes[0].reason).toBe("cooldown_active");
+  });
+
+  it("marks as failed when Stripe charge throws", async () => {
+    const pro = {
+      id: 4,
+      credit_balance_cents: 500,
+      auto_topup_threshold_cents: 3000,
+      auto_topup_amount_cents: 15000,
+      stripe_customer_id: "cus_xyz",
+    };
+
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      if (call++ === 0) return makeSelectChain([pro]); // professionals
+      return makeSelectChain([]); // ledger check — no recent auto-topup
+    });
+
+    mockStripe.customers.retrieve.mockResolvedValue({
+      id: "cus_xyz",
+      deleted: false,
+      invoice_settings: { default_payment_method: "pm_test" },
+    });
+    mockStripe.paymentIntents.create.mockRejectedValue(new Error("Card declined"));
+
+    const res = await GET(makeReq());
+    const json = await res.json();
+    expect(json.failed_count).toBe(1);
+    expect(json.outcomes[0].status).toBe("failed");
+    expect(json.outcomes[0].reason).toBe("stripe_charge_error");
+  });
+
+  it("records charged outcome and ledger entry on successful Stripe charge", async () => {
+    const pro = {
+      id: 5,
+      credit_balance_cents: 500,
+      auto_topup_threshold_cents: 3000,
+      auto_topup_amount_cents: 15000,
+      stripe_customer_id: "cus_ok",
+    };
+
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      if (call++ === 0) return makeSelectChain([pro]); // professionals
+      return makeSelectChain([]); // ledger check — no recent auto-topup
+    });
+
+    mockStripe.customers.retrieve.mockResolvedValue({
+      id: "cus_ok",
+      deleted: false,
+      invoice_settings: { default_payment_method: "pm_card" },
+    });
+    mockStripe.paymentIntents.create.mockResolvedValue({
+      id: "pi_success",
+      status: "succeeded",
+    });
+    mockRecordLedgerEntry.mockResolvedValue(undefined);
+
+    const res = await GET(makeReq());
+    const json = await res.json();
+    expect(json.charged_count).toBe(1);
+    expect(json.total_charged_cents).toBe(15000);
+    expect(json.outcomes[0].status).toBe("charged");
+    expect(json.outcomes[0].paymentIntentId).toBe("pi_success");
+    expect(mockRecordLedgerEntry).toHaveBeenCalledOnce();
+  });
+
+  it("caps charge at AUTO_TOPUP_MAX_CENTS even if advisor set higher amount", async () => {
+    const pro = {
+      id: 6,
+      credit_balance_cents: 0,
+      auto_topup_threshold_cents: 5000,
+      auto_topup_amount_cents: AUTO_TOPUP_MAX_CENTS + 10000, // over the cap
+      stripe_customer_id: "cus_big",
+    };
+
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      if (call++ === 0) return makeSelectChain([pro]);
+      return makeSelectChain([]);
+    });
+
+    mockStripe.customers.retrieve.mockResolvedValue({
+      id: "cus_big",
+      deleted: false,
+      invoice_settings: { default_payment_method: "pm_big" },
+    });
+    mockStripe.paymentIntents.create.mockResolvedValue({ id: "pi_capped", status: "succeeded" });
+    mockRecordLedgerEntry.mockResolvedValue(undefined);
+
+    await GET(makeReq());
+
+    // Stripe was called with exactly AUTO_TOPUP_MAX_CENTS
+    expect(mockStripe.paymentIntents.create).toHaveBeenCalledWith(
+      expect.objectContaining({ amount: AUTO_TOPUP_MAX_CENTS }),
+      expect.anything(),
+    );
+  });
+});
+
+describe("AUTO_TOPUP_MAX_CENTS / AUTO_TOPUP_COOLDOWN_MS constants", () => {
+  it("max is $500 AUD (50000 cents)", () => {
+    expect(AUTO_TOPUP_MAX_CENTS).toBe(50000);
+  });
+
+  it("cooldown is 24 hours in ms", () => {
+    expect(AUTO_TOPUP_COOLDOWN_MS).toBe(24 * 60 * 60 * 1000);
+  });
+});

--- a/__tests__/api/cron-advisor-welcome-sequence.test.ts
+++ b/__tests__/api/cron-advisor-welcome-sequence.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+vi.mock("@/lib/html-escape", () => ({
+  escapeHtml: vi.fn((s: unknown) => String(s ?? "")),
+}));
+
+vi.mock("@/lib/url", () => ({
+  getSiteUrl: vi.fn(() => "https://invest.com.au"),
+}));
+
+const mockSendEmail = vi.fn(
+  async (..._args: unknown[]): Promise<{ ok: boolean; error?: string }> => ({ ok: true }),
+);
+vi.mock("@/lib/resend", () => ({
+  sendEmail: (...args: unknown[]) => mockSendEmail(...args),
+}));
+
+// ─── Supabase builder factory ─────────────────────────────────────────────────
+
+function makeBuilder(data: unknown = null, error: unknown = null) {
+  const terminal = { data, error };
+  const c: Record<string, unknown> = {
+    then: (resolve: (v: typeof terminal) => unknown) =>
+      Promise.resolve(resolve(terminal)),
+  };
+  for (const m of [
+    "select", "insert", "update", "upsert", "delete",
+    "eq", "neq", "gt", "gte", "lt", "lte", "in", "is", "not", "or",
+    "order", "limit", "range", "single", "maybeSingle", "filter",
+    "contains", "overlaps", "throwOnError",
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  return c;
+}
+
+const mockFrom = vi.fn((..._args: unknown[]) => makeBuilder());
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
+    from: (...args: unknown[]) => mockFrom(...args),
+  })),
+}));
+
+// ─── Import after mocks ───────────────────────────────────────────────────────
+
+import { GET, runtime, maxDuration } from "@/app/api/cron/advisor-welcome-sequence/route";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const SECRET = "test-cron-secret-welcome-seq-12345";
+
+function req(headers: Record<string, string> = {}): NextRequest {
+  return new Request("http://localhost/api/cron/advisor-welcome-sequence", { headers }) as unknown as NextRequest;
+}
+
+function authedReq(): NextRequest {
+  return req({ authorization: `Bearer ${SECRET}` });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("GET /api/cron/advisor-welcome-sequence — exports", () => {
+  it("exports runtime = 'nodejs'", () => {
+    expect(runtime).toBe("nodejs");
+  });
+
+  it("exports maxDuration = 120", () => {
+    expect(maxDuration).toBe(120);
+  });
+});
+
+describe("GET /api/cron/advisor-welcome-sequence — auth guards", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = SECRET;
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("returns 500 when CRON_SECRET is not set", async () => {
+    delete process.env.CRON_SECRET;
+    const res = await GET(authedReq());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toMatch(/misconfigured/i);
+  });
+
+  it("returns 500 when CRON_SECRET is too short", async () => {
+    process.env.CRON_SECRET = "tooshort";
+    const res = await GET(authedReq());
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 401 on wrong bearer token", async () => {
+    const res = await GET(req({ authorization: "Bearer wrong" }));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toMatch(/unauthorized/i);
+  });
+
+  it("returns 401 when authorization header is absent", async () => {
+    const res = await GET(req());
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /api/cron/advisor-welcome-sequence — DB error path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = SECRET;
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("returns 500 when professionals query fails", async () => {
+    mockFrom.mockReturnValueOnce(makeBuilder(null, { message: "db connection failed" }));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("fetch_failed");
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/cron/advisor-welcome-sequence — empty data path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = SECRET;
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("returns 200 with sent:0 when no eligible advisors", async () => {
+    mockFrom.mockReturnValueOnce(makeBuilder([], null)); // no advisors in window
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sent).toBe(0);
+    expect(body.failed).toBe(0);
+    expect(body.checked).toBe(0);
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("skips advisor with null email (guard inside loop)", async () => {
+    mockFrom.mockReturnValueOnce(
+      makeBuilder([{ id: 1, name: "No Email", email: null, slug: "no-email" }], null),
+    );
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sent).toBe(0);
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/cron/advisor-welcome-sequence — success path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = SECRET;
+    mockSendEmail.mockResolvedValue({ ok: true });
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("sends welcome email and updates professionals table", async () => {
+    // First call: SELECT query
+    const selectBuilder = makeBuilder(
+      [{ id: 10, name: "Alice Smith", email: "alice@example.com", slug: "alice-smith" }],
+      null,
+    );
+    mockFrom.mockReturnValueOnce(selectBuilder);
+    // Second call: UPDATE professionals (mark welcome_email_sent_at)
+    const updateBuilder = makeBuilder(null, null);
+    mockFrom.mockReturnValueOnce(updateBuilder);
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sent).toBe(1);
+    expect(body.failed).toBe(0);
+    expect(body.checked).toBe(1);
+
+    expect(mockSendEmail).toHaveBeenCalledOnce();
+    const callArg = mockSendEmail.mock.calls[0]?.[0] as {
+      to: string;
+      from: string;
+      subject: string;
+      html: string;
+      text: string;
+    };
+    expect(callArg.to).toBe("alice@example.com");
+    expect(callArg.from).toBe("Invest.com.au <advisors@invest.com.au>");
+    expect(callArg.subject).toContain("Welcome to Invest.com.au");
+    expect(callArg.html).toContain("Alice");
+    expect(callArg.html).toContain("alice-smith");
+  });
+
+  it("uses /advisor-portal URL when advisor has no slug", async () => {
+    mockFrom.mockReturnValueOnce(
+      makeBuilder([{ id: 11, name: "Bob Noslug", email: "bob@example.com", slug: null }], null),
+    );
+    mockFrom.mockReturnValueOnce(makeBuilder(null, null)); // update
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+
+    const callArg = mockSendEmail.mock.calls[0]?.[0] as { html: string; text: string };
+    expect(callArg.html).toContain("/advisor-portal");
+    expect(callArg.text).toContain("/advisor-portal");
+  });
+
+  it("counts failure when sendEmail returns ok:false", async () => {
+    mockSendEmail.mockResolvedValue({ ok: false, error: "rate limited" });
+
+    mockFrom.mockReturnValueOnce(
+      makeBuilder([{ id: 12, name: "Fail Advisor", email: "fail@example.com", slug: "fail" }], null),
+    );
+    // No update call — route only updates when ok is true
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sent).toBe(0);
+    expect(body.failed).toBe(1);
+    expect(body.checked).toBe(1);
+  });
+
+  it("processes multiple advisors and counts correctly", async () => {
+    // Two advisors to welcome
+    mockFrom.mockReturnValueOnce(
+      makeBuilder(
+        [
+          { id: 20, name: "Advisor A", email: "a@example.com", slug: "advisor-a" },
+          { id: 21, name: "Advisor B", email: "b@example.com", slug: "advisor-b" },
+        ],
+        null,
+      ),
+    );
+    // Two update calls
+    mockFrom.mockReturnValueOnce(makeBuilder(null, null));
+    mockFrom.mockReturnValueOnce(makeBuilder(null, null));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sent).toBe(2);
+    expect(body.failed).toBe(0);
+    expect(body.checked).toBe(2);
+    expect(mockSendEmail).toHaveBeenCalledTimes(2);
+  });
+});

--- a/__tests__/api/cron-award-badges.test.ts
+++ b/__tests__/api/cron-award-badges.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+vi.mock("@/lib/course-certificates", () => ({
+  cpdYearFor: vi.fn((_date: unknown) => 2026),
+}));
+
+// ─── Supabase builder factory ─────────────────────────────────────────────────
+
+function makeBuilder(data: unknown = null, error: unknown = null) {
+  const terminal = { data, error };
+  const c: Record<string, unknown> = {
+    then: (resolve: (v: typeof terminal) => unknown) =>
+      Promise.resolve(resolve(terminal)),
+  };
+  for (const m of [
+    "select", "insert", "update", "upsert", "delete",
+    "eq", "neq", "gt", "gte", "lt", "lte", "in", "is", "not", "or",
+    "order", "limit", "range", "single", "maybeSingle", "filter",
+    "contains", "overlaps", "throwOnError",
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  return c;
+}
+
+const mockFrom = vi.fn((..._args: unknown[]) => makeBuilder());
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
+    from: (...args: unknown[]) => mockFrom(...args),
+  })),
+}));
+
+// ─── Import after mocks ───────────────────────────────────────────────────────
+
+import { GET, runtime, maxDuration } from "@/app/api/cron/award-badges/route";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const SECRET = "test-cron-secret-award-badges-1234";
+
+function req(headers: Record<string, string> = {}): NextRequest {
+  return new Request("http://localhost/api/cron/award-badges", { headers }) as unknown as NextRequest;
+}
+
+function authedReq(): NextRequest {
+  return req({ authorization: `Bearer ${SECRET}` });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("GET /api/cron/award-badges — exports", () => {
+  it("exports runtime = 'nodejs'", () => {
+    expect(runtime).toBe("nodejs");
+  });
+
+  it("exports maxDuration = 300", () => {
+    expect(maxDuration).toBe(300);
+  });
+});
+
+describe("GET /api/cron/award-badges — auth guards", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = SECRET;
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("returns 500 when CRON_SECRET is not set", async () => {
+    delete process.env.CRON_SECRET;
+    const res = await GET(authedReq());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toMatch(/misconfigured/i);
+  });
+
+  it("returns 500 when CRON_SECRET is too short", async () => {
+    process.env.CRON_SECRET = "short";
+    const res = await GET(authedReq());
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 401 on wrong bearer token", async () => {
+    const res = await GET(req({ authorization: "Bearer wrong" }));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toMatch(/unauthorized/i);
+  });
+
+  it("returns 401 when authorization header is absent", async () => {
+    const res = await GET(req());
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /api/cron/award-badges — empty data path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = SECRET;
+    // All 6 badge category queries return empty
+    mockFrom.mockImplementation(() => makeBuilder([], null));
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("returns 200 with awarded:0 when no professionals match any badge", async () => {
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.awarded).toBe(0);
+  });
+});
+
+describe("GET /api/cron/award-badges — success path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = SECRET;
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("awards profile_complete badge and returns awarded count", async () => {
+    // profile_complete query: 1 advisor
+    mockFrom.mockReturnValueOnce(makeBuilder([{ id: 1 }], null));
+    // advisor_badges upsert for profile_complete → no error
+    mockFrom.mockReturnValueOnce(makeBuilder(null, null));
+    // top_rated query: empty
+    mockFrom.mockReturnValueOnce(makeBuilder([], null));
+    // first_review query: empty
+    mockFrom.mockReturnValueOnce(makeBuilder([], null));
+    // cpd_credits query: empty
+    mockFrom.mockReturnValueOnce(makeBuilder([], null));
+    // verified query: empty
+    mockFrom.mockReturnValueOnce(makeBuilder([], null));
+    // course_creator query: empty
+    mockFrom.mockReturnValueOnce(makeBuilder([], null));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.awarded).toBe(1);
+  });
+
+  it("awards cpd_compliant badge when advisor has >= 40 hours", async () => {
+    // profile_complete: empty
+    mockFrom.mockReturnValueOnce(makeBuilder([], null));
+    // top_rated: empty
+    mockFrom.mockReturnValueOnce(makeBuilder([], null));
+    // first_review: empty
+    mockFrom.mockReturnValueOnce(makeBuilder([], null));
+    // cpd_credits: advisor 5 has 45 hours_earned
+    mockFrom.mockReturnValueOnce(
+      makeBuilder([{ professional_id: 5, hours_earned: 45 }], null),
+    );
+    // cpd_compliant upsert
+    mockFrom.mockReturnValueOnce(makeBuilder(null, null));
+    // verified: empty
+    mockFrom.mockReturnValueOnce(makeBuilder([], null));
+    // courses: empty
+    mockFrom.mockReturnValueOnce(makeBuilder([], null));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.awarded).toBe(1);
+  });
+
+  it("does NOT award cpd_compliant when advisor hours < 40", async () => {
+    // profile_complete: empty
+    mockFrom.mockReturnValueOnce(makeBuilder([], null));
+    // top_rated: empty
+    mockFrom.mockReturnValueOnce(makeBuilder([], null));
+    // first_review: empty
+    mockFrom.mockReturnValueOnce(makeBuilder([], null));
+    // cpd_credits: advisor 6 has only 30 hours
+    mockFrom.mockReturnValueOnce(
+      makeBuilder([{ professional_id: 6, hours_earned: 30 }], null),
+    );
+    // verified: empty
+    mockFrom.mockReturnValueOnce(makeBuilder([], null));
+    // courses: empty
+    mockFrom.mockReturnValueOnce(makeBuilder([], null));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.awarded).toBe(0);
+  });
+
+  it("awards first_course badge when advisor has 1 published course", async () => {
+    // profile_complete: empty
+    mockFrom.mockReturnValueOnce(makeBuilder([], null));
+    // top_rated: empty
+    mockFrom.mockReturnValueOnce(makeBuilder([], null));
+    // first_review: empty
+    mockFrom.mockReturnValueOnce(makeBuilder([], null));
+    // cpd_credits: empty
+    mockFrom.mockReturnValueOnce(makeBuilder([], null));
+    // verified: empty
+    mockFrom.mockReturnValueOnce(makeBuilder([], null));
+    // courses: advisor 7 has 1 course
+    mockFrom.mockReturnValueOnce(
+      makeBuilder([{ advisor_professional_id: 7 }], null),
+    );
+    // first_course upsert
+    mockFrom.mockReturnValueOnce(makeBuilder(null, null));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.awarded).toBe(1);
+  });
+
+  it("awards both first_course and course_creator when advisor has >= 3 courses", async () => {
+    mockFrom.mockReturnValueOnce(makeBuilder([], null)); // profile_complete
+    mockFrom.mockReturnValueOnce(makeBuilder([], null)); // top_rated
+    mockFrom.mockReturnValueOnce(makeBuilder([], null)); // first_review
+    mockFrom.mockReturnValueOnce(makeBuilder([], null)); // cpd_credits
+    mockFrom.mockReturnValueOnce(makeBuilder([], null)); // verified
+    // courses: advisor 8 has 3 courses
+    mockFrom.mockReturnValueOnce(
+      makeBuilder(
+        [
+          { advisor_professional_id: 8 },
+          { advisor_professional_id: 8 },
+          { advisor_professional_id: 8 },
+        ],
+        null,
+      ),
+    );
+    // first_course upsert
+    mockFrom.mockReturnValueOnce(makeBuilder(null, null));
+    // course_creator upsert
+    mockFrom.mockReturnValueOnce(makeBuilder(null, null));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.awarded).toBe(2);
+  });
+
+  it("awards top_rated and first_review badges independently", async () => {
+    // profile_complete: empty
+    mockFrom.mockReturnValueOnce(makeBuilder([], null));
+    // top_rated: advisor 9
+    mockFrom.mockReturnValueOnce(makeBuilder([{ id: 9 }], null));
+    mockFrom.mockReturnValueOnce(makeBuilder(null, null)); // upsert
+    // first_review: advisor 9 also qualifies
+    mockFrom.mockReturnValueOnce(makeBuilder([{ id: 9 }], null));
+    mockFrom.mockReturnValueOnce(makeBuilder(null, null)); // upsert
+    // cpd_credits: empty
+    mockFrom.mockReturnValueOnce(makeBuilder([], null));
+    // verified: empty
+    mockFrom.mockReturnValueOnce(makeBuilder([], null));
+    // courses: empty
+    mockFrom.mockReturnValueOnce(makeBuilder([], null));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.awarded).toBe(2);
+  });
+});

--- a/__tests__/api/cron-comeback-rate-email.test.ts
+++ b/__tests__/api/cron-comeback-rate-email.test.ts
@@ -1,0 +1,365 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+vi.mock("@/lib/url", () => ({
+  getSiteUrl: vi.fn(() => "https://invest.com.au"),
+}));
+
+const mockSendEmail = vi.fn(
+  async (..._args: unknown[]): Promise<{ ok: boolean; error?: string }> => ({ ok: true }),
+);
+vi.mock("@/lib/resend", () => ({
+  sendEmail: (...args: unknown[]) => mockSendEmail(...args),
+}));
+
+vi.mock("@/lib/cron-run-log", () => ({
+  withCronRunLog: vi.fn(
+    async (_name: string, fn: () => Promise<{ response: unknown }>) => {
+      const result = await fn();
+      return result.response;
+    },
+  ),
+}));
+
+// ─── Supabase builder factory ─────────────────────────────────────────────────
+
+function makeBuilder(data: unknown = null, error: unknown = null) {
+  const terminal = { data, error };
+  const c: Record<string, unknown> = {
+    then: (resolve: (v: typeof terminal) => unknown) =>
+      Promise.resolve(resolve(terminal)),
+  };
+  for (const m of [
+    "select", "insert", "update", "upsert", "delete",
+    "eq", "neq", "gt", "gte", "lt", "lte", "in", "is", "not", "or",
+    "order", "limit", "range", "single", "maybeSingle", "filter",
+    "contains", "overlaps", "throwOnError",
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  return c;
+}
+
+const mockFrom = vi.fn((..._args: unknown[]) => makeBuilder());
+const mockListUsers = vi.fn(
+  async (
+    ..._args: unknown[]
+  ): Promise<{ data: { users: Array<{ id: string; email?: string }> }; error: unknown }> => ({
+    data: { users: [] },
+    error: null,
+  }),
+);
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
+    from: (...args: unknown[]) => mockFrom(...args),
+    auth: { admin: { listUsers: (...args: unknown[]) => mockListUsers(...args) } },
+  })),
+}));
+
+// ─── Import after mocks ───────────────────────────────────────────────────────
+
+import { GET, runtime, maxDuration } from "@/app/api/cron/comeback-rate-email/route";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const SECRET = "test-cron-secret-comeback-rate-12";
+
+function req(headers: Record<string, string> = {}): NextRequest {
+  return new Request("http://localhost/api/cron/comeback-rate-email", {
+    headers,
+  }) as unknown as NextRequest;
+}
+
+function authedReq(): NextRequest {
+  return req({ authorization: `Bearer ${SECRET}` });
+}
+
+function makeSnapshot(brokerId: number, productKind: string, rateBps: number, capturedAt = "2026-05-28T12:00:00Z") {
+  return { broker_id: brokerId, product_kind: productKind, rate_bps: rateBps, captured_at: capturedAt };
+}
+
+function makeMemoryRow(overrides: Partial<{
+  id: string;
+  user_id: string;
+  broker_id: number;
+  product_kind: string;
+  last_seen_rate_bps: number;
+  notified_rate_bps: number | null;
+  notified_at: string | null;
+  brokers: { slug: string; name: string };
+}> = {}) {
+  return {
+    id: "mem-1",
+    user_id: "user-001",
+    broker_id: 1,
+    product_kind: "savings_account",
+    last_seen_rate_bps: 450,
+    notified_rate_bps: null,
+    notified_at: null,
+    brokers: { slug: "ing", name: "ING" },
+    ...overrides,
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("GET /api/cron/comeback-rate-email — exports", () => {
+  it("exports runtime = 'nodejs'", () => {
+    expect(runtime).toBe("nodejs");
+  });
+
+  it("exports maxDuration = 120", () => {
+    expect(maxDuration).toBe(120);
+  });
+});
+
+describe("GET /api/cron/comeback-rate-email — auth guards", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = SECRET;
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("returns 500 when CRON_SECRET is not set", async () => {
+    delete process.env.CRON_SECRET;
+    const res = await GET(authedReq());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toMatch(/misconfigured/i);
+  });
+
+  it("returns 401 on wrong bearer token", async () => {
+    const res = await GET(req({ authorization: "Bearer wrong" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when authorization header is absent", async () => {
+    const res = await GET(req());
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /api/cron/comeback-rate-email — no-data paths", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = SECRET;
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("returns 200 with reason=no_snapshots when snapshots table is empty", async () => {
+    mockFrom.mockReturnValueOnce(makeBuilder([], null)); // savings_rate_snapshots
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.reason).toBe("no_snapshots");
+    expect(body.sent).toBe(0);
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 with sent:0 when memory rows table is empty", async () => {
+    // snapshots with one entry
+    mockFrom.mockReturnValueOnce(makeBuilder([makeSnapshot(1, "savings_account", 500)], null));
+    // memory rows empty
+    mockFrom.mockReturnValueOnce(makeBuilder([], null));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.sent).toBe(0);
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 with sent:0 when no rate changes qualify as candidates", async () => {
+    // Snapshot rate equals last_seen_rate_bps → no change
+    mockFrom.mockReturnValueOnce(makeBuilder([makeSnapshot(1, "savings_account", 450)], null));
+    mockFrom.mockReturnValueOnce(makeBuilder([makeMemoryRow({ last_seen_rate_bps: 450 })], null));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sent).toBe(0);
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/cron/comeback-rate-email — success path (rate increase)", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.CRON_SECRET = SECRET;
+    mockSendEmail.mockResolvedValue({ ok: true });
+    mockFrom.mockImplementation((..._args: unknown[]) => makeBuilder());
+    mockListUsers.mockResolvedValue({ data: { users: [] }, error: null });
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("sends email when rate has increased since last visit", async () => {
+    const userId = "user-rateup";
+    const email = "rateup@example.com";
+
+    // Current snapshot: 500 bps. User last saw 450 bps → moved up by 50 bps.
+    mockFrom.mockReturnValueOnce(makeBuilder([makeSnapshot(1, "savings_account", 500)], null));
+    mockFrom.mockReturnValueOnce(makeBuilder([makeMemoryRow({ user_id: userId, last_seen_rate_bps: 450 })], null));
+
+    mockListUsers.mockResolvedValue({ data: { users: [{ id: userId, email }] }, error: null });
+
+    // notification_preferences (deal_alerts not opted out)
+    mockFrom.mockReturnValueOnce(makeBuilder([{ user_id: userId, deal_alerts: true }], null));
+    // update notified_rate_bps
+    mockFrom.mockReturnValue(makeBuilder(null, null));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.sent).toBe(1);
+    expect(body.candidates).toBe(1);
+
+    expect(mockSendEmail).toHaveBeenCalledOnce();
+    const callArg = mockSendEmail.mock.calls[0]?.[0] as {
+      to: string;
+      subject: string;
+      html: string;
+    };
+    expect(callArg.to).toBe(email);
+    expect(callArg.subject).toContain("↑");
+    expect(callArg.subject).toContain("5.00%");
+    expect(callArg.html).toContain("ING");
+    expect(callArg.html).toContain("4.50%"); // old rate
+    expect(callArg.html).toContain("5.00%"); // new rate
+  });
+
+  it("sends email when rate has decreased, subject uses ↓ arrow", async () => {
+    const userId = "user-ratedown";
+    const email = "ratedown@example.com";
+
+    mockFrom.mockReturnValueOnce(makeBuilder([makeSnapshot(1, "savings_account", 400)], null));
+    mockFrom.mockReturnValueOnce(makeBuilder([makeMemoryRow({ user_id: userId, last_seen_rate_bps: 450 })], null));
+
+    mockListUsers.mockResolvedValue({ data: { users: [{ id: userId, email }] }, error: null });
+    mockFrom.mockReturnValueOnce(makeBuilder([{ user_id: userId, deal_alerts: true }], null));
+    mockFrom.mockReturnValue(makeBuilder(null, null));
+
+    const res = await GET(authedReq());
+    const body = await res.json();
+    expect(body.sent).toBe(1);
+
+    const callArg = mockSendEmail.mock.calls[0]?.[0] as { subject: string };
+    expect(callArg.subject).toContain("↓");
+    expect(callArg.subject).toContain("4.00%");
+  });
+
+  it("skips user who opted out of deal_alerts", async () => {
+    const userId = "user-optout";
+    const email = "optout@example.com";
+
+    mockFrom.mockReturnValueOnce(makeBuilder([makeSnapshot(1, "savings_account", 500)], null));
+    mockFrom.mockReturnValueOnce(makeBuilder([makeMemoryRow({ user_id: userId, last_seen_rate_bps: 450 })], null));
+
+    mockListUsers.mockResolvedValue({ data: { users: [{ id: userId, email }] }, error: null });
+    // deal_alerts = false → opted out
+    mockFrom.mockReturnValueOnce(makeBuilder([{ user_id: userId, deal_alerts: false }], null));
+
+    const res = await GET(authedReq());
+    const body = await res.json();
+    expect(body.sent).toBe(0);
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("skips user whose last notification was within cooldown (< 7 days)", async () => {
+    const userId = "user-cooldown";
+    const email = "cooldown@example.com";
+    const recentNotification = new Date(Date.now() - 2 * 86_400_000).toISOString(); // 2 days ago
+
+    mockFrom.mockReturnValueOnce(makeBuilder([makeSnapshot(1, "savings_account", 500)], null));
+    mockFrom.mockReturnValueOnce(makeBuilder([makeMemoryRow({
+      user_id: userId,
+      last_seen_rate_bps: 450,
+      notified_at: recentNotification,
+    })], null));
+
+    mockListUsers.mockResolvedValue({ data: { users: [{ id: userId, email }] }, error: null });
+    mockFrom.mockReturnValueOnce(makeBuilder([{ user_id: userId, deal_alerts: true }], null));
+
+    const res = await GET(authedReq());
+    const body = await res.json();
+    expect(body.sent).toBe(0);
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("skips candidate when notified_rate_bps already equals current rate", async () => {
+    const userId = "user-already-notified";
+    const email = "alreadynotified@example.com";
+
+    // Current rate = 500, already notified at 500
+    mockFrom.mockReturnValueOnce(makeBuilder([makeSnapshot(1, "savings_account", 500)], null));
+    mockFrom.mockReturnValueOnce(makeBuilder([makeMemoryRow({
+      user_id: userId,
+      last_seen_rate_bps: 450,
+      notified_rate_bps: 500,
+    })], null));
+
+    mockListUsers.mockResolvedValue({ data: { users: [{ id: userId, email }] }, error: null });
+    mockFrom.mockReturnValueOnce(makeBuilder([{ user_id: userId, deal_alerts: true }], null));
+
+    const res = await GET(authedReq());
+    const body = await res.json();
+    expect(body.sent).toBe(0);
+  });
+
+  it("marks notified_rate_bps on user_rate_memory after successful send", async () => {
+    const userId = "user-update";
+    const email = "update@example.com";
+
+    mockFrom.mockReturnValueOnce(makeBuilder([makeSnapshot(1, "savings_account", 500)], null));
+    mockFrom.mockReturnValueOnce(makeBuilder([makeMemoryRow({ user_id: userId, last_seen_rate_bps: 450 })], null));
+    mockListUsers.mockResolvedValue({ data: { users: [{ id: userId, email }] }, error: null });
+    mockFrom.mockReturnValueOnce(makeBuilder([{ user_id: userId, deal_alerts: true }], null));
+    // update notified_rate_bps
+    mockFrom.mockReturnValue(makeBuilder(null, null));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sent).toBe(1);
+    // Verify that mockFrom was called at least 4 times (snapshots, memory, prefs, update)
+    expect(mockFrom).toHaveBeenCalledTimes(4);
+    // The 4th call should be to user_rate_memory (the update)
+    const fourthCall = mockFrom.mock.calls[3];
+    expect(fourthCall?.[0]).toBe("user_rate_memory");
+  });
+
+  it("handles sendEmail throw gracefully and does not update notified_rate_bps", async () => {
+    const userId = "user-throw";
+    const email = "throw@example.com";
+
+    mockFrom.mockReturnValueOnce(makeBuilder([makeSnapshot(1, "savings_account", 500)], null));
+    mockFrom.mockReturnValueOnce(makeBuilder([makeMemoryRow({ user_id: userId, last_seen_rate_bps: 450 })], null));
+    mockListUsers.mockResolvedValue({ data: { users: [{ id: userId, email }] }, error: null });
+    mockFrom.mockReturnValueOnce(makeBuilder([{ user_id: userId, deal_alerts: true }], null));
+
+    mockSendEmail.mockRejectedValue(new Error("network error"));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sent).toBe(0);
+    // No update to user_rate_memory (4th call should not happen)
+    expect(mockFrom).toHaveBeenCalledTimes(3);
+  });
+});

--- a/__tests__/api/cron-cpd-reminder.test.ts
+++ b/__tests__/api/cron-cpd-reminder.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+vi.mock("@/lib/html-escape", () => ({
+  escapeHtml: vi.fn((s: unknown) => String(s ?? "")),
+}));
+
+vi.mock("@/lib/url", () => ({
+  getSiteUrl: vi.fn(() => "https://invest.com.au"),
+}));
+
+vi.mock("@/lib/course-certificates", () => ({
+  cpdYearFor: vi.fn((_date: unknown) => 2026),
+}));
+
+const mockSendEmail = vi.fn(
+  async (..._args: unknown[]): Promise<{ ok: boolean; error?: string }> => ({ ok: true }),
+);
+vi.mock("@/lib/resend", () => ({
+  sendEmail: (...args: unknown[]) => mockSendEmail(...args),
+}));
+
+// ─── Supabase builder factory ─────────────────────────────────────────────────
+
+function makeBuilder(data: unknown = null, error: unknown = null) {
+  const terminal = { data, error };
+  const c: Record<string, unknown> = {
+    then: (resolve: (v: typeof terminal) => unknown) =>
+      Promise.resolve(resolve(terminal)),
+  };
+  for (const m of [
+    "select", "insert", "update", "upsert", "delete",
+    "eq", "neq", "gt", "gte", "lt", "lte", "in", "is", "not", "or",
+    "order", "limit", "range", "single", "maybeSingle", "filter",
+    "contains", "overlaps", "throwOnError",
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  return c;
+}
+
+const mockFrom = vi.fn((..._args: unknown[]) => makeBuilder());
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
+    from: (...args: unknown[]) => mockFrom(...args),
+    auth: {
+      admin: {
+        listUsers: vi.fn(
+          async (..._a: unknown[]): Promise<{ data: { users: Array<{ id: string; email?: string }> }; error: unknown }> => ({
+            data: { users: [] },
+            error: null,
+          }),
+        ),
+      },
+    },
+  })),
+}));
+
+// ─── Import after mocks ───────────────────────────────────────────────────────
+
+import { GET, runtime, maxDuration } from "@/app/api/cron/cpd-reminder/route";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const SECRET = "test-cron-secret-cpd-remind-123456";
+
+function req(headers: Record<string, string> = {}): NextRequest {
+  return new Request("http://localhost/api/cron/cpd-reminder", { headers }) as unknown as NextRequest;
+}
+
+function authedReq(): NextRequest {
+  return req({ authorization: `Bearer ${SECRET}` });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("GET /api/cron/cpd-reminder — exports", () => {
+  it("exports runtime = 'nodejs'", () => {
+    expect(runtime).toBe("nodejs");
+  });
+
+  it("exports maxDuration = 120", () => {
+    expect(maxDuration).toBe(120);
+  });
+});
+
+describe("GET /api/cron/cpd-reminder — auth guards", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = SECRET;
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("returns 500 when CRON_SECRET is not set", async () => {
+    delete process.env.CRON_SECRET;
+    const res = await GET(authedReq());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toMatch(/misconfigured/i);
+  });
+
+  it("returns 500 when CRON_SECRET is too short (< 16 chars)", async () => {
+    process.env.CRON_SECRET = "tooshort";
+    const res = await GET(authedReq());
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 401 on wrong bearer token", async () => {
+    const res = await GET(req({ authorization: "Bearer wrong-secret" }));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toMatch(/unauthorized/i);
+  });
+
+  it("returns 401 when authorization header is absent", async () => {
+    const res = await GET(req());
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /api/cron/cpd-reminder — DB error paths", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = SECRET;
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("returns 500 when cpd_credits query fails", async () => {
+    mockFrom.mockReturnValueOnce(makeBuilder(null, { message: "cpd_credits down" }));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("cpd_fetch_failed");
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when professionals query fails", async () => {
+    mockFrom.mockReturnValueOnce(makeBuilder([], null)); // cpd_credits ok
+    mockFrom.mockReturnValueOnce(makeBuilder(null, { message: "professionals down" }));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("advisor_fetch_failed");
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/cron/cpd-reminder — empty data path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = SECRET;
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("returns 200 with sent:0 when no advisors exist", async () => {
+    mockFrom.mockReturnValueOnce(makeBuilder([], null)); // cpd_credits
+    mockFrom.mockReturnValueOnce(makeBuilder([], null)); // professionals
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sent).toBe(0);
+    expect(body.skipped).toBe(0);
+    expect(body.cpd_year).toBe(2026);
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("skips advisor who has >= 30 hours (above threshold)", async () => {
+    mockFrom.mockReturnValueOnce(
+      makeBuilder([{ professional_id: 1, hours: 35 }], null),
+    ); // cpd_credits
+    mockFrom.mockReturnValueOnce(
+      makeBuilder([{ id: 1, name: "John Smith", email: "john@example.com" }], null),
+    ); // professionals
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sent).toBe(0);
+    expect(body.skipped).toBe(1);
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("skips advisor with no email", async () => {
+    mockFrom.mockReturnValueOnce(makeBuilder([], null)); // cpd_credits (no record = 0 hours)
+    mockFrom.mockReturnValueOnce(
+      makeBuilder([{ id: 2, name: "No Email", email: null }], null),
+    ); // professionals
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.skipped).toBe(1);
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/cron/cpd-reminder — success path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = SECRET;
+    mockSendEmail.mockResolvedValue({ ok: true });
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("sends email and returns sent:1 for advisor below threshold", async () => {
+    mockFrom.mockReturnValueOnce(
+      makeBuilder([{ professional_id: 10, hours: 20 }], null),
+    ); // cpd_credits: 20 hours
+    mockFrom.mockReturnValueOnce(
+      makeBuilder([{ id: 10, name: "Jane Doe", email: "jane@example.com" }], null),
+    ); // professionals
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sent).toBe(1);
+    expect(body.skipped).toBe(0);
+    expect(body.cpd_year).toBe(2026);
+
+    expect(mockSendEmail).toHaveBeenCalledOnce();
+    const callArg = mockSendEmail.mock.calls[0]?.[0] as {
+      to: string;
+      from: string;
+      subject: string;
+      html: string;
+      text: string;
+    };
+    expect(callArg.to).toBe("jane@example.com");
+    expect(callArg.from).toBe("Invest.com.au <advisors@invest.com.au>");
+    expect(callArg.subject).toContain("CPD reminder");
+    expect(callArg.subject).toContain("2026");
+    expect(callArg.html).toContain("Jane");
+    expect(callArg.text).toContain("Jane");
+  });
+
+  it("sends email when advisor has 0 hours (not in cpd_credits)", async () => {
+    mockFrom.mockReturnValueOnce(makeBuilder([], null)); // no cpd_credits rows
+    mockFrom.mockReturnValueOnce(
+      makeBuilder([{ id: 11, name: "Zero Hours", email: "zero@example.com" }], null),
+    );
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sent).toBe(1);
+
+    const callArg = mockSendEmail.mock.calls[0]?.[0] as { subject: string };
+    expect(callArg.subject).toContain("40 hours");
+  });
+
+  it("counts send failures without throwing", async () => {
+    mockSendEmail.mockResolvedValue({ ok: false, error: "Resend timeout" });
+
+    mockFrom.mockReturnValueOnce(makeBuilder([], null)); // cpd_credits
+    mockFrom.mockReturnValueOnce(
+      makeBuilder([{ id: 12, name: "Fail User", email: "fail@example.com" }], null),
+    );
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // send failed → not counted in sent, but no throw
+    expect(body.sent).toBe(0);
+    expect(mockSendEmail).toHaveBeenCalledOnce();
+  });
+
+  it("sends to multiple advisors below threshold", async () => {
+    mockFrom.mockReturnValueOnce(
+      makeBuilder(
+        [
+          { professional_id: 20, hours: 10 },
+          { professional_id: 21, hours: 5 },
+        ],
+        null,
+      ),
+    );
+    mockFrom.mockReturnValueOnce(
+      makeBuilder(
+        [
+          { id: 20, name: "Advisor A", email: "a@example.com" },
+          { id: 21, name: "Advisor B", email: "b@example.com" },
+        ],
+        null,
+      ),
+    );
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sent).toBe(2);
+    expect(mockSendEmail).toHaveBeenCalledTimes(2);
+  });
+});

--- a/__tests__/api/cron-cpd-year-renewal.test.ts
+++ b/__tests__/api/cron-cpd-year-renewal.test.ts
@@ -1,0 +1,318 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+vi.mock("@/lib/url", () => ({
+  getSiteUrl: vi.fn(() => "https://invest.com.au"),
+}));
+
+const mockCpdYearFor = vi.fn((..._a: unknown[]): number => 2026);
+vi.mock("@/lib/course-certificates", () => ({
+  cpdYearFor: (...args: unknown[]) => mockCpdYearFor(...args),
+}));
+
+const mockSendEmail = vi.fn(
+  async (..._args: unknown[]): Promise<{ ok: boolean; error?: string }> => ({ ok: true }),
+);
+vi.mock("@/lib/resend", () => ({
+  sendEmail: (...args: unknown[]) => mockSendEmail(...args),
+}));
+
+// withCronRunLog pass-through
+vi.mock("@/lib/cron-run-log", () => ({
+  withCronRunLog: vi.fn(
+    async (_name: string, fn: () => Promise<{ response: unknown; stats?: Record<string, unknown> }>) => {
+      const result = await fn();
+      return result.response;
+    },
+  ),
+}));
+
+// ─── Supabase builder factory ─────────────────────────────────────────────────
+
+function makeBuilder(data: unknown = null, error: unknown = null) {
+  const terminal = { data, error };
+  const c: Record<string, unknown> = {
+    then: (resolve: (v: typeof terminal) => unknown) =>
+      Promise.resolve(resolve(terminal)),
+  };
+  for (const m of [
+    "select", "insert", "update", "upsert", "delete",
+    "eq", "neq", "gt", "gte", "lt", "lte", "in", "is", "not", "or",
+    "order", "limit", "range", "single", "maybeSingle", "filter",
+    "contains", "overlaps", "throwOnError",
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  return c;
+}
+
+const mockFrom = vi.fn((..._args: unknown[]) => makeBuilder());
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
+    from: (...args: unknown[]) => mockFrom(...args),
+  })),
+}));
+
+// ─── Import after mocks ───────────────────────────────────────────────────────
+
+import { GET, runtime, maxDuration } from "@/app/api/cron/cpd-year-renewal/route";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const SECRET = "test-cron-secret-cpd-year-renewal12";
+
+function req(headers: Record<string, string> = {}): NextRequest {
+  return new Request("http://localhost/api/cron/cpd-year-renewal", { headers }) as unknown as NextRequest;
+}
+
+function authedReq(): NextRequest {
+  return req({ authorization: `Bearer ${SECRET}` });
+}
+
+// Fix the Date so tests see July (UTC month = 6)
+function stubJuly() {
+  vi.setSystemTime(new Date("2026-07-01T06:00:00.000Z"));
+}
+
+function stubNonJuly() {
+  vi.setSystemTime(new Date("2026-05-15T08:00:00.000Z"));
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("GET /api/cron/cpd-year-renewal — exports", () => {
+  it("exports runtime = 'nodejs'", () => {
+    expect(runtime).toBe("nodejs");
+  });
+
+  it("exports maxDuration = 120", () => {
+    expect(maxDuration).toBe(120);
+  });
+});
+
+describe("GET /api/cron/cpd-year-renewal — auth guards", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = SECRET;
+    vi.useFakeTimers();
+    stubJuly();
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+    vi.useRealTimers();
+  });
+
+  it("returns 500 when CRON_SECRET is not set", async () => {
+    delete process.env.CRON_SECRET;
+    const res = await GET(authedReq());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toMatch(/misconfigured/i);
+  });
+
+  it("returns 500 when CRON_SECRET is too short", async () => {
+    process.env.CRON_SECRET = "tooshort";
+    const res = await GET(authedReq());
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 401 on wrong bearer token", async () => {
+    const res = await GET(req({ authorization: "Bearer bad-token" }));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toMatch(/unauthorized/i);
+  });
+
+  it("returns 401 when authorization header is absent", async () => {
+    const res = await GET(req());
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /api/cron/cpd-year-renewal — skip non-July path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = SECRET;
+    vi.useFakeTimers();
+    stubNonJuly();
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+    vi.useRealTimers();
+  });
+
+  it("returns 200 with skipped:true when not July", async () => {
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.skipped).toBe(true);
+    expect(body.reason).toMatch(/not july/i);
+    expect(mockSendEmail).not.toHaveBeenCalled();
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/cron/cpd-year-renewal — DB error paths (July)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = SECRET;
+    vi.useFakeTimers();
+    stubJuly();
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+    vi.useRealTimers();
+  });
+
+  it("returns 500 when advisor_badges query fails", async () => {
+    mockFrom.mockReturnValueOnce(makeBuilder(null, { message: "badges table down" }));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("fetch_failed");
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when professionals query fails", async () => {
+    mockFrom.mockReturnValueOnce(
+      makeBuilder([{ professional_id: 1 }], null),
+    ); // advisor_badges ok
+    mockFrom.mockReturnValueOnce(makeBuilder(null, { message: "professionals down" }));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("fetch_failed");
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/cron/cpd-year-renewal — empty data path (July)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = SECRET;
+    vi.useFakeTimers();
+    stubJuly();
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+    vi.useRealTimers();
+  });
+
+  it("returns 200 with sent:0 when no badges exist", async () => {
+    mockFrom.mockReturnValueOnce(makeBuilder([], null)); // advisor_badges: empty
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.sent).toBe(0);
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 with sent:0 when badge holders have no active email", async () => {
+    mockFrom.mockReturnValueOnce(
+      makeBuilder([{ professional_id: 100 }], null),
+    ); // advisor_badges
+    mockFrom.mockReturnValueOnce(makeBuilder([], null)); // professionals (no active advisors with email)
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.sent).toBe(0);
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/cron/cpd-year-renewal — success path (July)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = SECRET;
+    vi.useFakeTimers();
+    stubJuly();
+    mockSendEmail.mockResolvedValue({ ok: true });
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+    vi.useRealTimers();
+  });
+
+  it("sends renewal email and returns sent:1", async () => {
+    mockFrom.mockReturnValueOnce(
+      makeBuilder([{ professional_id: 5 }], null),
+    ); // advisor_badges
+    mockFrom.mockReturnValueOnce(
+      makeBuilder(
+        [{ id: 5, name: "Alice Smith", email: "alice@example.com" }],
+        null,
+      ),
+    ); // professionals
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.sent).toBe(1);
+
+    expect(mockSendEmail).toHaveBeenCalledOnce();
+    const callArg = mockSendEmail.mock.calls[0]?.[0] as {
+      to: string;
+      subject: string;
+      html: string;
+    };
+    expect(callArg.to).toBe("alice@example.com");
+    expect(callArg.subject).toContain("CPD year");
+    expect(callArg.html).toContain("Alice");
+  });
+
+  it("still counts sent even when sendEmail throws (caught per-advisor)", async () => {
+    mockSendEmail.mockRejectedValue(new Error("Send error"));
+
+    mockFrom.mockReturnValueOnce(
+      makeBuilder([{ professional_id: 6 }], null),
+    ); // advisor_badges
+    mockFrom.mockReturnValueOnce(
+      makeBuilder(
+        [{ id: 6, name: "Bob Jones", email: "bob@example.com" }],
+        null,
+      ),
+    ); // professionals
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // error was caught per-advisor — sent stays 0 but no 500
+    expect(body.success).toBe(true);
+    expect(body.sent).toBe(0);
+  });
+
+  it("deduplicates badge rows for same professional_id", async () => {
+    // Two badge rows for the same professional
+    mockFrom.mockReturnValueOnce(
+      makeBuilder(
+        [{ professional_id: 7 }, { professional_id: 7 }],
+        null,
+      ),
+    ); // advisor_badges
+    mockFrom.mockReturnValueOnce(
+      makeBuilder(
+        [{ id: 7, name: "Carol Lee", email: "carol@example.com" }],
+        null,
+      ),
+    ); // professionals — only 1 advisor row
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    // Only 1 email should be sent (dedup via Set)
+    expect(mockSendEmail).toHaveBeenCalledOnce();
+  });
+});

--- a/__tests__/api/cron-dispatch.test.ts
+++ b/__tests__/api/cron-dispatch.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NextRequest } from "next/server";
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+vi.mock("@/lib/cron-auth", () => ({
+  requireCronAuth: vi.fn(() => null),
+}));
+
+vi.mock("@/lib/cron-groups", () => ({
+  CRON_GROUPS: {
+    "daily-0": ["/api/cron/heartbeat", "/api/cron/cleanup"],
+    "hourly-0": ["/api/cron/cron-health-alert"],
+  },
+}));
+
+// Queue of { data, error } results for supabase calls
+const dbQueue: Array<{ data?: unknown; error?: { message: string } | null }> = [];
+let dbIdx = 0;
+
+function makeChain(result: { data?: unknown; error?: { message: string } | null }) {
+  const chain: Record<string, unknown> = {};
+  for (const m of ["select", "insert", "update", "eq", "single"]) {
+    chain[m] = vi.fn(() => chain);
+  }
+  chain.then = (resolve: (v: { data: unknown; error: unknown }) => unknown) =>
+    Promise.resolve(resolve({ data: result.data ?? null, error: result.error ?? null }));
+  chain.catch = () => chain;
+  return chain;
+}
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
+    from: vi.fn(() => makeChain(dbQueue[dbIdx++] ?? { data: null, error: null })),
+  })),
+}));
+
+import { GET } from "@/app/api/cron/dispatch/[group]/route";
+import { requireCronAuth } from "@/lib/cron-auth";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function makeReq(group: string): [NextRequest, { params: Promise<{ group: string }> }] {
+  const req = new Request(`http://localhost/api/cron/dispatch/${group}`) as unknown as NextRequest;
+  const params = Promise.resolve({ group });
+  return [req, { params }];
+}
+
+function ok200() {
+  return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+}
+function err500() {
+  return Promise.resolve(new Response(JSON.stringify({ ok: false }), { status: 500 }));
+}
+
+beforeEach(() => {
+  dbQueue.length = 0;
+  dbIdx = 0;
+  mockFetch.mockReset();
+  vi.mocked(requireCronAuth).mockReturnValue(null);
+});
+
+describe("GET /api/cron/dispatch/[group]", () => {
+  it("returns 401 when auth fails", async () => {
+    vi.mocked(requireCronAuth).mockReturnValueOnce(
+      new Response(null, { status: 401 }) as unknown as ReturnType<typeof requireCronAuth>,
+    );
+    const [req, ctx] = makeReq("daily-0");
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 for unknown group", async () => {
+    // diagnostic insert
+    dbQueue.push({ data: { id: 1 }, error: null });
+    const [req, ctx] = makeReq("unknown-group");
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toMatch(/unknown cron group/i);
+  });
+
+  it("returns 200 with ok:true when all handlers succeed", async () => {
+    // diagnostic insert + 2 handlers × 2 db calls each (insert + update)
+    dbQueue.push({ data: { id: 99 }, error: null }); // diagnostic
+    dbQueue.push({ data: { id: 1 }, error: null });   // handler 1 insert
+    dbQueue.push({ data: null, error: null });          // handler 1 update
+    dbQueue.push({ data: { id: 2 }, error: null });   // handler 2 insert
+    dbQueue.push({ data: null, error: null });          // handler 2 update
+    mockFetch.mockResolvedValue(ok200());
+    const [req, ctx] = makeReq("daily-0");
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.group).toBe("daily-0");
+    expect(body.total).toBe(2);
+    expect(body.failed).toBe(0);
+  });
+
+  it("returns 207 when one handler returns 500", async () => {
+    dbQueue.push({ data: { id: 99 }, error: null }); // diagnostic
+    dbQueue.push({ data: { id: 1 }, error: null });   // handler 1 insert
+    dbQueue.push({ data: null, error: null });          // handler 1 update
+    dbQueue.push({ data: { id: 2 }, error: null });   // handler 2 insert
+    dbQueue.push({ data: null, error: null });          // handler 2 update
+    mockFetch
+      .mockResolvedValueOnce(ok200())
+      .mockResolvedValueOnce(err500());
+    const [req, ctx] = makeReq("daily-0");
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(207);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.failed).toBe(1);
+  });
+
+  it("marks handler as failed when fetch throws (status 0)", async () => {
+    dbQueue.push({ data: { id: 99 }, error: null });
+    dbQueue.push({ data: { id: 1 }, error: null });
+    dbQueue.push({ data: null, error: null });
+    mockFetch.mockRejectedValue(new Error("ECONNREFUSED"));
+    const [req, ctx] = makeReq("hourly-0");
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(207);
+    const body = await res.json();
+    expect(body.failed).toBe(1);
+    expect(body.results[0].ok).toBe(false);
+  });
+
+  it("continues if diagnostic cron_run_log insert fails", async () => {
+    dbQueue.push({ data: null, error: { message: "constraint" } }); // diag fails
+    dbQueue.push({ data: { id: 1 }, error: null });
+    dbQueue.push({ data: null, error: null });
+    mockFetch.mockResolvedValue(ok200());
+    const [req, ctx] = makeReq("hourly-0");
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(200);
+  });
+
+  it("includes path and timing in results", async () => {
+    dbQueue.push({ data: { id: 99 }, error: null });
+    dbQueue.push({ data: { id: 1 }, error: null });
+    dbQueue.push({ data: null, error: null });
+    mockFetch.mockResolvedValue(ok200());
+    const [req, ctx] = makeReq("hourly-0");
+    const res = await GET(req, ctx);
+    const body = await res.json();
+    expect(body.results[0].path).toBe("/api/cron/cron-health-alert");
+    expect(typeof body.results[0].durationMs).toBe("number");
+  });
+});

--- a/__tests__/api/cron-life-event-wizard-nudge.test.ts
+++ b/__tests__/api/cron-life-event-wizard-nudge.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+vi.mock("@/lib/html-escape", () => ({
+  escapeHtml: vi.fn((s: unknown) => String(s ?? "")),
+}));
+
+const mockSendEmail = vi.fn(
+  async (..._args: unknown[]): Promise<{ ok: boolean; error?: string }> => ({ ok: true }),
+);
+vi.mock("@/lib/resend", () => ({
+  sendEmail: (...args: unknown[]) => mockSendEmail(...args),
+}));
+
+vi.mock("@/lib/cron-run-log", () => ({
+  withCronRunLog: vi.fn(
+    async (_name: string, fn: () => Promise<{ response: unknown }>) => {
+      const result = await fn();
+      return result.response;
+    },
+  ),
+}));
+
+// Use real LIFE_EVENTS and checklist so we can construct valid wizard rows
+// (these are pure data, no side effects).
+vi.mock("@/lib/life-events", async (importOriginal) => {
+  return await importOriginal<typeof import("@/lib/life-events")>();
+});
+
+vi.mock("@/lib/life-event-checklist", async (importOriginal) => {
+  return await importOriginal<typeof import("@/lib/life-event-checklist")>();
+});
+
+// ─── Supabase builder factory ─────────────────────────────────────────────────
+
+function makeBuilder(data: unknown = null, error: unknown = null) {
+  const terminal = { data, error };
+  const c: Record<string, unknown> = {
+    then: (resolve: (v: typeof terminal) => unknown) =>
+      Promise.resolve(resolve(terminal)),
+  };
+  for (const m of [
+    "select", "insert", "update", "upsert", "delete",
+    "eq", "neq", "gt", "gte", "lt", "lte", "in", "is", "not", "or",
+    "order", "limit", "range", "single", "maybeSingle", "filter",
+    "contains", "overlaps", "throwOnError",
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  return c;
+}
+
+const mockFrom = vi.fn((..._args: unknown[]) => makeBuilder());
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
+    from: (...args: unknown[]) => mockFrom(...args),
+    auth: { admin: { listUsers: vi.fn(async (..._a: unknown[]) => ({ data: { users: [] }, error: null })) } },
+  })),
+}));
+
+// ─── Import after mocks ───────────────────────────────────────────────────────
+
+import { GET, runtime, maxDuration } from "@/app/api/cron/life-event-wizard-nudge/route";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const SECRET = "test-cron-secret-life-event-12345";
+
+function req(headers: Record<string, string> = {}): NextRequest {
+  return new Request("http://localhost/api/cron/life-event-wizard-nudge", {
+    headers,
+  }) as unknown as NextRequest;
+}
+
+function authedReq(): NextRequest {
+  return req({ authorization: `Bearer ${SECRET}` });
+}
+
+/** Create a wizard row with partial progress for buying_first_home (has 6 steps; done 2) */
+function makeWizardRow(overrides: Record<string, unknown> = {}) {
+  return {
+    user_id: "user-001",
+    life_event_id: "buying_first_home",
+    step: 2,
+    // Only first step done — partial progress
+    form_data: { completed: ["check_eligibility"] },
+    updated_at: new Date(Date.now() - 8 * 86_400_000).toISOString(), // 8 days ago
+    ...overrides,
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("GET /api/cron/life-event-wizard-nudge — exports", () => {
+  it("exports runtime = 'nodejs'", () => {
+    expect(runtime).toBe("nodejs");
+  });
+
+  it("exports maxDuration = 60", () => {
+    expect(maxDuration).toBe(60);
+  });
+});
+
+describe("GET /api/cron/life-event-wizard-nudge — auth guards", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.CRON_SECRET = SECRET;
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("returns 500 when CRON_SECRET is not set", async () => {
+    delete process.env.CRON_SECRET;
+    const res = await GET(authedReq());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toMatch(/misconfigured/i);
+  });
+
+  it("returns 401 on wrong bearer token", async () => {
+    const res = await GET(req({ authorization: "Bearer wrong" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when authorization header is absent", async () => {
+    const res = await GET(req());
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /api/cron/life-event-wizard-nudge — DB error path", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.CRON_SECRET = SECRET;
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("returns 500 when life_event_wizard_state query fails", async () => {
+    mockFrom.mockReturnValueOnce(makeBuilder(null, { message: "DB error" }));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("fetch_failed");
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/cron/life-event-wizard-nudge — empty data paths", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.CRON_SECRET = SECRET;
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("returns 200 with no-wizard message when no stale wizards", async () => {
+    mockFrom.mockReturnValueOnce(makeBuilder([], null));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sent).toBe(0);
+    expect(body.message).toMatch(/no stale/i);
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 with sent:0 when rows have no partial progress (completed all steps)", async () => {
+    // buying_first_home has 6 steps; mark all done
+    const allSteps = ["check_eligibility", "budget", "pre_approval", "find_broker", "conveyancer", "building_inspection"];
+    const row = makeWizardRow({ form_data: { completed: allSteps } });
+    mockFrom.mockReturnValueOnce(makeBuilder([row], null));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sent).toBe(0);
+    expect(body.message).toMatch(/no stale/i);
+  });
+
+  it("returns 200 with sent:0 when rows have no progress at all (done=0)", async () => {
+    const row = makeWizardRow({ form_data: { completed: [] } });
+    mockFrom.mockReturnValueOnce(makeBuilder([row], null));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // done=0 → filtered out (not partial)
+    expect(body.sent).toBe(0);
+  });
+});
+
+describe("GET /api/cron/life-event-wizard-nudge — success path", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.CRON_SECRET = SECRET;
+    mockSendEmail.mockResolvedValue({ ok: true });
+    mockFrom.mockImplementation((..._args: unknown[]) => makeBuilder());
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("sends nudge email for partial-progress wizard", async () => {
+    const userId = "user-partial";
+    const email = "partial@example.com";
+    const row = makeWizardRow({ user_id: userId });
+
+    // life_event_wizard_state
+    mockFrom.mockReturnValueOnce(makeBuilder([row], null));
+    // auth.users
+    mockFrom.mockReturnValueOnce(makeBuilder([{ id: userId, email }], null));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sent).toBe(1);
+    expect(body.skipped).toBe(0);
+
+    expect(mockSendEmail).toHaveBeenCalledOnce();
+    const callArg = mockSendEmail.mock.calls[0]?.[0] as {
+      to: string;
+      from: string;
+      subject: string;
+      html: string;
+    };
+    expect(callArg.to).toBe(email);
+    expect(callArg.from).toContain("reminders@invest.com.au");
+    expect(callArg.subject).toMatch(/checklist/i);
+    expect(callArg.html).toContain("Buying My First Home");
+    expect(callArg.html).toContain("1 of 6 steps");
+  });
+
+  it("groups multiple wizards per user into a single email", async () => {
+    const userId = "user-multi";
+    const email = "multi@example.com";
+    const row1 = makeWizardRow({ user_id: userId, life_event_id: "buying_first_home" });
+    const row2 = makeWizardRow({
+      user_id: userId,
+      life_event_id: "getting_married",
+      form_data: { completed: ["combine_finances"] },
+    });
+
+    mockFrom.mockReturnValueOnce(makeBuilder([row1, row2], null));
+    mockFrom.mockReturnValueOnce(makeBuilder([{ id: userId, email }], null));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sent).toBe(1); // one email for two wizards
+    expect(mockSendEmail).toHaveBeenCalledOnce();
+
+    const callArg = mockSendEmail.mock.calls[0]?.[0] as { subject: string; html: string };
+    expect(callArg.subject).toMatch(/2 in-progress/i);
+  });
+
+  it("skips user with no email and increments skipped", async () => {
+    const userId = "user-noemail";
+    const row = makeWizardRow({ user_id: userId });
+
+    mockFrom.mockReturnValueOnce(makeBuilder([row], null));
+    mockFrom.mockReturnValueOnce(makeBuilder([], null)); // no user rows
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sent).toBe(0);
+    expect(body.skipped).toBe(1);
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("handles send failure gracefully (continues, does not count sent)", async () => {
+    const userId = "user-sendfail";
+    const email = "fail@example.com";
+    const row = makeWizardRow({ user_id: userId });
+
+    mockFrom.mockReturnValueOnce(makeBuilder([row], null));
+    mockFrom.mockReturnValueOnce(makeBuilder([{ id: userId, email }], null));
+
+    mockSendEmail.mockResolvedValue({ ok: false, error: "Resend timeout" });
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sent).toBe(0);
+  });
+
+  it("uses singular subject line for single wizard", async () => {
+    const userId = "user-single";
+    const email = "single@example.com";
+    const row = makeWizardRow({ user_id: userId });
+
+    mockFrom.mockReturnValueOnce(makeBuilder([row], null));
+    mockFrom.mockReturnValueOnce(makeBuilder([{ id: userId, email }], null));
+
+    await GET(authedReq());
+    const callArg = mockSendEmail.mock.calls[0]?.[0] as { subject: string };
+    expect(callArg.subject).toMatch(/checklist is waiting/i);
+    expect(callArg.subject).not.toMatch(/checklists/i);
+  });
+});

--- a/__tests__/api/cron-market-event-reminders.test.ts
+++ b/__tests__/api/cron-market-event-reminders.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+vi.mock("@/lib/seo", () => ({
+  SITE_URL: "https://invest.com.au",
+}));
+
+// withCronRunLog pass-through
+vi.mock("@/lib/cron-run-log", () => ({
+  withCronRunLog: vi.fn(
+    async (_name: string, fn: () => Promise<{ response: unknown; stats?: Record<string, unknown> }>) => {
+      const result = await fn();
+      return result.response;
+    },
+  ),
+}));
+
+// ─── Supabase builder factory ─────────────────────────────────────────────────
+
+function makeBuilder(data: unknown = null, error: unknown = null) {
+  const terminal = { data, error };
+  const c: Record<string, unknown> = {
+    then: (resolve: (v: typeof terminal) => unknown) =>
+      Promise.resolve(resolve(terminal)),
+  };
+  for (const m of [
+    "select", "insert", "update", "upsert", "delete",
+    "eq", "neq", "gt", "gte", "lt", "lte", "in", "is", "not", "or",
+    "order", "limit", "range", "single", "maybeSingle", "filter",
+    "contains", "overlaps", "throwOnError",
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  return c;
+}
+
+const mockFrom = vi.fn((..._args: unknown[]) => makeBuilder());
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
+    from: (...args: unknown[]) => mockFrom(...args),
+  })),
+}));
+
+// ─── Import after mocks ───────────────────────────────────────────────────────
+
+import { GET, runtime, maxDuration } from "@/app/api/cron/market-event-reminders/route";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const SECRET = "test-cron-secret-market-events-123";
+
+function req(headers: Record<string, string> = {}): NextRequest {
+  return new Request("http://localhost/api/cron/market-event-reminders", { headers }) as unknown as NextRequest;
+}
+
+function authedReq(): NextRequest {
+  return req({ authorization: `Bearer ${SECRET}` });
+}
+
+const SAMPLE_EVENT = {
+  id: 1,
+  event_date: "2026-05-30",
+  event_type: "rba",
+  title: "RBA Rate Decision",
+  description: "Reserve Bank of Australia announces cash rate decision for May.",
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("GET /api/cron/market-event-reminders — exports", () => {
+  it("exports runtime = 'nodejs'", () => {
+    expect(runtime).toBe("nodejs");
+  });
+
+  it("exports maxDuration = 30", () => {
+    expect(maxDuration).toBe(30);
+  });
+});
+
+describe("GET /api/cron/market-event-reminders — auth guards", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = SECRET;
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("returns 500 when CRON_SECRET is not set", async () => {
+    delete process.env.CRON_SECRET;
+    const res = await GET(authedReq());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toMatch(/misconfigured/i);
+  });
+
+  it("returns 500 when CRON_SECRET is too short", async () => {
+    process.env.CRON_SECRET = "tiny";
+    const res = await GET(authedReq());
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 401 on wrong bearer token", async () => {
+    const res = await GET(req({ authorization: "Bearer wrong" }));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toMatch(/unauthorized/i);
+  });
+
+  it("returns 401 when authorization header is absent", async () => {
+    const res = await GET(req());
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /api/cron/market-event-reminders — DB error path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = SECRET;
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("returns 500 when market_events query fails", async () => {
+    mockFrom.mockReturnValueOnce(makeBuilder(null, { message: "db timeout" }));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("fetch_failed");
+  });
+});
+
+describe("GET /api/cron/market-event-reminders — empty data path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = SECRET;
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("returns 200 with pushed:0 when no events tomorrow", async () => {
+    mockFrom.mockReturnValueOnce(makeBuilder([], null));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.pushed).toBe(0);
+    expect(body.events).toBe(0);
+  });
+});
+
+describe("GET /api/cron/market-event-reminders — push paths", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = SECRET;
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+    delete process.env.ADMIN_API_KEY;
+  });
+
+  it("returns pushed:0 when ADMIN_API_KEY is not set (sendPush returns false)", async () => {
+    delete process.env.ADMIN_API_KEY;
+    mockFrom.mockReturnValueOnce(makeBuilder([SAMPLE_EVENT], null));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.events).toBe(1);
+    expect(body.pushed).toBe(0);
+  });
+
+  it("returns pushed:1 when fetch succeeds for the event", async () => {
+    process.env.ADMIN_API_KEY = "test-admin-key";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async (..._args: unknown[]): Promise<{ ok: boolean }> => ({ ok: true }),
+      ),
+    );
+
+    mockFrom.mockReturnValueOnce(makeBuilder([SAMPLE_EVENT], null));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.pushed).toBe(1);
+    expect(body.events).toBe(1);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("returns pushed:0 when fetch fails for the event", async () => {
+    process.env.ADMIN_API_KEY = "test-admin-key";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async (..._args: unknown[]): Promise<{ ok: boolean }> => ({ ok: false }),
+      ),
+    );
+
+    mockFrom.mockReturnValueOnce(makeBuilder([SAMPLE_EVENT], null));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.pushed).toBe(0);
+    expect(body.events).toBe(1);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("returns pushed:0 when fetch throws (network error)", async () => {
+    process.env.ADMIN_API_KEY = "test-admin-key";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (..._args: unknown[]): Promise<never> => {
+        throw new Error("network error");
+      }),
+    );
+
+    mockFrom.mockReturnValueOnce(makeBuilder([SAMPLE_EVENT], null));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.pushed).toBe(0);
+    expect(body.events).toBe(1);
+
+    vi.unstubAllGlobals();
+  });
+
+  it("handles multiple events and counts each push result independently", async () => {
+    process.env.ADMIN_API_KEY = "test-admin-key";
+    let callCount = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (..._args: unknown[]): Promise<{ ok: boolean }> => {
+        callCount++;
+        // First event succeeds, second fails
+        return { ok: callCount === 1 };
+      }),
+    );
+
+    const event2 = { ...SAMPLE_EVENT, id: 2, event_type: "asx", title: "ASX Earnings" };
+    mockFrom.mockReturnValueOnce(makeBuilder([SAMPLE_EVENT, event2], null));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.events).toBe(2);
+    expect(body.pushed).toBe(1);
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/__tests__/api/cron-office-hours-reminders.test.ts
+++ b/__tests__/api/cron-office-hours-reminders.test.ts
@@ -1,0 +1,328 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+vi.mock("@/lib/html-escape", () => ({
+  escapeHtml: vi.fn((s: unknown) => String(s ?? "")),
+}));
+
+const mockSendEmail = vi.fn(
+  async (..._args: unknown[]): Promise<{ ok: boolean; error?: string }> => ({ ok: true }),
+);
+vi.mock("@/lib/resend", () => ({
+  sendEmail: (...args: unknown[]) => mockSendEmail(...args),
+}));
+
+vi.mock("@/lib/cron-run-log", () => ({
+  withCronRunLog: vi.fn(
+    async (_name: string, fn: () => Promise<{ response: unknown }>) => {
+      const result = await fn();
+      return result.response;
+    },
+  ),
+}));
+
+// ─── Supabase builder factory ─────────────────────────────────────────────────
+
+function makeBuilder(data: unknown = null, error: unknown = null) {
+  const terminal = { data, error };
+  const c: Record<string, unknown> = {
+    then: (resolve: (v: typeof terminal) => unknown) =>
+      Promise.resolve(resolve(terminal)),
+  };
+  for (const m of [
+    "select", "insert", "update", "upsert", "delete",
+    "eq", "neq", "gt", "gte", "lt", "lte", "in", "is", "not", "or",
+    "order", "limit", "range", "single", "maybeSingle", "filter",
+    "contains", "overlaps", "throwOnError",
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  return c;
+}
+
+const mockFrom = vi.fn((..._args: unknown[]) => makeBuilder());
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
+    from: (...args: unknown[]) => mockFrom(...args),
+    auth: { admin: { listUsers: vi.fn(async (..._a: unknown[]) => ({ data: { users: [] }, error: null })) } },
+  })),
+}));
+
+// ─── Import after mocks ───────────────────────────────────────────────────────
+
+import { GET, runtime, maxDuration } from "@/app/api/cron/office-hours-reminders/route";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const SECRET = "test-cron-secret-officehrs-12345";
+
+function req(headers: Record<string, string> = {}): NextRequest {
+  return new Request("http://localhost/api/cron/office-hours-reminders", {
+    headers,
+  }) as unknown as NextRequest;
+}
+
+function authedReq(): NextRequest {
+  return req({ authorization: `Bearer ${SECRET}` });
+}
+
+const tomorrowIso = new Date(Date.now() + 86_400_000).toISOString();
+
+function makeSession(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    title: "Investing Basics Q&A",
+    description: "Ask anything about investing.",
+    scheduled_at: tomorrowIso,
+    professionals: { name: "Alice Advisor", slug: "alice-advisor" },
+    ...overrides,
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("GET /api/cron/office-hours-reminders — exports", () => {
+  it("exports runtime = 'nodejs'", () => {
+    expect(runtime).toBe("nodejs");
+  });
+
+  it("exports maxDuration = 60", () => {
+    expect(maxDuration).toBe(60);
+  });
+});
+
+describe("GET /api/cron/office-hours-reminders — auth guards", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.CRON_SECRET = SECRET;
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("returns 500 when CRON_SECRET is not set", async () => {
+    delete process.env.CRON_SECRET;
+    const res = await GET(authedReq());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toMatch(/misconfigured/i);
+  });
+
+  it("returns 401 on wrong bearer token", async () => {
+    const res = await GET(req({ authorization: "Bearer wrong" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when authorization header is absent", async () => {
+    const res = await GET(req());
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /api/cron/office-hours-reminders — DB error path", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.CRON_SECRET = SECRET;
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("returns 500 when advisor_office_hours fetch fails", async () => {
+    mockFrom.mockReturnValueOnce(makeBuilder(null, { message: "DB error" }));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("fetch_failed");
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/cron/office-hours-reminders — empty data paths", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.CRON_SECRET = SECRET;
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("returns 200 with no sessions message when no sessions starting tomorrow", async () => {
+    mockFrom.mockReturnValueOnce(makeBuilder([], null));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sent).toBe(0);
+    expect(body.message).toMatch(/no sessions/i);
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 when sessions exist but all RSVPs already reminded", async () => {
+    mockFrom.mockReturnValueOnce(makeBuilder([makeSession()], null));
+    // rsvps with reminded_at IS NULL → empty (all already reminded)
+    mockFrom.mockReturnValueOnce(makeBuilder([], null));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sent).toBe(0);
+    expect(body.message).toMatch(/already reminded/i);
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/cron/office-hours-reminders — success path", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.CRON_SECRET = SECRET;
+    mockSendEmail.mockResolvedValue({ ok: true });
+    mockFrom.mockImplementation((..._args: unknown[]) => makeBuilder());
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("sends reminder email and marks reminded_at for the RSVP", async () => {
+    const userId = "user-rsvp-001";
+    const email = "rsvpuser@example.com";
+    const session = makeSession({ id: 42 });
+
+    // advisor_office_hours
+    mockFrom.mockReturnValueOnce(makeBuilder([session], null));
+    // office_hour_rsvps (not yet reminded)
+    mockFrom.mockReturnValueOnce(makeBuilder([{ user_id: userId, session_id: 42, reminded_at: null }], null));
+    // auth.users
+    mockFrom.mockReturnValueOnce(makeBuilder([{ id: userId, email }], null));
+    // update reminded_at
+    mockFrom.mockReturnValueOnce(makeBuilder(null, null));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sent).toBe(1);
+    expect(body.skipped).toBe(0);
+
+    expect(mockSendEmail).toHaveBeenCalledOnce();
+    const callArg = mockSendEmail.mock.calls[0]?.[0] as {
+      to: string;
+      subject: string;
+      html: string;
+      from: string;
+    };
+    expect(callArg.to).toBe(email);
+    expect(callArg.from).toContain("reminders@invest.com.au");
+    expect(callArg.subject).toMatch(/tomorrow/i);
+    expect(callArg.html).toContain("Investing Basics Q&amp;A");
+    expect(callArg.html).toContain("Alice Advisor");
+  });
+
+  it("skips RSVPs with no matching user email", async () => {
+    const userId = "user-noemail";
+    const session = makeSession({ id: 43 });
+
+    mockFrom.mockReturnValueOnce(makeBuilder([session], null));
+    mockFrom.mockReturnValueOnce(makeBuilder([{ user_id: userId, session_id: 43, reminded_at: null }], null));
+    // no user rows
+    mockFrom.mockReturnValueOnce(makeBuilder([], null));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sent).toBe(0);
+    expect(body.skipped).toBe(1);
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("skips RSVP when session has no professional (advisor)", async () => {
+    const userId = "user-noadvisor";
+    const email = "noadvisor@example.com";
+    const session = makeSession({ id: 44, professionals: null });
+
+    mockFrom.mockReturnValueOnce(makeBuilder([session], null));
+    mockFrom.mockReturnValueOnce(makeBuilder([{ user_id: userId, session_id: 44, reminded_at: null }], null));
+    mockFrom.mockReturnValueOnce(makeBuilder([{ id: userId, email }], null));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sent).toBe(0);
+    expect(body.skipped).toBe(1);
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("handles array-shaped professionals field by using first element", async () => {
+    const userId = "user-arraypros";
+    const email = "arraypros@example.com";
+    const session = makeSession({
+      id: 45,
+      professionals: [{ name: "Bob Broker", slug: "bob-broker" }, { name: "Carol CFP", slug: "carol-cfp" }],
+    });
+
+    mockFrom.mockReturnValueOnce(makeBuilder([session], null));
+    mockFrom.mockReturnValueOnce(makeBuilder([{ user_id: userId, session_id: 45, reminded_at: null }], null));
+    mockFrom.mockReturnValueOnce(makeBuilder([{ id: userId, email }], null));
+    mockFrom.mockReturnValueOnce(makeBuilder(null, null));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sent).toBe(1);
+
+    const callArg = mockSendEmail.mock.calls[0]?.[0] as { html: string };
+    expect(callArg.html).toContain("Bob Broker");
+  });
+
+  it("counts sends correctly across multiple sessions with RSVPs", async () => {
+    const u1 = "user-s1";
+    const u2 = "user-s2";
+    const s1 = makeSession({ id: 101 });
+    const s2 = makeSession({ id: 102, title: "Advanced ETF Q&A" });
+
+    mockFrom.mockReturnValueOnce(makeBuilder([s1, s2], null));
+    mockFrom.mockReturnValueOnce(makeBuilder([
+      { user_id: u1, session_id: 101, reminded_at: null },
+      { user_id: u2, session_id: 102, reminded_at: null },
+    ], null));
+    mockFrom.mockReturnValueOnce(makeBuilder([
+      { id: u1, email: "s1user@example.com" },
+      { id: u2, email: "s2user@example.com" },
+    ], null));
+    // Two update calls for reminded_at
+    mockFrom.mockReturnValue(makeBuilder(null, null));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sent).toBe(2);
+    expect(mockSendEmail).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not mark reminded_at when send fails", async () => {
+    const userId = "user-sendfail";
+    const email = "sendfail@example.com";
+    const session = makeSession({ id: 50 });
+
+    mockFrom.mockReturnValueOnce(makeBuilder([session], null));
+    mockFrom.mockReturnValueOnce(makeBuilder([{ user_id: userId, session_id: 50, reminded_at: null }], null));
+    mockFrom.mockReturnValueOnce(makeBuilder([{ id: userId, email }], null));
+
+    mockSendEmail.mockResolvedValue({ ok: false, error: "SMTP timeout" });
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sent).toBe(0);
+    // No update call for reminded_at should have happened
+    // (3 mockFrom calls consumed: sessions, rsvps, users — no 4th)
+    expect(mockFrom).toHaveBeenCalledTimes(3);
+  });
+});

--- a/__tests__/api/cron-rate-change-digest.test.ts
+++ b/__tests__/api/cron-rate-change-digest.test.ts
@@ -1,0 +1,340 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+vi.mock("@/lib/cron-run-log", () => ({
+  withCronRunLog: vi.fn(
+    async (_name: string, fn: () => Promise<{ response: unknown }>) => {
+      const result = await fn();
+      return result.response;
+    },
+  ),
+}));
+
+// ─── Supabase builder factory ─────────────────────────────────────────────────
+
+function makeBuilder(data: unknown = null, error: unknown = null) {
+  const terminal = { data, error, count: null };
+  const c: Record<string, unknown> = {
+    then: (resolve: (v: typeof terminal) => unknown) =>
+      Promise.resolve(resolve(terminal)),
+  };
+  for (const m of [
+    "select", "insert", "update", "upsert", "delete",
+    "eq", "neq", "gt", "gte", "lt", "lte", "in", "is", "not", "or",
+    "order", "limit", "range", "single", "maybeSingle", "filter",
+    "contains", "overlaps", "throwOnError",
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  return c;
+}
+
+const mockFrom = vi.fn((..._args: unknown[]) => makeBuilder());
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
+    from: (...args: unknown[]) => mockFrom(...args),
+    auth: { admin: { listUsers: vi.fn(async (..._a: unknown[]) => ({ data: { users: [] }, error: null })) } },
+  })),
+}));
+
+// ─── Import after mocks ───────────────────────────────────────────────────────
+
+import { GET, runtime, maxDuration } from "@/app/api/cron/rate-change-digest/route";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const SECRET = "test-cron-secret-ratechange-12345";
+
+function req(headers: Record<string, string> = {}): NextRequest {
+  return new Request("http://localhost/api/cron/rate-change-digest", {
+    headers,
+  }) as unknown as NextRequest;
+}
+
+function authedReq(): NextRequest {
+  return req({ authorization: `Bearer ${SECRET}` });
+}
+
+function makeBatchRow(capturedAt: string) {
+  return { captured_at: capturedAt };
+}
+
+function makeSnapshotRow(brokerId: number, productKind: string, rateBps: number, capturedAt: string, brokerSlug = "ing", brokerName = "ING") {
+  return {
+    broker_id: brokerId,
+    product_kind: productKind,
+    rate_bps: rateBps,
+    captured_at: capturedAt,
+    brokers: { slug: brokerSlug, name: brokerName },
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("GET /api/cron/rate-change-digest — exports", () => {
+  it("exports runtime = 'nodejs'", () => {
+    expect(runtime).toBe("nodejs");
+  });
+
+  it("exports maxDuration = 60", () => {
+    expect(maxDuration).toBe(60);
+  });
+});
+
+describe("GET /api/cron/rate-change-digest — auth guards", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.CRON_SECRET = SECRET;
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("returns 500 when CRON_SECRET is not set", async () => {
+    delete process.env.CRON_SECRET;
+    const res = await GET(authedReq());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toMatch(/misconfigured/i);
+  });
+
+  it("returns 500 when CRON_SECRET is too short", async () => {
+    process.env.CRON_SECRET = "tooshort";
+    const res = await GET(authedReq());
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 401 on wrong bearer token", async () => {
+    const res = await GET(req({ authorization: "Bearer wrong" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when authorization header is absent", async () => {
+    const res = await GET(req());
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /api/cron/rate-change-digest — no-data paths", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.CRON_SECRET = SECRET;
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("returns 200 with reason=no_data when snapshots table is empty", async () => {
+    mockFrom.mockReturnValueOnce(makeBuilder([], null)); // batches query
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.reason).toBe("no_data");
+    expect(body.changes).toBe(0);
+  });
+
+  it("returns 200 with reason=no_data when batches query errors", async () => {
+    mockFrom.mockReturnValueOnce(makeBuilder(null, { message: "table missing" }));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.reason).toBe("no_data");
+    expect(body.changes).toBe(0);
+  });
+
+  it("returns 200 with reason=single_batch when only one distinct captured_at", async () => {
+    const at = "2026-05-28T12:00:00Z";
+    // All rows same timestamp → only 1 distinct
+    mockFrom.mockReturnValueOnce(makeBuilder([makeBatchRow(at), makeBatchRow(at)], null));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.reason).toBe("single_batch");
+    expect(body.changes).toBe(0);
+  });
+
+  it("returns 200 with changes:0 when rates are identical between batches", async () => {
+    const newerAt = "2026-05-28T12:00:00Z";
+    const olderAt = "2026-05-27T12:00:00Z";
+
+    // batches: two distinct timestamps
+    mockFrom.mockReturnValueOnce(makeBuilder([makeBatchRow(newerAt), makeBatchRow(olderAt)], null));
+
+    // newest batch: ING 500 bps
+    mockFrom.mockReturnValueOnce(makeBuilder([makeSnapshotRow(1, "savings_account", 500, newerAt)], null));
+    // previous batch: ING 500 bps (same rate — no change)
+    mockFrom.mockReturnValueOnce(makeBuilder([makeSnapshotRow(1, "savings_account", 500, olderAt)], null));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.changes).toBe(0);
+  });
+});
+
+describe("GET /api/cron/rate-change-digest — success path", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.CRON_SECRET = SECRET;
+    mockFrom.mockImplementation((..._args: unknown[]) => makeBuilder());
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("detects rate increase and inserts change log row", async () => {
+    const newerAt = "2026-05-28T12:00:00Z";
+    const olderAt = "2026-05-27T12:00:00Z";
+
+    mockFrom.mockReturnValueOnce(makeBuilder([makeBatchRow(newerAt), makeBatchRow(olderAt)], null));
+    // newest: 550 bps
+    mockFrom.mockReturnValueOnce(makeBuilder([makeSnapshotRow(1, "savings_account", 550, newerAt)], null));
+    // previous: 500 bps → delta = 50, direction = "up"
+    mockFrom.mockReturnValueOnce(makeBuilder([makeSnapshotRow(1, "savings_account", 500, olderAt)], null));
+    // upsert rate_change_log → success
+    mockFrom.mockReturnValueOnce({ ...makeBuilder(null, null), count: 1 });
+    // feed_events fanout → success
+    mockFrom.mockReturnValueOnce(makeBuilder(null, null));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.changes).toBe(1);
+    expect(body.newestAt).toBe(newerAt);
+    expect(body.previousAt).toBe(olderAt);
+  });
+
+  it("detects rate decrease (direction=down)", async () => {
+    const newerAt = "2026-05-28T12:00:00Z";
+    const olderAt = "2026-05-27T12:00:00Z";
+
+    mockFrom.mockReturnValueOnce(makeBuilder([makeBatchRow(newerAt), makeBatchRow(olderAt)], null));
+    // newest: 400 bps (dropped)
+    mockFrom.mockReturnValueOnce(makeBuilder([makeSnapshotRow(1, "savings_account", 400, newerAt)], null));
+    // previous: 500 bps
+    mockFrom.mockReturnValueOnce(makeBuilder([makeSnapshotRow(1, "savings_account", 500, olderAt)], null));
+
+    // Capture upsert to verify direction
+    let capturedInsertRows: unknown = null;
+    const upsertBuilder = { ...makeBuilder(null, null), count: 1 };
+    (upsertBuilder as Record<string, unknown>)["upsert"] = vi.fn((data: unknown) => {
+      capturedInsertRows = data;
+      return upsertBuilder;
+    });
+    mockFrom.mockReturnValueOnce(upsertBuilder);
+    mockFrom.mockReturnValueOnce(makeBuilder(null, null));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.changes).toBe(1);
+
+    const rows = capturedInsertRows as Array<{ direction: string; delta_bps: number }>;
+    expect(rows[0]?.direction).toBe("down");
+    expect(rows[0]?.delta_bps).toBe(-100);
+  });
+
+  it("marks new broker as direction=new when not in previous batch", async () => {
+    const newerAt = "2026-05-28T12:00:00Z";
+    const olderAt = "2026-05-27T12:00:00Z";
+
+    mockFrom.mockReturnValueOnce(makeBuilder([makeBatchRow(newerAt), makeBatchRow(olderAt)], null));
+    // newest: broker 99 (new)
+    mockFrom.mockReturnValueOnce(makeBuilder([makeSnapshotRow(99, "savings_account", 500, newerAt, "newbank", "New Bank")], null));
+    // previous: empty — broker 99 didn't exist
+    mockFrom.mockReturnValueOnce(makeBuilder([], null));
+
+    let capturedInsertRows: unknown = null;
+    const upsertBuilder = { ...makeBuilder(null, null), count: 1 };
+    (upsertBuilder as Record<string, unknown>)["upsert"] = vi.fn((data: unknown) => {
+      capturedInsertRows = data;
+      return upsertBuilder;
+    });
+    mockFrom.mockReturnValueOnce(upsertBuilder);
+    mockFrom.mockReturnValueOnce(makeBuilder(null, null));
+
+    const res = await GET(authedReq());
+    const body = await res.json();
+    expect(body.changes).toBe(1);
+
+    const rows = capturedInsertRows as Array<{ direction: string; old_rate_bps: number | null }>;
+    expect(rows[0]?.direction).toBe("new");
+    expect(rows[0]?.old_rate_bps).toBeNull();
+  });
+
+  it("returns 500 when rate_change_log upsert fails", async () => {
+    const newerAt = "2026-05-28T12:00:00Z";
+    const olderAt = "2026-05-27T12:00:00Z";
+
+    mockFrom.mockReturnValueOnce(makeBuilder([makeBatchRow(newerAt), makeBatchRow(olderAt)], null));
+    mockFrom.mockReturnValueOnce(makeBuilder([makeSnapshotRow(1, "savings_account", 550, newerAt)], null));
+    mockFrom.mockReturnValueOnce(makeBuilder([makeSnapshotRow(1, "savings_account", 500, olderAt)], null));
+
+    // upsert fails
+    mockFrom.mockReturnValueOnce({ ...makeBuilder(null, { message: "unique violation" }), count: null });
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toBeTruthy();
+  });
+
+  it("logs feed_events fanout failure as non-blocking (still returns ok)", async () => {
+    const newerAt = "2026-05-28T12:00:00Z";
+    const olderAt = "2026-05-27T12:00:00Z";
+
+    mockFrom.mockReturnValueOnce(makeBuilder([makeBatchRow(newerAt), makeBatchRow(olderAt)], null));
+    mockFrom.mockReturnValueOnce(makeBuilder([makeSnapshotRow(1, "savings_account", 550, newerAt)], null));
+    mockFrom.mockReturnValueOnce(makeBuilder([makeSnapshotRow(1, "savings_account", 500, olderAt)], null));
+    // upsert rate_change_log success
+    mockFrom.mockReturnValueOnce({ ...makeBuilder(null, null), count: 1 });
+    // feed_events fanout fails (non-blocking)
+    mockFrom.mockReturnValueOnce(makeBuilder(null, { message: "fanout error" }));
+
+    const res = await GET(authedReq());
+    // Still 200 — fanout failure is non-blocking
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.changes).toBe(1);
+  });
+
+  it("handles multiple broker changes in one run", async () => {
+    const newerAt = "2026-05-28T12:00:00Z";
+    const olderAt = "2026-05-27T12:00:00Z";
+
+    mockFrom.mockReturnValueOnce(makeBuilder([makeBatchRow(newerAt), makeBatchRow(olderAt)], null));
+    // newest: ING up, UBank down
+    mockFrom.mockReturnValueOnce(makeBuilder([
+      makeSnapshotRow(1, "savings_account", 550, newerAt, "ing", "ING"),
+      makeSnapshotRow(2, "savings_account", 380, newerAt, "ubank", "UBank"),
+    ], null));
+    // previous
+    mockFrom.mockReturnValueOnce(makeBuilder([
+      makeSnapshotRow(1, "savings_account", 500, olderAt, "ing", "ING"),
+      makeSnapshotRow(2, "savings_account", 420, olderAt, "ubank", "UBank"),
+    ], null));
+
+    mockFrom.mockReturnValueOnce({ ...makeBuilder(null, null), count: 2 });
+    mockFrom.mockReturnValueOnce(makeBuilder(null, null));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.changes).toBe(2);
+  });
+});

--- a/__tests__/api/cron-refresh-leaderboard.test.ts
+++ b/__tests__/api/cron-refresh-leaderboard.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+// ─── Supabase builder factory ─────────────────────────────────────────────────
+
+function makeBuilder(data: unknown = null, error: unknown = null) {
+  const terminal = { data, error };
+  const c: Record<string, unknown> = {
+    then: (resolve: (v: typeof terminal) => unknown) =>
+      Promise.resolve(resolve(terminal)),
+  };
+  for (const m of [
+    "select", "insert", "update", "upsert", "delete",
+    "eq", "neq", "gt", "gte", "lt", "lte", "in", "is", "not", "or",
+    "order", "limit", "range", "single", "maybeSingle", "filter",
+    "contains", "overlaps", "throwOnError",
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  return c;
+}
+
+const mockFrom = vi.fn((..._args: unknown[]) => makeBuilder());
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
+    from: (...args: unknown[]) => mockFrom(...args),
+  })),
+}));
+
+// ─── Import after mocks ───────────────────────────────────────────────────────
+
+import { GET, runtime, maxDuration } from "@/app/api/cron/refresh-leaderboard/route";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const SECRET = "test-cron-secret-refresh-leaderboard";
+
+function req(headers: Record<string, string> = {}): NextRequest {
+  return new Request("http://localhost/api/cron/refresh-leaderboard", { headers }) as unknown as NextRequest;
+}
+
+function authedReq(): NextRequest {
+  return req({ authorization: `Bearer ${SECRET}` });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("GET /api/cron/refresh-leaderboard — exports", () => {
+  it("exports runtime = 'nodejs'", () => {
+    expect(runtime).toBe("nodejs");
+  });
+
+  it("exports maxDuration = 300", () => {
+    expect(maxDuration).toBe(300);
+  });
+});
+
+describe("GET /api/cron/refresh-leaderboard — auth guards", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = SECRET;
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("returns 500 when CRON_SECRET is not set", async () => {
+    delete process.env.CRON_SECRET;
+    const res = await GET(authedReq());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toMatch(/misconfigured/i);
+  });
+
+  it("returns 500 when CRON_SECRET is too short", async () => {
+    process.env.CRON_SECRET = "tooshort";
+    const res = await GET(authedReq());
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 401 on wrong bearer token", async () => {
+    const res = await GET(req({ authorization: "Bearer wrong" }));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toMatch(/unauthorized/i);
+  });
+
+  it("returns 401 when authorization header is absent", async () => {
+    const res = await GET(req());
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /api/cron/refresh-leaderboard — empty data path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = SECRET;
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("returns 200 with ranked:0 when no active advisors", async () => {
+    mockFrom.mockReturnValueOnce(makeBuilder([], null)); // professionals: empty
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.ranked).toBe(0);
+  });
+
+  it("returns 200 with ranked:0 when professionals returns null", async () => {
+    mockFrom.mockReturnValueOnce(makeBuilder(null, null)); // professionals: null (falsy check)
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.ranked).toBe(0);
+  });
+});
+
+describe("GET /api/cron/refresh-leaderboard — success path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = SECRET;
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("computes scores and upserts leaderboard rows", async () => {
+    const advisor = {
+      id: 1,
+      rating: 4.9,
+      review_count: 10,
+      avg_response_minutes: 60,
+      profile_score: 80,
+    };
+    mockFrom.mockReturnValueOnce(makeBuilder([advisor], null)); // professionals
+    mockFrom.mockReturnValueOnce(makeBuilder([], null));        // advisor_badges (no badges)
+    mockFrom.mockReturnValueOnce(makeBuilder(null, null));      // leaderboard upsert
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.ranked).toBe(1);
+  });
+
+  it("includes badge count in score calculation", async () => {
+    const advisor = {
+      id: 2,
+      rating: 4.0,
+      review_count: 3,
+      avg_response_minutes: null,
+      profile_score: 50,
+    };
+    mockFrom.mockReturnValueOnce(makeBuilder([advisor], null)); // professionals
+    // advisor has 2 badges
+    mockFrom.mockReturnValueOnce(
+      makeBuilder([{ professional_id: 2 }, { professional_id: 2 }], null),
+    ); // advisor_badges
+    mockFrom.mockReturnValueOnce(makeBuilder(null, null)); // upsert
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ranked).toBe(1);
+  });
+
+  it("ranks multiple advisors (higher score = lower rank number)", async () => {
+    const advisors = [
+      // Low scorer
+      { id: 10, rating: 3.0, review_count: 1, avg_response_minutes: null, profile_score: 20 },
+      // High scorer
+      { id: 11, rating: 5.0, review_count: 20, avg_response_minutes: 30, profile_score: 100 },
+    ];
+    mockFrom.mockReturnValueOnce(makeBuilder(advisors, null)); // professionals
+    mockFrom.mockReturnValueOnce(makeBuilder([], null));       // badges
+    mockFrom.mockReturnValueOnce(makeBuilder(null, null));     // upsert
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ranked).toBe(2);
+  });
+
+  it("still returns 200 when leaderboard upsert fails (error logged, not thrown)", async () => {
+    const advisor = {
+      id: 3,
+      rating: 4.5,
+      review_count: 5,
+      avg_response_minutes: 120,
+      profile_score: 70,
+    };
+    mockFrom.mockReturnValueOnce(makeBuilder([advisor], null)); // professionals
+    mockFrom.mockReturnValueOnce(makeBuilder([], null));        // badges
+    mockFrom.mockReturnValueOnce(makeBuilder(null, { message: "upsert failed" })); // upsert error
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // Still returns the count even on upsert error
+    expect(body.ranked).toBe(1);
+  });
+
+  it("caps score components at their maximum values", async () => {
+    // review_count: 100 → reviewScore capped at 30
+    // rating: 5.0 → ratingScore capped at 30
+    // avg_response_minutes: 0 → max responseScore = 20
+    // profile_score: 100 → profileScore = 10
+    // 5 badges → badgeScore capped at 10
+    const advisor = {
+      id: 4,
+      rating: 5.0,
+      review_count: 100,
+      avg_response_minutes: 0,
+      profile_score: 100,
+    };
+    mockFrom.mockReturnValueOnce(makeBuilder([advisor], null));
+    // 5 badges
+    mockFrom.mockReturnValueOnce(
+      makeBuilder(
+        Array.from({ length: 5 }, () => ({ professional_id: 4 })),
+        null,
+      ),
+    );
+    mockFrom.mockReturnValueOnce(makeBuilder(null, null)); // upsert
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ranked).toBe(1);
+  });
+});

--- a/__tests__/api/cron-retry-consumer-webhooks.test.ts
+++ b/__tests__/api/cron-retry-consumer-webhooks.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+const mockRetryFailedConsumerWebhooks = vi.fn(
+  async (..._a: unknown[]): Promise<{
+    groups: number;
+    retried: number;
+    skipped_succeeded: number;
+    skipped_max_attempts: number;
+    skipped_no_secret: number;
+    skipped_hook_gone: number;
+  }> => ({
+    groups: 0,
+    retried: 0,
+    skipped_succeeded: 0,
+    skipped_max_attempts: 0,
+    skipped_no_secret: 0,
+    skipped_hook_gone: 0,
+  }),
+);
+vi.mock("@/lib/consumer-webhook-dispatch", () => ({
+  retryFailedConsumerWebhooks: (...args: unknown[]) => mockRetryFailedConsumerWebhooks(...args),
+}));
+
+// wrapCronHandler: thin wrapper — call handler and return its response
+vi.mock("@/lib/cron-run-log", () => ({
+  wrapCronHandler: vi.fn(
+    (_name: string, handler: (req: NextRequest) => Promise<unknown>) =>
+      (req: NextRequest) =>
+        handler(req),
+  ),
+}));
+
+// ─── Import after mocks ───────────────────────────────────────────────────────
+
+import { GET, runtime, maxDuration } from "@/app/api/cron/retry-consumer-webhooks/route";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const SECRET = "test-cron-secret-retry-webhooks-123";
+
+function req(headers: Record<string, string> = {}): NextRequest {
+  return new Request("http://localhost/api/cron/retry-consumer-webhooks", { headers }) as unknown as NextRequest;
+}
+
+function authedReq(): NextRequest {
+  return req({ authorization: `Bearer ${SECRET}` });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("GET /api/cron/retry-consumer-webhooks — exports", () => {
+  it("exports runtime = 'nodejs'", () => {
+    expect(runtime).toBe("nodejs");
+  });
+
+  it("exports maxDuration = 60", () => {
+    expect(maxDuration).toBe(60);
+  });
+});
+
+describe("GET /api/cron/retry-consumer-webhooks — auth guards", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = SECRET;
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("returns 500 when CRON_SECRET is not set", async () => {
+    delete process.env.CRON_SECRET;
+    const res = await GET(authedReq());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toMatch(/misconfigured/i);
+  });
+
+  it("returns 500 when CRON_SECRET is too short", async () => {
+    process.env.CRON_SECRET = "tooshort";
+    const res = await GET(authedReq());
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 401 on wrong bearer token", async () => {
+    const res = await GET(req({ authorization: "Bearer wrong" }));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toMatch(/unauthorized/i);
+  });
+
+  it("returns 401 when authorization header is absent", async () => {
+    const res = await GET(req());
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /api/cron/retry-consumer-webhooks — empty queue path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = SECRET;
+    mockRetryFailedConsumerWebhooks.mockResolvedValue({
+      groups: 0,
+      retried: 0,
+      skipped_succeeded: 0,
+      skipped_max_attempts: 0,
+      skipped_no_secret: 0,
+      skipped_hook_gone: 0,
+    });
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("returns 200 with ok:true and all-zero stats when queue is empty", async () => {
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.groups).toBe(0);
+    expect(body.retried).toBe(0);
+    expect(body.skipped_succeeded).toBe(0);
+    expect(body.skipped_max_attempts).toBe(0);
+    expect(body.skipped_no_secret).toBe(0);
+    expect(body.skipped_hook_gone).toBe(0);
+  });
+
+  it("calls retryFailedConsumerWebhooks once", async () => {
+    await GET(authedReq());
+    expect(mockRetryFailedConsumerWebhooks).toHaveBeenCalledOnce();
+  });
+});
+
+describe("GET /api/cron/retry-consumer-webhooks — success path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = SECRET;
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("returns stats from retryFailedConsumerWebhooks in response body", async () => {
+    mockRetryFailedConsumerWebhooks.mockResolvedValue({
+      groups: 3,
+      retried: 2,
+      skipped_succeeded: 0,
+      skipped_max_attempts: 1,
+      skipped_no_secret: 0,
+      skipped_hook_gone: 0,
+    });
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.groups).toBe(3);
+    expect(body.retried).toBe(2);
+    expect(body.skipped_max_attempts).toBe(1);
+  });
+
+  it("returns skipped_hook_gone when webhook was deleted or deactivated", async () => {
+    mockRetryFailedConsumerWebhooks.mockResolvedValue({
+      groups: 2,
+      retried: 0,
+      skipped_succeeded: 0,
+      skipped_max_attempts: 0,
+      skipped_no_secret: 0,
+      skipped_hook_gone: 2,
+    });
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.skipped_hook_gone).toBe(2);
+    expect(body.retried).toBe(0);
+  });
+
+  it("returns skipped_no_secret when hook has no signing secret", async () => {
+    mockRetryFailedConsumerWebhooks.mockResolvedValue({
+      groups: 1,
+      retried: 0,
+      skipped_succeeded: 0,
+      skipped_max_attempts: 0,
+      skipped_no_secret: 1,
+      skipped_hook_gone: 0,
+    });
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.skipped_no_secret).toBe(1);
+  });
+
+  it("returns mixed stats when some retried, some skipped", async () => {
+    mockRetryFailedConsumerWebhooks.mockResolvedValue({
+      groups: 5,
+      retried: 2,
+      skipped_succeeded: 0,
+      skipped_max_attempts: 1,
+      skipped_no_secret: 1,
+      skipped_hook_gone: 1,
+    });
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.groups).toBe(5);
+    expect(body.retried).toBe(2);
+    expect(body.skipped_max_attempts).toBe(1);
+    expect(body.skipped_no_secret).toBe(1);
+    expect(body.skipped_hook_gone).toBe(1);
+  });
+});

--- a/__tests__/api/cron-streak-at-risk.test.ts
+++ b/__tests__/api/cron-streak-at-risk.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+const mockIsStreakAtRisk = vi.fn((..._a: unknown[]): boolean => false);
+vi.mock("@/lib/streak", () => ({
+  isStreakAtRisk: (...args: unknown[]) => mockIsStreakAtRisk(...args),
+}));
+
+const mockDispatchPushToUser = vi.fn(
+  async (..._a: unknown[]): Promise<{ sent: number; failed: number; skipped_no_sub: boolean; stale_removed: number }> => ({
+    sent: 1,
+    failed: 0,
+    skipped_no_sub: false,
+    stale_removed: 0,
+  }),
+);
+vi.mock("@/lib/push-dispatch", () => ({
+  dispatchPushToUser: (...args: unknown[]) => mockDispatchPushToUser(...args),
+}));
+
+// withCronRunLog pass-through
+vi.mock("@/lib/cron-run-log", () => ({
+  withCronRunLog: vi.fn(
+    async (_name: string, fn: () => Promise<{ response: unknown; stats?: Record<string, unknown> }>) => {
+      const result = await fn();
+      return result.response;
+    },
+  ),
+}));
+
+// ─── Supabase builder factory ─────────────────────────────────────────────────
+
+function makeBuilder(data: unknown = null, error: unknown = null) {
+  const terminal = { data, error };
+  const c: Record<string, unknown> = {
+    then: (resolve: (v: typeof terminal) => unknown) =>
+      Promise.resolve(resolve(terminal)),
+  };
+  for (const m of [
+    "select", "insert", "update", "upsert", "delete",
+    "eq", "neq", "gt", "gte", "lt", "lte", "in", "is", "not", "or",
+    "order", "limit", "range", "single", "maybeSingle", "filter",
+    "contains", "overlaps", "throwOnError",
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  return c;
+}
+
+const mockFrom = vi.fn((..._args: unknown[]) => makeBuilder());
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
+    from: (...args: unknown[]) => mockFrom(...args),
+  })),
+}));
+
+// ─── Import after mocks ───────────────────────────────────────────────────────
+
+import { GET, runtime, maxDuration } from "@/app/api/cron/streak-at-risk/route";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const SECRET = "test-cron-secret-streak-at-risk-123";
+
+function req(headers: Record<string, string> = {}): NextRequest {
+  return new Request("http://localhost/api/cron/streak-at-risk", { headers }) as unknown as NextRequest;
+}
+
+function authedReq(): NextRequest {
+  return req({ authorization: `Bearer ${SECRET}` });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("GET /api/cron/streak-at-risk — exports", () => {
+  it("exports runtime = 'nodejs'", () => {
+    expect(runtime).toBe("nodejs");
+  });
+
+  it("exports maxDuration = 120", () => {
+    expect(maxDuration).toBe(120);
+  });
+});
+
+describe("GET /api/cron/streak-at-risk — auth guards", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = SECRET;
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("returns 500 when CRON_SECRET is not set", async () => {
+    delete process.env.CRON_SECRET;
+    const res = await GET(authedReq());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toMatch(/misconfigured/i);
+  });
+
+  it("returns 500 when CRON_SECRET is too short", async () => {
+    process.env.CRON_SECRET = "tooshort";
+    const res = await GET(authedReq());
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 401 on wrong bearer token", async () => {
+    const res = await GET(req({ authorization: "Bearer wrong" }));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toMatch(/unauthorized/i);
+  });
+
+  it("returns 401 when authorization header is absent", async () => {
+    const res = await GET(req());
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /api/cron/streak-at-risk — empty checkins path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = SECRET;
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("returns 200 with sent:0 when no rows returned from DB", async () => {
+    mockFrom.mockReturnValueOnce(makeBuilder([], null)); // user_daily_checkins: empty
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.sent).toBe(0);
+    expect(mockDispatchPushToUser).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 with sent:0 when rows is null", async () => {
+    mockFrom.mockReturnValueOnce(makeBuilder(null, null)); // user_daily_checkins: null
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sent).toBe(0);
+    expect(mockDispatchPushToUser).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/cron/streak-at-risk — no at-risk users path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = SECRET;
+    // isStreakAtRisk returns false for all users
+    mockIsStreakAtRisk.mockReturnValue(false);
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("returns 200 with sent:0 when no user streaks are at risk", async () => {
+    mockFrom.mockReturnValueOnce(
+      makeBuilder(
+        [
+          { user_id: "user-1", check_in_date: "2026-05-28", streak_count: 5 },
+          { user_id: "user-2", check_in_date: "2026-05-28", streak_count: 3 },
+        ],
+        null,
+      ),
+    );
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sent).toBe(0);
+    expect(mockDispatchPushToUser).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/cron/streak-at-risk — success push path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = SECRET;
+    mockDispatchPushToUser.mockResolvedValue({
+      sent: 1,
+      failed: 0,
+      skipped_no_sub: false,
+      stale_removed: 0,
+    });
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("sends push and returns sent:1 for one at-risk user", async () => {
+    mockFrom.mockReturnValueOnce(
+      makeBuilder(
+        [{ user_id: "user-at-risk", check_in_date: "2026-05-28", streak_count: 7 }],
+        null,
+      ),
+    );
+    mockIsStreakAtRisk.mockReturnValue(true);
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.sent).toBe(1);
+
+    expect(mockDispatchPushToUser).toHaveBeenCalledOnce();
+    const callArgs = mockDispatchPushToUser.mock.calls[0] as [string, { title: string; body: string; url: string; tag: string }];
+    expect(callArgs[0]).toBe("user-at-risk");
+    expect(callArgs[1].title).toContain("7-day streak");
+    expect(callArgs[1].url).toBe("/feed");
+    expect(callArgs[1].tag).toBe("streak-at-risk");
+  });
+
+  it("does not count user when dispatchPushToUser returns sent:0", async () => {
+    mockFrom.mockReturnValueOnce(
+      makeBuilder(
+        [{ user_id: "user-no-sub", check_in_date: "2026-05-28", streak_count: 3 }],
+        null,
+      ),
+    );
+    mockIsStreakAtRisk.mockReturnValue(true);
+    mockDispatchPushToUser.mockResolvedValue({
+      sent: 0,
+      failed: 0,
+      skipped_no_sub: true,
+      stale_removed: 0,
+    });
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sent).toBe(0);
+  });
+
+  it("handles multiple users — sends push to each at-risk user", async () => {
+    mockFrom.mockReturnValueOnce(
+      makeBuilder(
+        [
+          { user_id: "user-a", check_in_date: "2026-05-28", streak_count: 5 },
+          { user_id: "user-b", check_in_date: "2026-05-28", streak_count: 2 },
+          { user_id: "user-c", check_in_date: "2026-05-27", streak_count: 10 },
+        ],
+        null,
+      ),
+    );
+    // Only first two are at risk
+    mockIsStreakAtRisk
+      .mockReturnValueOnce(true)   // user-a: at risk
+      .mockReturnValueOnce(true)   // user-b: at risk
+      .mockReturnValueOnce(false); // user-c: not at risk
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sent).toBe(2);
+    expect(mockDispatchPushToUser).toHaveBeenCalledTimes(2);
+  });
+
+  it("groups multiple checkin rows per user before evaluating streak", async () => {
+    // user-multi has 2 rows (sorted descending by date in the DB query)
+    mockFrom.mockReturnValueOnce(
+      makeBuilder(
+        [
+          { user_id: "user-multi", check_in_date: "2026-05-28", streak_count: 3 },
+          { user_id: "user-multi", check_in_date: "2026-05-27", streak_count: 2 },
+          { user_id: "user-multi", check_in_date: "2026-05-26", streak_count: 1 },
+        ],
+        null,
+      ),
+    );
+    mockIsStreakAtRisk.mockReturnValueOnce(true);
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    // isStreakAtRisk was called once (one user, grouped)
+    expect(mockIsStreakAtRisk).toHaveBeenCalledOnce();
+    expect(mockDispatchPushToUser).toHaveBeenCalledOnce();
+  });
+});

--- a/__tests__/api/cron-user-health-score-email.test.ts
+++ b/__tests__/api/cron-user-health-score-email.test.ts
@@ -1,0 +1,298 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+vi.mock("@/lib/url", () => ({
+  getSiteUrl: vi.fn(() => "https://invest.com.au"),
+}));
+
+const mockComputeUserHealthScore = vi.fn(
+  (..._args: unknown[]): { overall: number; diversification: number; cost: number; riskAlignment: number; engagement: number; grade: string } =>
+    ({ overall: 72, diversification: 70, cost: 80, riskAlignment: 65, engagement: 75, grade: "B" }),
+);
+vi.mock("@/lib/user-health-score", () => ({
+  computeUserHealthScore: (...args: unknown[]) => mockComputeUserHealthScore(...args),
+}));
+
+const mockComputeCurrentStreak = vi.fn((..._args: unknown[]): number => 0);
+vi.mock("@/lib/streak", () => ({
+  computeCurrentStreak: (...args: unknown[]) => mockComputeCurrentStreak(...args),
+}));
+
+const mockSendEmail = vi.fn(
+  async (..._args: unknown[]): Promise<{ ok: boolean; error?: string }> => ({ ok: true }),
+);
+vi.mock("@/lib/resend", () => ({
+  sendEmail: (...args: unknown[]) => mockSendEmail(...args),
+}));
+
+vi.mock("@/lib/cron-run-log", () => ({
+  withCronRunLog: vi.fn(
+    async (_name: string, fn: () => Promise<{ response: unknown }>) => {
+      const result = await fn();
+      return result.response;
+    },
+  ),
+}));
+
+// ─── Supabase builder factory ─────────────────────────────────────────────────
+
+function makeBuilder(data: unknown = null, error: unknown = null) {
+  const terminal = { data, error };
+  const c: Record<string, unknown> = {
+    then: (resolve: (v: typeof terminal) => unknown) =>
+      Promise.resolve(resolve(terminal)),
+  };
+  for (const m of [
+    "select", "insert", "update", "upsert", "delete",
+    "eq", "neq", "gt", "gte", "lt", "lte", "in", "is", "not", "or",
+    "order", "limit", "range", "single", "maybeSingle", "filter",
+    "contains", "overlaps", "throwOnError",
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  return c;
+}
+
+const mockFrom = vi.fn((..._args: unknown[]) => makeBuilder());
+const mockListUsers = vi.fn(
+  async (
+    ..._args: unknown[]
+  ): Promise<{ data: { users: Array<{ id: string; email?: string }> }; error: unknown }> => ({
+    data: { users: [] },
+    error: null,
+  }),
+);
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
+    from: (...args: unknown[]) => mockFrom(...args),
+    auth: { admin: { listUsers: (...args: unknown[]) => mockListUsers(...args) } },
+  })),
+}));
+
+// ─── Import after mocks ───────────────────────────────────────────────────────
+
+import { GET, runtime, maxDuration } from "@/app/api/cron/user-health-score-email/route";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const SECRET = "test-cron-secret-health-score-123";
+
+function req(headers: Record<string, string> = {}): NextRequest {
+  return new Request("http://localhost/api/cron/user-health-score-email", {
+    headers,
+  }) as unknown as NextRequest;
+}
+
+function authedReq(): NextRequest {
+  return req({ authorization: `Bearer ${SECRET}` });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("GET /api/cron/user-health-score-email — exports", () => {
+  it("exports runtime = 'nodejs'", () => {
+    expect(runtime).toBe("nodejs");
+  });
+
+  it("exports maxDuration = 300", () => {
+    expect(maxDuration).toBe(300);
+  });
+});
+
+describe("GET /api/cron/user-health-score-email — auth guards", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.CRON_SECRET = SECRET;
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("returns 500 when CRON_SECRET is not set", async () => {
+    delete process.env.CRON_SECRET;
+    const res = await GET(authedReq());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toMatch(/misconfigured/i);
+  });
+
+  it("returns 500 when CRON_SECRET is too short", async () => {
+    process.env.CRON_SECRET = "tooshort";
+    const res = await GET(authedReq());
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 401 on wrong bearer token", async () => {
+    const res = await GET(req({ authorization: "Bearer wrong" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when authorization header is absent", async () => {
+    const res = await GET(req());
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /api/cron/user-health-score-email — empty data path", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.CRON_SECRET = SECRET;
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("returns 200 with sent:0 and scored:0 when no users have weekly_digest", async () => {
+    // notification_preferences → empty
+    mockFrom.mockReturnValueOnce(makeBuilder([], null));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.sent).toBe(0);
+    expect(body.scored).toBe(0);
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/cron/user-health-score-email — success path", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.env.CRON_SECRET = SECRET;
+    mockComputeUserHealthScore.mockReturnValue({
+      overall: 72, diversification: 70, cost: 80, riskAlignment: 65, engagement: 75, grade: "B",
+    });
+    mockComputeCurrentStreak.mockReturnValue(3);
+    mockSendEmail.mockResolvedValue({ ok: true });
+    mockFrom.mockImplementation((..._args: unknown[]) => makeBuilder());
+    mockListUsers.mockResolvedValue({ data: { users: [] }, error: null });
+  });
+  afterEach(() => {
+    delete process.env.CRON_SECRET;
+  });
+
+  it("scores users and sends health score email", async () => {
+    const userId = "user-health-001";
+    const email = "healthy@example.com";
+
+    // notification_preferences
+    mockFrom.mockReturnValueOnce(makeBuilder([{ user_id: userId, weekly_digest: true }], null));
+
+    // Bulk parallel queries (Promise.all of 6)
+    mockFrom.mockReturnValue(makeBuilder([], null)); // default for all parallel queries
+
+    mockListUsers.mockResolvedValue({ data: { users: [{ id: userId, email }] }, error: null });
+
+    // upsert health score log
+    mockFrom.mockReturnValue(makeBuilder(null, null));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.scored).toBe(1);
+    expect(body.sent).toBe(1);
+
+    expect(mockSendEmail).toHaveBeenCalledOnce();
+    const callArg = mockSendEmail.mock.calls[0]?.[0] as {
+      to: string;
+      subject: string;
+      html: string;
+    };
+    expect(callArg.to).toBe(email);
+    expect(callArg.subject).toMatch(/health score/i);
+    expect(callArg.subject).toContain("B");
+    expect(callArg.subject).toContain("72");
+    expect(callArg.html).toContain("72");
+    expect(callArg.html).toContain("Diversification");
+  });
+
+  it("includes delta vs last month when prev score exists", async () => {
+    const userId = "user-delta";
+    const email = "delta@example.com";
+
+    // Route calls in order:
+    // 1. notification_preferences
+    // 2-7. Promise.all: holdings, profiles, goals, shortlisted, checkins, prevScores
+    // 8. upsert (user_health_score_log)
+    mockFrom
+      .mockReturnValueOnce(makeBuilder([{ user_id: userId, weekly_digest: true }], null)) // 1. notification_preferences
+      .mockReturnValueOnce(makeBuilder([], null))   // 2. investor_holdings
+      .mockReturnValueOnce(makeBuilder([], null))   // 3. investor_profiles
+      .mockReturnValueOnce(makeBuilder([], null))   // 4. investor_goals
+      .mockReturnValueOnce(makeBuilder([], null))   // 5. user_shortlisted_brokers
+      .mockReturnValueOnce(makeBuilder([], null))   // 6. user_daily_checkins
+      .mockReturnValueOnce(makeBuilder([{ user_id: userId, overall: 60, scored_month: "2026-04-01" }], null)) // 7. user_health_score_log (prevScores)
+      .mockReturnValue(makeBuilder(null, null));    // 8. upsert
+
+    mockListUsers.mockResolvedValue({ data: { users: [{ id: userId, email }] }, error: null });
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sent).toBe(1);
+
+    const callArg = mockSendEmail.mock.calls[0]?.[0] as { subject: string };
+    // Delta = 72 - 60 = +12 should appear in subject
+    expect(callArg.subject).toContain("+12");
+  });
+
+  it("scores user but does not send email when no email in listUsers", async () => {
+    const userId = "user-noemail";
+
+    mockFrom.mockReturnValueOnce(makeBuilder([{ user_id: userId, weekly_digest: true }], null));
+    mockFrom.mockReturnValue(makeBuilder([], null));
+    mockListUsers.mockResolvedValue({ data: { users: [{ id: userId }] }, error: null });
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.scored).toBe(1);
+    expect(body.sent).toBe(0);
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("counts scored:1 even when sendEmail throws, and continues", async () => {
+    const userId = "user-throw";
+    const email = "throw@example.com";
+
+    mockFrom.mockReturnValueOnce(makeBuilder([{ user_id: userId, weekly_digest: true }], null));
+    mockFrom.mockReturnValue(makeBuilder([], null));
+    mockListUsers.mockResolvedValue({ data: { users: [{ id: userId, email }] }, error: null });
+
+    mockSendEmail.mockRejectedValue(new Error("Resend network error"));
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // sendEmail threw → sent not incremented, but scored still 1
+    expect(body.scored).toBe(1);
+    expect(body.sent).toBe(0);
+  });
+
+  it("upserts score log row for each scored user", async () => {
+    const userId = "user-upsert";
+    const email = "upsert@example.com";
+
+    mockFrom.mockReturnValueOnce(makeBuilder([{ user_id: userId, weekly_digest: true }], null));
+    mockFrom.mockReturnValue(makeBuilder([], null));
+    mockListUsers.mockResolvedValue({ data: { users: [{ id: userId, email }] }, error: null });
+
+    const res = await GET(authedReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    // scored=1 verifies the per-user loop ran and upsert was attempted
+    expect(body.scored).toBe(1);
+    // mockFrom should have been called: 1 (prefs) + 6 (parallel) + 1 (upsert) = 8
+    // but slugs=[] skips brokers query, so 7 calls + 1 upsert = 8
+    expect(mockFrom.mock.calls.length).toBeGreaterThanOrEqual(7);
+  });
+});

--- a/__tests__/api/events.test.ts
+++ b/__tests__/api/events.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Hoisted mock refs ─────────────────────────────────────────────────────────
+
+const { mockIsRateLimited, mockFrom } = vi.hoisted(() => ({
+  mockIsRateLimited: vi.fn<(...args: unknown[]) => Promise<boolean>>(async () => false),
+  mockFrom: vi.fn(() => makeChain()),
+}));
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: (...args: unknown[]) => mockIsRateLimited(...args),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({ from: mockFrom })),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeChain(res: { data?: unknown; error?: unknown } = {}) {
+  const chain: Record<string, unknown> = {};
+  for (const m of [
+    "select", "eq", "neq", "gte", "lte", "lt", "gt", "is", "in", "not", "or",
+    "order", "limit", "range", "maybeSingle", "single", "filter",
+  ]) {
+    chain[m] = vi.fn(() => chain);
+  }
+  chain.then = (resolve: (v: unknown) => unknown) =>
+    Promise.resolve(resolve({ data: res.data ?? null, error: res.error ?? null }));
+  chain.catch = () => chain;
+  return chain;
+}
+
+function makeReq(params: Record<string, string> = {}, ip = "1.2.3.4"): NextRequest {
+  const url = new URL("http://localhost/api/events");
+  for (const [k, v] of Object.entries(params)) {
+    url.searchParams.set(k, v);
+  }
+  return new NextRequest(url.toString(), {
+    method: "GET",
+    headers: { "x-forwarded-for": ip },
+  });
+}
+
+const SAMPLE_EVENT = {
+  id: 1,
+  title: "Market Outlook 2026",
+  event_type: "webinar",
+  status: "published",
+  starts_at: new Date(Date.now() + 86_400_000).toISOString(),
+  professional: {
+    id: 10,
+    name: "Jane Advisor",
+    firm_name: "Wealth Co",
+    slug: "jane-advisor",
+    profile_image_url: null,
+    location_state: "NSW",
+  },
+};
+
+// ── Route under test (imported after all mocks) ───────────────────────────────
+import { GET } from "@/app/api/events/route";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// GET /api/events
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("GET /api/events", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+    mockFrom.mockReturnValue(makeChain({ data: [], error: null }));
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsRateLimited.mockResolvedValue(true);
+    const res = await GET(makeReq());
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toMatch(/too many requests/i);
+  });
+
+  it("passes rate-limit key based on IP", async () => {
+    await GET(makeReq({}, "8.8.8.8"));
+    expect(mockIsRateLimited).toHaveBeenCalledWith("public-events-8.8.8.8", 60, 1);
+  });
+
+  it("uses x-real-ip header as fallback when x-forwarded-for is absent", async () => {
+    const req = new NextRequest("http://localhost/api/events", {
+      method: "GET",
+      headers: { "x-real-ip": "3.3.3.3" },
+    });
+    await GET(req);
+    expect(mockIsRateLimited).toHaveBeenCalledWith("public-events-3.3.3.3", 60, 1);
+  });
+
+  it("uses 'unknown' when no IP header is present", async () => {
+    const req = new NextRequest("http://localhost/api/events", { method: "GET" });
+    await GET(req);
+    expect(mockIsRateLimited).toHaveBeenCalledWith("public-events-unknown", 60, 1);
+  });
+
+  it("returns 500 when DB query fails", async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: { message: "db down" } }));
+    const res = await GET(makeReq());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toMatch(/failed to fetch events/i);
+  });
+
+  it("returns 200 with empty events array when none are published", async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: null }));
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.events).toEqual([]);
+  });
+
+  it("returns 200 with events on success", async () => {
+    mockFrom.mockReturnValue(makeChain({ data: [SAMPLE_EVENT], error: null }));
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.events).toHaveLength(1);
+    expect(body.events[0].title).toBe("Market Outlook 2026");
+    expect(body.events[0].professional.name).toBe("Jane Advisor");
+  });
+
+  it("applies event_type filter when provided", async () => {
+    const chain = makeChain({ data: [SAMPLE_EVENT], error: null });
+    mockFrom.mockReturnValue(chain);
+    await GET(makeReq({ event_type: "webinar" }));
+    const eqFn = chain.eq as ReturnType<typeof vi.fn>;
+    expect(eqFn).toHaveBeenCalledWith("event_type", "webinar");
+  });
+
+  it("applies state filter when provided", async () => {
+    const chain = makeChain({ data: [SAMPLE_EVENT], error: null });
+    mockFrom.mockReturnValue(chain);
+    await GET(makeReq({ state: "NSW" }));
+    const eqFn = chain.eq as ReturnType<typeof vi.fn>;
+    expect(eqFn).toHaveBeenCalledWith("professional.location_state", "NSW");
+  });
+
+  it("does not apply event_type filter when param is absent", async () => {
+    const chain = makeChain({ data: [], error: null });
+    mockFrom.mockReturnValue(chain);
+    await GET(makeReq());
+    const eqFn = chain.eq as ReturnType<typeof vi.fn>;
+    // eq is still called for status=published, but not for event_type
+    const calls = (eqFn as ReturnType<typeof vi.fn>).mock.calls as [string, string][];
+    const eventTypeCalls = calls.filter(([field]) => field === "event_type");
+    expect(eventTypeCalls).toHaveLength(0);
+  });
+
+  it("always filters by status=published", async () => {
+    const chain = makeChain({ data: [], error: null });
+    mockFrom.mockReturnValue(chain);
+    await GET(makeReq());
+    const eqFn = chain.eq as ReturnType<typeof vi.fn>;
+    const calls = (eqFn as ReturnType<typeof vi.fn>).mock.calls as [string, string][];
+    expect(calls.some(([field, val]) => field === "status" && val === "published")).toBe(true);
+  });
+
+  it("returns multiple events in the response", async () => {
+    const events = [
+      { ...SAMPLE_EVENT, id: 1, title: "Event A" },
+      { ...SAMPLE_EVENT, id: 2, title: "Event B" },
+    ];
+    mockFrom.mockReturnValue(makeChain({ data: events, error: null }));
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.events).toHaveLength(2);
+  });
+});

--- a/__tests__/api/firm-portal-performance.test.ts
+++ b/__tests__/api/firm-portal-performance.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Hoisted mock refs ─────────────────────────────────────────────────────────
+
+const {
+  mockIsAllowed,
+  mockRequireAdvisorSession,
+  mockResolveFirmAdminContext,
+  mockGetFirmPerformanceSummary,
+} = vi.hoisted(() => ({
+  mockIsAllowed: vi.fn<(...args: unknown[]) => Promise<boolean>>(async () => true),
+  mockRequireAdvisorSession: vi.fn<
+    (...args: unknown[]) => Promise<number | null>
+  >(async () => 42),
+  mockResolveFirmAdminContext: vi.fn<
+    (...args: unknown[]) => Promise<{ firmId: number; advisorId: number } | null>
+  >(async () => ({ firmId: 7, advisorId: 42 })),
+  mockGetFirmPerformanceSummary: vi.fn<
+    (...args: unknown[]) => Promise<Record<string, unknown> | null>
+  >(async () => ({ members: [], leaderboard: [] })),
+}));
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: (...args: unknown[]) => mockIsAllowed(...args),
+  ipKey: (_req: unknown) => "ip:test",
+}));
+
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: (...args: unknown[]) => mockRequireAdvisorSession(...args),
+}));
+
+vi.mock("@/lib/firm-billing", () => ({
+  resolveFirmAdminContext: (...args: unknown[]) => mockResolveFirmAdminContext(...args),
+}));
+
+vi.mock("@/lib/firm-performance", () => ({
+  getFirmPerformanceSummary: (...args: unknown[]) => mockGetFirmPerformanceSummary(...args),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeReq(): NextRequest {
+  return new NextRequest("http://localhost/api/firm-portal/performance", {
+    method: "GET",
+    headers: { "x-forwarded-for": "1.2.3.4" },
+  });
+}
+
+// ── Route under test (imported after all mocks) ───────────────────────────────
+import { GET } from "@/app/api/firm-portal/performance/route";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// GET /api/firm-portal/performance
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("GET /api/firm-portal/performance", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+    mockRequireAdvisorSession.mockResolvedValue(42);
+    mockResolveFirmAdminContext.mockResolvedValue({ firmId: 7, advisorId: 42 });
+    mockGetFirmPerformanceSummary.mockResolvedValue({ members: [], leaderboard: [] });
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsAllowed.mockResolvedValue(false);
+    const res = await GET(makeReq());
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toMatch(/too many requests/i);
+  });
+
+  it("returns 401 when there is no advisor session", async () => {
+    mockRequireAdvisorSession.mockResolvedValue(null);
+    const res = await GET(makeReq());
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toMatch(/unauthorized/i);
+  });
+
+  it("returns 403 when caller is not a firm admin", async () => {
+    mockResolveFirmAdminContext.mockResolvedValue(null);
+    const res = await GET(makeReq());
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toMatch(/firm admin/i);
+  });
+
+  it("returns 500 when getFirmPerformanceSummary returns null", async () => {
+    mockGetFirmPerformanceSummary.mockResolvedValue(null);
+    const res = await GET(makeReq());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toMatch(/failed to load performance/i);
+  });
+
+  it("returns 200 with summary on success", async () => {
+    const summary = {
+      members: [
+        { professionalId: 10, name: "Alice", views30d: 100, enquiries30d: 5 },
+        { professionalId: 11, name: "Bob", views30d: 80, enquiries30d: 3 },
+      ],
+      leaderboard: [{ rank: 1, professionalId: 10 }],
+    };
+    mockGetFirmPerformanceSummary.mockResolvedValue(summary);
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.summary).toEqual(summary);
+    expect(body.summary.members).toHaveLength(2);
+  });
+
+  it("calls getFirmPerformanceSummary with the correct firmId", async () => {
+    mockResolveFirmAdminContext.mockResolvedValue({ firmId: 99, advisorId: 42 });
+    await GET(makeReq());
+    expect(mockGetFirmPerformanceSummary).toHaveBeenCalledWith(99);
+  });
+
+  it("calls resolveFirmAdminContext with the professionalId from session", async () => {
+    mockRequireAdvisorSession.mockResolvedValue(55);
+    mockResolveFirmAdminContext.mockResolvedValue({ firmId: 7, advisorId: 55 });
+    await GET(makeReq());
+    expect(mockResolveFirmAdminContext).toHaveBeenCalledWith(55);
+  });
+
+  it("checks rate limit before any auth", async () => {
+    // Rate limited — advisor session should never be called
+    mockIsAllowed.mockResolvedValue(false);
+    await GET(makeReq());
+    expect(mockRequireAdvisorSession).not.toHaveBeenCalled();
+  });
+
+  it("does not call getFirmPerformanceSummary when not a firm admin", async () => {
+    mockResolveFirmAdminContext.mockResolvedValue(null);
+    await GET(makeReq());
+    expect(mockGetFirmPerformanceSummary).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/api/follows-advisor-feed.test.ts
+++ b/__tests__/api/follows-advisor-feed.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for GET /api/follows/advisor/feed
+ *
+ * Auth: createClient (server) + supabase.auth.getUser (required)
+ * Admin: createAdminClient for follows + posts queries
+ *
+ * Branches: 429, 401, 200 (no follows → empty posts), 500 (posts fetch error),
+ *           200 (posts array)
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const { mockGetUser, mockAdminFrom, mockIsRateLimited } = vi.hoisted(() => ({
+  mockGetUser: vi.fn(
+    async (): Promise<{ data: { user: { id: string; email?: string } | null }; error: unknown }> => ({
+      data: { user: { id: "u1", email: "u@e.com" } },
+      error: null,
+    }),
+  ),
+  mockAdminFrom: vi.fn((..._a: unknown[]): Record<string, unknown> => ({ then: vi.fn() })),
+  mockIsRateLimited: vi.fn(async (..._a: unknown[]): Promise<boolean> => false),
+}));
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: (..._args: unknown[]) => mockGetUser() },
+  })),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
+    from: (..._args: unknown[]) => mockAdminFrom(),
+  })),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: (..._args: unknown[]) => mockIsRateLimited(),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+// ── Route under test ──────────────────────────────────────────────────────────
+
+import { GET } from "@/app/api/follows/advisor/feed/route";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeBuilder(data: unknown = null, error: unknown = null) {
+  const c: Record<string, unknown> = {
+    then: (r: (v: { data: unknown; error: unknown }) => unknown) =>
+      Promise.resolve(r({ data, error })),
+  };
+  for (const m of [
+    "select", "insert", "update", "upsert", "delete",
+    "eq", "neq", "gt", "gte", "lt", "lte", "in", "is", "not", "or",
+    "order", "limit", "range", "single", "maybeSingle", "filter",
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  return c;
+}
+
+function makeReq(): NextRequest {
+  return new NextRequest("http://localhost/api/follows/advisor/feed", {
+    headers: { "x-forwarded-for": "1.2.3.4" },
+  });
+}
+
+const POST_ROW = {
+  id: 10,
+  body: "Market update",
+  post_type: "text",
+  link_url: null,
+  link_title: null,
+  reaction_count: 5,
+  comment_count: 2,
+  created_at: "2026-05-01T10:00:00Z",
+  professional: { name: "Jane Smith", slug: "jane-smith", photo_url: null, type: "planner" },
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("GET /api/follows/advisor/feed", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1", email: "u@e.com" } }, error: null });
+    mockIsRateLimited.mockResolvedValue(false);
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockIsRateLimited.mockResolvedValue(true);
+    const res = await GET(makeReq());
+    expect(res.status).toBe(429);
+    const body = await res.json() as Record<string, unknown>;
+    expect(typeof body.error).toBe("string");
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+    const res = await GET(makeReq());
+    expect(res.status).toBe(401);
+    const body = await res.json() as Record<string, unknown>;
+    expect(typeof body.error).toBe("string");
+  });
+
+  it("returns 200 with empty posts when user follows nobody", async () => {
+    // follows query returns empty array
+    mockAdminFrom.mockImplementation((..._a: unknown[]) => makeBuilder([], null));
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.posts).toEqual([]);
+  });
+
+  it("returns 200 with empty posts when follows data is null", async () => {
+    mockAdminFrom.mockImplementation((..._a: unknown[]) => makeBuilder(null, null));
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.posts).toEqual([]);
+  });
+
+  it("returns 500 when posts query fails", async () => {
+    // follows query succeeds with followed IDs
+    mockAdminFrom.mockImplementationOnce((..._a: unknown[]) =>
+      makeBuilder([{ following_professional_id: 42 }], null),
+    );
+    // posts query fails
+    mockAdminFrom.mockImplementation((..._a: unknown[]) =>
+      makeBuilder(null, { message: "db error" }),
+    );
+    const res = await GET(makeReq());
+    expect(res.status).toBe(500);
+    const body = await res.json() as Record<string, unknown>;
+    expect(typeof body.error).toBe("string");
+  });
+
+  it("returns 200 with posts array when user follows advisors with posts", async () => {
+    // follows query
+    mockAdminFrom.mockImplementationOnce((..._a: unknown[]) =>
+      makeBuilder([{ following_professional_id: 42 }], null),
+    );
+    // posts query
+    mockAdminFrom.mockImplementation((..._a: unknown[]) =>
+      makeBuilder([POST_ROW], null),
+    );
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(Array.isArray(body.posts)).toBe(true);
+    expect((body.posts as unknown[]).length).toBe(1);
+  });
+
+  it("returns 200 with empty posts when posts data is null", async () => {
+    mockAdminFrom.mockImplementationOnce((..._a: unknown[]) =>
+      makeBuilder([{ following_professional_id: 42 }], null),
+    );
+    // posts query returns null data
+    mockAdminFrom.mockImplementation((..._a: unknown[]) => makeBuilder(null, null));
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.posts).toEqual([]);
+  });
+});

--- a/__tests__/api/hub-quiz-capture.test.ts
+++ b/__tests__/api/hub-quiz-capture.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NextRequest } from "next/server";
+
+// ── Hoisted mock refs ─────────────────────────────────────────────────────────
+
+const { mockIsAllowed, mockIsValidEmail, mockIsDisposableEmail, mockAdminFrom } = vi.hoisted(() => ({
+  mockIsAllowed: vi.fn<(...args: unknown[]) => Promise<boolean>>(async () => true),
+  mockIsValidEmail: vi.fn<(email: string) => boolean>(() => true),
+  mockIsDisposableEmail: vi.fn<(email: string) => boolean>(() => false),
+  mockAdminFrom: vi.fn(() => makeChain()),
+}));
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+vi.mock("@/lib/rate-limit-db", () => ({
+  isAllowed: (...args: unknown[]) => mockIsAllowed(...args),
+  ipKey: (_req: unknown) => "ip:test",
+}));
+
+vi.mock("@/lib/validate-email", () => ({
+  isValidEmail: (email: string) => mockIsValidEmail(email),
+  isDisposableEmail: (email: string) => mockIsDisposableEmail(email),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeChain(res: { data?: unknown; error?: unknown } = {}) {
+  const chain: Record<string, unknown> = {};
+  for (const m of [
+    "select", "insert", "update", "delete", "upsert",
+    "eq", "neq", "lt", "lte", "gte", "is", "in", "not", "or",
+    "order", "limit", "range", "maybeSingle", "single", "filter",
+  ]) {
+    chain[m] = vi.fn(() => chain);
+  }
+  chain.then = (resolve: (v: unknown) => unknown) =>
+    Promise.resolve(resolve({ data: res.data ?? null, error: res.error ?? null }));
+  chain.catch = () => chain;
+  return chain;
+}
+
+function makeReq(body: unknown): NextRequest {
+  return new Request("http://localhost/api/hub-quiz/capture", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-forwarded-for": "1.2.3.4" },
+    body: JSON.stringify(body),
+  }) as unknown as NextRequest;
+}
+
+// ── Route under test (imported after all mocks) ───────────────────────────────
+import { POST } from "@/app/api/hub-quiz/capture/route";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// POST /api/hub-quiz/capture
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("POST /api/hub-quiz/capture", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsAllowed.mockResolvedValue(true);
+    mockIsValidEmail.mockReturnValue(true);
+    mockIsDisposableEmail.mockReturnValue(false);
+    mockAdminFrom.mockReturnValue(makeChain({ data: null, error: null }));
+  });
+
+  it("returns 400 for invalid JSON", async () => {
+    const req = new Request("http://localhost/api/hub-quiz/capture", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "not-json{{",
+    }) as unknown as NextRequest;
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/invalid json/i);
+  });
+
+  it("returns 400 when hubSlug is missing (Zod required)", async () => {
+    const res = await POST(makeReq({ email: "test@example.com" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/invalid body/i);
+  });
+
+  it("returns 400 when hubSlug exceeds 64 chars", async () => {
+    const res = await POST(makeReq({ hubSlug: "h".repeat(65) }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/invalid body/i);
+  });
+
+  it("returns 200 success when no email provided (no DB write needed)", async () => {
+    const res = await POST(makeReq({ hubSlug: "investing" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    // Admin client should not have been used (no email = no DB write)
+    expect(mockAdminFrom).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when email is provided but invalid", async () => {
+    mockIsValidEmail.mockReturnValue(false);
+    const res = await POST(makeReq({ hubSlug: "investing", email: "not-an-email" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/valid email/i);
+  });
+
+  it("returns 400 when email is disposable", async () => {
+    mockIsValidEmail.mockReturnValue(true);
+    mockIsDisposableEmail.mockReturnValue(true);
+    const res = await POST(makeReq({ hubSlug: "investing", email: "test@mailinator.com" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/real email/i);
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockIsAllowed.mockResolvedValue(false);
+    const res = await POST(makeReq({ hubSlug: "investing", email: "user@example.com" }));
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toMatch(/too many requests/i);
+  });
+
+  it("returns 500 when quiz_leads insert fails", async () => {
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) return makeChain({ data: null, error: { message: "insert boom" } });
+      return makeChain({ data: null, error: null });
+    });
+    const res = await POST(makeReq({ hubSlug: "investing", email: "user@example.com" }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toMatch(/failed to save/i);
+  });
+
+  it("returns 200 on successful capture with email", async () => {
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      call++;
+      // First call: quiz_leads insert succeeds
+      if (call === 1) return makeChain({ data: null, error: null });
+      // Second call: email_captures upsert
+      return makeChain({ data: null, error: null });
+    });
+    const res = await POST(makeReq({ hubSlug: "investing", email: "user@example.com", name: "Alice" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+  });
+
+  it("returns 200 and includes resultKey in insert when provided", async () => {
+    const insertCalls: unknown[] = [];
+    mockAdminFrom.mockImplementation(() => {
+      const chain = makeChain({ data: null, error: null });
+      const insertFn = chain.insert as ReturnType<typeof vi.fn>;
+      insertFn.mockImplementation((v: unknown) => {
+        insertCalls.push(v);
+        return chain;
+      });
+      return chain;
+    });
+    await POST(makeReq({
+      hubSlug: "etf",
+      email: "user@example.com",
+      resultKey: "vanguard-etf",
+      answers: { q1: "a1" },
+    }));
+    // The first insert should include top_match_slug
+    const firstInsert = insertCalls[0] as Record<string, unknown>;
+    expect(firstInsert).toBeDefined();
+    expect(firstInsert?.top_match_slug).toBe("vanguard-etf");
+  });
+
+  it("normalises email to lowercase and trims whitespace", async () => {
+    const insertCalls: unknown[] = [];
+    let callNum = 0;
+    mockAdminFrom.mockImplementation(() => {
+      callNum++;
+      const chain = makeChain({ data: null, error: null });
+      if (callNum === 1) {
+        const insertFn = chain.insert as ReturnType<typeof vi.fn>;
+        insertFn.mockImplementation((v: unknown) => {
+          insertCalls.push(v);
+          return chain;
+        });
+      }
+      return chain;
+    });
+    await POST(makeReq({ hubSlug: "broker", email: "  USER@Example.COM  " }));
+    const inserted = insertCalls[0] as Record<string, unknown>;
+    expect(inserted?.email).toBe("user@example.com");
+  });
+
+  it("email_captures upsert error does not bubble up (fire-and-forget)", async () => {
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) return makeChain({ data: null, error: null }); // quiz_leads OK
+      return makeChain({ data: null, error: { message: "upsert failure" } }); // email_captures fails
+    });
+    // Should still return 200 — error is fire-and-forget
+    const res = await POST(makeReq({ hubSlug: "investing", email: "user@example.com" }));
+    expect(res.status).toBe(200);
+  });
+});

--- a/__tests__/api/market-events-ical.test.ts
+++ b/__tests__/api/market-events-ical.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const { mockServerFrom } = vi.hoisted(() => ({ mockServerFrom: vi.fn() }));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({ from: mockServerFrom })),
+}));
+
+vi.mock("@/lib/seo", () => ({
+  SITE_URL: "https://invest.com.au",
+}));
+
+import { GET } from "@/app/api/market-events/ical/route";
+
+// ─── Builder helper ───────────────────────────────────────────────────────────
+
+function makeBuilder(data: unknown = [], error: unknown = null) {
+  const c: Record<string, unknown> = {
+    then: (r: (v: { data: unknown; error: unknown }) => unknown) =>
+      Promise.resolve(r({ data, error })),
+  };
+  for (const m of [
+    "select", "eq", "gte", "lte", "order", "limit",
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  return c;
+}
+
+const ALL_DAY_EVENT = {
+  id: 1,
+  event_date: "2026-06-10",
+  event_type: "rba",
+  title: "RBA Cash Rate Decision",
+  description: "Reserve Bank of Australia interest rate decision",
+  source_url: "https://rba.gov.au",
+  is_all_day: true,
+  start_time: null,
+  timezone: "Australia/Sydney",
+};
+
+const TIMED_EVENT = {
+  id: 2,
+  event_date: "2026-06-15",
+  event_type: "asx",
+  title: "ASX Rebalance",
+  description: "S&P/ASX 200 index quarterly rebalance",
+  source_url: "",
+  is_all_day: false,
+  start_time: "14:30",
+  timezone: "Australia/Sydney",
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("GET /api/market-events/ical — response shape", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 200 with text/calendar content-type", async () => {
+    mockServerFrom.mockReturnValue(makeBuilder([ALL_DAY_EVENT]));
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toMatch(/text\/calendar/);
+  });
+
+  it("sets Content-Disposition attachment header for .ics download", async () => {
+    mockServerFrom.mockReturnValue(makeBuilder([ALL_DAY_EVENT]));
+    const res = await GET();
+    const disposition = res.headers.get("Content-Disposition") ?? "";
+    expect(disposition).toContain("attachment");
+    expect(disposition).toContain(".ics");
+  });
+
+  it("sets Cache-Control header", async () => {
+    mockServerFrom.mockReturnValue(makeBuilder([ALL_DAY_EVENT]));
+    const res = await GET();
+    expect(res.headers.get("Cache-Control")).toContain("max-age=3600");
+  });
+
+  it("returns 500 on DB error", async () => {
+    mockServerFrom.mockReturnValue(makeBuilder(null, { message: "db fail" }));
+    const res = await GET();
+    expect(res.status).toBe(500);
+  });
+});
+
+describe("GET /api/market-events/ical — iCal structure", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("includes VCALENDAR wrapper with required properties", async () => {
+    mockServerFrom.mockReturnValue(makeBuilder([ALL_DAY_EVENT]));
+    const res = await GET();
+    const body = await res.text();
+    expect(body).toContain("BEGIN:VCALENDAR");
+    expect(body).toContain("END:VCALENDAR");
+    expect(body).toContain("VERSION:2.0");
+    expect(body).toContain("CALSCALE:GREGORIAN");
+    expect(body).toContain("METHOD:PUBLISH");
+  });
+
+  it("includes PRODID identifying invest.com.au", async () => {
+    mockServerFrom.mockReturnValue(makeBuilder([ALL_DAY_EVENT]));
+    const res = await GET();
+    const body = await res.text();
+    expect(body).toContain("PRODID:");
+    expect(body).toContain("invest.com.au");
+  });
+
+  it("includes X-WR-CALNAME for calendar apps", async () => {
+    mockServerFrom.mockReturnValue(makeBuilder([ALL_DAY_EVENT]));
+    const res = await GET();
+    const body = await res.text();
+    expect(body).toContain("X-WR-CALNAME:");
+  });
+
+  it("returns empty calendar (no VEVENTs) when no events returned", async () => {
+    mockServerFrom.mockReturnValue(makeBuilder([]));
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain("BEGIN:VCALENDAR");
+    expect(body).not.toContain("BEGIN:VEVENT");
+  });
+});
+
+describe("GET /api/market-events/ical — all-day events", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("renders a VEVENT for an all-day event", async () => {
+    mockServerFrom.mockReturnValue(makeBuilder([ALL_DAY_EVENT]));
+    const res = await GET();
+    const body = await res.text();
+    expect(body).toContain("BEGIN:VEVENT");
+    expect(body).toContain("END:VEVENT");
+  });
+
+  it("uses VALUE=DATE format for all-day events", async () => {
+    mockServerFrom.mockReturnValue(makeBuilder([ALL_DAY_EVENT]));
+    const res = await GET();
+    const body = await res.text();
+    expect(body).toContain("DTSTART;VALUE=DATE:20260610");
+    expect(body).toContain("DTEND;VALUE=DATE:20260611");
+  });
+
+  it("embeds the event title as SUMMARY", async () => {
+    mockServerFrom.mockReturnValue(makeBuilder([ALL_DAY_EVENT]));
+    const res = await GET();
+    const body = await res.text();
+    expect(body).toContain("SUMMARY:RBA Cash Rate Decision");
+  });
+
+  it("embeds the event description as DESCRIPTION", async () => {
+    mockServerFrom.mockReturnValue(makeBuilder([ALL_DAY_EVENT]));
+    const res = await GET();
+    const body = await res.text();
+    expect(body).toContain("DESCRIPTION:");
+    expect(body).toContain("Reserve Bank");
+  });
+
+  it("uses source_url as URL when present", async () => {
+    mockServerFrom.mockReturnValue(makeBuilder([ALL_DAY_EVENT]));
+    const res = await GET();
+    const body = await res.text();
+    expect(body).toContain("URL:https://rba.gov.au");
+  });
+
+  it("falls back to calendar page URL when source_url is empty", async () => {
+    mockServerFrom.mockReturnValue(makeBuilder([{ ...ALL_DAY_EVENT, source_url: "" }]));
+    const res = await GET();
+    const body = await res.text();
+    expect(body).toContain("URL:https://invest.com.au/calendar");
+  });
+
+  it("includes CATEGORIES from event_type uppercased", async () => {
+    mockServerFrom.mockReturnValue(makeBuilder([ALL_DAY_EVENT]));
+    const res = await GET();
+    const body = await res.text();
+    expect(body).toContain("CATEGORIES:RBA");
+  });
+
+  it("includes a unique UID for each event", async () => {
+    mockServerFrom.mockReturnValue(makeBuilder([ALL_DAY_EVENT]));
+    const res = await GET();
+    const body = await res.text();
+    expect(body).toContain("UID:market-event-1@invest.com.au");
+  });
+});
+
+describe("GET /api/market-events/ical — timed events", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("uses TZID-qualified DTSTART for timed events", async () => {
+    mockServerFrom.mockReturnValue(makeBuilder([TIMED_EVENT]));
+    const res = await GET();
+    const body = await res.text();
+    // DTSTART;TZID=Australia/Sydney:20260615T143000
+    expect(body).toContain("DTSTART;TZID=Australia/Sydney:20260615T");
+  });
+
+  it("uses DURATION:PT1H for timed events (no explicit DTEND)", async () => {
+    mockServerFrom.mockReturnValue(makeBuilder([TIMED_EVENT]));
+    const res = await GET();
+    const body = await res.text();
+    expect(body).toContain("DURATION:PT1H");
+  });
+
+  it("renders multiple events as separate VEVENTs", async () => {
+    mockServerFrom.mockReturnValue(makeBuilder([ALL_DAY_EVENT, TIMED_EVENT]));
+    const res = await GET();
+    const body = await res.text();
+    const count = (body.match(/BEGIN:VEVENT/g) ?? []).length;
+    expect(count).toBe(2);
+  });
+});
+
+describe("GET /api/market-events/ical — query filters", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("queries with is_published=true filter", async () => {
+    const chain = makeBuilder([ALL_DAY_EVENT]);
+    mockServerFrom.mockReturnValue(chain);
+    await GET();
+    const eqCalls = (chain.eq as ReturnType<typeof vi.fn>).mock.calls;
+    expect(eqCalls.some((c) => c[0] === "is_published" && c[1] === true)).toBe(true);
+  });
+
+  it("applies a limit of 500 to the query", async () => {
+    const chain = makeBuilder([ALL_DAY_EVENT]);
+    mockServerFrom.mockReturnValue(chain);
+    await GET();
+    expect((chain.limit as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe(500);
+  });
+});

--- a/__tests__/api/office-hours-id-questions-qid-upvote.test.ts
+++ b/__tests__/api/office-hours-id-questions-qid-upvote.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Tests for POST + DELETE /api/office-hours/[id]/questions/[qid]/upvote
+ *
+ * Auth: createClient + supabase.auth.getUser (required)
+ * POST branches: 400 (bad ids), 401, 429, 409 (23505 duplicate), 500, 201
+ * DELETE branches: 400 (bad ids), 401, 500, 200
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const { mockGetUser, mockFrom, mockIsRateLimited, mockRpc } = vi.hoisted(() => ({
+  mockGetUser: vi.fn(
+    async (): Promise<{ data: { user: { id: string; email?: string } | null }; error: unknown }> => ({
+      data: { user: { id: "u1", email: "u@e.com" } },
+      error: null,
+    }),
+  ),
+  mockFrom: vi.fn((..._a: unknown[]): Record<string, unknown> => ({ then: vi.fn() })),
+  mockIsRateLimited: vi.fn(async (..._a: unknown[]): Promise<boolean> => false),
+  mockRpc: vi.fn(async (..._a: unknown[]): Promise<{ data: unknown; error: unknown }> => ({
+    data: null,
+    error: null,
+  })),
+}));
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: (..._args: unknown[]) => mockGetUser() },
+    from: (..._args: unknown[]) => mockFrom(),
+    rpc: (name: string, args: Record<string, unknown>) => mockRpc(name, args),
+  })),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: (..._args: unknown[]) => mockIsRateLimited(),
+}));
+
+// ── Route under test ──────────────────────────────────────────────────────────
+
+import { POST, DELETE } from "@/app/api/office-hours/[id]/questions/[qid]/upvote/route";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeBuilder(data: unknown = null, error: unknown = null) {
+  const c: Record<string, unknown> = {
+    then: (r: (v: { data: unknown; error: unknown }) => unknown) =>
+      Promise.resolve(r({ data, error })),
+  };
+  for (const m of [
+    "select", "insert", "update", "upsert", "delete",
+    "eq", "neq", "gt", "gte", "lt", "lte", "in", "is", "not", "or",
+    "order", "limit", "range", "single", "maybeSingle", "filter",
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  return c;
+}
+
+function makeReq(sessionId: string, questionId: string, method: "POST" | "DELETE"): NextRequest {
+  return new NextRequest(
+    `http://localhost/api/office-hours/${sessionId}/questions/${questionId}/upvote`,
+    { method },
+  );
+}
+
+type UpvoteParams = { params: Promise<{ id: string; qid: string }> };
+
+function makeParams(id: string, qid: string): UpvoteParams {
+  return { params: Promise.resolve({ id, qid }) };
+}
+
+// ── POST tests ────────────────────────────────────────────────────────────────
+
+describe("POST /api/office-hours/[id]/questions/[qid]/upvote", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1", email: "u@e.com" } }, error: null });
+    mockIsRateLimited.mockResolvedValue(false);
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder(null, null));
+    mockRpc.mockResolvedValue({ data: null, error: null });
+  });
+
+  it("returns 400 for non-integer session id", async () => {
+    const res = await POST(makeReq("abc", "3", "POST"), makeParams("abc", "3"));
+    expect(res.status).toBe(400);
+    const body = await res.json() as Record<string, unknown>;
+    expect(typeof body.error).toBe("string");
+  });
+
+  it("returns 400 for non-integer question id", async () => {
+    const res = await POST(makeReq("5", "xyz", "POST"), makeParams("5", "xyz"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for zero question id", async () => {
+    const res = await POST(makeReq("5", "0", "POST"), makeParams("5", "0"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+    const res = await POST(makeReq("5", "3", "POST"), makeParams("5", "3"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockIsRateLimited.mockResolvedValue(true);
+    const res = await POST(makeReq("5", "3", "POST"), makeParams("5", "3"));
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 409 when already upvoted (23505)", async () => {
+    mockFrom.mockImplementation((..._a: unknown[]) =>
+      makeBuilder(null, { code: "23505", message: "unique violation" }),
+    );
+    const res = await POST(makeReq("5", "3", "POST"), makeParams("5", "3"));
+    expect(res.status).toBe(409);
+    const body = await res.json() as Record<string, unknown>;
+    expect(typeof body.error).toBe("string");
+  });
+
+  it("returns 500 when insert fails with non-duplicate error", async () => {
+    mockFrom.mockImplementation((..._a: unknown[]) =>
+      makeBuilder(null, { code: "42501", message: "permission denied" }),
+    );
+    const res = await POST(makeReq("5", "3", "POST"), makeParams("5", "3"));
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 201 on successful upvote", async () => {
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder(null, null));
+    const res = await POST(makeReq("5", "3", "POST"), makeParams("5", "3"));
+    expect(res.status).toBe(201);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.success).toBe(true);
+  });
+
+  it("calls increment_oh_upvote rpc after successful insert", async () => {
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder(null, null));
+    await POST(makeReq("5", "3", "POST"), makeParams("5", "3"));
+    expect(mockRpc).toHaveBeenCalledWith("increment_oh_upvote", { question_id_arg: 3 });
+  });
+});
+
+// ── DELETE tests ──────────────────────────────────────────────────────────────
+
+describe("DELETE /api/office-hours/[id]/questions/[qid]/upvote", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1", email: "u@e.com" } }, error: null });
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder(null, null));
+    mockRpc.mockResolvedValue({ data: null, error: null });
+  });
+
+  it("returns 400 for non-integer session id", async () => {
+    const res = await DELETE(makeReq("abc", "3", "DELETE"), makeParams("abc", "3"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for non-integer question id", async () => {
+    const res = await DELETE(makeReq("5", "nope", "DELETE"), makeParams("5", "nope"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+    const res = await DELETE(makeReq("5", "3", "DELETE"), makeParams("5", "3"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 500 when delete fails", async () => {
+    mockFrom.mockImplementation((..._a: unknown[]) =>
+      makeBuilder(null, { message: "delete error" }),
+    );
+    const res = await DELETE(makeReq("5", "3", "DELETE"), makeParams("5", "3"));
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 200 on successful upvote removal", async () => {
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder(null, null));
+    const res = await DELETE(makeReq("5", "3", "DELETE"), makeParams("5", "3"));
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.success).toBe(true);
+  });
+
+  it("calls decrement_oh_upvote rpc after successful delete", async () => {
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder(null, null));
+    await DELETE(makeReq("5", "3", "DELETE"), makeParams("5", "3"));
+    expect(mockRpc).toHaveBeenCalledWith("decrement_oh_upvote", { question_id_arg: 3 });
+  });
+});

--- a/__tests__/api/office-hours-id-rsvp.test.ts
+++ b/__tests__/api/office-hours-id-rsvp.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for POST + DELETE /api/office-hours/[id]/rsvp
+ *
+ * Auth: createClient + supabase.auth.getUser (required)
+ * POST branches: 400 (bad id), 401, 429, 404 (no session), 409 (ended/transcript),
+ *                409 (23505 duplicate), 500 (insert error), 201
+ * DELETE branches: 400 (bad id), 401, 500 (delete error), 200
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const { mockGetUser, mockFrom, mockIsRateLimited } = vi.hoisted(() => ({
+  mockGetUser: vi.fn(
+    async (): Promise<{ data: { user: { id: string; email?: string } | null }; error: unknown }> => ({
+      data: { user: { id: "u1", email: "u@e.com" } },
+      error: null,
+    }),
+  ),
+  mockFrom: vi.fn((..._a: unknown[]): Record<string, unknown> => ({ then: vi.fn() })),
+  mockIsRateLimited: vi.fn(async (..._a: unknown[]): Promise<boolean> => false),
+}));
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: (..._args: unknown[]) => mockGetUser() },
+    from: (..._args: unknown[]) => mockFrom(),
+  })),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: (..._args: unknown[]) => mockIsRateLimited(),
+}));
+
+// ── Route under test ──────────────────────────────────────────────────────────
+
+import { POST, DELETE } from "@/app/api/office-hours/[id]/rsvp/route";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeBuilder(data: unknown = null, error: unknown = null) {
+  const c: Record<string, unknown> = {
+    then: (r: (v: { data: unknown; error: unknown }) => unknown) =>
+      Promise.resolve(r({ data, error })),
+  };
+  for (const m of [
+    "select", "insert", "update", "upsert", "delete",
+    "eq", "neq", "gt", "gte", "lt", "lte", "in", "is", "not", "or",
+    "order", "limit", "range", "single", "maybeSingle", "filter",
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  return c;
+}
+
+function makeReq(id: string, method: "POST" | "DELETE"): NextRequest {
+  return new NextRequest(`http://localhost/api/office-hours/${id}/rsvp`, { method });
+}
+
+const SESSION_ROW = { id: 5, status: "upcoming", is_published: true };
+
+// ── POST tests ────────────────────────────────────────────────────────────────
+
+describe("POST /api/office-hours/[id]/rsvp", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1", email: "u@e.com" } }, error: null });
+    mockIsRateLimited.mockResolvedValue(false);
+  });
+
+  it("returns 400 for non-integer session id", async () => {
+    const res = await POST(makeReq("abc", "POST"), { params: Promise.resolve({ id: "abc" }) });
+    expect(res.status).toBe(400);
+    const body = await res.json() as Record<string, unknown>;
+    expect(typeof body.error).toBe("string");
+  });
+
+  it("returns 400 for zero session id", async () => {
+    const res = await POST(makeReq("0", "POST"), { params: Promise.resolve({ id: "0" }) });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+    const res = await POST(makeReq("5", "POST"), { params: Promise.resolve({ id: "5" }) });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockIsRateLimited.mockResolvedValue(true);
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder(SESSION_ROW));
+    const res = await POST(makeReq("5", "POST"), { params: Promise.resolve({ id: "5" }) });
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 404 when session is not found", async () => {
+    // First from() call = session lookup → returns null
+    mockFrom.mockImplementationOnce((..._a: unknown[]) => makeBuilder(null));
+    const res = await POST(makeReq("5", "POST"), { params: Promise.resolve({ id: "5" }) });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when session is not published", async () => {
+    mockFrom.mockImplementationOnce((..._a: unknown[]) =>
+      makeBuilder({ id: 5, status: "upcoming", is_published: false }),
+    );
+    const res = await POST(makeReq("5", "POST"), { params: Promise.resolve({ id: "5" }) });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 409 when session status is ended", async () => {
+    mockFrom.mockImplementationOnce((..._a: unknown[]) =>
+      makeBuilder({ id: 5, status: "ended", is_published: true }),
+    );
+    const res = await POST(makeReq("5", "POST"), { params: Promise.resolve({ id: "5" }) });
+    expect(res.status).toBe(409);
+    const body = await res.json() as Record<string, unknown>;
+    expect(typeof body.error).toBe("string");
+  });
+
+  it("returns 409 when session status is transcript", async () => {
+    mockFrom.mockImplementationOnce((..._a: unknown[]) =>
+      makeBuilder({ id: 5, status: "transcript", is_published: true }),
+    );
+    const res = await POST(makeReq("5", "POST"), { params: Promise.resolve({ id: "5" }) });
+    expect(res.status).toBe(409);
+  });
+
+  it("returns 409 when RSVP is already submitted (23505)", async () => {
+    // session lookup
+    mockFrom.mockImplementationOnce((..._a: unknown[]) => makeBuilder(SESSION_ROW));
+    // insert → 23505
+    mockFrom.mockImplementationOnce((..._a: unknown[]) =>
+      makeBuilder(null, { code: "23505", message: "unique violation" }),
+    );
+    const res = await POST(makeReq("5", "POST"), { params: Promise.resolve({ id: "5" }) });
+    expect(res.status).toBe(409);
+    const body = await res.json() as Record<string, unknown>;
+    expect(typeof body.error).toBe("string");
+  });
+
+  it("returns 500 when insert fails with a non-unique error", async () => {
+    mockFrom.mockImplementationOnce((..._a: unknown[]) => makeBuilder(SESSION_ROW));
+    mockFrom.mockImplementationOnce((..._a: unknown[]) =>
+      makeBuilder(null, { code: "42501", message: "permission denied" }),
+    );
+    const res = await POST(makeReq("5", "POST"), { params: Promise.resolve({ id: "5" }) });
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 201 on successful RSVP", async () => {
+    mockFrom.mockImplementationOnce((..._a: unknown[]) => makeBuilder(SESSION_ROW));
+    // insert succeeds
+    mockFrom.mockImplementationOnce((..._a: unknown[]) => makeBuilder(null, null));
+    // update rsvp_count (best-effort, ignored)
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder(null));
+    const res = await POST(makeReq("5", "POST"), { params: Promise.resolve({ id: "5" }) });
+    expect(res.status).toBe(201);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.success).toBe(true);
+  });
+});
+
+// ── DELETE tests ──────────────────────────────────────────────────────────────
+
+describe("DELETE /api/office-hours/[id]/rsvp", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1", email: "u@e.com" } }, error: null });
+  });
+
+  it("returns 400 for non-integer session id", async () => {
+    const res = await DELETE(makeReq("xyz", "DELETE"), { params: Promise.resolve({ id: "xyz" }) });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+    const res = await DELETE(makeReq("5", "DELETE"), { params: Promise.resolve({ id: "5" }) });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 500 when delete fails", async () => {
+    mockFrom.mockImplementation((..._a: unknown[]) =>
+      makeBuilder(null, { message: "delete error" }),
+    );
+    const res = await DELETE(makeReq("5", "DELETE"), { params: Promise.resolve({ id: "5" }) });
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 200 with success:true on successful unRSVP", async () => {
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder(null, null));
+    const res = await DELETE(makeReq("5", "DELETE"), { params: Promise.resolve({ id: "5" }) });
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.success).toBe(true);
+  });
+});

--- a/__tests__/api/office-hours.test.ts
+++ b/__tests__/api/office-hours.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for GET /api/office-hours
+ *
+ * Auth: none (public)
+ * Branches: 500 (db error), 200 (default filter), 200 (valid status param),
+ *           200 (invalid status param → defaults to upcoming/live/transcript),
+ *           200 (limit clamped), Cache-Control header present
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const { mockFrom } = vi.hoisted(() => ({
+  mockFrom: vi.fn((..._a: unknown[]): Record<string, unknown> => ({ then: vi.fn() })),
+}));
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({ from: (..._args: unknown[]) => mockFrom() })),
+}));
+
+// ── Route under test ──────────────────────────────────────────────────────────
+
+import { GET } from "@/app/api/office-hours/route";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeBuilder(data: unknown = [], error: unknown = null) {
+  const c: Record<string, unknown> = {
+    then: (r: (v: { data: unknown; error: unknown }) => unknown) =>
+      Promise.resolve(r({ data, error })),
+  };
+  for (const m of [
+    "select", "insert", "update", "upsert", "delete",
+    "eq", "neq", "gt", "gte", "lt", "lte", "in", "is", "not", "or",
+    "order", "limit", "range", "single", "maybeSingle", "filter",
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  return c;
+}
+
+function makeReq(params: Record<string, string> = {}): NextRequest {
+  const url = new URL("http://localhost/api/office-hours");
+  for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
+  return new NextRequest(url.toString());
+}
+
+const SESSION = {
+  id: 1,
+  title: "AMA: ETF Basics",
+  scheduled_at: "2026-06-01T10:00:00Z",
+  ends_at: null,
+  status: "upcoming",
+  max_questions: 20,
+  rsvp_count: 5,
+  advisor_id: 42,
+  professionals: { id: 42, name: "Jane Smith", slug: "jane-smith", type: "planner", firm_name: "AusSuper", headshot_url: null },
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("GET /api/office-hours", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder([SESSION]));
+  });
+
+  it("returns 500 when DB query fails", async () => {
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder(null, { message: "db error" }));
+    const res = await GET(makeReq());
+    expect(res.status).toBe(500);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.error).toBe("fetch_failed");
+  });
+
+  it("returns 200 with sessions array on success", async () => {
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(Array.isArray(body.sessions)).toBe(true);
+    expect((body.sessions as unknown[]).length).toBe(1);
+  });
+
+  it("returns empty sessions array when data is null", async () => {
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder(null));
+    const res = await GET(makeReq());
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.sessions).toEqual([]);
+  });
+
+  it("applies valid status filter", async () => {
+    const b = makeBuilder([{ ...SESSION, status: "live" }]);
+    const eqSpy = b.eq as ReturnType<typeof vi.fn>;
+    mockFrom.mockImplementation((..._a: unknown[]) => b);
+    const res = await GET(makeReq({ status: "live" }));
+    expect(res.status).toBe(200);
+    // eq("status", "live") should have been called
+    expect(eqSpy).toHaveBeenCalledWith("status", "live");
+  });
+
+  it("falls back to default filter for invalid status param", async () => {
+    const b = makeBuilder([SESSION]);
+    const inSpy = b.in as ReturnType<typeof vi.fn>;
+    mockFrom.mockImplementation((..._a: unknown[]) => b);
+    const res = await GET(makeReq({ status: "invalid_status" }));
+    expect(res.status).toBe(200);
+    expect(inSpy).toHaveBeenCalledWith("status", ["upcoming", "live", "transcript"]);
+  });
+
+  it("clamps limit to 50 when given a larger value", async () => {
+    const b = makeBuilder([SESSION]);
+    const limitSpy = b.limit as ReturnType<typeof vi.fn>;
+    mockFrom.mockImplementation((..._a: unknown[]) => b);
+    await GET(makeReq({ limit: "100" }));
+    expect(limitSpy).toHaveBeenCalledWith(50);
+  });
+
+  it("defaults to 20 when limit param is 0 (falsy → fallback)", async () => {
+    // parseInt("0") = 0, which is falsy → 0 || 20 = 20, then Math.max(1,20) = 20
+    const b = makeBuilder([SESSION]);
+    const limitSpy = b.limit as ReturnType<typeof vi.fn>;
+    mockFrom.mockImplementation((..._a: unknown[]) => b);
+    await GET(makeReq({ limit: "0" }));
+    expect(limitSpy).toHaveBeenCalledWith(20);
+  });
+
+  it("defaults limit to 20 when param is missing", async () => {
+    const b = makeBuilder([SESSION]);
+    const limitSpy = b.limit as ReturnType<typeof vi.fn>;
+    mockFrom.mockImplementation((..._a: unknown[]) => b);
+    await GET(makeReq());
+    expect(limitSpy).toHaveBeenCalledWith(20);
+  });
+
+  it("includes Cache-Control header", async () => {
+    const res = await GET(makeReq());
+    expect(res.headers.get("Cache-Control")).toContain("public");
+  });
+});

--- a/__tests__/api/org-auth-dashboard.test.ts
+++ b/__tests__/api/org-auth-dashboard.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Hoisted mock refs ─────────────────────────────────────────────────────────
+
+const { mockRequireOrgSession, mockAdminFrom } = vi.hoisted(() => ({
+  mockRequireOrgSession: vi.fn<() => Promise<{ organisationId: number; role: string; userId: string }>>(
+    async () => ({ organisationId: 5, role: "admin", userId: "user-org-5" }),
+  ),
+  mockAdminFrom: vi.fn(() => makeChain()),
+}));
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+vi.mock("@/lib/require-org-session", () => ({
+  requireOrgSession: () => mockRequireOrgSession(),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeChain(res: { data?: unknown; error?: unknown; count?: number | null } = {}) {
+  const chain: Record<string, unknown> = {};
+  for (const m of [
+    "select", "insert", "update", "delete", "upsert",
+    "eq", "neq", "lt", "lte", "gte", "is", "in", "not", "or",
+    "order", "limit", "range", "maybeSingle", "single", "like", "head",
+  ]) {
+    chain[m] = vi.fn(() => chain);
+  }
+  chain.then = (resolve: (v: unknown) => unknown) =>
+    Promise.resolve(
+      resolve({ data: res.data ?? null, error: res.error ?? null, count: res.count ?? null }),
+    );
+  chain.catch = () => chain;
+  return chain;
+}
+
+const SESSION = { organisationId: 5, role: "admin", userId: "user-org-5" };
+
+// ── Route under test ──────────────────────────────────────────────────────────
+import { GET } from "@/app/api/org-auth/dashboard/route";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// GET
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("GET /api/org-auth/dashboard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireOrgSession.mockResolvedValue(SESSION);
+  });
+
+  it("returns 401 when requireOrgSession throws a 401 Response", async () => {
+    mockRequireOrgSession.mockRejectedValue(
+      new Response(JSON.stringify({ error: "Unauthorised" }), { status: 401 }),
+    );
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 500 when requireOrgSession throws an unexpected Error", async () => {
+    mockRequireOrgSession.mockRejectedValue(new Error("unexpected"));
+    const res = await GET();
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 500 when the courses query fails", async () => {
+    mockAdminFrom.mockReturnValue(makeChain({ data: null, error: { message: "courses boom" } }));
+    const res = await GET();
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toMatch(/Failed to load dashboard/i);
+  });
+
+  it("returns zeroed stats when org has no published courses", async () => {
+    mockAdminFrom.mockReturnValue(makeChain({ data: [], error: null }));
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.enrollments_this_month).toBe(0);
+    expect(body.revenue_this_month_cents).toBe(0);
+    expect(body.total_enrollments).toBe(0);
+    expect(body.total_revenue_cents).toBe(0);
+    expect(body.active_courses).toBe(0);
+    expect(body.cpd_hours_issued).toBe(0);
+  });
+
+  it("returns zeroed stats when courses returns null", async () => {
+    mockAdminFrom.mockReturnValue(makeChain({ data: null, error: null }));
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.active_courses).toBe(0);
+  });
+
+  it("returns 500 when purchases query fails", async () => {
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      call += 1;
+      if (call === 1) return makeChain({ data: [{ id: 10 }], error: null });
+      return makeChain({ data: null, error: { message: "purchases boom" } });
+    });
+    const res = await GET();
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toMatch(/Failed to load dashboard/i);
+  });
+
+  it("returns correct stats with purchases but no CPD data", async () => {
+    const now = new Date();
+    const thisMonth = new Date(now.getFullYear(), now.getMonth(), 15).toISOString();
+    const lastMonth = new Date(now.getFullYear(), now.getMonth() - 1, 15).toISOString();
+    const purchases = [
+      { id: 1, amount_cents: 5000, purchased_at: thisMonth, course_id: 10 },
+      { id: 2, amount_cents: 3000, purchased_at: thisMonth, course_id: 10 },
+      { id: 3, amount_cents: 2000, purchased_at: lastMonth, course_id: 10 },
+    ];
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      call += 1;
+      if (call === 1) return makeChain({ data: [{ id: 10 }], error: null });
+      if (call === 2) return makeChain({ data: purchases, error: null });
+      return makeChain({ data: null, error: null }); // CPD query returns null — graceful
+    });
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.total_enrollments).toBe(3);
+    expect(body.total_revenue_cents).toBe(10000);
+    expect(body.enrollments_this_month).toBe(2);
+    expect(body.revenue_this_month_cents).toBe(8000);
+    expect(body.active_courses).toBe(1);
+    expect(body.cpd_hours_issued).toBe(0);
+  });
+
+  it("sums CPD hours correctly", async () => {
+    const now = new Date();
+    const thisMonth = new Date(now.getFullYear(), now.getMonth(), 15).toISOString();
+    const purchases = [
+      { id: 1, amount_cents: 5000, purchased_at: thisMonth, course_id: 10 },
+    ];
+    const cpdData = [
+      { hours_earned: 3.5, course_id: 10 },
+      { hours_earned: 1.5, course_id: 10 },
+      { hours_earned: null, course_id: 10 }, // null should be treated as 0
+    ];
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      call += 1;
+      if (call === 1) return makeChain({ data: [{ id: 10 }, { id: 11 }], error: null });
+      if (call === 2) return makeChain({ data: purchases, error: null });
+      return makeChain({ data: cpdData, error: null });
+    });
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.cpd_hours_issued).toBe(5);
+    expect(body.active_courses).toBe(2);
+  });
+
+  it("returns 200 with cpd_hours_issued=0 when CPD query fails (non-fatal)", async () => {
+    const now = new Date();
+    const thisMonth = new Date(now.getFullYear(), now.getMonth(), 15).toISOString();
+    const purchases = [
+      { id: 1, amount_cents: 1000, purchased_at: thisMonth, course_id: 10 },
+    ];
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      call += 1;
+      if (call === 1) return makeChain({ data: [{ id: 10 }], error: null });
+      if (call === 2) return makeChain({ data: purchases, error: null });
+      // CPD query fails — should warn but not fail the response
+      return makeChain({ data: null, error: { message: "cpd boom" } });
+    });
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.cpd_hours_issued).toBe(0);
+    expect(body.total_enrollments).toBe(1);
+  });
+
+  it("returns 200 with empty purchases returning zeroed this-month stats", async () => {
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      call += 1;
+      if (call === 1) return makeChain({ data: [{ id: 10 }, { id: 11 }], error: null });
+      if (call === 2) return makeChain({ data: [], error: null });
+      return makeChain({ data: [], error: null });
+    });
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.total_enrollments).toBe(0);
+    expect(body.enrollments_this_month).toBe(0);
+    expect(body.active_courses).toBe(2);
+  });
+});

--- a/__tests__/api/org-auth-events.test.ts
+++ b/__tests__/api/org-auth-events.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NextRequest } from "next/server";
+
+// ── Hoisted mock refs ─────────────────────────────────────────────────────────
+
+const { mockRequireOrgSession, mockIsRateLimited, mockAdminFrom } = vi.hoisted(() => ({
+  mockRequireOrgSession: vi.fn<() => Promise<{ organisationId: number; role: string; userId: string }>>(
+    async () => ({ organisationId: 5, role: "admin", userId: "user-org-5" }),
+  ),
+  mockIsRateLimited: vi.fn<(...args: unknown[]) => Promise<boolean>>(async () => false),
+  mockAdminFrom: vi.fn(() => makeChain()),
+}));
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: (...args: unknown[]) => mockIsRateLimited(...args),
+}));
+
+vi.mock("@/lib/require-org-session", () => ({
+  requireOrgSession: () => mockRequireOrgSession(),
+}));
+
+vi.mock("@/lib/validation/withValidatedBody", () => ({
+  withValidatedBody: (
+    schema: { safeParse: (v: unknown) => { success: boolean; data?: unknown; error?: { issues: Array<{ message: string }> } } },
+    handler: (req: NextRequest, body: unknown) => unknown,
+  ) =>
+    async (req: NextRequest) => {
+      let rawBody: unknown;
+      try {
+        rawBody = await req.json();
+      } catch {
+        const { NextResponse } = await import("next/server");
+        return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+      }
+      const parsed = schema.safeParse(rawBody);
+      if (!parsed.success) {
+        const { NextResponse } = await import("next/server");
+        const firstMsg = parsed.error?.issues[0]?.message ?? "Validation error";
+        return NextResponse.json(
+          { error: firstMsg, code: "validation_error", issues: parsed.error?.issues ?? [] },
+          { status: 400 },
+        );
+      }
+      return handler(req, parsed.data);
+    },
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeChain(res: { data?: unknown; error?: unknown; count?: number | null } = {}) {
+  const chain: Record<string, unknown> = {};
+  for (const m of [
+    "select", "insert", "update", "delete", "upsert",
+    "eq", "neq", "lt", "lte", "gte", "is", "in", "not", "or",
+    "order", "limit", "range", "maybeSingle", "single", "like", "head",
+  ]) {
+    chain[m] = vi.fn(() => chain);
+  }
+  chain.then = (resolve: (v: unknown) => unknown) =>
+    Promise.resolve(
+      resolve({ data: res.data ?? null, error: res.error ?? null, count: res.count ?? null }),
+    );
+  chain.catch = () => chain;
+  return chain;
+}
+
+function makeReq(method: string, body?: unknown, ip = "1.2.3.4"): NextRequest {
+  return new Request("http://localhost/api/org-auth/events", {
+    method,
+    headers: {
+      "x-forwarded-for": ip,
+      ...(body !== undefined ? { "content-type": "application/json" } : {}),
+    },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  }) as unknown as NextRequest;
+}
+
+const SESSION = { organisationId: 5, role: "admin", userId: "user-org-5" };
+
+const VALID_EVENT_BODY = {
+  title: "Webinar on ETFs",
+  starts_at: "2026-06-01T10:00:00Z",
+};
+
+const SAMPLE_EVENT = {
+  id: 1,
+  title: "Webinar on ETFs",
+  description: null,
+  event_type: "webinar",
+  starts_at: "2026-06-01T10:00:00Z",
+  ends_at: null,
+  timezone: "Australia/Sydney",
+  location: null,
+  meeting_url: null,
+  max_attendees: null,
+  price_cents: 0,
+  status: "draft",
+  rsvp_count: 0,
+  created_at: "2026-05-01T00:00:00Z",
+};
+
+// ── Route under test ──────────────────────────────────────────────────────────
+import { GET, POST } from "@/app/api/org-auth/events/route";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// GET
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("GET /api/org-auth/events", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+    mockRequireOrgSession.mockResolvedValue(SESSION);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsRateLimited.mockResolvedValue(true);
+    const res = await GET(makeReq("GET"));
+    expect(res.status).toBe(429);
+    expect((await res.json()).error).toMatch(/too many requests/i);
+  });
+
+  it("returns 401 when requireOrgSession throws a 401 Response", async () => {
+    mockRequireOrgSession.mockRejectedValue(
+      new Response(JSON.stringify({ error: "Unauthorised" }), { status: 401 }),
+    );
+    const res = await GET(makeReq("GET"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 500 when requireOrgSession throws an unexpected Error", async () => {
+    mockRequireOrgSession.mockRejectedValue(new Error("unexpected"));
+    const res = await GET(makeReq("GET"));
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 500 when the events DB query fails", async () => {
+    mockAdminFrom.mockReturnValue(makeChain({ data: null, error: { message: "db error" } }));
+    const res = await GET(makeReq("GET"));
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toMatch(/Failed to load events/i);
+  });
+
+  it("returns 200 with empty array when org has no events", async () => {
+    mockAdminFrom.mockReturnValue(makeChain({ data: null, error: null }));
+    const res = await GET(makeReq("GET"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.events).toEqual([]);
+  });
+
+  it("returns 200 with events array on success", async () => {
+    mockAdminFrom.mockReturnValue(makeChain({ data: [SAMPLE_EVENT], error: null }));
+    const res = await GET(makeReq("GET"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.events).toHaveLength(1);
+    expect(body.events[0].title).toBe("Webinar on ETFs");
+    expect(body.events[0].status).toBe("draft");
+  });
+
+  it("returns 200 with multiple events", async () => {
+    const events = [
+      { ...SAMPLE_EVENT, id: 1, title: "Event A" },
+      { ...SAMPLE_EVENT, id: 2, title: "Event B" },
+    ];
+    mockAdminFrom.mockReturnValue(makeChain({ data: events, error: null }));
+    const res = await GET(makeReq("GET"));
+    expect(res.status).toBe(200);
+    expect((await res.json()).events).toHaveLength(2);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// POST
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("POST /api/org-auth/events", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+    mockRequireOrgSession.mockResolvedValue(SESSION);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsRateLimited.mockResolvedValue(true);
+    const res = await POST(makeReq("POST", VALID_EVENT_BODY));
+    expect(res.status).toBe(429);
+    expect((await res.json()).error).toMatch(/too many requests/i);
+  });
+
+  it("returns 401 when requireOrgSession throws a 401 Response", async () => {
+    mockRequireOrgSession.mockRejectedValue(
+      new Response(JSON.stringify({ error: "Unauthorised" }), { status: 401 }),
+    );
+    const res = await POST(makeReq("POST", VALID_EVENT_BODY));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    const req = new Request("http://localhost/api/org-auth/events", {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-forwarded-for": "1.2.3.4" },
+      body: "not-json{{",
+    }) as unknown as NextRequest;
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/invalid json/i);
+  });
+
+  it("returns 400 when title is too short (Zod min 3)", async () => {
+    const res = await POST(makeReq("POST", { title: "Hi", starts_at: "2026-06-01T10:00:00Z" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("validation_error");
+  });
+
+  it("returns 400 when starts_at is missing (required field)", async () => {
+    const res = await POST(makeReq("POST", { title: "Valid Event Title" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("validation_error");
+  });
+
+  it("returns 400 when starts_at is not a valid datetime", async () => {
+    const res = await POST(makeReq("POST", { title: "Valid Event Title", starts_at: "not-a-date" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("validation_error");
+  });
+
+  it("returns 400 when event_type is an invalid enum value", async () => {
+    const res = await POST(makeReq("POST", { ...VALID_EVENT_BODY, event_type: "party" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("validation_error");
+  });
+
+  it("returns 400 when meeting_url is not a valid URL", async () => {
+    const res = await POST(makeReq("POST", { ...VALID_EVENT_BODY, meeting_url: "not-a-url" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("validation_error");
+  });
+
+  it("returns 400 when max_attendees is zero (min 1)", async () => {
+    const res = await POST(makeReq("POST", { ...VALID_EVENT_BODY, max_attendees: 0 }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("validation_error");
+  });
+
+  it("returns 500 when the insert fails", async () => {
+    mockAdminFrom.mockReturnValue(makeChain({ data: null, error: { message: "insert boom" } }));
+    const res = await POST(makeReq("POST", VALID_EVENT_BODY));
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toMatch(/Failed to create event/i);
+  });
+
+  it("returns 201 with the new event on success", async () => {
+    mockAdminFrom.mockReturnValue(makeChain({ data: SAMPLE_EVENT, error: null }));
+    const res = await POST(makeReq("POST", VALID_EVENT_BODY));
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.event.title).toBe("Webinar on ETFs");
+    expect(body.event.status).toBe("draft");
+  });
+
+  it("returns 201 with all optional fields on a full-body request", async () => {
+    const fullBody = {
+      title: "Full Event",
+      starts_at: "2026-06-01T10:00:00Z",
+      ends_at: "2026-06-01T12:00:00Z",
+      event_type: "workshop",
+      description: "A workshop about investing",
+      timezone: "Australia/Melbourne",
+      location: "123 Collins St, Melbourne",
+      meeting_url: "https://zoom.us/j/12345",
+      max_attendees: 100,
+      price_cents: 5000,
+    };
+    const fullEvent = { ...SAMPLE_EVENT, ...fullBody };
+    mockAdminFrom.mockReturnValue(makeChain({ data: fullEvent, error: null }));
+    const res = await POST(makeReq("POST", fullBody));
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.event.event_type).toBe("workshop");
+    expect(body.event.price_cents).toBe(5000);
+  });
+
+  it("returns 500 when requireOrgSession throws an unexpected Error after rate-limit check", async () => {
+    mockRequireOrgSession.mockRejectedValue(new Error("unexpected crash"));
+    const res = await POST(makeReq("POST", VALID_EVENT_BODY));
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/org-auth-stripe-connect-onboard.test.ts
+++ b/__tests__/api/org-auth-stripe-connect-onboard.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Hoisted mock refs ─────────────────────────────────────────────────────────
+
+const {
+  mockRequireOrgSession,
+  mockAdminFrom,
+  mockStripeAccountsCreate,
+  mockStripeAccountLinksCreate,
+  mockStripeAccountsUpdate,
+} = vi.hoisted(() => ({
+  mockRequireOrgSession: vi.fn<() => Promise<{ organisationId: number; role: string; userId: string }>>(
+    async () => ({ organisationId: 5, role: "admin", userId: "user-org-5" }),
+  ),
+  mockAdminFrom: vi.fn(() => makeChain()),
+  mockStripeAccountsCreate: vi.fn<(..._a: unknown[]) => Promise<{ id: string }>>(
+    async () => ({ id: "acct_new123" }),
+  ),
+  mockStripeAccountLinksCreate: vi.fn<(..._a: unknown[]) => Promise<{ url: string }>>(
+    async () => ({ url: "https://connect.stripe.com/onboard/acct_new123" }),
+  ),
+  mockStripeAccountsUpdate: vi.fn<(..._a: unknown[]) => Promise<{ id: string }>>(
+    async () => ({ id: "acct_existing" }),
+  ),
+}));
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+vi.mock("@/lib/require-org-session", () => ({
+  requireOrgSession: () => mockRequireOrgSession(),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+vi.mock("stripe", () => {
+  return {
+    default: vi.fn().mockImplementation(() => ({
+      accounts: {
+        create: (...args: unknown[]) => mockStripeAccountsCreate(...args),
+        update: (...args: unknown[]) => mockStripeAccountsUpdate(...args),
+      },
+      accountLinks: {
+        create: (...args: unknown[]) => mockStripeAccountLinksCreate(...args),
+      },
+    })),
+  };
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeChain(res: { data?: unknown; error?: unknown; count?: number | null } = {}) {
+  const chain: Record<string, unknown> = {};
+  for (const m of [
+    "select", "insert", "update", "delete", "upsert",
+    "eq", "neq", "lt", "lte", "gte", "is", "in", "not", "or",
+    "order", "limit", "range", "maybeSingle", "single", "like", "head",
+  ]) {
+    chain[m] = vi.fn(() => chain);
+  }
+  chain.then = (resolve: (v: unknown) => unknown) =>
+    Promise.resolve(
+      resolve({ data: res.data ?? null, error: res.error ?? null, count: res.count ?? null }),
+    );
+  chain.catch = () => chain;
+  return chain;
+}
+
+const SESSION_ADMIN = { organisationId: 5, role: "admin", userId: "user-org-5" };
+const SESSION_VIEWER = { organisationId: 5, role: "viewer", userId: "user-org-5" };
+
+const ORG_NO_ACCOUNT = { id: 5, email: "org@example.com", stripe_connect_account_id: null };
+const ORG_WITH_ACCOUNT = {
+  id: 5,
+  email: "org@example.com",
+  stripe_connect_account_id: "acct_existing",
+};
+
+// ── Route under test ──────────────────────────────────────────────────────────
+import { POST } from "@/app/api/org-auth/stripe-connect/onboard/route";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// POST
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("POST /api/org-auth/stripe-connect/onboard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireOrgSession.mockResolvedValue(SESSION_ADMIN);
+    mockStripeAccountsCreate.mockResolvedValue({ id: "acct_new123" });
+    mockStripeAccountLinksCreate.mockResolvedValue({
+      url: "https://connect.stripe.com/onboard/acct_new123",
+    });
+  });
+
+  it("returns 401 when requireOrgSession throws a 401 Response", async () => {
+    mockRequireOrgSession.mockRejectedValue(
+      new Response(JSON.stringify({ error: "Unauthorised" }), { status: 401 }),
+    );
+    const res = await POST();
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 500 when requireOrgSession throws an unexpected Error", async () => {
+    mockRequireOrgSession.mockRejectedValue(new Error("unexpected"));
+    const res = await POST();
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 403 when the caller is not an admin", async () => {
+    mockRequireOrgSession.mockResolvedValue(SESSION_VIEWER);
+    const res = await POST();
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toMatch(/Only org admins/i);
+  });
+
+  it("returns 404 when org is not found", async () => {
+    mockAdminFrom.mockReturnValue(makeChain({ data: null, error: { message: "not found" } }));
+    const res = await POST();
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toMatch(/Organisation not found/i);
+  });
+
+  it("returns 404 when org query returns null data with no error", async () => {
+    mockAdminFrom.mockReturnValue(makeChain({ data: null, error: null }));
+    const res = await POST();
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toMatch(/Organisation not found/i);
+  });
+
+  it("creates a new Stripe account when org has none and returns onboarding URL", async () => {
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      call += 1;
+      if (call === 1) return makeChain({ data: ORG_NO_ACCOUNT, error: null }); // org fetch
+      return makeChain({ data: null, error: null }); // persist account ID update
+    });
+    const res = await POST();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.url).toBe("https://connect.stripe.com/onboard/acct_new123");
+    expect(mockStripeAccountsCreate).toHaveBeenCalledOnce();
+    expect(mockStripeAccountLinksCreate).toHaveBeenCalledOnce();
+  });
+
+  it("skips account creation when org already has a stripe_connect_account_id", async () => {
+    mockAdminFrom.mockReturnValue(makeChain({ data: ORG_WITH_ACCOUNT, error: null }));
+    mockStripeAccountLinksCreate.mockResolvedValue({
+      url: "https://connect.stripe.com/onboard/acct_existing",
+    });
+    const res = await POST();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.url).toBe("https://connect.stripe.com/onboard/acct_existing");
+    // Should NOT create a new account
+    expect(mockStripeAccountsCreate).not.toHaveBeenCalled();
+    expect(mockStripeAccountLinksCreate).toHaveBeenCalledOnce();
+  });
+
+  it("still returns the onboarding URL even when persisting the account ID fails", async () => {
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      call += 1;
+      if (call === 1) return makeChain({ data: ORG_NO_ACCOUNT, error: null }); // org fetch
+      return makeChain({ data: null, error: { message: "update failed" } }); // persist fails
+    });
+    const res = await POST();
+    // Route continues even if DB update fails
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.url).toBeDefined();
+  });
+
+  it("returns 500 when Stripe account creation throws", async () => {
+    mockAdminFrom.mockReturnValue(makeChain({ data: ORG_NO_ACCOUNT, error: null }));
+    mockStripeAccountsCreate.mockRejectedValue(new Error("Stripe API error"));
+    const res = await POST();
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toMatch(/Internal server error/i);
+  });
+
+  it("returns 500 when Stripe account link creation throws", async () => {
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      call += 1;
+      if (call === 1) return makeChain({ data: ORG_NO_ACCOUNT, error: null });
+      return makeChain({ data: null, error: null });
+    });
+    mockStripeAccountLinksCreate.mockRejectedValue(new Error("Stripe link error"));
+    const res = await POST();
+    expect(res.status).toBe(500);
+  });
+
+  it("passes account link correct refresh and return URLs", async () => {
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      call += 1;
+      if (call === 1) return makeChain({ data: ORG_WITH_ACCOUNT, error: null });
+      return makeChain({ data: null, error: null });
+    });
+    mockStripeAccountLinksCreate.mockResolvedValue({ url: "https://stripe.com/link" });
+    await POST();
+    const callArgs = mockStripeAccountLinksCreate.mock.calls[0];
+    const linkParams = callArgs?.[0] as { account: string; type: string; refresh_url: string; return_url: string } | undefined;
+    expect(linkParams?.account).toBe("acct_existing");
+    expect(linkParams?.type).toBe("account_onboarding");
+    expect(linkParams?.refresh_url).toContain("stripe=refresh");
+    expect(linkParams?.return_url).toContain("stripe=complete");
+  });
+});

--- a/__tests__/api/org-auth-team-invite.test.ts
+++ b/__tests__/api/org-auth-team-invite.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NextRequest } from "next/server";
+
+// ── Hoisted mock refs ─────────────────────────────────────────────────────────
+
+const { mockRequireOrgSession, mockIsRateLimited, mockAdminFrom } = vi.hoisted(() => ({
+  mockRequireOrgSession: vi.fn<() => Promise<{ organisationId: number; role: string; userId: string }>>(
+    async () => ({ organisationId: 5, role: "admin", userId: "user-org-5" }),
+  ),
+  mockIsRateLimited: vi.fn<(...args: unknown[]) => Promise<boolean>>(async () => false),
+  mockAdminFrom: vi.fn(() => makeChain()),
+}));
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: (...args: unknown[]) => mockIsRateLimited(...args),
+}));
+
+vi.mock("@/lib/require-org-session", () => ({
+  requireOrgSession: () => mockRequireOrgSession(),
+}));
+
+vi.mock("@/lib/validation/withValidatedBody", () => ({
+  withValidatedBody: (
+    schema: { safeParse: (v: unknown) => { success: boolean; data?: unknown; error?: { issues: Array<{ message: string }> } } },
+    handler: (req: NextRequest, body: unknown) => unknown,
+  ) =>
+    async (req: NextRequest) => {
+      let rawBody: unknown;
+      try {
+        rawBody = await req.json();
+      } catch {
+        const { NextResponse } = await import("next/server");
+        return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+      }
+      const parsed = schema.safeParse(rawBody);
+      if (!parsed.success) {
+        const { NextResponse } = await import("next/server");
+        const firstMsg = parsed.error?.issues[0]?.message ?? "Validation error";
+        return NextResponse.json(
+          { error: firstMsg, code: "validation_error", issues: parsed.error?.issues ?? [] },
+          { status: 400 },
+        );
+      }
+      return handler(req, parsed.data);
+    },
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockAdminFrom })),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeChain(res: { data?: unknown; error?: unknown; count?: number | null } = {}) {
+  const chain: Record<string, unknown> = {};
+  for (const m of [
+    "select", "insert", "update", "delete", "upsert",
+    "eq", "neq", "lt", "lte", "gte", "is", "in", "not", "or",
+    "order", "limit", "range", "maybeSingle", "single", "like", "head",
+  ]) {
+    chain[m] = vi.fn(() => chain);
+  }
+  chain.then = (resolve: (v: unknown) => unknown) =>
+    Promise.resolve(
+      resolve({ data: res.data ?? null, error: res.error ?? null, count: res.count ?? null }),
+    );
+  chain.catch = () => chain;
+  return chain;
+}
+
+function makeReq(method: string, body?: unknown, ip = "1.2.3.4"): NextRequest {
+  return new Request("http://localhost/api/org-auth/team/invite", {
+    method,
+    headers: {
+      "x-forwarded-for": ip,
+      ...(body !== undefined ? { "content-type": "application/json" } : {}),
+    },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  }) as unknown as NextRequest;
+}
+
+const SESSION_ADMIN = { organisationId: 5, role: "admin", userId: "user-org-5" };
+const SESSION_VIEWER = { organisationId: 5, role: "viewer", userId: "user-org-5" };
+
+const VALID_BODY = { email: "newmember@example.com", role: "editor" };
+
+const SAMPLE_MEMBER = {
+  id: 42,
+  organisation_id: 5,
+  invited_email: "newmember@example.com",
+  role: "editor",
+  status: "pending",
+  invited_at: "2026-05-01T00:00:00Z",
+};
+
+// ── Route under test ──────────────────────────────────────────────────────────
+import { POST } from "@/app/api/org-auth/team/invite/route";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// POST
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("POST /api/org-auth/team/invite", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+    mockRequireOrgSession.mockResolvedValue(SESSION_ADMIN);
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsRateLimited.mockResolvedValue(true);
+    const res = await POST(makeReq("POST", VALID_BODY));
+    expect(res.status).toBe(429);
+    expect((await res.json()).error).toMatch(/too many requests/i);
+  });
+
+  it("returns 401 when requireOrgSession throws a 401 Response", async () => {
+    mockRequireOrgSession.mockRejectedValue(
+      new Response(JSON.stringify({ error: "Unauthorised" }), { status: 401 }),
+    );
+    const res = await POST(makeReq("POST", VALID_BODY));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 500 when requireOrgSession throws an unexpected Error", async () => {
+    mockRequireOrgSession.mockRejectedValue(new Error("unexpected"));
+    const res = await POST(makeReq("POST", VALID_BODY));
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    const req = new Request("http://localhost/api/org-auth/team/invite", {
+      method: "POST",
+      headers: { "content-type": "application/json", "x-forwarded-for": "1.2.3.4" },
+      body: "not-json{{",
+    }) as unknown as NextRequest;
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/invalid json/i);
+  });
+
+  it("returns 400 when email is missing", async () => {
+    const res = await POST(makeReq("POST", { role: "editor" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("validation_error");
+  });
+
+  it("returns 400 when email is invalid", async () => {
+    const res = await POST(makeReq("POST", { email: "not-an-email", role: "editor" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("validation_error");
+  });
+
+  it("returns 400 when role is an invalid enum value", async () => {
+    const res = await POST(makeReq("POST", { email: "valid@example.com", role: "superuser" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("validation_error");
+  });
+
+  it("returns 400 when role is missing", async () => {
+    const res = await POST(makeReq("POST", { email: "valid@example.com" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).code).toBe("validation_error");
+  });
+
+  it("returns 403 when the caller is not an admin", async () => {
+    mockRequireOrgSession.mockResolvedValue(SESSION_VIEWER);
+    const res = await POST(makeReq("POST", VALID_BODY));
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toMatch(/Only org admins/i);
+  });
+
+  it("returns 404 when organisation not found", async () => {
+    mockAdminFrom.mockReturnValue(makeChain({ data: null, error: { message: "not found" } }));
+    const res = await POST(makeReq("POST", VALID_BODY));
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toMatch(/Organisation not found/i);
+  });
+
+  it("returns 500 when member count query fails", async () => {
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      call += 1;
+      if (call === 1) return makeChain({ data: { max_seats: 5 }, error: null });
+      return makeChain({ data: null, error: { message: "count boom" }, count: null });
+    });
+    const res = await POST(makeReq("POST", VALID_BODY));
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toMatch(/Failed to check seat limit/i);
+  });
+
+  it("returns 403 when seat limit is reached", async () => {
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      call += 1;
+      if (call === 1) return makeChain({ data: { max_seats: 3 }, error: null });
+      return makeChain({ data: null, error: null, count: 3 });
+    });
+    const res = await POST(makeReq("POST", VALID_BODY));
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toMatch(/Seat limit reached/i);
+  });
+
+  it("returns 409 when email already has an active or pending invite", async () => {
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      call += 1;
+      if (call === 1) return makeChain({ data: { max_seats: 10 }, error: null });
+      if (call === 2) return makeChain({ data: null, error: null, count: 2 });
+      return makeChain({ data: { id: 99 }, error: null });
+    });
+    const res = await POST(makeReq("POST", VALID_BODY));
+    expect(res.status).toBe(409);
+    expect((await res.json()).error).toMatch(/already has an active or pending invitation/i);
+  });
+
+  it("returns 500 when the insert fails", async () => {
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      call += 1;
+      if (call === 1) return makeChain({ data: { max_seats: 10 }, error: null });
+      if (call === 2) return makeChain({ data: null, error: null, count: 2 });
+      if (call === 3) return makeChain({ data: null, error: null }); // no existing invite
+      return makeChain({ data: null, error: { message: "insert boom" } });
+    });
+    const res = await POST(makeReq("POST", VALID_BODY));
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toMatch(/Failed to send invitation/i);
+  });
+
+  it("returns 201 with the new member on success", async () => {
+    let call = 0;
+    mockAdminFrom.mockImplementation(() => {
+      call += 1;
+      if (call === 1) return makeChain({ data: { max_seats: 10 }, error: null });
+      if (call === 2) return makeChain({ data: null, error: null, count: 2 });
+      if (call === 3) return makeChain({ data: null, error: null }); // no existing invite
+      return makeChain({ data: SAMPLE_MEMBER, error: null });
+    });
+    const res = await POST(makeReq("POST", VALID_BODY));
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.member.invited_email).toBe("newmember@example.com");
+    expect(body.member.status).toBe("pending");
+    expect(body.member.role).toBe("editor");
+  });
+
+  it("all three valid roles are accepted (admin, editor, viewer)", async () => {
+    for (const role of ["admin", "editor", "viewer"] as const) {
+      vi.clearAllMocks();
+      mockIsRateLimited.mockResolvedValue(false);
+      mockRequireOrgSession.mockResolvedValue(SESSION_ADMIN);
+      let call = 0;
+      mockAdminFrom.mockImplementation(() => {
+        call += 1;
+        if (call === 1) return makeChain({ data: { max_seats: 10 }, error: null });
+        if (call === 2) return makeChain({ data: null, error: null, count: 0 });
+        if (call === 3) return makeChain({ data: null, error: null });
+        return makeChain({ data: { ...SAMPLE_MEMBER, role }, error: null });
+      });
+      const res = await POST(makeReq("POST", { email: "test@example.com", role }));
+      expect(res.status).toBe(201);
+    }
+  });
+});

--- a/__tests__/api/quotes-slug.test.ts
+++ b/__tests__/api/quotes-slug.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NextRequest } from "next/server";
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: vi.fn().mockResolvedValue(false),
+}));
+
+// ─── DB queue ────────────────────────────────────────────────────────────────
+
+interface DbResult {
+  data?: unknown;
+  error?: { message: string } | null;
+}
+
+let dbQueue: DbResult[] = [];
+let dbIdx = 0;
+
+function makeChain(res: DbResult) {
+  const chain: Record<string, unknown> = {};
+  const methods = ["select","update","insert","eq","neq","lt","lte","gte","not","in","or","order","limit","maybeSingle","single"];
+  for (const m of methods) chain[m] = vi.fn(() => chain);
+  const r = { data: res.data ?? null, error: res.error ?? null };
+  chain.then = (resolve: (v: typeof r) => unknown) => Promise.resolve(resolve(r));
+  chain.catch = () => chain;
+  return chain;
+}
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({
+    from: vi.fn(() => makeChain(dbQueue[dbIdx++] ?? { error: null })),
+  })),
+}));
+
+import { GET } from "@/app/api/quotes/[slug]/route";
+import { isRateLimited } from "@/lib/rate-limit";
+
+function makeReq(slug = "job-abc123"): [NextRequest, { params: Promise<{ slug: string }> }] {
+  const req = new Request(`http://localhost/api/quotes/${slug}`, {
+    headers: { "x-forwarded-for": "1.2.3.4" },
+  }) as unknown as NextRequest;
+  return [req, { params: Promise.resolve({ slug }) }];
+}
+
+function auction(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    slug: "job-abc123",
+    job_title: "Help with SMSF",
+    job_description: "Need an SMSF accountant",
+    budget_band: "2000-5000",
+    advisor_types: ["smsf_accountant"],
+    location: "Sydney",
+    contact_name: "Alice Smith",
+    status: "open",
+    ends_at: new Date(Date.now() + 7 * 86400000).toISOString(),
+    winning_bid_id: null,
+    created_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  dbQueue = [];
+  dbIdx = 0;
+  vi.clearAllMocks();
+  vi.mocked(isRateLimited).mockResolvedValue(false);
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("GET /api/quotes/[slug]", () => {
+  it("returns 429 when rate limited", async () => {
+    vi.mocked(isRateLimited).mockResolvedValueOnce(true);
+    const [req, ctx] = makeReq();
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(429);
+  });
+
+  it("returns 404 when job not found", async () => {
+    dbQueue.push({ data: null }); // maybySingle returns null
+    const [req, ctx] = makeReq();
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 200 with job and bids on success", async () => {
+    dbQueue.push({ data: auction() }); // advisor_auctions
+    dbQueue.push({ data: [{ id: 10, bid_amount: 1500, status: "active" }] }); // advisor_auction_bids
+
+    const [req, ctx] = makeReq();
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { job: { slug: string }; bids: unknown[] };
+    expect(body.job.slug).toBe("job-abc123");
+    expect(body.bids).toHaveLength(1);
+  });
+
+  it("returns 200 with empty bids when none exist", async () => {
+    dbQueue.push({ data: auction() });
+    dbQueue.push({ data: [] }); // no bids
+
+    const [req, ctx] = makeReq();
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(200);
+    const body = await res.json() as { bids: unknown[] };
+    expect(body.bids).toHaveLength(0);
+  });
+
+  it("returns 500 when DB throws", async () => {
+    // Force a throw by providing a bad chain (will throw on await)
+    const { createAdminClient } = await import("@/lib/supabase/admin");
+    vi.mocked(createAdminClient).mockImplementationOnce(() => ({
+      from: () => { throw new Error("connection lost"); },
+    } as never));
+
+    const [req, ctx] = makeReq();
+    const res = await GET(req, ctx);
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/rate-memory.test.ts
+++ b/__tests__/api/rate-memory.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Hoisted mock refs ─────────────────────────────────────────────────────────
+
+const { mockIsRateLimited, mockGetUser, mockFrom } = vi.hoisted(() => ({
+  mockIsRateLimited: vi.fn<(...args: unknown[]) => Promise<boolean>>(async () => false),
+  mockGetUser: vi.fn<
+    () => Promise<{ data: { user: { id: string; email?: string } | null }; error: unknown }>
+  >(async () => ({ data: { user: { id: "u1", email: "u@e.com" } }, error: null })),
+  mockFrom: vi.fn(() => makeChain()),
+}));
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: (...args: unknown[]) => mockIsRateLimited(...args),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: mockGetUser },
+    from: mockFrom,
+  })),
+}));
+
+/**
+ * withValidatedBody — real Zod validation pass-through for testing all schema paths.
+ */
+vi.mock("@/lib/validation/withValidatedBody", () => ({
+  withValidatedBody: (
+    schema: {
+      safeParse: (
+        v: unknown,
+      ) => { success: boolean; data?: unknown; error?: { issues: Array<{ message: string }> } };
+    },
+    handler: (req: NextRequest, body: unknown) => unknown,
+  ) =>
+    async (req: NextRequest) => {
+      let rawBody: unknown;
+      try {
+        rawBody = await req.json();
+      } catch {
+        const { NextResponse } = await import("next/server");
+        return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+      }
+      const parsed = schema.safeParse(rawBody);
+      if (!parsed.success) {
+        const { NextResponse } = await import("next/server");
+        const firstMsg = parsed.error?.issues[0]?.message ?? "Validation error";
+        return NextResponse.json(
+          { error: firstMsg, code: "validation_error", issues: parsed.error?.issues ?? [] },
+          { status: 400 },
+        );
+      }
+      return handler(req, parsed.data);
+    },
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeChain(res: { data?: unknown; error?: unknown } = {}) {
+  const chain: Record<string, unknown> = {};
+  for (const m of [
+    "select", "insert", "update", "delete", "upsert",
+    "eq", "neq", "lt", "lte", "gte", "is", "in", "not", "or",
+    "order", "limit", "range", "maybeSingle", "single", "filter",
+  ]) {
+    chain[m] = vi.fn(() => chain);
+  }
+  chain.then = (resolve: (v: unknown) => unknown) =>
+    Promise.resolve(resolve({ data: res.data ?? null, error: res.error ?? null }));
+  chain.catch = () => chain;
+  return chain;
+}
+
+const VALID_BODY = {
+  brokerId: 1,
+  productKind: "savings_account" as const,
+  currentRateBps: 475,
+};
+
+function makePostReq(body: unknown, ip = "1.2.3.4"): NextRequest {
+  return new NextRequest("http://localhost/api/rate-memory", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-forwarded-for": ip },
+    body: JSON.stringify(body),
+  });
+}
+
+// ── Route under test (imported after all mocks) ───────────────────────────────
+import { POST } from "@/app/api/rate-memory/route";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// POST /api/rate-memory
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("POST /api/rate-memory", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsRateLimited.mockResolvedValue(false);
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } }, error: null });
+    // Default: no existing record (maybeSingle returns null), upsert succeeds
+    let call = 0;
+    mockFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) return makeChain({ data: null, error: null }); // SELECT existing
+      return makeChain({ data: null, error: null }); // UPSERT
+    });
+  });
+
+  it("returns 429 when rate-limited", async () => {
+    mockIsRateLimited.mockResolvedValue(true);
+    const res = await POST(makePostReq(VALID_BODY));
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toMatch(/too many requests/i);
+  });
+
+  it("passes the correct rate-limit key with IP", async () => {
+    mockIsRateLimited.mockResolvedValue(true);
+    await POST(makePostReq(VALID_BODY, "9.9.9.9"));
+    expect(mockIsRateLimited).toHaveBeenCalledWith("rate_memory:9.9.9.9", 30, 60);
+  });
+
+  it("returns 401 when user is not authenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+    const res = await POST(makePostReq(VALID_BODY));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toMatch(/unauthenticated/i);
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    const req = new NextRequest("http://localhost/api/rate-memory", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "not-json{{",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when brokerId is missing", async () => {
+    const res = await POST(makePostReq({ productKind: "savings_account", currentRateBps: 400 }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("validation_error");
+  });
+
+  it("returns 400 when brokerId is not a positive integer", async () => {
+    const res = await POST(makePostReq({ brokerId: -1, productKind: "savings_account", currentRateBps: 400 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when productKind is invalid", async () => {
+    const res = await POST(makePostReq({ brokerId: 1, productKind: "mortgage", currentRateBps: 400 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when currentRateBps is negative", async () => {
+    const res = await POST(makePostReq({ brokerId: 1, productKind: "savings_account", currentRateBps: -1 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when currentRateBps exceeds max (99999)", async () => {
+    const res = await POST(makePostReq({ brokerId: 1, productKind: "savings_account", currentRateBps: 100000 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 200 with previousRateBps=null when no prior record exists", async () => {
+    let call = 0;
+    mockFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) return makeChain({ data: null, error: null }); // no existing record
+      return makeChain({ data: null, error: null }); // upsert
+    });
+    const res = await POST(makePostReq(VALID_BODY));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.previousRateBps).toBeNull();
+    expect(body.currentRateBps).toBe(475);
+  });
+
+  it("returns 200 with previousRateBps from existing record", async () => {
+    let call = 0;
+    mockFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) return makeChain({ data: { last_seen_rate_bps: 450 }, error: null }); // existing record
+      return makeChain({ data: null, error: null }); // upsert
+    });
+    const res = await POST(makePostReq(VALID_BODY));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.previousRateBps).toBe(450);
+    expect(body.currentRateBps).toBe(475);
+  });
+
+  it("accepts 'term_deposit' as a valid productKind", async () => {
+    let call = 0;
+    mockFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) return makeChain({ data: null, error: null });
+      return makeChain({ data: null, error: null });
+    });
+    const res = await POST(makePostReq({ brokerId: 2, productKind: "term_deposit", currentRateBps: 500 }));
+    expect(res.status).toBe(200);
+  });
+
+  it("accepts 'savings_account' as a valid productKind", async () => {
+    let call = 0;
+    mockFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) return makeChain({ data: null, error: null });
+      return makeChain({ data: null, error: null });
+    });
+    const res = await POST(makePostReq({ brokerId: 3, productKind: "savings_account", currentRateBps: 0 }));
+    expect(res.status).toBe(200);
+  });
+
+  it("queries existing record scoped to correct user_id, broker_id, product_kind", async () => {
+    const chain1 = makeChain({ data: null, error: null });
+    let call = 0;
+    mockFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) return chain1;
+      return makeChain({ data: null, error: null });
+    });
+    await POST(makePostReq({ brokerId: 5, productKind: "savings_account", currentRateBps: 300 }));
+    const eqFn = chain1.eq as ReturnType<typeof vi.fn>;
+    expect(eqFn).toHaveBeenCalledWith("user_id", "u1");
+    expect(eqFn).toHaveBeenCalledWith("broker_id", 5);
+    expect(eqFn).toHaveBeenCalledWith("product_kind", "savings_account");
+  });
+
+  it("returns 400 when brokerId is a float (non-integer)", async () => {
+    const res = await POST(makePostReq({ brokerId: 1.5, productKind: "savings_account", currentRateBps: 400 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("accepts currentRateBps=0 (boundary min)", async () => {
+    let call = 0;
+    mockFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) return makeChain({ data: null, error: null });
+      return makeChain({ data: null, error: null });
+    });
+    const res = await POST(makePostReq({ brokerId: 1, productKind: "savings_account", currentRateBps: 0 }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.currentRateBps).toBe(0);
+  });
+
+  it("accepts currentRateBps=99999 (boundary max)", async () => {
+    let call = 0;
+    mockFrom.mockImplementation(() => {
+      call++;
+      if (call === 1) return makeChain({ data: null, error: null });
+      return makeChain({ data: null, error: null });
+    });
+    const res = await POST(makePostReq({ brokerId: 1, productKind: "savings_account", currentRateBps: 99999 }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.currentRateBps).toBe(99999);
+  });
+});

--- a/__tests__/api/rba-polls-leaderboard.test.ts
+++ b/__tests__/api/rba-polls-leaderboard.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+function makeBuilder(data: unknown = null, error: unknown = null) {
+  const c: Record<string, unknown> = {
+    then: (r: (v: { data: unknown; error: unknown }) => unknown) =>
+      Promise.resolve(r({ data, error })),
+  };
+  for (const m of [
+    "select", "insert", "update", "upsert", "delete", "eq", "neq", "gt", "gte",
+    "lt", "lte", "in", "is", "not", "or", "order", "limit", "range", "single",
+    "maybeSingle", "filter",
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  return c;
+}
+
+const mockFrom = vi.fn((..._a: unknown[]) => makeBuilder());
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
+import { GET } from "@/app/api/rba-polls/leaderboard/route";
+
+const sampleAccuracy = [
+  { voter_user_id: "u1", polls_participated: 5, correct_predictions: 4, accuracy_pct: 80 },
+  { voter_user_id: "u2", polls_participated: 3, correct_predictions: 2, accuracy_pct: 66.67 },
+];
+
+const sampleProfiles = [
+  { user_id: "u1", display_name: "Alice", badge: "gold", reputation: 120 },
+  { user_id: "u2", display_name: "Bob", badge: "silver", reputation: 80 },
+];
+
+describe("GET /api/rba-polls/leaderboard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    let callCount = 0;
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      callCount++;
+      if (callCount === 1) return makeBuilder(sampleAccuracy, null);
+      return makeBuilder(sampleProfiles, null);
+    });
+  });
+
+  it("returns a ranked leaderboard with display names and badges", async () => {
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.leaderboard).toHaveLength(2);
+
+    const first = json.leaderboard[0] as {
+      rank: number;
+      display_name: string;
+      badge: string;
+      polls_participated: number;
+      correct_predictions: number;
+      accuracy_pct: number;
+    };
+    expect(first.rank).toBe(1);
+    expect(first.display_name).toBe("Alice");
+    expect(first.badge).toBe("gold");
+    expect(first.polls_participated).toBe(5);
+    expect(first.correct_predictions).toBe(4);
+    expect(first.accuracy_pct).toBe(80);
+
+    const second = json.leaderboard[1] as { rank: number; display_name: string };
+    expect(second.rank).toBe(2);
+    expect(second.display_name).toBe("Bob");
+  });
+
+  it("uses Anonymous and empty badge when profile is missing", async () => {
+    let callCount = 0;
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      callCount++;
+      if (callCount === 1) return makeBuilder(sampleAccuracy, null);
+      return makeBuilder([], null); // no profiles found
+    });
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    const first = json.leaderboard[0] as { display_name: string; badge: string };
+    expect(first.display_name).toBe("Anonymous");
+    expect(first.badge).toBe("");
+  });
+
+  it("uses Anonymous when profiles data is null", async () => {
+    let callCount = 0;
+    mockFrom.mockImplementation((..._a: unknown[]) => {
+      callCount++;
+      if (callCount === 1) return makeBuilder(sampleAccuracy, null);
+      return makeBuilder(null, null);
+    });
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    const first = json.leaderboard[0] as { display_name: string };
+    expect(first.display_name).toBe("Anonymous");
+  });
+
+  it("returns empty leaderboard when accuracy table is empty", async () => {
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder([], null));
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.leaderboard).toEqual([]);
+  });
+
+  it("returns empty leaderboard when accuracy data is null", async () => {
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder(null, null));
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.leaderboard).toEqual([]);
+  });
+
+  it("returns 500 when accuracy view query fails", async () => {
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder(null, { message: "view error" }));
+    const res = await GET();
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toBe("fetch_failed");
+  });
+
+  it("sets Cache-Control header with longer TTL than polls endpoint", async () => {
+    const res = await GET();
+    const cc = res.headers.get("Cache-Control") ?? "";
+    expect(cc).toContain("max-age=300");
+  });
+
+  it("accuracy_pct is returned as a Number (not string)", async () => {
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    const first = json.leaderboard[0] as { accuracy_pct: unknown };
+    expect(typeof first.accuracy_pct).toBe("number");
+  });
+});

--- a/__tests__/api/saved-comparisons-id.test.ts
+++ b/__tests__/api/saved-comparisons-id.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/logger", () => ({ logger: () => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() }) }));
+
+const mockGetUser = vi.fn();
+const mockFromFn = vi.fn();
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: mockGetUser },
+    from: mockFromFn,
+  })),
+}));
+
+import { GET, PATCH, DELETE } from "@/app/api/saved-comparisons/[id]/route";
+
+function makeChain(res: unknown) {
+  const c: Record<string, unknown> = {};
+  for (const m of ["select", "update", "delete", "eq", "single", "order"]) { c[m] = vi.fn(() => c); }
+  c.then = (resolve: (v: unknown) => void) => Promise.resolve(resolve(res));
+  return c;
+}
+
+function makeParams(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+function makeReq(method: string, body?: unknown) {
+  return new NextRequest(`http://localhost/api/saved-comparisons/comp-1`, {
+    method,
+    ...(body !== undefined ? { body: JSON.stringify(body), headers: { "Content-Type": "application/json" } } : {}),
+  });
+}
+
+const comparison = { id: "comp-1", name: "My Compare", broker_slugs: ["abc"], quiz_results: null, notes: null, created_at: "2026-01-01", updated_at: "2026-01-02" };
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("GET /api/saved-comparisons/[id]", () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const res = await GET(makeReq("GET"), makeParams("comp-1"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when comparison not found", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+    mockFromFn.mockReturnValue(makeChain({ data: null, error: { message: "not found" } }));
+    const res = await GET(makeReq("GET"), makeParams("comp-1"));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns comparison data on success", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+    mockFromFn.mockReturnValue(makeChain({ data: comparison, error: null }));
+    const res = await GET(makeReq("GET"), makeParams("comp-1"));
+    const body = await res.json();
+    expect(body.comparison.name).toBe("My Compare");
+  });
+});
+
+describe("PATCH /api/saved-comparisons/[id]", () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const res = await PATCH(makeReq("PATCH", { name: "Updated" }), makeParams("comp-1"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when name is empty string", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+    const res = await PATCH(makeReq("PATCH", { name: "   " }), makeParams("comp-1"));
+    expect(res.status).toBe(400);
+  });
+
+  it("updates name and returns comparison", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+    mockFromFn.mockReturnValue(makeChain({ data: { ...comparison, name: "Updated" }, error: null }));
+    const res = await PATCH(makeReq("PATCH", { name: "Updated" }), makeParams("comp-1"));
+    const body = await res.json();
+    expect(body.comparison.name).toBe("Updated");
+  });
+
+  it("sets notes to null when notes is empty string", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+    mockFromFn.mockReturnValue(makeChain({ data: { ...comparison, notes: null }, error: null }));
+    const res = await PATCH(makeReq("PATCH", { notes: "" }), makeParams("comp-1"));
+    const body = await res.json();
+    expect(body.comparison.notes).toBeNull();
+  });
+});
+
+describe("DELETE /api/saved-comparisons/[id]", () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const res = await DELETE(makeReq("DELETE"), makeParams("comp-1"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 500 when delete errors", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+    mockFromFn.mockReturnValue(makeChain({ data: null, error: { message: "delete failed" } }));
+    const res = await DELETE(makeReq("DELETE"), makeParams("comp-1"));
+    expect(res.status).toBe(500);
+  });
+
+  it("returns success:true on successful delete", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+    mockFromFn.mockReturnValue(makeChain({ data: null, error: null }));
+    const res = await DELETE(makeReq("DELETE"), makeParams("comp-1"));
+    const body = await res.json();
+    expect(body.success).toBe(true);
+  });
+});

--- a/__tests__/api/user-lists-slug-clone.test.ts
+++ b/__tests__/api/user-lists-slug-clone.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Tests for POST /api/user-lists/[slug]/clone
+ *
+ * Auth: createClient + supabase.auth.getUser (required)
+ * The route reads slug from req.nextUrl.pathname — no params arg.
+ *
+ * Branches: 401, 404 (source list not found), 403 (not public),
+ *           500 (new list insert fails), 201 (success, items copied),
+ *           201 (success, no items)
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const { mockGetUser, mockFrom } = vi.hoisted(() => ({
+  mockGetUser: vi.fn(
+    async (): Promise<{ data: { user: { id: string; email?: string } | null }; error: unknown }> => ({
+      data: { user: { id: "u1", email: "u@e.com" } },
+      error: null,
+    }),
+  ),
+  mockFrom: vi.fn((..._a: unknown[]): Record<string, unknown> => ({ then: vi.fn() })),
+}));
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: (..._args: unknown[]) => mockGetUser() },
+    from: (..._args: unknown[]) => mockFrom(),
+  })),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+vi.mock("@/lib/utils", () => ({
+  slugify: vi.fn((text: string) => text.toLowerCase().replace(/\s+/g, "-")),
+}));
+
+// ── Route under test ──────────────────────────────────────────────────────────
+
+import { POST } from "@/app/api/user-lists/[slug]/clone/route";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeBuilder(data: unknown = null, error: unknown = null) {
+  const c: Record<string, unknown> = {
+    then: (r: (v: { data: unknown; error: unknown }) => unknown) =>
+      Promise.resolve(r({ data, error })),
+  };
+  for (const m of [
+    "select", "insert", "update", "upsert", "delete",
+    "eq", "neq", "gt", "gte", "lt", "lte", "in", "is", "not", "or",
+    "order", "limit", "range", "single", "maybeSingle", "filter",
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  return c;
+}
+
+function makeReq(slug: string): NextRequest {
+  return new NextRequest(`http://localhost/api/user-lists/${slug}/clone`, { method: "POST" });
+}
+
+const SOURCE_LIST = {
+  id: 7,
+  title: "Top ASX ETFs",
+  description: "Great ETFs for Australian investors",
+  is_public: true,
+};
+
+const NEW_LIST = {
+  id: 8,
+  slug: "copy-of-top-asx-etfs-abc123",
+};
+
+const ITEMS = [
+  { item_type: "broker", item_ref: "ref-1", label: "CBA", notes: null },
+  { item_type: "etf", item_ref: "ref-2", label: "VAS", notes: "Good one" },
+];
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("POST /api/user-lists/[slug]/clone", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1", email: "u@e.com" } }, error: null });
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+    const res = await POST(makeReq("top-asx-etfs"));
+    expect(res.status).toBe(401);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.error).toBe("unauthorized");
+  });
+
+  it("returns 404 when source list not found", async () => {
+    // source lookup → null
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder(null, null));
+    const res = await POST(makeReq("missing-list"));
+    expect(res.status).toBe(404);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.error).toBe("not_found");
+  });
+
+  it("returns 403 when source list is not public", async () => {
+    mockFrom.mockImplementation((..._a: unknown[]) =>
+      makeBuilder({ ...SOURCE_LIST, is_public: false }, null),
+    );
+    const res = await POST(makeReq("private-list"));
+    expect(res.status).toBe(403);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.error).toBe("list_not_public");
+  });
+
+  it("returns 500 when new list insert fails", async () => {
+    // source lookup → success
+    mockFrom.mockImplementationOnce((..._a: unknown[]) => makeBuilder(SOURCE_LIST, null));
+    // new list insert → error
+    mockFrom.mockImplementation((..._a: unknown[]) =>
+      makeBuilder(null, { message: "insert failed" }),
+    );
+    const res = await POST(makeReq("top-asx-etfs"));
+    expect(res.status).toBe(500);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.error).toBe("clone_failed");
+  });
+
+  it("returns 500 when new list insert returns null data", async () => {
+    mockFrom.mockImplementationOnce((..._a: unknown[]) => makeBuilder(SOURCE_LIST, null));
+    // insert returns null data with no error
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder(null, null));
+    const res = await POST(makeReq("top-asx-etfs"));
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 201 with new slug on successful clone (no items)", async () => {
+    // source lookup
+    mockFrom.mockImplementationOnce((..._a: unknown[]) => makeBuilder(SOURCE_LIST, null));
+    // new list insert → returns new list
+    mockFrom.mockImplementationOnce((..._a: unknown[]) => makeBuilder(NEW_LIST, null));
+    // items query → empty
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder([], null));
+    const res = await POST(makeReq("top-asx-etfs"));
+    expect(res.status).toBe(201);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.ok).toBe(true);
+    expect(typeof body.slug).toBe("string");
+  });
+
+  it("returns 201 with new slug when source has items and copies them", async () => {
+    // source lookup
+    mockFrom.mockImplementationOnce((..._a: unknown[]) => makeBuilder(SOURCE_LIST, null));
+    // new list insert
+    mockFrom.mockImplementationOnce((..._a: unknown[]) => makeBuilder(NEW_LIST, null));
+    // items query → has items
+    mockFrom.mockImplementationOnce((..._a: unknown[]) => makeBuilder(ITEMS, null));
+    // items insert (copy)
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder(null, null));
+    const res = await POST(makeReq("top-asx-etfs"));
+    expect(res.status).toBe(201);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.ok).toBe(true);
+    expect(body.slug).toBe(NEW_LIST.slug);
+  });
+
+  it("still returns 201 when items copy insert fails (non-fatal)", async () => {
+    mockFrom.mockImplementationOnce((..._a: unknown[]) => makeBuilder(SOURCE_LIST, null));
+    mockFrom.mockImplementationOnce((..._a: unknown[]) => makeBuilder(NEW_LIST, null));
+    mockFrom.mockImplementationOnce((..._a: unknown[]) => makeBuilder(ITEMS, null));
+    // items insert fails non-fatally
+    mockFrom.mockImplementation((..._a: unknown[]) =>
+      makeBuilder(null, { message: "items copy failed" }),
+    );
+    const res = await POST(makeReq("top-asx-etfs"));
+    expect(res.status).toBe(201);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.ok).toBe(true);
+  });
+
+  it("generates title prefixed with Copy of", async () => {
+    mockFrom.mockImplementationOnce((..._a: unknown[]) => makeBuilder(SOURCE_LIST, null));
+    const insertSpy = vi.fn((..._a: unknown[]) => makeBuilder(NEW_LIST, null));
+    mockFrom.mockImplementationOnce((..._a: unknown[]) => {
+      const c = makeBuilder(NEW_LIST, null);
+      (c as Record<string, unknown>).insert = insertSpy;
+      return c;
+    });
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder([], null));
+    await POST(makeReq("top-asx-etfs"));
+    // The insert arg for the new list should contain a title starting with "Copy of"
+    if (insertSpy.mock.calls.length > 0) {
+      const arg = insertSpy.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+      if (arg) {
+        expect(String(arg.title)).toMatch(/^Copy of /);
+      }
+    }
+  });
+});

--- a/__tests__/api/user-lists-slug-follow.test.ts
+++ b/__tests__/api/user-lists-slug-follow.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Tests for POST + DELETE /api/user-lists/[slug]/follow
+ *
+ * Auth: createClient + supabase.auth.getUser (required)
+ * The route reads slug from req.nextUrl.pathname — no params arg.
+ *
+ * POST branches: 401, 404 (list not found), 403 (not public), 409 (own list),
+ *                409 (23505 duplicate → ok+already), 500, 200
+ * DELETE branches: 401, 404 (list not found), 500, 200
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const { mockGetUser, mockFrom } = vi.hoisted(() => ({
+  mockGetUser: vi.fn(
+    async (): Promise<{ data: { user: { id: string; email?: string } | null }; error: unknown }> => ({
+      data: { user: { id: "u1", email: "u@e.com" } },
+      error: null,
+    }),
+  ),
+  mockFrom: vi.fn((..._a: unknown[]): Record<string, unknown> => ({ then: vi.fn() })),
+}));
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    auth: { getUser: (..._args: unknown[]) => mockGetUser() },
+    from: (..._args: unknown[]) => mockFrom(),
+  })),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() })),
+}));
+
+// ── Route under test ──────────────────────────────────────────────────────────
+
+import { POST, DELETE } from "@/app/api/user-lists/[slug]/follow/route";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeBuilder(data: unknown = null, error: unknown = null) {
+  const c: Record<string, unknown> = {
+    then: (r: (v: { data: unknown; error: unknown }) => unknown) =>
+      Promise.resolve(r({ data, error })),
+  };
+  for (const m of [
+    "select", "insert", "update", "upsert", "delete",
+    "eq", "neq", "gt", "gte", "lt", "lte", "in", "is", "not", "or",
+    "order", "limit", "range", "single", "maybeSingle", "filter",
+  ]) {
+    c[m] = vi.fn(() => c);
+  }
+  return c;
+}
+
+function makeReq(slug: string, method: "POST" | "DELETE"): NextRequest {
+  return new NextRequest(`http://localhost/api/user-lists/${slug}/follow`, { method });
+}
+
+const LIST_ROW = { id: 7, is_public: true, owner_user_id: "owner-uuid" };
+
+// ── POST tests ────────────────────────────────────────────────────────────────
+
+describe("POST /api/user-lists/[slug]/follow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1", email: "u@e.com" } }, error: null });
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+    const res = await POST(makeReq("great-list", "POST"));
+    expect(res.status).toBe(401);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.error).toBe("unauthorized");
+  });
+
+  it("returns 404 when list is not found", async () => {
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder(null, null));
+    const res = await POST(makeReq("missing-slug", "POST"));
+    expect(res.status).toBe(404);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.error).toBe("not_found");
+  });
+
+  it("returns 403 when list is not public", async () => {
+    // resolveList returns a private list
+    mockFrom.mockImplementationOnce((..._a: unknown[]) =>
+      makeBuilder({ ...LIST_ROW, is_public: false }, null),
+    );
+    const res = await POST(makeReq("private-list", "POST"));
+    expect(res.status).toBe(403);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.error).toBe("list_not_public");
+  });
+
+  it("returns 409 when user tries to follow their own list", async () => {
+    // owner_user_id matches the authenticated user
+    mockFrom.mockImplementationOnce((..._a: unknown[]) =>
+      makeBuilder({ ...LIST_ROW, owner_user_id: "u1" }, null),
+    );
+    const res = await POST(makeReq("my-list", "POST"));
+    expect(res.status).toBe(409);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.error).toBe("cannot_follow_own_list");
+  });
+
+  it("returns 200 with ok+already:true on 23505 duplicate follow", async () => {
+    // resolveList
+    mockFrom.mockImplementationOnce((..._a: unknown[]) => makeBuilder(LIST_ROW, null));
+    // insert → 23505
+    mockFrom.mockImplementation((..._a: unknown[]) =>
+      makeBuilder(null, { code: "23505", message: "unique violation" }),
+    );
+    const res = await POST(makeReq("great-list", "POST"));
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.ok).toBe(true);
+    expect(body.already).toBe(true);
+  });
+
+  it("returns 500 on non-duplicate insert error", async () => {
+    mockFrom.mockImplementationOnce((..._a: unknown[]) => makeBuilder(LIST_ROW, null));
+    mockFrom.mockImplementation((..._a: unknown[]) =>
+      makeBuilder(null, { code: "42501", message: "permission denied" }),
+    );
+    const res = await POST(makeReq("great-list", "POST"));
+    expect(res.status).toBe(500);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.error).toBe("follow_failed");
+  });
+
+  it("returns 200 with ok+following:true on successful follow", async () => {
+    mockFrom.mockImplementationOnce((..._a: unknown[]) => makeBuilder(LIST_ROW, null));
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder(null, null));
+    const res = await POST(makeReq("great-list", "POST"));
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.ok).toBe(true);
+    expect(body.following).toBe(true);
+  });
+});
+
+// ── DELETE tests ──────────────────────────────────────────────────────────────
+
+describe("DELETE /api/user-lists/[slug]/follow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1", email: "u@e.com" } }, error: null });
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+    const res = await DELETE(makeReq("great-list", "DELETE"));
+    expect(res.status).toBe(401);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.error).toBe("unauthorized");
+  });
+
+  it("returns 404 when list is not found", async () => {
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder(null, null));
+    const res = await DELETE(makeReq("missing-slug", "DELETE"));
+    expect(res.status).toBe(404);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.error).toBe("not_found");
+  });
+
+  it("returns 500 when delete fails", async () => {
+    mockFrom.mockImplementationOnce((..._a: unknown[]) => makeBuilder(LIST_ROW, null));
+    mockFrom.mockImplementation((..._a: unknown[]) =>
+      makeBuilder(null, { message: "delete error" }),
+    );
+    const res = await DELETE(makeReq("great-list", "DELETE"));
+    expect(res.status).toBe(500);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.error).toBe("unfollow_failed");
+  });
+
+  it("returns 200 with ok+following:false on successful unfollow", async () => {
+    mockFrom.mockImplementationOnce((..._a: unknown[]) => makeBuilder(LIST_ROW, null));
+    mockFrom.mockImplementation((..._a: unknown[]) => makeBuilder(null, null));
+    const res = await DELETE(makeReq("great-list", "DELETE"));
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.ok).toBe(true);
+    expect(body.following).toBe(false);
+  });
+});

--- a/__tests__/api/verified-count.test.ts
+++ b/__tests__/api/verified-count.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Hoisted mock refs ─────────────────────────────────────────────────────────
+
+const { mockFrom } = vi.hoisted(() => ({
+  mockFrom: vi.fn(() => makeChain()),
+}));
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({ from: mockFrom })),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeChain(res: { data?: unknown; error?: unknown } = {}) {
+  const chain: Record<string, unknown> = {};
+  for (const m of [
+    "select", "eq", "neq", "lt", "lte", "gte", "is", "in", "not", "or",
+    "order", "limit", "range", "maybeSingle", "single", "filter",
+  ]) {
+    chain[m] = vi.fn(() => chain);
+  }
+  chain.then = (resolve: (v: unknown) => unknown) =>
+    Promise.resolve(resolve({ data: res.data ?? null, error: res.error ?? null }));
+  chain.catch = () => chain;
+  return chain;
+}
+
+/**
+ * The route reads type/ref from the URL pathname directly, not from route params.
+ * We must build a real URL so req.nextUrl.pathname is correct.
+ */
+function makeReq(type: string, ref: string): NextRequest {
+  return new NextRequest(`http://localhost/api/verified-count/${type}/${ref}`, {
+    method: "GET",
+  });
+}
+
+// ── Route under test (imported after all mocks) ───────────────────────────────
+import { GET } from "@/app/api/verified-count/[type]/[ref]/route";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// GET /api/verified-count/[type]/[ref]
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("GET /api/verified-count/[type]/[ref]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFrom.mockReturnValue(makeChain({ data: null, error: null }));
+  });
+
+  it("returns 400 for an invalid type", async () => {
+    const res = await GET(makeReq("invalid-type", "some-ref"));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_params");
+  });
+
+  it("returns 400 for empty ref", async () => {
+    // We can't pass empty string in URL path — simulate with a space-only ref
+    // that decodes to empty-ish. Use a direct pathname query instead.
+    const req = new NextRequest("http://localhost/api/verified-count/broker/", {
+      method: "GET",
+    });
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("invalid_params");
+  });
+
+  it("returns 400 for unknown type 'stock'", async () => {
+    const res = await GET(makeReq("stock", "CBA"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 500 when DB query fails", async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: { message: "db error" } }));
+    const res = await GET(makeReq("broker", "commsec"));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("fetch_failed");
+  });
+
+  it("returns 200 with verified_count=0 when no row found (maybeSingle null)", async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: null }));
+    const res = await GET(makeReq("broker", "commsec"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.verified_count).toBe(0);
+    expect(body.product_type).toBe("broker");
+    expect(body.product_ref).toBe("commsec");
+  });
+
+  it("returns 200 with verified_count from DB row", async () => {
+    mockFrom.mockReturnValue(makeChain({ data: { verified_count: 42 }, error: null }));
+    const res = await GET(makeReq("etf", "vgs"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.verified_count).toBe(42);
+    expect(body.product_type).toBe("etf");
+    expect(body.product_ref).toBe("vgs");
+  });
+
+  it("returns Cache-Control header with correct values", async () => {
+    mockFrom.mockReturnValue(makeChain({ data: { verified_count: 5 }, error: null }));
+    const res = await GET(makeReq("advisor", "jane-smith"));
+    expect(res.headers.get("Cache-Control")).toContain("public");
+    expect(res.headers.get("Cache-Control")).toContain("max-age=60");
+    expect(res.headers.get("Cache-Control")).toContain("stale-while-revalidate=300");
+  });
+
+  it("accepts 'broker' as a valid type", async () => {
+    mockFrom.mockReturnValue(makeChain({ data: { verified_count: 1 }, error: null }));
+    const res = await GET(makeReq("broker", "nabtrade"));
+    expect(res.status).toBe(200);
+  });
+
+  it("accepts 'etf' as a valid type", async () => {
+    mockFrom.mockReturnValue(makeChain({ data: { verified_count: 2 }, error: null }));
+    const res = await GET(makeReq("etf", "iwld"));
+    expect(res.status).toBe(200);
+  });
+
+  it("accepts 'advisor' as a valid type", async () => {
+    mockFrom.mockReturnValue(makeChain({ data: { verified_count: 10 }, error: null }));
+    const res = await GET(makeReq("advisor", "john-doe"));
+    expect(res.status).toBe(200);
+  });
+
+  it("accepts 'property' as a valid type", async () => {
+    mockFrom.mockReturnValue(makeChain({ data: { verified_count: 3 }, error: null }));
+    const res = await GET(makeReq("property", "prop-123"));
+    expect(res.status).toBe(200);
+  });
+
+  it("URL-decodes the ref correctly", async () => {
+    mockFrom.mockReturnValue(makeChain({ data: { verified_count: 7 }, error: null }));
+    const res = await GET(makeReq("broker", "some%20broker"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.product_ref).toBe("some broker");
+  });
+
+  it("queries the DB with correct product_type and product_ref filters", async () => {
+    const chain = makeChain({ data: { verified_count: 5 }, error: null });
+    mockFrom.mockReturnValue(chain);
+    await GET(makeReq("broker", "pearler"));
+    const eqFn = chain.eq as ReturnType<typeof vi.fn>;
+    expect(eqFn).toHaveBeenCalledWith("product_type", "broker");
+    expect(eqFn).toHaveBeenCalledWith("product_ref", "pearler");
+  });
+});

--- a/__tests__/lib/invest-categories.test.ts
+++ b/__tests__/lib/invest-categories.test.ts
@@ -166,6 +166,8 @@ describe("IA intent (2026-05-07 refactor)", () => {
         "water-rights",
         // 2026-06 — ASX-listed securities (instrument-class category)
         "listed-securities",
+        // 2026-06-10 — MM-V01b discovery vertical with live listings
+        "digital-infrastructure",
       ].sort(),
     );
   });
@@ -180,7 +182,7 @@ describe("IA intent (2026-05-07 refactor)", () => {
     );
   });
 
-  it("the 13 guide slugs (sector hubs + retained education) are tagged as guide", () => {
+  it("the 19 guide slugs (sector hubs + retained education) are tagged as guide", () => {
     const guideSlugs = getGuideCategories()
       .map((c) => c.slug)
       .sort();
@@ -199,6 +201,14 @@ describe("IA intent (2026-05-07 refactor)", () => {
         "reits",
         "smsf",
         "uranium",
+        // MM-V01b discovery verticals without listings supply yet —
+        // guide by default, flipped to opportunity once seeded.
+        "aquaculture",
+        "insurance-linked-securities",
+        "litigation-funding",
+        "livestock",
+        "public-social-infrastructure",
+        "venture-capital",
       ].sort(),
     );
   });

--- a/__tests__/lib/marketplace-emails.test.ts
+++ b/__tests__/lib/marketplace-emails.test.ts
@@ -1,0 +1,392 @@
+import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
+
+// ─── Mocks ───────────────────────────────────────────────────────────
+
+const sendEmailMock = vi.fn(
+  async (_args: { to: string; subject: string; html: string; from: string }) => ({
+    ok: true,
+  }),
+);
+
+vi.mock("@/lib/resend", () => ({
+  sendEmail: (args: { to: string; subject: string; html: string; from: string }) =>
+    sendEmailMock(args),
+}));
+
+vi.mock("@/lib/seo", () => ({
+  SITE_URL: "https://invest.com.au",
+}));
+
+import {
+  sendProviderNewMatchRequest,
+  sendProviderDailyDigest,
+  sendConsumerProviderAccepted,
+  sendConsumerStaleBriefNudge,
+  sendProConsultationBooked,
+  sendConsumerConsultationPending,
+  sendConsumerConsultationConfirmed,
+} from "@/lib/marketplace-emails";
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+function lastHtml(): string {
+  const call = sendEmailMock.mock.calls[sendEmailMock.mock.calls.length - 1]?.[0];
+  if (!call) throw new Error("sendEmail was not called");
+  return (call as { html: string }).html;
+}
+
+function lastCall() {
+  const call = sendEmailMock.mock.calls[sendEmailMock.mock.calls.length - 1]?.[0];
+  if (!call) throw new Error("sendEmail was not called");
+  return call as { to: string; subject: string; html: string; from: string };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────
+
+describe("marketplace-emails", () => {
+  beforeEach(() => {
+    sendEmailMock.mockClear();
+    sendEmailMock.mockResolvedValue({ ok: true });
+  });
+
+  afterAll(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ─── sendProviderNewMatchRequest ────────────────────────────────
+
+  describe("sendProviderNewMatchRequest", () => {
+    const base = {
+      providerEmail: "pro@firm.com",
+      providerName: "Alice Smith",
+      briefTitle: "SMSF Setup Help",
+      briefSlug: "smsf-setup-help",
+      acceptCreditsCost: 3,
+      briefBudgetBand: "mid_range",
+      briefLocation: "Melbourne",
+    };
+
+    it("returns true and calls sendEmail once", async () => {
+      const ok = await sendProviderNewMatchRequest(base);
+      expect(ok).toBe(true);
+      expect(sendEmailMock).toHaveBeenCalledOnce();
+    });
+
+    it("sends to the provider email with a subject containing the brief title", async () => {
+      await sendProviderNewMatchRequest(base);
+      const c = lastCall();
+      expect(c.to).toBe("pro@firm.com");
+      expect(c.subject).toContain("SMSF Setup Help");
+    });
+
+    it("HTML contains provider name, brief title, credit cost, and CTA link", async () => {
+      await sendProviderNewMatchRequest(base);
+      const html = lastHtml();
+      expect(html).toContain("Alice");
+      expect(html).toContain("SMSF Setup Help");
+      expect(html).toContain("3 credits");
+      expect(html).toContain("/advisor-portal/briefs/smsf-setup-help");
+    });
+
+    it("includes budget and location when provided", async () => {
+      await sendProviderNewMatchRequest(base);
+      const html = lastHtml();
+      expect(html).toContain("mid range"); // underscores replaced with spaces
+      expect(html).toContain("Melbourne");
+    });
+
+    it("omits budget block when briefBudgetBand is null", async () => {
+      await sendProviderNewMatchRequest({ ...base, briefBudgetBand: null });
+      const html = lastHtml();
+      expect(html).not.toContain("Budget:");
+    });
+
+    it("omits location block when briefLocation is null", async () => {
+      await sendProviderNewMatchRequest({ ...base, briefLocation: null });
+      const html = lastHtml();
+      expect(html).not.toContain("Location:");
+    });
+
+    it("does not inject raw HTML when brief title contains angle brackets", async () => {
+      await sendProviderNewMatchRequest({ ...base, briefTitle: "<script>alert(1)</script>" });
+      // The title appears in the subject (plain text) and in the HTML body;
+      // either the tag is escaped or the raw <script> tag is absent from the html.
+      // The email helper concatenates strings so the value appears as-is in
+      // the HTML body — this test documents the current behaviour and ensures
+      // no execution context is added on top (e.g. an extra unescaped eval).
+      // What we verify here: the email was still sent (i.e. didn't throw).
+      expect(sendEmailMock).toHaveBeenCalledOnce();
+    });
+  });
+
+  // ─── sendProviderDailyDigest ─────────────────────────────────────
+
+  describe("sendProviderDailyDigest", () => {
+    it("returns true on success", async () => {
+      const ok = await sendProviderDailyDigest({
+        providerEmail: "pro@firm.com",
+        providerName: "Bob Jones",
+        unacceptedCount: 5,
+        topBriefTitles: ["Brief A", "Brief B", "Brief C"],
+      });
+      expect(ok).toBe(true);
+    });
+
+    it("uses singular subject when count is 1", async () => {
+      await sendProviderDailyDigest({
+        providerEmail: "pro@firm.com",
+        providerName: "Bob Jones",
+        unacceptedCount: 1,
+        topBriefTitles: ["Only Brief"],
+      });
+      expect(lastCall().subject).toMatch(/^1 Match Request waiting/);
+    });
+
+    it("uses plural subject when count > 1", async () => {
+      await sendProviderDailyDigest({
+        providerEmail: "pro@firm.com",
+        providerName: "Bob",
+        unacceptedCount: 3,
+        topBriefTitles: [],
+      });
+      expect(lastCall().subject).toMatch(/^3 Match Requests waiting/);
+    });
+
+    it("lists up to 3 brief titles in the body", async () => {
+      await sendProviderDailyDigest({
+        providerEmail: "pro@firm.com",
+        providerName: "Bob",
+        unacceptedCount: 4,
+        topBriefTitles: ["A", "B", "C", "D"],
+      });
+      const html = lastHtml();
+      expect(html).toContain("A");
+      expect(html).toContain("B");
+      expect(html).toContain("C");
+      // 4th item is sliced off
+      expect(html).not.toContain(">D<");
+      // items 1-3 rendered as list items
+      expect(html).toContain("<li");
+    });
+
+    it("renders without list when topBriefTitles is empty", async () => {
+      await sendProviderDailyDigest({
+        providerEmail: "pro@firm.com",
+        providerName: "Bob",
+        unacceptedCount: 2,
+        topBriefTitles: [],
+      });
+      const html = lastHtml();
+      expect(html).not.toContain("<li");
+    });
+  });
+
+  // ─── sendConsumerProviderAccepted ───────────────────────────────
+
+  describe("sendConsumerProviderAccepted", () => {
+    const base = {
+      consumerEmail: "user@example.com",
+      consumerName: "Chris Taylor",
+      briefTitle: "Super Review",
+      briefSlug: "super-review",
+      providerName: "Alpha Advisers",
+      providerKind: "firm" as const,
+    };
+
+    it("returns true and calls sendEmail", async () => {
+      const ok = await sendConsumerProviderAccepted(base);
+      expect(ok).toBe(true);
+      expect(sendEmailMock).toHaveBeenCalledOnce();
+    });
+
+    it("addresses consumer by first name", async () => {
+      await sendConsumerProviderAccepted(base);
+      expect(lastHtml()).toContain("Chris");
+    });
+
+    it('falls back to "there" when consumerName is empty', async () => {
+      await sendConsumerProviderAccepted({ ...base, consumerName: "" });
+      expect(lastHtml()).toContain("Hi there");
+    });
+
+    it("labels expert_team as Pro Squad", async () => {
+      await sendConsumerProviderAccepted({ ...base, providerKind: "expert_team" });
+      expect(lastHtml()).toContain("Pro Squad");
+    });
+
+    it("labels individual as Verified Pro", async () => {
+      await sendConsumerProviderAccepted({ ...base, providerKind: "individual" });
+      expect(lastHtml()).toContain("Verified Pro");
+    });
+
+    it("links to the brief tracker page", async () => {
+      await sendConsumerProviderAccepted(base);
+      expect(lastHtml()).toContain("/briefs/super-review");
+    });
+  });
+
+  // ─── sendConsumerStaleBriefNudge ─────────────────────────────────
+
+  describe("sendConsumerStaleBriefNudge", () => {
+    const base = {
+      consumerEmail: "user@example.com",
+      consumerName: "Dana Lee",
+      briefTitle: "Retirement Planning",
+      briefSlug: "retirement-planning",
+      hoursLive: 36,
+      willAutoBroaden: true,
+    };
+
+    it("returns true on success", async () => {
+      expect(await sendConsumerStaleBriefNudge(base)).toBe(true);
+    });
+
+    it("includes hours-live count and brief title in HTML", async () => {
+      await sendConsumerStaleBriefNudge(base);
+      const html = lastHtml();
+      expect(html).toContain("36 hours");
+    });
+
+    it("includes auto-broaden note when willAutoBroaden is true", async () => {
+      await sendConsumerStaleBriefNudge(base);
+      expect(lastHtml()).toContain("broaden");
+    });
+
+    it("omits auto-broaden note when willAutoBroaden is false", async () => {
+      await sendConsumerStaleBriefNudge({ ...base, willAutoBroaden: false });
+      expect(lastHtml()).not.toContain("automatically broaden");
+    });
+
+    it('falls back to "there" when consumerName is empty', async () => {
+      await sendConsumerStaleBriefNudge({ ...base, consumerName: "" });
+      expect(lastHtml()).toContain("Hi there");
+    });
+  });
+
+  // ─── sendProConsultationBooked ───────────────────────────────────
+
+  describe("sendProConsultationBooked", () => {
+    const base = {
+      providerEmail: "pro@firm.com",
+      providerName: "Eve Expert",
+      consumerName: "Frank N",
+      consumerEmail: "frank@example.com",
+      briefTitle: "Tax Optimisation",
+      briefSlug: "tax-opt",
+      startAt: "2 Jun 10:00 AM",
+      endAt: "2 Jun 11:00 AM",
+      notes: null,
+    };
+
+    it("returns true on success", async () => {
+      expect(await sendProConsultationBooked(base)).toBe(true);
+    });
+
+    it("includes timing and consumer name in HTML", async () => {
+      await sendProConsultationBooked(base);
+      const html = lastHtml();
+      expect(html).toContain("2 Jun 10:00 AM");
+      expect(html).toContain("Frank N");
+    });
+
+    it("falls back to consumer email when consumerName is empty", async () => {
+      await sendProConsultationBooked({ ...base, consumerName: "" });
+      expect(lastHtml()).toContain("frank@example.com");
+    });
+
+    it("includes notes block when notes is provided", async () => {
+      await sendProConsultationBooked({ ...base, notes: "Please be on time" });
+      expect(lastHtml()).toContain("Please be on time");
+    });
+
+    it("omits notes block when notes is null", async () => {
+      await sendProConsultationBooked(base); // notes: null
+      expect(lastHtml()).not.toContain("Notes from consumer:");
+    });
+  });
+
+  // ─── sendConsumerConsultationPending ─────────────────────────────
+
+  describe("sendConsumerConsultationPending", () => {
+    const base = {
+      consumerEmail: "user@example.com",
+      consumerName: "Grace H",
+      providerName: "Henry Wealth",
+      briefTitle: "Debt Reduction",
+      briefSlug: "debt-reduction",
+      startAt: "3 Jun 2:00 PM",
+      endAt: "3 Jun 3:00 PM",
+    };
+
+    it("returns true and calls sendEmail", async () => {
+      expect(await sendConsumerConsultationPending(base)).toBe(true);
+      expect(sendEmailMock).toHaveBeenCalledOnce();
+    });
+
+    it("uses consumer name in greeting", async () => {
+      await sendConsumerConsultationPending(base);
+      expect(lastHtml()).toContain("Grace");
+    });
+
+    it("includes provider name and timing", async () => {
+      await sendConsumerConsultationPending(base);
+      const html = lastHtml();
+      expect(html).toContain("Henry Wealth");
+      expect(html).toContain("3 Jun 2:00 PM");
+    });
+  });
+
+  // ─── sendConsumerConsultationConfirmed ───────────────────────────
+
+  describe("sendConsumerConsultationConfirmed", () => {
+    const base = {
+      consumerEmail: "user@example.com",
+      consumerName: "Iris K",
+      providerName: "Jake Fin",
+      briefTitle: "ETF Portfolio",
+      briefSlug: "etf-portfolio",
+      startAt: "5 Jun 9:00 AM",
+      endAt: "5 Jun 10:00 AM",
+      meetUrl: "https://meet.google.com/abc-defg-hij",
+    };
+
+    it("returns true on success", async () => {
+      expect(await sendConsumerConsultationConfirmed(base)).toBe(true);
+    });
+
+    it("includes the meeting URL in HTML when provided", async () => {
+      await sendConsumerConsultationConfirmed(base);
+      expect(lastHtml()).toContain("https://meet.google.com/abc-defg-hij");
+    });
+
+    it("shows fallback text when meetUrl is null", async () => {
+      await sendConsumerConsultationConfirmed({ ...base, meetUrl: null });
+      const html = lastHtml();
+      expect(html).toContain("share the meeting link separately");
+      expect(html).not.toContain("https://meet.google.com");
+    });
+
+    it('falls back to "there" when consumerName is empty', async () => {
+      await sendConsumerConsultationConfirmed({ ...base, consumerName: "" });
+      expect(lastHtml()).toContain("Hi there");
+    });
+  });
+
+  // ─── Return false on sendEmail failure ───────────────────────────
+
+  describe("returns false when sendEmail fails", () => {
+    it("sendProviderNewMatchRequest propagates ok:false", async () => {
+      sendEmailMock.mockResolvedValueOnce({ ok: false });
+      const ok = await sendProviderNewMatchRequest({
+        providerEmail: "x@x.com",
+        providerName: "X",
+        briefTitle: "T",
+        briefSlug: "t",
+        acceptCreditsCost: 1,
+        briefBudgetBand: null,
+        briefLocation: null,
+      });
+      expect(ok).toBe(false);
+    });
+  });
+});

--- a/__tests__/lib/taxonomy-consistency.test.ts
+++ b/__tests__/lib/taxonomy-consistency.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import {
+  VERTICAL_TO_CATEGORY,
+  FUND_SUB_TO_CATEGORY,
+  categoryForListing,
+  isCanonicalVertical,
+} from "@/lib/listing-url";
+import {
+  getAllInvestCategories,
+  getAllInvestCategorySlugs,
+} from "@/lib/invest-categories";
+
+/**
+ * These tests guard against the taxonomy fork that caused the
+ * 2026-04-26 listing-filter UX bug: the badge bar rendered DB-vertical
+ * counts (uranium / oil_gas / hydrogen) that the pill row could not
+ * filter by, because invest-categories.ts had no entry for them.
+ *
+ * Concretely, every value in VERTICAL_TO_CATEGORY (and every value in
+ * FUND_SUB_TO_CATEGORY) MUST resolve to a real category slug declared
+ * in invest-categories.ts — otherwise the filter UI drops listings on
+ * the floor.
+ */
+describe("taxonomy consistency: listing-url ↔ invest-categories", () => {
+  const slugs = new Set(getAllInvestCategorySlugs());
+
+  it.each(Object.entries(VERTICAL_TO_CATEGORY))(
+    "DB vertical %s → category slug %s exists in invest-categories.ts",
+    (_vertical, categorySlug) => {
+      expect(slugs.has(categorySlug)).toBe(true);
+    },
+  );
+
+  it.each(Object.entries(FUND_SUB_TO_CATEGORY))(
+    "fund sub_category %s → category slug %s exists in invest-categories.ts",
+    (_sub, categorySlug) => {
+      expect(slugs.has(categorySlug)).toBe(true);
+    },
+  );
+
+  it("every category dbVertical value is a known InvestListingVertical", () => {
+    const known = new Set(Object.keys(VERTICAL_TO_CATEGORY));
+    for (const cat of getAllInvestCategories()) {
+      for (const v of cat.dbVerticals) {
+        expect(known.has(v)).toBe(true);
+      }
+    }
+  });
+
+  it("commodity sector listings route via listed-securities, not the vertical map", () => {
+    // Uranium / oil-gas / hydrogen were the categories the 2026-04-26
+    // audit found missing from the pill row. The shipped fix (2026-06-07,
+    // founder sign-off) groups their listings as an instrument class:
+    // listing_kind === "listed_security" routes to the
+    // "listed-securities" category before the vertical map is consulted,
+    // and the raw sector verticals are deliberately non-canonical.
+    const required = ["uranium", "oil-gas", "hydrogen"];
+    for (const slug of required) {
+      // The sector hub category itself must still exist…
+      expect(slugs.has(slug)).toBe(true);
+      // …its listings route via the instrument-class category…
+      expect(
+        categoryForListing({ vertical: slug, listing_kind: "listed_security" }),
+      ).toBe("listed-securities");
+      // …and the raw vertical stays out of the canonical set so it can't
+      // pollute category counts (see isCanonicalVertical docstring).
+      expect(isCanonicalVertical(slug)).toBe(false);
+    }
+    expect(slugs.has("listed-securities")).toBe(true);
+  });
+});

--- a/lib/invest-categories.ts
+++ b/lib/invest-categories.ts
@@ -103,6 +103,13 @@ const INTENT_BY_SLUG: Record<string, InvestCategoryIntent> = {
   // sign-off 2026-06-07; lean lane per docs/strategy/REGULATORY-AVOID-LIST.md).
   "listed-securities": "opportunity",
 
+  // MM-V01b discovery verticals (registered 2026-06-10). Only
+  // digital-infrastructure has live listings supply today; the other six
+  // (aquaculture, insurance-linked-securities, litigation-funding,
+  // livestock, public-social-infrastructure, venture-capital) stay on the
+  // "guide" default until seeded, then flip to opportunity here.
+  "digital-infrastructure": "opportunity",
+
   // Compare (4) — 301-redirected to canonical Compare/duplicate. The
   // entries are kept in categories[] for back-compat with iterators
   // that key off the array; redirects in next.config.ts intercept the
@@ -2235,6 +2242,280 @@ const categoriesRaw: Omit<InvestCategory, "intent">[] = [
     intro: `A factual directory of ASX-listed companies grouped by investment theme — uranium, hydrogen, oil & gas, critical minerals and more. These are publicly traded securities: you buy and sell them yourself through your own broker. We don't issue, sell, arrange or recommend them, and nothing here is a recommendation or an offer. General information only — do your own research and consider seeking licensed advice before investing.`,
     sections: [],
     faqs: [],
+    subcategories: [],
+  },
+
+  // ─── MM-V01b discovery-page verticals (registered 2026-06-10) ───
+  // PR #803 shipped hand-built /invest/<slug>/listings pages for these
+  // seven verticals but never registered them here, so the /invest
+  // filter IA could not select their listings (the 2026-04-26 taxonomy
+  // fork — guarded by __tests__/lib/taxonomy-consistency.test.ts).
+  // digital-infrastructure has live listings and is tagged opportunity;
+  // the rest default to "guide" until they have listings supply.
+  {
+    slug: "aquaculture",
+    label: "Aquaculture",
+    dbVerticals: ["aquaculture"],
+    color: {
+      bg: "bg-cyan-50",
+      border: "border-cyan-200",
+      text: "text-cyan-700",
+      accent: "bg-cyan-600",
+      gradient: "from-cyan-50 to-white",
+    },
+    icon: "sprout",
+    title: `Aquaculture Investment in Australia — Salmon, Oysters & Marine Farming (${yr})`,
+    h1: "Aquaculture Investment in Australia",
+    metaDescription: `Browse Australian aquaculture investment opportunities — salmon, oysters, prawns and marine farming. Lease structures, biosecurity and FIRB rules. ${upd}.`,
+    intro: `Australia's aquaculture industry spans Tasmanian salmon, Sydney rock oysters, prawn farming and emerging seaweed ventures. Browse aquaculture investment opportunities, from direct farm acquisitions and leases to agribusiness funds with marine farming exposure.`,
+    sections: [
+      {
+        heading: "How Aquaculture Investment Works in Australia",
+        body: "Access routes include direct acquisition or lease of licensed farming operations, agribusiness private equity funds, and managed investment schemes with aquaculture exposure. Marine farming operates under state-issued leases and licences, so due diligence covers lease tenure and conditions, biosecurity history, water quality and environmental compliance alongside the financials.",
+      },
+      {
+        heading: "Key Risks to Understand",
+        body: "Aquaculture carries production risks that land-based agriculture does not — disease and biosecurity events, marine heatwaves and water-quality incidents can affect an entire harvest. Licence and lease conditions are regulated at state level and can change. Review operator track record, insurance arrangements and environmental approvals before committing capital.",
+      },
+    ],
+    faqs: [
+      {
+        question: "How can I invest in aquaculture in Australia?",
+        answer: "Common routes are buying or leasing a licensed operation directly, investing through agribusiness private equity funds, or holding ASX-listed seafood producers. Direct operations require state licences and leases; funds typically have minimum investment and investor-eligibility requirements set out in their offer documents.",
+      },
+      {
+        question: "Do FIRB rules apply to aquaculture investments?",
+        answer: "Foreign investors generally need FIRB notification for agricultural land and agribusiness acquisitions above the relevant thresholds, and aquaculture leases over Crown waters can involve additional state approvals. The rules depend on the structure and value of the deal — specialist advice is recommended for cross-border transactions.",
+      },
+    ],
+    subcategories: [],
+  },
+  {
+    slug: "digital-infrastructure",
+    label: "Digital Infrastructure",
+    dbVerticals: ["digital-infrastructure"],
+    color: {
+      bg: "bg-violet-50",
+      border: "border-violet-200",
+      text: "text-violet-700",
+      accent: "bg-violet-600",
+      gradient: "from-violet-50 to-white",
+    },
+    icon: "cpu",
+    title: `Digital Infrastructure Investment in Australia — Data Centres, Fibre & AI Compute (${yr})`,
+    h1: "Digital Infrastructure Investment in Australia",
+    metaDescription: `Browse Australian digital infrastructure investment opportunities — data centres, fibre networks, subsea cables, AI compute and tower assets. ${upd}.`,
+    intro: `Digital infrastructure — data centres, fibre networks, subsea cables, mobile towers and AI compute facilities — has become a distinct infrastructure asset class in Australia. Browse current opportunities, from unlisted funds and syndicates to development-stage projects.`,
+    sections: [
+      {
+        heading: "What Counts as Digital Infrastructure?",
+        body: "The asset class covers data centres (hyperscale, colocation and edge), fibre and subsea cable networks, mobile tower portfolios and specialised AI compute facilities. Revenue is typically contracted with corporate and government tenants on multi-year terms, which is why investors often analyse these assets with an infrastructure lens — contracted cash flows, capacity utilisation and power security — rather than as property or technology plays.",
+      },
+      {
+        heading: "Access Routes and Structures",
+        body: "Australian investors access the sector through ASX-listed operators, unlisted infrastructure funds, private syndicates and direct development projects. Unlisted vehicles commonly carry minimum-investment and wholesale-investor requirements set out in their offer documents. Key diligence points include tenant covenants and contract tenure, power supply and pricing, connectivity, and refresh capital requirements.",
+      },
+    ],
+    faqs: [
+      {
+        question: "How do I invest in data centres in Australia?",
+        answer: "Routes include ASX-listed data centre operators, unlisted infrastructure funds with digital assets, and private placements in development projects. Listed exposure can be bought through any broker; unlisted vehicles have their own eligibility and minimum-investment rules disclosed in the offer documents.",
+      },
+      {
+        question: "What drives returns in digital infrastructure?",
+        answer: "Returns are driven by contracted tenancy revenue, capacity utilisation, power costs and asset valuations. Demand from cloud and AI workloads has supported the sector's growth, but individual outcomes depend on the specific asset, contract terms and capital structure — review each offer document carefully.",
+      },
+    ],
+    subcategories: [],
+  },
+  {
+    slug: "insurance-linked-securities",
+    label: "Insurance-Linked Securities",
+    dbVerticals: ["insurance-linked-securities"],
+    color: {
+      bg: "bg-slate-50",
+      border: "border-slate-200",
+      text: "text-slate-700",
+      accent: "bg-slate-600",
+      gradient: "from-slate-50 to-white",
+    },
+    icon: "shield",
+    title: `Insurance-Linked Securities (ILS) Investment in Australia — Cat Bonds & Reinsurance (${yr})`,
+    h1: "Insurance-Linked Securities in Australia",
+    metaDescription: `Browse insurance-linked securities opportunities for Australian investors — catastrophe bonds, collateralised reinsurance and ILS funds. ${upd}.`,
+    intro: `Insurance-linked securities (ILS) — catastrophe bonds, collateralised reinsurance and ILS funds — offer returns tied to insurance risk rather than equity or credit markets. Browse ILS opportunities accessible to Australian investors.`,
+    sections: [
+      {
+        heading: "How ILS Investing Works",
+        body: "ILS investors take on defined insurance risks — for example, losses from a specified natural catastrophe — in exchange for premium income. If the covered event does not occur during the risk period, investors earn the coupon; if it does, part or all of the principal pays claims. Because the trigger is an insured event rather than market movements, ILS returns historically show low correlation with shares and bonds.",
+      },
+      {
+        heading: "Access for Australian Investors",
+        body: "Most ILS exposure is accessed through specialist ILS funds, which are typically offered to wholesale or sophisticated investors under the Corporations Act tests. Diligence points include the perils and regions covered, attachment points and modelled loss probabilities, collateral arrangements, and the manager's track record across past catastrophe seasons.",
+      },
+    ],
+    faqs: [
+      {
+        question: "What are catastrophe bonds?",
+        answer: "Catastrophe (cat) bonds are securities whose principal is at risk if a specified insured event — such as a cyclone or earthquake of defined severity — occurs during the bond's term. Investors receive premium-funded coupons for bearing that risk. They are a core instrument of the broader ILS market.",
+      },
+      {
+        question: "Can retail investors access ILS in Australia?",
+        answer: "Direct ILS funds are generally limited to wholesale or sophisticated investors. Retail investors sometimes gain indirect exposure through diversified alternative funds that allocate to ILS. Eligibility requirements and risks are set out in each fund's offer documents.",
+      },
+    ],
+    subcategories: [],
+  },
+  {
+    slug: "litigation-funding",
+    label: "Litigation Funding",
+    dbVerticals: ["litigation-funding"],
+    color: {
+      bg: "bg-amber-50",
+      border: "border-amber-200",
+      text: "text-amber-700",
+      accent: "bg-amber-600",
+      gradient: "from-amber-50 to-white",
+    },
+    icon: "scale",
+    title: `Litigation Funding Investment in Australia — Class Actions & Case Co-Investment (${yr})`,
+    h1: "Litigation Funding Investment in Australia",
+    metaDescription: `Browse litigation funding investment opportunities in Australia — class action funding, single-case co-investment and listed funders. ${upd}.`,
+    intro: `Litigation funding finances legal claims — most visibly class actions — in exchange for a share of any settlement or judgment. Australia is one of the world's most established litigation funding markets. Browse opportunities from listed funders to case co-investment vehicles.`,
+    sections: [
+      {
+        heading: "How Litigation Funding Returns Work",
+        body: "Funders pay a case's legal costs and typically receive a negotiated percentage of the resolution sum, or a multiple of capital deployed, if the case succeeds. If the case fails, the funder usually bears the costs — including potential adverse-costs exposure. Returns are therefore uncorrelated with markets but concentrated in case outcomes, durations and court processes.",
+      },
+      {
+        heading: "Ways to Access the Sector",
+        body: "Access routes include ASX-listed litigation funders, unlisted funds that diversify across case portfolios, and single-case co-investment for wholesale investors. Portfolio diversification matters: single-case outcomes are binary, while portfolio vehicles spread duration and judgment risk across many matters and jurisdictions.",
+      },
+    ],
+    faqs: [
+      {
+        question: "How do litigation funders make money?",
+        answer: "A funder pays the legal costs of a claim in exchange for an agreed share of any settlement or judgment — commonly a percentage of the resolution or a multiple of funds deployed. If the claim fails, the funder typically loses its outlay and may bear adverse costs, which is why diversified portfolios are the dominant institutional structure.",
+      },
+      {
+        question: "Is litigation funding regulated in Australia?",
+        answer: "Yes. Funders of class actions have been subject to evolving regulatory requirements, including managed investment scheme and AFSL obligations in certain periods, and court oversight of funding arrangements. The regulatory settings have changed several times — check the current requirements and each offer's disclosures before investing.",
+      },
+    ],
+    subcategories: [],
+  },
+  {
+    slug: "livestock",
+    label: "Livestock & Pastoral",
+    dbVerticals: ["livestock"],
+    color: {
+      bg: "bg-lime-50",
+      border: "border-lime-200",
+      text: "text-lime-700",
+      accent: "bg-lime-600",
+      gradient: "from-lime-50 to-white",
+    },
+    icon: "map-pin",
+    title: `Livestock & Pastoral Station Investment in Australia (${yr})`,
+    h1: "Livestock & Pastoral Investment in Australia",
+    metaDescription: `Browse Australian livestock and pastoral investment opportunities — cattle stations, sheep properties and agricultural funds. FIRB rules covered. ${upd}.`,
+    intro: `Australia runs some of the world's largest cattle and sheep operations, from northern pastoral stations measured in thousands of square kilometres to high-rainfall finishing country. Browse livestock and pastoral investment opportunities, from station acquisitions to agricultural funds with livestock exposure.`,
+    sections: [
+      {
+        heading: "How Livestock Investment Works",
+        body: "Investors access the sector through direct station ownership or leasehold, livestock trading and agistment arrangements, ASX-listed pastoral companies, and agricultural funds. Returns combine livestock trading income with rural land values, and operations are exposed to seasonal conditions, water security and commodity prices for beef, lamb and wool.",
+      },
+      {
+        heading: "Due Diligence for Pastoral Assets",
+        body: "Key diligence points include land tenure (freehold versus pastoral lease and its conditions), carrying capacity and stocking history, water entitlements and infrastructure, herd or flock genetics and health status, and market access including processing capacity and live-export exposure where relevant. Foreign buyers should check FIRB agricultural land thresholds, which are cumulative.",
+      },
+    ],
+    faqs: [
+      {
+        question: "How much does a cattle station cost in Australia?",
+        answer: "Values range enormously — from a few million dollars for smaller grazing properties to well over a hundred million for large northern pastoral aggregations with significant carrying capacity and water assets. Value is driven by carrying capacity, rainfall and water security, infrastructure and land tenure.",
+      },
+      {
+        question: "Can foreign investors buy Australian pastoral land?",
+        answer: "Yes, subject to FIRB rules for agricultural land, which apply cumulative monetary thresholds and a national-interest assessment. Pastoral leases in some jurisdictions carry additional state approval requirements. Cross-border buyers should obtain specialist advice before contracting.",
+      },
+    ],
+    subcategories: [],
+  },
+  {
+    slug: "public-social-infrastructure",
+    label: "Social Infrastructure",
+    dbVerticals: ["public-social-infrastructure"],
+    color: {
+      bg: "bg-teal-50",
+      border: "border-teal-200",
+      text: "text-teal-700",
+      accent: "bg-teal-600",
+      gradient: "from-teal-50 to-white",
+    },
+    icon: "building",
+    title: `Public & Social Infrastructure Investment in Australia — SDA, Social Housing & SIBs (${yr})`,
+    h1: "Public & Social Infrastructure Investment",
+    metaDescription: `Browse Australian social infrastructure investment opportunities — NDIS Specialist Disability Accommodation, social housing and social impact bonds. ${upd}.`,
+    intro: `Social infrastructure spans NDIS Specialist Disability Accommodation (SDA), social and affordable housing, and social impact bonds — assets whose income is partly or wholly backed by government programs. Browse current opportunities across funds, direct property and impact structures.`,
+    sections: [
+      {
+        heading: "Where the Income Comes From",
+        body: "Much of the sector's appeal is the source of revenue: SDA payments are funded through the NDIS for eligible dwellings and participants, social housing programs involve state-backed leases or availability payments, and social impact bonds pay returns linked to measured program outcomes. Government backing reduces tenant-default risk but introduces policy and program-rule risk — payment frameworks and eligibility criteria can and do change.",
+      },
+      {
+        heading: "Access Routes and What to Check",
+        body: "Investors access the sector through specialist SDA and affordable-housing funds, direct dwelling ownership within registered programs, and outcome-linked instruments. Diligence points include program registration and compliance obligations, vacancy and participant-matching risk for SDA, the credit standing of any availability-payment counterparty, and exit liquidity — these assets trade in thinner markets than mainstream property.",
+      },
+    ],
+    faqs: [
+      {
+        question: "What is Specialist Disability Accommodation (SDA) investment?",
+        answer: "SDA is purpose-built housing for NDIS participants with extreme functional impairment or very high support needs. Approved dwellings attract SDA payments under the NDIS framework in addition to rent contributions. Investment is available through direct dwelling ownership in registered programs or via specialist SDA funds; program rules and design standards are set by the NDIS.",
+      },
+      {
+        question: "What are social impact bonds?",
+        answer: "Social impact bonds (SIBs) are outcome-based contracts where investors fund a social program and receive returns from government if independently measured outcomes — such as reduced reoffending or improved housing stability — are achieved. Returns depend on program performance, so both the delivery partner's capability and the measurement framework matter.",
+      },
+    ],
+    subcategories: [],
+  },
+  {
+    slug: "venture-capital",
+    label: "Venture Capital",
+    dbVerticals: ["venture-capital"],
+    color: {
+      bg: "bg-fuchsia-50",
+      border: "border-fuchsia-200",
+      text: "text-fuchsia-700",
+      accent: "bg-fuchsia-600",
+      gradient: "from-fuchsia-50 to-white",
+    },
+    icon: "rocket",
+    title: `Venture Capital Investment in Australia — VC Funds, ESIC & Co-Investing (${yr})`,
+    h1: "Venture Capital Investment in Australia",
+    metaDescription: `Browse Australian venture capital opportunities — VC funds, co-investment vehicles, ESIC tax incentives and listed VC access routes. ${upd}.`,
+    intro: `Australian venture capital has matured into an established asset class, anchored by large local funds and a pipeline of globally competitive startups. Browse VC opportunities — fund commitments, co-investment vehicles and early-stage company rounds.`,
+    sections: [
+      {
+        heading: "How Australians Access Venture Capital",
+        body: "Primary routes are commitments to VC funds (typically wholesale-investor only, with multi-year capital calls and 10+ year horizons), co-investment platforms that syndicate access to individual rounds, direct angel investing, and a small number of ASX-listed vehicles holding venture portfolios. Fund selection matters enormously: VC return dispersion between managers is among the widest of any asset class.",
+      },
+      {
+        heading: "ESIC and Tax Settings",
+        body: "Investments in qualifying Early Stage Innovation Companies (ESICs) can attract a non-refundable carry-forward tax offset of 20% of the amount invested (capped) and a modified CGT exemption on shares held between one and ten years, subject to eligibility tests for both the company and the investor. The rules are specific — confirm current ATO guidance and the company's ESIC status before relying on the concessions.",
+      },
+    ],
+    faqs: [
+      {
+        question: "What is the minimum investment for VC funds in Australia?",
+        answer: "Institutional VC funds commonly set minimums in the hundreds of thousands of dollars and are restricted to wholesale investors, while syndicate and co-investment platforms can offer lower minimums for individual deals. Each vehicle's offer documents set out its eligibility tests, fees and capital-call schedule.",
+      },
+      {
+        question: "What are ESIC tax incentives?",
+        answer: "Qualifying investors in an Early Stage Innovation Company may receive a 20% non-refundable carry-forward tax offset (capped at $200,000 per year for sophisticated investors and $10,000 for retail investors) plus a modified CGT exemption for shares held 1–10 years. Both the company and the investment must meet the legislated tests at the time shares are issued.",
+      },
+    ],
     subcategories: [],
   },
 ];

--- a/lib/invest-listing-routes.ts
+++ b/lib/invest-listing-routes.ts
@@ -40,6 +40,15 @@ export const STATIC_LISTING_SLUGS = [
   "private-equity",
   "royalties",
   "listed-securities",
+  // MM-V01b discovery vertical (PR #803) — its hand-built page was never
+  // registered here, so categoryListingsHref fell back to the
+  // /invest?category= filter, which couldn't select it either (no
+  // invest-categories entry until 2026-06-10). The other six MM-V01b
+  // verticals stay guide-intent and unregistered until they have listings
+  // supply — LISTING_PAGE_SLUGS must stay exactly the opportunity set
+  // (enforced by __tests__/lib/invest-listing-routes.test.ts), so flip
+  // intent and register here in the same change.
+  "digital-infrastructure",
 ] as const;
 
 /**


### PR DESCRIPTION
## What

Two recoveries from the 2026-06-10 outstanding-branch audit.

### 1. Taxonomy registration fix (live bug)

PR #803 (MM-V01b) shipped hand-built `/invest/<slug>/listings` discovery pages for seven verticals but never registered them in `lib/invest-categories.ts` or `lib/invest-listing-routes.ts`. `VERTICAL_TO_CATEGORY` mapped those verticals to category slugs that didn't exist, so the `/invest` filter IA couldn't select their listings — same fork class as the 2026-04-26 filter UX incident. **`digital-infrastructure` has 10 active listings in prod affected today** (verified via read-only SQL).

- Seven new category entries, copy adapted from the existing sector hub pages (factual, AFSL-safe, no performance claims).
- `digital-infrastructure` tagged **opportunity** (live supply) and registered in `STATIC_LISTING_SLUGS`.
- The other six default to **guide** intent (hidden from Browse-Opportunities IA until seeded) and stay out of `LISTING_PAGE_SLUGS` — that registry must remain exactly the opportunity set, enforced by `invest-listing-routes.test.ts`. Flip intent + register together when they gain supply.

### 2. Orphan test rescue (69 files, ~950 tests)

Recovered from five abandoned branches whose **target code merged but tests never did**: `claude/optimistic-thompson-10Vd7` (57 files), `claude/audit-remediation/d-route-tests` (10), `d-route-tests` (4), `claude/ecstatic-albattani-SbQM7` (5), `claude/fix-listings-filter-D6zM8` (1, the taxonomy guard above), `claude/audit-remediation/l-observability` (subset).

Six donor files were **dropped, not rescued**: `posthog-events` / `posthog-server` / `auth-callback` (target analytics wiring never merged), `admin/ai-chat` (route diverged — needs rewrite), `user-lists-clone` / `user-lists-follow` (superseded by newer equivalents in this same set).

Drive-by fixes to keep the rescued set honest against today's main: office-hours reminder test asserts the HTML-escaped title (route escapes via `escapeHtml`); generate-draft test gets its missing `afterEach` import and a TS-strict-safe `then()` mock signature.

## Verification

- 1,650 tests green locally (rescued set + full invest-IA sweep)
- `tsc --noEmit` clean (strict + noUncheckedIndexedAccess)
- `eslint --max-warnings 0` clean on all changed files

https://claude.ai/code/session_01JVVUm5AJ1AH78AsebCXzt4

---
_Generated by [Claude Code](https://claude.ai/code/session_01JVVUm5AJ1AH78AsebCXzt4)_