### PR TITLE
feat(quiz): use the readiness stage as an urgency signal in advisor matching

### DIFF
--- a/__tests__/lib/quiz-advisor-scoring.test.ts
+++ b/__tests__/lib/quiz-advisor-scoring.test.ts
@@ -158,4 +158,41 @@ describe("scoreQuizAdvisors", () => {
     const out3 = scoreQuizAdvisors([dasp], { advisorType: "tax-agent", isInternational: true, investorCountry: "uk" });
     expect(scoreOf(out3, "dasp")).toBeLessThan(scoreOf(out2, "dasp"));
   });
+
+  describe("urgency (stage = ready / under-contract)", () => {
+    const fast = () => adv({ id: 1, slug: "fast", avg_response_minutes: 60 });
+    const slow = () => adv({ id: 2, slug: "slow", avg_response_minutes: 2000 });
+    const base: QuizAdvisorScoringContext = { advisorType: "financial-planner" };
+
+    it("boosts a fast responder for an urgent user", () => {
+      const calm = scoreQuizAdvisors([fast(), slow()], base);
+      const urgent = scoreQuizAdvisors([fast(), slow()], { ...base, stage: "ready" });
+      // The fast responder gains under urgency; the slow one doesn't.
+      expect(scoreOf(urgent, "fast")).toBeGreaterThan(scoreOf(calm, "fast"));
+      expect(scoreOf(urgent, "slow")).toBe(scoreOf(calm, "slow"));
+      expect(urgent[0]?.slug).toBe("fast");
+    });
+
+    it("treats under-contract as urgent too", () => {
+      const calm = scoreQuizAdvisors([fast()], base);
+      const urgent = scoreQuizAdvisors([fast()], { ...base, stage: "under-contract" });
+      expect(scoreOf(urgent, "fast")).toBeGreaterThan(scoreOf(calm, "fast"));
+    });
+
+    it("damps an explicitly closed book harder for an urgent user", () => {
+      const closed = () => adv({ id: 3, slug: "closed", accepts_new_clients: false });
+      const calm = scoreQuizAdvisors([closed()], base);
+      const urgent = scoreQuizAdvisors([closed()], { ...base, stage: "ready" });
+      expect(scoreOf(urgent, "closed")).toBeLessThan(scoreOf(calm, "closed"));
+    });
+
+    it("is a no-op for exploring/learning and when stage is absent (regression)", () => {
+      for (const stage of [undefined, "exploring", "learning"] as const) {
+        const out = scoreQuizAdvisors([fast(), slow()], { ...base, stage });
+        const baseline = scoreQuizAdvisors([fast(), slow()], base);
+        expect(scoreOf(out, "fast")).toBe(scoreOf(baseline, "fast"));
+        expect(scoreOf(out, "slow")).toBe(scoreOf(baseline, "slow"));
+      }
+    });
+  });
 });

--- a/app/api/advisor-match/route.ts
+++ b/app/api/advisor-match/route.ts
@@ -42,6 +42,8 @@ const Body = z.object({
   investorCountry: z.string().max(20).optional(),
   visaStatus: z.string().max(40).optional(),
   investorGoalIntl: z.string().max(40).optional(),
+  /** Quiz readiness stage — "ready"/"under-contract" boost responsiveness. */
+  stage: z.string().max(20).optional(),
   excludeIds: z.array(z.number()).max(50).optional(),
   limit: z.number().int().min(1).max(10).optional(),
 });
@@ -142,6 +144,7 @@ export async function POST(request: NextRequest) {
     investorCountry: input.investorCountry,
     visaStatus: input.visaStatus,
     investorGoalIntl: input.investorGoalIntl,
+    stage: input.stage,
   };
 
   // Whitelist the OUTPUT too — the client only needs display + reason fields

--- a/app/quiz/_components/AdvisorResultsScreen.tsx
+++ b/app/quiz/_components/AdvisorResultsScreen.tsx
@@ -258,6 +258,9 @@ export default function AdvisorResultsScreen({ advisorType, quizAnswers, platfor
           investorCountry,
           visaStatus,
           investorGoalIntl,
+          // Readiness stage — "ready"/"under-contract" lets the scorer favour
+          // fast responders with an open book for users who want to act now.
+          stage: quizAnswers.stage || undefined,
           limit: 5,
         }),
       });

--- a/lib/quiz-advisor-scoring.ts
+++ b/lib/quiz-advisor-scoring.ts
@@ -80,6 +80,18 @@ export interface QuizAdvisorScoringContext {
   investorCountry?: string;
   visaStatus?: string;
   investorGoalIntl?: string;
+  /**
+   * Quiz readiness stage. "ready" / "under-contract" mark a high-urgency
+   * user: a fast responder earns a small additive bonus and an explicitly
+   * closed advisor is damped harder. Optional — callers that don't collect
+   * stage (e.g. the get-matched lanes) are completely unaffected.
+   */
+  stage?: string;
+}
+
+/** True when the user signalled urgency (ready to act / settlement clock). */
+function isUrgentStage(stage?: string): boolean {
+  return stage === "ready" || stage === "under-contract";
 }
 
 export interface ScoredQuizAdvisor extends QuizAdvisorCandidate {
@@ -213,13 +225,25 @@ function scoreOne(c: QuizAdvisorCandidate, ctx: QuizAdvisorScoringContext): numb
   }
   score += Math.min(20, quality);
 
+  // 4b) Urgency (stage = ready / under-contract): the user wants to act NOW,
+  //     so verified responsiveness earns a small bonus on top of the capped
+  //     quality block. Additive and urgency-gated — a no-stage call scores
+  //     identically to before.
+  const urgent = isUrgentStage(ctx.stage);
+  if (urgent && respMin != null) {
+    if (respMin <= 120) score += 4;
+    else if (respMin <= 1440) score += 2;
+  }
+
   // 5) Availability damp — if the advisor is EXPLICITLY not taking clients,
   //    damp (don't exclude; the flag is often unset = unknown = assume open).
+  //    A closed book matters far more to someone ready to engage this week,
+  //    so urgency damps harder.
   const explicitlyClosed =
     c.accepts_new_clients === false ||
     c.accepting_new_clients === false ||
     (typeof c.availability_status === "string" && /closed|paused|full|not[_-]?accepting/i.test(c.availability_status));
-  if (explicitlyClosed) score *= 0.7;
+  if (explicitlyClosed) score *= urgent ? 0.5 : 0.7;
 
   return Math.round(Math.max(0, Math.min(100, score)));
 }


### PR DESCRIPTION
Quiz elevation (Task 1) — wave 2. Closes the engine audit's #2 gap: the quiz collects `stage` (ready / under-contract / exploring / learning) but the advisor scorer never read it, so a user with a settlement clock saw the same ranking as someone browsing.

**Change.** For `stage = ready` or `under-contract` the scorer now:
- grants a small additive bonus to **verified fast responders** (+4 if they typically reply within 2h, +2 same-day) on top of the capped quality block, and
- damps an **explicitly closed book** harder (×0.5 vs the normal ×0.7) — a closed book matters far more to someone ready to engage this week.

Threaded quiz screen → `/api/advisor-match` (zod `stage` field) → `scoreQuizAdvisors`. `stage` is optional in the scoring context, so callers that don't collect it — the get-matched lanes (#1512's surface, untouched) — are byte-identical, pinned by a no-op regression test across absent/`exploring`/`learning` stages.

**Scope discipline.** Files are fully disjoint from wave 1 (#1530) and from #1512 (`app/get-matched/*`, `lib/getmatched/*`), so squash-merge ordering can't conflict.

The driver audit's remaining a11y flags turned out to be already handled by design: per-step screen-reader announcement is done by moving focus to the question heading (deliberate, documented in `QuizQuestionScreen.tsx`), resume/start-over both move focus, and option cards are real buttons under a truthful `role="group"`. No invented work shipped.

**Validation.** Scorer suite 13→17 (fast-responder boost, under-contract parity, closed-book damp, no-op regression); both `advisor-match` API suites green untouched; `tsc --noEmit` + `eslint --max-warnings 0` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdSEBPnPofJaBPhWy1dggf)_