### PR TITLE
feat(quiz): cross-border corridor coverage + universal "not sure" paths

### DIFF
--- a/__tests__/lib/quiz-advisor-match-reasons.test.ts
+++ b/__tests__/lib/quiz-advisor-match-reasons.test.ts
@@ -89,6 +89,60 @@ describe("buildAdvisorMatchReasons", () => {
     expect(reasons.some((r) => r.includes("FIRB"))).toBe(true);
   });
 
+  it("routes the India→AU and China→AU business journeys to an investor-visa specialty", () => {
+    // The brief's named non-UK/US corridors: a migrating HNW investor's journey
+    // is selected by the international goal, not the passport. Before the
+    // goal-driven corridors these surfaced only a generic intl/fallback reason.
+    const siv: AdvisorMatchAttrs = {
+      ...base,
+      type: "financial_planner",
+      specialties: ["Significant Investor Visa (SIV)", "High Net Worth Advisory"],
+    };
+    const indiaReasons = buildAdvisorMatchReasons(siv, {
+      isInternational: true,
+      investorCountry: "india",
+      investorGoalIntl: "business",
+      advisorType: "financial-planner",
+    });
+    expect(indiaReasons).toContain("Specialises in Significant Investor Visa (SIV)");
+
+    const chinaReasons = buildAdvisorMatchReasons(siv, {
+      isInternational: true,
+      investorCountry: "china",
+      investorGoalIntl: "business",
+    });
+    expect(chinaReasons).toContain("Specialises in Significant Investor Visa (SIV)");
+  });
+
+  it("routes a cross-border shares/savings goal to an international-tax specialty", () => {
+    const advisor: AdvisorMatchAttrs = {
+      ...base,
+      type: "tax_agent",
+      specialties: ["Individual Tax Returns", "International Tax"],
+    };
+    const sharesReasons = buildAdvisorMatchReasons(advisor, {
+      isInternational: true,
+      investorCountry: "singapore",
+      investorGoalIntl: "shares",
+      advisorType: "tax-agent",
+    });
+    expect(sharesReasons).toContain("Specialises in International Tax");
+  });
+
+  it("keeps a US person on the FATCA/PFIC corridor", () => {
+    const advisor: AdvisorMatchAttrs = {
+      ...base,
+      type: "tax_agent",
+      specialties: ["FATCA-Aware US Expat Planning"],
+    };
+    const reasons = buildAdvisorMatchReasons(advisor, {
+      isInternational: true,
+      investorCountry: "usa",
+      advisorType: "tax-agent",
+    });
+    expect(reasons).toContain("Specialises in FATCA-Aware US Expat Planning");
+  });
+
   it("adds a language reason when the advisor speaks the investor's language", () => {
     const advisor: AdvisorMatchAttrs = {
       ...base,

--- a/__tests__/lib/quiz-questions.test.ts
+++ b/__tests__/lib/quiz-questions.test.ts
@@ -72,4 +72,18 @@ describe("quiz question ↔ answer-schema contract", () => {
       }
     }
   });
+
+  it("offers a valid 'not sure' path on every subjective judgment question", () => {
+    // The brief: "'not sure' is a valid path throughout." goal/mode/advisor_type
+    // already had one (other/unsure/not-sure); these four are the subjective
+    // judgment calls where an undecided user is most likely to abandon. The key
+    // must also survive its schema (asserted by the contract loop above), so the
+    // answer persists as a neutral no-signal rather than silently nulling.
+    for (const id of ["experience", "complexity", "amount", "priority"] as const) {
+      const keys = UNIFIED_QUESTIONS[id].options.map((o) => o.key);
+      expect(keys, `${id} offers a not_sure option`).toContain("not_sure");
+      // It must be last so it doesn't anchor the real choices.
+      expect(keys[keys.length - 1], `${id} not_sure is last`).toBe("not_sure");
+    }
+  });
 });

--- a/lib/quiz-advisor-match-reasons.ts
+++ b/lib/quiz-advisor-match-reasons.ts
@@ -100,10 +100,24 @@ export const INTL_KEYWORDS = [
 /**
  * Corridor-specific specialty keywords for an international user's situation
  * (§5.5: route international by corridor specialty). Matches the canonical
- * CROSS_BORDER_SPECIALTIES strings in lib/advisor-specialties.ts — without
- * these, "UK Pension Transfer" / "DASP Processing" contain no generic
- * INTL_KEYWORD at all, so the exact-corridor specialist scored as if they had
- * no relevant specialty. Shared by the scorer and the match reasons.
+ * cross-border specialty strings in lib/advisor-specialties.ts — without these,
+ * "UK Pension Transfer" / "DASP Processing" / "Significant Investor Visa"
+ * contain no generic INTL_KEYWORD at all, so the exact-corridor specialist
+ * scored as if they had no relevant specialty. Shared by the scorer and the
+ * match reasons.
+ *
+ * Two kinds of corridor:
+ *  - **Country-driven** (UK pension, US FATCA/PFIC, departing-visa DASP): the
+ *    passport/visa alone selects the AU specialty, because the asset itself is
+ *    country-specific (a transferable UK pension; FATCA/PFIC reporting).
+ *  - **Goal-driven** (property → FIRB; business → investor-visa/SIV; shares or
+ *    savings → international tax): for the non-UK/US source markets the brief
+ *    names — India→AU, China→AU, Hong Kong, Singapore, the UAE — there is no
+ *    country-specific AU specialty, so the *journey* (the stated international
+ *    goal) selects it. Before this, those corridors fell through to the generic
+ *    INTL pool and an exact-fit specialist (e.g. a Significant Investor Visa
+ *    structurer for a migrating HNW investor) ranked no better than a
+ *    generalist and surfaced a generic "why matched" reason.
  */
 export function corridorKeywordsFor(ctx: {
   investorCountry?: string;
@@ -111,12 +125,41 @@ export function corridorKeywordsFor(ctx: {
   investorGoalIntl?: string;
 }): string[] {
   const out: string[] = [];
+
+  // ── Country-driven corridors ──
   if (ctx.investorCountry === "uk") out.push("uk pension", "pension transfer", "qrops");
-  if (ctx.investorCountry === "usa") out.push("fatca", "us expat", "us tax");
+  if (ctx.investorCountry === "usa") out.push("fatca", "us expat", "us tax", "pfic");
   // DASP (Departing Australia Superannuation Payment) is specifically the
   // temporary-visa-holder pathway.
   if (ctx.visaStatus === "temp_visa") out.push("dasp", "departing australia");
-  if (ctx.investorGoalIntl === "property") out.push("firb", "non-resident property");
+
+  // ── Goal-driven corridors (country-agnostic; the journey selects the
+  //    specialty for every market that lacks a country-specific AU asset) ──
+  switch (ctx.investorGoalIntl) {
+    case "property":
+      out.push("firb", "non-resident property");
+      break;
+    case "business":
+      // Migrating-investor / business-setup journey — the classic Significant
+      // Investor Visa source markets (China, Hong Kong, India, Singapore, …).
+      out.push(
+        "significant investor visa",
+        "siv",
+        "investor visa",
+        "business innovation",
+        "skilled migration",
+        "international tax",
+        "business structuring",
+      );
+      break;
+    case "shares":
+    case "savings":
+      // Cross-border portfolio / cash → non-resident tax treatment is the
+      // first-order need.
+      out.push("international tax", "non-resident");
+      break;
+  }
+
   return out;
 }
 

--- a/lib/quiz-answer-schemas.ts
+++ b/lib/quiz-answer-schemas.ts
@@ -52,16 +52,23 @@ export const QuizStageSchema = safeEnum([
 
 export const QuizModeSchema = safeEnum(["diy", "help", "unsure"]);
 
+// "not_sure" is a first-class, neutral no-signal answer on the four subjective
+// judgment questions (experience / complexity / amount / priority) — it lets an
+// undecided user proceed instead of abandoning. It degrades safely everywhere:
+// amount → AMOUNT_MULTIPLIER fallback 1.0; experience/priority → not in
+// ANSWER_WEIGHT_MAP, so no weight; complexity → `=== "complex"` is false.
 export const QuizExperienceSchema = safeEnum([
   "beginner",
   "intermediate",
   "pro",
+  "not_sure",
 ]);
 
 export const QuizComplexitySchema = safeEnum([
   "simple",
   "moderate",
   "complex",
+  "not_sure",
 ]);
 
 export const QuizAmountSchema = safeEnum([
@@ -69,6 +76,7 @@ export const QuizAmountSchema = safeEnum([
   "medium",
   "large",
   "whale",
+  "not_sure",
 ]);
 
 export const QuizPrioritySchema = safeEnum([
@@ -76,6 +84,7 @@ export const QuizPrioritySchema = safeEnum([
   "safety",
   "tools",
   "simple",
+  "not_sure",
 ]);
 
 export const QuizAdvisorTypeSchema = safeEnum([

--- a/lib/quiz-questions.ts
+++ b/lib/quiz-questions.ts
@@ -111,6 +111,7 @@ export const UNIFIED_QUESTIONS: Record<QuestionId, QuizQuestionDef> = {
       { key: "beginner", label: "Complete beginner", sub: "Just getting started" },
       { key: "intermediate", label: "Some experience", sub: "I've invested before but want to improve" },
       { key: "pro", label: "Advanced / professional", sub: "I know what I'm doing" },
+      { key: "not_sure", label: "Not sure", sub: "We'll keep things clear either way" },
     ],
   },
   complexity: {
@@ -119,6 +120,7 @@ export const UNIFIED_QUESTIONS: Record<QuestionId, QuizQuestionDef> = {
       { key: "simple", label: "Simple", sub: "Just getting started, straightforward situation" },
       { key: "moderate", label: "Moderate", sub: "Some assets, want to make good decisions" },
       { key: "complex", label: "Complex", sub: "Tax, SMSF, property, business, or multiple goals" },
+      { key: "not_sure", label: "I'm not sure", sub: "We'll start simple — you can add detail later" },
     ],
   },
   amount: {
@@ -128,6 +130,7 @@ export const UNIFIED_QUESTIONS: Record<QuestionId, QuizQuestionDef> = {
       { key: "medium", label: "$10,000 – $100,000", sub: "Building a portfolio" },
       { key: "large", label: "$100,000 – $500,000", sub: "Significant savings" },
       { key: "whale", label: "$500,000+", sub: "Major wealth decisions" },
+      { key: "not_sure", label: "Not sure yet", sub: "We'll show options across the range" },
     ],
   },
   priority: {
@@ -137,6 +140,7 @@ export const UNIFIED_QUESTIONS: Record<QuestionId, QuizQuestionDef> = {
       { key: "safety", label: "Safety (CHESS sponsored)", sub: "Shares held directly in your name" },
       { key: "tools", label: "Best tools & research", sub: "Advanced charting, analysis, screeners" },
       { key: "simple", label: "Simplicity / set & forget", sub: "Easy, automated, and stress-free" },
+      { key: "not_sure", label: "No strong preference", sub: "Show me well-rounded options" },
     ],
   },
   advisor_type: {


### PR DESCRIPTION
Find-advisor quiz elevation (Task 1) — wave 1, engine + question-config only. No schema, no UI rebuild, disjoint from the in-flight #1512 (`app/get-matched/*`). Two safe, additive, well-tested improvements.

### 1. Cross-border corridor coverage (matching engine)
`corridorKeywordsFor()` routed only UK (pension/QROPS), US (FATCA), departing temp-visa (DASP) and property-goal (FIRB). The brief's other named journeys — **India→AU, China→AU**, Hong Kong, Singapore, the UAE — have no country-specific AU asset, so the international *goal* should select the specialty, not the passport. Without a corridor keyword set those users fell through to the generic `INTL_KEYWORDS` pool: an exact-fit specialist (a Significant Investor Visa structurer; an International Tax agent for a cross-border portfolio) scored no better than a generalist and the "why we matched you" panel showed a generic reason.

Added goal-driven corridors matching the canonical specialty strings in `lib/advisor-specialties.ts`:
- `business` → `significant investor visa` / `siv` / `investor visa` / `business innovation` / `skilled migration` / `international tax` / `business structuring`
- `shares` | `savings` → `international tax` / `non-resident`
- `pfic` added to the US corridor

Purely additive — it can only raise a corridor specialist's score and sharpen the reason, never lower an existing match. The scorer inherits it via the shared import.

### 2. Universal "not sure" path (question config)
The brief requires *"'not sure' is a valid path throughout"*, but only goal/mode/advisor_type offered one. Added a reassuring **"Not sure"** option (last, so it doesn't anchor) to the four subjective judgment questions — experience, complexity, amount, priority — the most likely abandonment point for an undecided user. `not_sure` is added to each matching enum so it validates + persists (the contract test requires every option key to survive its schema), and it degrades to a neutral no-signal everywhere it flows:
- amount → `AMOUNT_MULTIPLIER` fallback `1.0`
- experience/priority → absent from `ANSWER_WEIGHT_MAP`, so no weight
- complexity → `=== "complex"` is `false`
- lead route's `INVESTMENT_MAP` skips it → records a null band, not a wrong one

No scoring/outcome/routing path changes for any existing answer.

### Validation
`__tests__/lib/quiz-advisor-match-reasons.test.ts` 16→19; `quiz-questions` + `quiz-answer-schemas` extended; full quiz-lib regression **102 + 37 tests green**; `tsc --noEmit` + `eslint --max-warnings 0` clean.

### Audit-confirmed (no action needed)
The driver-component audit confirmed two brief criteria are **already met**: no email/phone/name reaches `localStorage` (only answer keys + position, 7-day TTL, clean restart), and edge states degrade gracefully (client fallback scores, zero-result fallbacks, double-submit guards).

Next waves (separate PRs): the `stage=ready` urgency signal, results-card CTA primacy (`Book a call` when `booking_link` present), and the a11y polish the audit flagged (focus-to-heading on first step, `aria-live` progress).