### PR TITLE
fix(community): align forum writes with live prod schema (ledger-fork drift)

### DIFF
--- a/app/api/community/posts/route.ts
+++ b/app/api/community/posts/route.ts
@@ -194,21 +194,30 @@ export async function POST(req: NextRequest) {
       }
     }
 
-    // Update thread counters: reply_count, last_reply_at, last_reply_by
+    // Update thread counters. NOTE: prod forum_threads has no last_reply_by
+    // column (ledger fork) — including it made this whole update silently
+    // fail, so reply_count never bumped on any live reply. Keep the payload
+    // to columns that exist in prod, and surface errors instead of
+    // discarding them.
     const { data: currentThread } = await admin
       .from("forum_threads")
       .select("reply_count")
       .eq("id", thread_id)
       .single();
 
-    await admin
+    const { error: threadCounterError } = await admin
       .from("forum_threads")
       .update({
         reply_count: (currentThread?.reply_count ?? 0) + 1,
         last_reply_at: new Date().toISOString(),
-        last_reply_by: displayName,
       })
       .eq("id", thread_id);
+    if (threadCounterError) {
+      log.warn("Thread reply-counter update failed", {
+        thread_id,
+        error: threadCounterError.message,
+      });
+    }
 
     // Update category post_count and last_post_at
     const { data: currentCat } = await admin

--- a/lib/community/recount.ts
+++ b/lib/community/recount.ts
@@ -30,9 +30,12 @@ export async function recountThread(threadId: number): Promise<void> {
     .eq("thread_id", threadId)
     .eq("is_removed", false);
 
+  // Prod column is `value` (the local migration file says `vote` — ledger
+  // fork; the vote API route also writes `value`). Verified against live
+  // information_schema 2026-06-10.
   const { data: votes, error: votesError } = await admin
     .from("forum_votes")
-    .select("vote")
+    .select("value")
     .eq("target_type", "thread")
     .eq("target_id", threadId);
 
@@ -45,7 +48,7 @@ export async function recountThread(threadId: number): Promise<void> {
     return;
   }
 
-  const voteScore = (votes ?? []).reduce((sum, v) => sum + (v.vote ?? 0), 0);
+  const voteScore = (votes ?? []).reduce((sum, v) => sum + (v.value ?? 0), 0);
 
   const { error: updateError } = await admin
     .from("forum_threads")

--- a/scripts/community-reconcile-counters.ts
+++ b/scripts/community-reconcile-counters.ts
@@ -28,7 +28,9 @@ const ASK_AN_ADVISOR_CATEGORY = {
     "Pose general questions for verified financial professionals to answer. General information only — not personal advice.",
   icon: "user-check",
   color: "#06b6d4",
-  status: "active",
+  // Prod's forum_categories.status is a GENERATED column derived from
+  // is_active — inserting status directly errors (verified 2026-06-10).
+  is_active: true,
 };
 
 async function ensureAskAnAdvisorCategory(): Promise<"created" | "exists"> {


### PR DESCRIPTION
Follow-up to #1493. Running the counter reconciliation against prod (founder-instructed) surfaced live schema drift vs the local migration files — the migration-ledger fork in action:

- **`forum_votes.value`** is the real column (migration file says `vote`; the vote API route already used `value`). `recountThread` selected the nonexistent column, so recounts silently no-op'd through the fail-soft path.
- **`forum_threads.last_reply_by` doesn't exist in prod** — the posts route's counter update included it, so the whole update has been silently failing on every live reply (reply_count never bumped). Payload trimmed to live columns; the error is now logged.
- **`forum_categories.status` is GENERATED** from `is_active` in prod — the reconciliation script now seeds `is_active`.

Prod data state (already reconciled via Supabase MCP, DML-only, verified): drifted threads 14→0, drifted categories 7→0, `ask-an-advisor` category created (status `active`). True numbers revealed: 14 threads, 0 real replies — the cold-start playbook's premise confirmed.

Tests 39/39 green on affected suites, tsc + eslint clean.

https://claude.ai/code/session_017y4MnruPudSpcLLKarEWRr

---
_Generated by [Claude Code](https://claude.ai/code/session_017y4MnruPudSpcLLKarEWRr)_