### PR TITLE
feat(quiz): "Book a call" primary CTA when the matched advisor has a booking link

### DIFF
--- a/app/api/advisor-match/route.ts
+++ b/app/api/advisor-match/route.ts
@@ -86,6 +86,7 @@ function toCandidate(row: Record<string, unknown>): QuizAdvisorCandidate {
     avg_response_minutes: asNum(row.avg_response_minutes),
     response_time_hours: asNum(row.response_time_hours),
     initial_consultation_free: asBool(row.initial_consultation_free),
+    booking_link: asStr(row.booking_link),
     trust_score_overall: asNum(row.trust_score_overall),
     country_eligibility: (row.country_eligibility ?? null) as QuizAdvisorCandidate["country_eligibility"],
   };
@@ -173,6 +174,7 @@ export async function POST(request: NextRequest) {
     avg_response_minutes: a.avg_response_minutes,
     response_time_hours: a.response_time_hours,
     initial_consultation_free: a.initial_consultation_free,
+    booking_link: a.booking_link,
     matchScore: a.matchScore,
     confidence: a.confidence,
   }));

--- a/app/quiz/_components/AdvisorMatchedScreen.tsx
+++ b/app/quiz/_components/AdvisorMatchedScreen.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import Icon from "@/components/Icon";
 import { buildAdvisorMatchReasons, type AdvisorMatchContext } from "@/lib/quiz-advisor-match-reasons";
 import { confidenceLabel, type MatchConfidence } from "@/lib/quiz-advisor-scoring";
+import { trackEvent } from "@/lib/tracking";
 
 export interface MatchedAdvisor {
   id: number;
@@ -30,6 +31,7 @@ export interface MatchedAdvisor {
   avg_response_minutes?: number | null;
   response_time_hours?: number | null;
   initial_consultation_free?: boolean | null;
+  booking_link?: string | null;
   matchScore?: number;
   confidence?: MatchConfidence;
 }
@@ -319,10 +321,37 @@ export default function AdvisorMatchedScreen({
           )}
 
           <div className="space-y-2.5">
+            {/* CTA primacy: when the advisor publishes a booking link, "Book a
+                call" is the unmistakable primary action (the user picks a time
+                directly — still ONE advisor); the request-introduction flow
+                stays available as the secondary path. Without a booking link
+                the introduction request remains primary, unchanged. */}
+            {currentMatch.booking_link && (
+              <a
+                href={currentMatch.booking_link}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() =>
+                  trackEvent(
+                    "advisor_booking_click",
+                    { advisor_slug: currentMatch.slug, source: "quiz_match" },
+                    "/quiz",
+                  )
+                }
+                className="w-full py-4 bg-amber-500 hover:bg-amber-600 active:bg-amber-700 text-slate-900 font-bold text-sm rounded-xl transition-colors flex items-center justify-center gap-2 shadow-md shadow-amber-200"
+              >
+                <Icon name="calendar" size={16} />
+                Book a call with {currentMatch.name.split(" ")[0]} — free, no obligation
+              </a>
+            )}
             <button
               onClick={() => onConfirm(currentMatch)}
               disabled={confirming}
-              className="w-full py-4 bg-amber-500 hover:bg-amber-600 active:bg-amber-700 text-slate-900 font-bold text-sm rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 shadow-md shadow-amber-200"
+              className={
+                currentMatch.booking_link
+                  ? "w-full py-3 bg-white border border-slate-300 hover:border-slate-400 hover:bg-slate-50 text-slate-700 font-bold text-sm rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+                  : "w-full py-4 bg-amber-500 hover:bg-amber-600 active:bg-amber-700 text-slate-900 font-bold text-sm rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 shadow-md shadow-amber-200"
+              }
             >
               {confirming ? (
                 <>
@@ -332,6 +361,8 @@ export default function AdvisorMatchedScreen({
                   </svg>
                   Connecting you…
                 </>
+              ) : currentMatch.booking_link ? (
+                <>Or send my details and let {currentMatch.name.split(" ")[0]} reach out</>
               ) : (
                 <>
                   Yes, send my details to {currentMatch.name.split(" ")[0]} — it&apos;s free

--- a/app/quiz/_components/AdvisorResultsScreen.tsx
+++ b/app/quiz/_components/AdvisorResultsScreen.tsx
@@ -54,6 +54,7 @@ function toMatchedAdvisor(a: ScoredQuizAdvisor): MatchedAdvisor {
     avg_response_minutes: a.avg_response_minutes ?? null,
     response_time_hours: a.response_time_hours ?? null,
     initial_consultation_free: a.initial_consultation_free ?? null,
+    booking_link: a.booking_link ?? null,
     matchScore: a.matchScore,
     confidence: a.confidence,
   };

--- a/docs/strategy/FIN_NOTEBOOK.md
+++ b/docs/strategy/FIN_NOTEBOOK.md
@@ -14,6 +14,30 @@
 
 ## Active strategic decisions log
 
+### 2026-06-10 — Quiz elevation (Task-1 brief) shipped in 4 waves; booking-CTA primacy changes funnel economics
+
+Four merged PRs (#1530, #1534, #1536, #1537 pending CI) close the find-advisor
+quiz brief's acceptance criteria against the post-#434 engine:
+- **Goal-driven cross-border corridors** — India/China/HK/Singapore/UAE →AU
+  journeys now hit first-class specialty matching (SIV / investor-visa /
+  international-tax) instead of the generic intl pool; the passport-driven
+  corridors (UK pension, US FATCA/PFIC, DASP) are unchanged.
+- **"Not sure" is a valid path on every judgment question** (experience /
+  complexity / amount / priority), degrading to a neutral no-signal.
+- **stage=ready / under-contract is now an urgency signal**: fast responders
+  get a small scoring bonus; explicitly-closed books damp harder. Get-matched
+  lanes unaffected (stage optional in context).
+- **Booking-CTA primacy** (strategic): when an advisor publishes a
+  `booking_link`, "Book a call" is the primary CTA on the matched screen and
+  the introduction-request becomes secondary. This trades a captured lead row
+  for a direct calendar booking on a fraction of matches — by design per the
+  product brief (conversion > capture). `advisor_booking_click` (source
+  `quiz_match`) tracks the volume; revisit if booking clicks materially
+  cannibalise `/api/advisor-lead` volume without producing engagements.
+- Audit also confirmed already-met criteria (no PII in quiz localStorage,
+  7-day TTL resume, closest-match fallbacks, focus-based a11y announcements)
+  — don't re-scope these from older briefs.
+
 ### 2026-06-10 — Decision Engine COMPLETE: P1–P9 all merged; /find-advisor folded; engine now learns from outcomes
 
 The 9-phase program from the same-day "vision locked" entry below is fully

--- a/lib/quiz-advisor-scoring.ts
+++ b/lib/quiz-advisor-scoring.ts
@@ -62,6 +62,9 @@ export interface QuizAdvisorCandidate {
   avg_response_minutes?: number | null;
   response_time_hours?: number | null;
   initial_consultation_free?: boolean | null;
+  /** Advisor's published booking URL (same field the profile BookingWidget
+   *  uses) — drives the "Book a call" primary CTA on the matched screen. */
+  booking_link?: string | null;
   trust_score_overall?: number | null;
   country_eligibility?: CountryEligibility | Record<string, unknown> | null;
 }


### PR DESCRIPTION
Quiz elevation (Task 1) — wave 4, the brief's last substantive acceptance criterion: *"primary CTA ('Book a call' when `booking_link` exists, else 'Request introduction')"*.

**Before.** The matched-advisor screen had a single path — "send my details" — even when the advisor publishes a booking URL (the same `professionals.booking_link` the public profile's BookingWidget uses).

**After.** When `booking_link` exists, **"Book a call with {first} — free, no obligation"** is the unmistakable amber primary (opens the advisor's booking page, `noopener`, fires a `quiz_match`-attributed `advisor_booking_click` via `lib/tracking`); the request-introduction flow stays available as a clearly-labelled outlined secondary ("Or send my details and let {first} reach out"). Without a booking link the screen is **byte-identical** to before.

**Single-lead allocation preserved:** booking is a direct calendar action with the ONE matched advisor; the introduction path still goes through the existing `/api/advisor-lead` confirm flow.

**Plumbing.** `booking_link` threads `QuizAdvisorCandidate` → `toCandidate` → the `/api/advisor-match` output whitelist → `MatchedAdvisor`. It's a public display field (published by the advisor, already rendered on profiles) — not a commercially-sensitive scoring input, so exposing it honours the whitelist's intent.

**Validation.** `advisor-match` API suites + scorer suite green (29); `tsc --noEmit` + `eslint --max-warnings 0` clean; `calendar` icon verified present in the Icon map (its `name` prop is untyped, so tsc alone wouldn't catch a typo).

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdSEBPnPofJaBPhWy1dggf)_