### PR TITLE
fix(quiz): honest results-screen signals — preview labelling, rematch count, capture re-entry

### DIFF
--- a/app/quiz/_components/AdvisorMatchedScreen.tsx
+++ b/app/quiz/_components/AdvisorMatchedScreen.tsx
@@ -361,7 +361,14 @@ export default function AdvisorMatchedScreen({
                     <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
                     </svg>
-                    Show me a different advisor
+                    {/* Remaining-count keeps the choice honest: the user knows
+                        whether "different" means one more option or several. */}
+                    {(() => {
+                      const remaining = allMatches.length - matchIndex - 1;
+                      return remaining > 0
+                        ? `Show me a different advisor (${remaining} more)`
+                        : "Show me a different advisor";
+                    })()}
                   </>
                 )}
               </button>

--- a/app/quiz/_components/AdvisorResultsScreen.tsx
+++ b/app/quiz/_components/AdvisorResultsScreen.tsx
@@ -487,9 +487,9 @@ export default function AdvisorResultsScreen({ advisorType, quizAnswers, platfor
             <div className="flex items-center gap-2 mb-2">
               <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-emerald-50 border border-emerald-200 text-emerald-700 text-[0.6rem] md:text-[0.65rem] font-bold uppercase tracking-wider rounded-full">
                 <Icon name="check" size={10} className="text-emerald-600" />
-                Sample match
+                Example profile
               </span>
-              <span className="text-[0.6rem] md:text-[0.65rem] text-slate-500">— typical advisor of this type</span>
+              <span className="text-[0.6rem] md:text-[0.65rem] text-slate-500">— the kind of professional we match you with; your match comes next</span>
             </div>
             <div className="flex items-start gap-3">
               <div className="w-12 h-12 md:w-14 md:h-14 rounded-full bg-slate-100 flex items-center justify-center shrink-0 overflow-hidden">
@@ -522,10 +522,15 @@ export default function AdvisorResultsScreen({ advisorType, quizAnswers, platfor
                       {previewAdvisor.review_count > 0 && <span>({previewAdvisor.review_count})</span>}
                     </span>
                   )}
-                  <span className="inline-flex items-center gap-0.5">
-                    <Icon name="clock" size={10} />
-                    Replies within 24h
-                  </span>
+                  {/* No response-time chip here: the API deliberately keeps
+                      response metrics server-side, so any figure would be a
+                      hardcoded claim. Verified signals only. */}
+                  {previewAdvisor.location_display && (
+                    <span className="inline-flex items-center gap-0.5">
+                      <Icon name="map-pin" size={10} />
+                      {previewAdvisor.location_display}
+                    </span>
+                  )}
                 </div>
                 {previewAdvisor.specialties && previewAdvisor.specialties.length > 0 && (
                   <div className="mt-1.5 flex flex-wrap gap-1">

--- a/app/quiz/_components/QuizInlineEmailCapture.tsx
+++ b/app/quiz/_components/QuizInlineEmailCapture.tsx
@@ -31,7 +31,21 @@ export default function QuizInlineEmailCapture({ onSubmit, status }: Props) {
   const isLoading = status === "loading";
   const canSubmit = isValidEmail && !isLoading;
 
-  if (dismissed) return null;
+  // Dismissed → keep a quiet re-entry point instead of vanishing entirely.
+  // Cold recovery used to be impossible: once the ✕ was tapped the only way
+  // back to the PDF/email option was retaking the quiz.
+  if (dismissed) {
+    return (
+      <div className="mb-4 md:mb-6 text-center">
+        <button
+          onClick={() => setDismissed(false)}
+          className="text-xs text-slate-500 hover:text-slate-700 underline underline-offset-2 transition-colors"
+        >
+          Changed your mind? Email me my results
+        </button>
+      </div>
+    );
+  }
 
   // Success state — replace the form with a thank-you so the user knows
   // their submission landed.


### PR DESCRIPTION
Quiz elevation (Task 1) — wave 3. Three truth-and-clarity fixes on the advisor results flow, from the driver-component audit. Presentational only; no lib/API/test surface touched.

**1. Honest preview card.** The pre-contact preview showed a *real* advisor under a "Sample match — typical advisor of this type" badge, plus a hardcoded **"Replies within 24h"** chip. The API deliberately keeps response metrics server-side, so that figure was an unverifiable claim — the exact class the brief bans ("dynamic, never hardcoded generic"). Relabelled to **"Example profile — the kind of professional we match you with; your match comes next"** and replaced the fake chip with the advisor's verified location (`location_display`, already in the API whitelist).

**2. Rematch count.** "Show me a different advisor" now appends the remaining count — *"(2 more)"* — so the user knows whether "different" means one option or several. Derived from props already on `AdvisorMatchedScreen` (`allMatches.length - matchIndex - 1`).

**3. Email-capture re-entry.** Dismissing the post-results capture used to return `null` permanently — the only way back to the PDF/email option was retaking the quiz. The dismissed state now renders a quiet *"Changed your mind? Email me my results"* link that restores the form. State stays local to `QuizInlineEmailCapture`.

**Verified-already (no change needed):** the audit's other flags were found already handled — the "Possible match" honesty panel with the describe-and-quote path exists (`AdvisorMatchedScreen:158-168`), and the "Showing result X of Y" position counter exists (`:170-180`).

**Validation.** `tsc --noEmit` + `eslint --max-warnings 0` clean; no component tests exist for these screens (quiz suites are lib-level and unaffected — all green on the two predecessor PRs #1530/#1534 that just merged).

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdSEBPnPofJaBPhWy1dggf)_