### PR TITLE
fix(db): recover unlanded api-billing/consumer-webhook schema [DO-NOT-MERGE: founder review]

### DIFF
--- a/supabase/migrations/20260610140000_api_billing_tiers.sql
+++ b/supabase/migrations/20260610140000_api_billing_tiers.sql
@@ -1,0 +1,62 @@
+-- Migration: API billing tiers — self-serve Stripe subscriptions for API keys.
+--
+-- Adds:
+--   1. `stripe_subscription_id`  — the Stripe subscription that controls this key's tier.
+--   2. `stripe_customer_id`      — Stripe customer (one per owner_email, reused across keys).
+--   3. `requests_this_month`     — running monthly counter (reset by cron, analogous to
+--                                  requests_today for the daily window).
+--   4. `billing_period_start`    — UTC start of the current billing period (for the UI).
+--
+--   api_key_subscriptions        — join table: one row per (api_key, stripe_subscription);
+--                                  lets us look up a key quickly from a subscription event.
+--
+-- Rollback strategy:
+--   ALTER TABLE api_keys DROP COLUMN IF EXISTS stripe_subscription_id;
+--   ALTER TABLE api_keys DROP COLUMN IF EXISTS stripe_customer_id;
+--   ALTER TABLE api_keys DROP COLUMN IF EXISTS requests_this_month;
+--   ALTER TABLE api_keys DROP COLUMN IF EXISTS billing_period_start;
+--   DROP TABLE IF EXISTS api_key_subscriptions;
+
+-- ── 1. Extend api_keys ────────────────────────────────────────────────────────
+
+ALTER TABLE api_keys
+  ADD COLUMN IF NOT EXISTS stripe_subscription_id TEXT,
+  ADD COLUMN IF NOT EXISTS stripe_customer_id     TEXT,
+  ADD COLUMN IF NOT EXISTS requests_this_month    INTEGER DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS billing_period_start   TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_api_keys_stripe_sub
+  ON api_keys(stripe_subscription_id)
+  WHERE stripe_subscription_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_api_keys_stripe_customer
+  ON api_keys(stripe_customer_id)
+  WHERE stripe_customer_id IS NOT NULL;
+
+-- ── 2. Join table: api_key_subscriptions ─────────────────────────────────────
+-- Allows the webhook handler to find all api_keys attached to a Stripe
+-- subscription without a full-table scan.
+
+CREATE TABLE IF NOT EXISTS api_key_subscriptions (
+  id                      BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  api_key_id              UUID        NOT NULL REFERENCES api_keys(id) ON DELETE CASCADE,
+  stripe_subscription_id  TEXT        NOT NULL,
+  stripe_customer_id      TEXT        NOT NULL,
+  tier                    TEXT        NOT NULL CHECK (tier IN ('free', 'basic', 'pro', 'enterprise')),
+  status                  TEXT        NOT NULL DEFAULT 'active',   -- active | canceled | past_due
+  created_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at              TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (api_key_id, stripe_subscription_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_api_key_subs_sub_id
+  ON api_key_subscriptions(stripe_subscription_id);
+
+CREATE INDEX IF NOT EXISTS idx_api_key_subs_key_id
+  ON api_key_subscriptions(api_key_id);
+
+ALTER TABLE api_key_subscriptions ENABLE ROW LEVEL SECURITY;
+-- Service-role only — no authenticated-user policy needed (admin/webhook use)
+DROP POLICY IF EXISTS "Service manage api_key_subscriptions" ON api_key_subscriptions;
+CREATE POLICY "Service manage api_key_subscriptions"
+  ON api_key_subscriptions FOR ALL USING (true);

--- a/supabase/migrations/20260610140100_api_consumer_webhooks.sql
+++ b/supabase/migrations/20260610140100_api_consumer_webhooks.sql
@@ -1,0 +1,31 @@
+-- Migration: consumer webhook registrations for the public API.
+--
+-- API key holders on basic+ tiers can register HTTPS endpoints to receive
+-- event payloads (e.g. broker data changes, health score updates).
+-- Payloads are signed with a per-registration secret (HMAC-SHA256).
+--
+-- Rollback strategy:
+--   DROP TABLE IF EXISTS api_consumer_webhooks;
+
+CREATE TABLE IF NOT EXISTS api_consumer_webhooks (
+  id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  api_key_id   UUID        NOT NULL REFERENCES api_keys(id) ON DELETE CASCADE,
+  url          TEXT        NOT NULL,
+  events       TEXT[]      NOT NULL DEFAULT '{}',  -- e.g. '{"broker.updated","health_score.updated"}'
+  secret_hash  TEXT        NOT NULL,               -- SHA-256 of the signing secret (secret shown once)
+  secret_prefix TEXT       NOT NULL,               -- first 8 chars for identification
+  is_active    BOOLEAN     NOT NULL DEFAULT true,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  -- Enforce max 5 webhook endpoints per key (prevents abuse)
+  CONSTRAINT api_consumer_webhooks_url_len CHECK (char_length(url) <= 2048)
+);
+
+CREATE INDEX IF NOT EXISTS idx_api_consumer_webhooks_key
+  ON api_consumer_webhooks(api_key_id);
+
+ALTER TABLE api_consumer_webhooks ENABLE ROW LEVEL SECURITY;
+-- Service-role only (admin/cron use the service key)
+DROP POLICY IF EXISTS "Service manage api_consumer_webhooks" ON api_consumer_webhooks;
+CREATE POLICY "Service manage api_consumer_webhooks"
+  ON api_consumer_webhooks FOR ALL USING (true);

--- a/supabase/migrations/20260610140200_consumer_webhook_deliveries.sql
+++ b/supabase/migrations/20260610140200_consumer_webhook_deliveries.sql
@@ -1,0 +1,66 @@
+-- Migration: consumer_webhook_deliveries + signing_secret column on api_consumer_webhooks.
+--
+-- Adds the delivery half of the consumer webhook system. Every POST attempt
+-- to a registered endpoint is recorded here for observability and retry.
+--
+-- Also adds a `signing_secret` column to api_consumer_webhooks. The original
+-- table only stored `secret_hash` (SHA-256 of the secret) which is sufficient
+-- for external verification but cannot be used for HMAC-signing outbound
+-- payloads. The plain signing secret is stored here (service-role only) so
+-- the dispatch worker can sign each delivery. Existing rows (created before
+-- this migration) get NULL — they cannot receive deliveries until re-registered.
+--
+-- Rollback strategy:
+--   ALTER TABLE api_consumer_webhooks DROP COLUMN IF EXISTS signing_secret;
+--   DROP TABLE IF EXISTS consumer_webhook_deliveries;
+
+-- ── 1. signing_secret column ────────────────────────────────────────────────
+
+ALTER TABLE api_consumer_webhooks
+  ADD COLUMN IF NOT EXISTS signing_secret TEXT;
+
+COMMENT ON COLUMN api_consumer_webhooks.signing_secret
+  IS 'Plain-text HMAC signing secret for outbound delivery signing. Service-role only (deny-all anon RLS). NULL on rows pre-dating this migration.';
+
+-- ── 2. consumer_webhook_deliveries table ───────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS consumer_webhook_deliveries (
+  id               UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  webhook_id       UUID        NOT NULL REFERENCES api_consumer_webhooks(id) ON DELETE CASCADE,
+  event_type       TEXT        NOT NULL,
+  -- JSON payload delivered (kept for replay / debugging)
+  payload          JSONB       NOT NULL DEFAULT '{}',
+  -- HTTP response from the consumer endpoint (NULL = network/timeout error)
+  response_status  INT,
+  -- First 2 KB of response body (NULL = could not read)
+  response_body    TEXT,
+  -- Error string when fetch itself threw (timeout, DNS failure, etc.)
+  error_message    TEXT,
+  -- Monotonically increasing count of how many times this event has been
+  -- attempted to this endpoint. Starts at 1 on first attempt.
+  attempt_count    INT         NOT NULL DEFAULT 1,
+  -- NULL until the delivery succeeds (response_status 2xx)
+  delivered_at     TIMESTAMPTZ,
+  -- Whether this record should be picked up by the retry worker
+  needs_retry      BOOLEAN     NOT NULL DEFAULT false,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_consumer_webhook_deliveries_webhook
+  ON consumer_webhook_deliveries(webhook_id);
+
+CREATE INDEX IF NOT EXISTS idx_consumer_webhook_deliveries_event
+  ON consumer_webhook_deliveries(event_type);
+
+CREATE INDEX IF NOT EXISTS idx_consumer_webhook_deliveries_retry
+  ON consumer_webhook_deliveries(needs_retry, created_at)
+  WHERE needs_retry = true;
+
+ALTER TABLE consumer_webhook_deliveries ENABLE ROW LEVEL SECURITY;
+
+-- Service-role only — dispatch worker uses admin client (legitimate cron/service caller).
+-- No anon or authenticated-role access is permitted: the deliveries table contains
+-- potentially-sensitive response bodies and attempt metadata.
+DROP POLICY IF EXISTS "Service manage consumer_webhook_deliveries" ON consumer_webhook_deliveries;
+CREATE POLICY "Service manage consumer_webhook_deliveries"
+  ON consumer_webhook_deliveries FOR ALL USING (true);


### PR DESCRIPTION
## ⛔ DO NOT MERGE without founder review — Tier D hold

**Precondition before merge:** founder decision on whether to (a) land this schema and human-trigger `supabase db push`, or (b) remove the dead code paths instead. Set no env var and push nothing to the DB until that call is made.

## What this is

The 2026-06-10 branch audit found that **#1241 (API billing tiers)** and **#1244 (consumer webhook delivery)** merged their application code, but their schema never reached prod or the 2026-06-09 baseline:

| Missing in prod | Referenced by (merged, live) |
|---|---|
| `api_keys` billing columns (`stripe_subscription_id`, `stripe_customer_id`, `requests_this_month`, `billing_period_start`) | `lib/api-auth.ts`, `/api/v1/usage`, `/api/v1/billing/checkout` |
| `api_key_subscriptions` | `lib/stripe-webhook/handlers/api-key-subscription.ts` |
| `api_consumer_webhooks` (+ `signing_secret`) | `/api/v1/webhooks`, `lib/consumer-webhook-dispatch.ts` |
| `consumer_webhook_deliveries` | `lib/consumer-webhook-dispatch.ts`, `/api/cron/retry-consumer-webhooks` |

Verified via read-only `information_schema` queries against prod (2026-06-10).

**Impact today:** `/api/v1/webhooks` errors on use; `fireConsumerWebhook` (called at the tail of four crons) and the every-30m `retry-consumer-webhooks` cron fail silently against missing tables on every run. The Stripe billing path is dormant (price-ID env vars unset → 503 by design), so no user-facing billing breakage.

## What's in the PR

The three migration files recovered **verbatim** from `origin/big-api-billing` / `origin/big-webhook-delivery`, with:
- timestamps renamed (`20260610140000–140200`) to sort after the baseline
- `DROP POLICY IF EXISTS` guards added so `CREATE POLICY` is idempotent per migration rules

All three carry rollback headers, `IF NOT EXISTS` DDL, RLS enabled with service-role-only policies.

## Notes for the review

- Merging only adds files to the repo ledger. Applying to prod is a separate human-triggered `supabase db push` (DB migration rules §4).
- If the decision is (b) remove dead code instead, close this PR and the audit doc lists the four cron call-sites + three routes to strip.

https://claude.ai/code/session_01JVVUm5AJ1AH78AsebCXzt4

---
_Generated by [Claude Code](https://claude.ai/code/session_01JVVUm5AJ1AH78AsebCXzt4)_