### PR TITLE
feat(afsl): cross-link Adviser Register Atlas advisers on licensee pages

### DIFF
--- a/app/afsl/[number]/page.tsx
+++ b/app/afsl/[number]/page.tsx
@@ -14,6 +14,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { Suspense } from "react";
 import { notFound } from "next/navigation";
+import { advisersForLicence, registerMeta } from "@/lib/adviser-register";
 import {
   AFSL_STATUS_LABELS,
   getAfslLicensee,
@@ -202,6 +203,33 @@ export default async function AfslLicenseePage({ params }: Props) {
           authorised representatives, search ASIC Connect directly.
         </p>
       </section>
+
+      {/* Advisers authorised under this licence — Adviser Register Atlas
+          cross-link. Empty while the bundled extract is the synthetic
+          preview, so nothing fictional can attach to a real licensee. */}
+      {!registerMeta().sample && advisersForLicence(licensee.afsl_number).length > 0 && (
+        <section className="border border-slate-200 rounded-xl p-5 space-y-3">
+          <h2 className="font-semibold text-slate-900">
+            Financial advisers authorised under this licence
+          </h2>
+          <p className="text-sm text-slate-600">
+            Current advisers on ASIC&apos;s Financial Advisers Register acting for this licensee.
+          </p>
+          <ul className="divide-y divide-slate-100 rounded-lg border border-slate-200 overflow-hidden">
+            {advisersForLicence(licensee.afsl_number).map((a) => (
+              <li key={a.number}>
+                <Link
+                  href={`/adviser-register/${a.slug}`}
+                  className="flex items-center justify-between gap-3 px-4 py-2.5 hover:bg-slate-50 transition-colors"
+                >
+                  <span className="text-sm font-medium text-slate-800">{a.name}</span>
+                  <span className="text-xs text-slate-500">{a.role}</span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
 
       {/* Fuzzy search — pre-seeded with this firm's name so users can explore
           related licences (e.g. a group with multiple AFSLs). */}

--- a/lib/adviser-register.ts
+++ b/lib/adviser-register.ts
@@ -111,6 +111,22 @@ export function searchRegister(query: string): RegisterSearchResult[] {
   return results.slice(0, REGISTER_SEARCH_MAX_RESULTS);
 }
 
+/** Current advisers authorised under a given AFS licence number — the
+ * Atlas ↔ AFSL-page cross-link. Empty while the dataset is the preview
+ * (callers must also check registerMeta().sample before rendering). */
+export function advisersForLicence(licenceNumber: string, limit = 8): RegisterAdviser[] {
+  const n = licenceNumber.replace(/\D/g, "");
+  if (!n) return [];
+  const out: RegisterAdviser[] = [];
+  for (const a of data.advisers) {
+    if (a.licenseeNumber === n) {
+      out.push(a);
+      if (out.length >= limit) break;
+    }
+  }
+  return out;
+}
+
 /** Licensees by current-adviser headcount, for the hub's browse module. */
 export function topLicensees(limit = 12): { name: string; count: number }[] {
   const counts = new Map<string, number>();


### PR DESCRIPTION
Small follow-up to #1545/#1546: `/afsl/[number]` licensee pages now list the current Financial Advisers Register advisers authorised under the licence, each linking to their `/adviser-register` record (new `advisersForLicence` helper in the Atlas lib).

Sample-gated: the section renders nothing while the bundled Atlas dataset is the synthetic preview, and switches on automatically when `npm run data:far` ingests the real extract — completing the licence → adviser → claim-CTA loop between the two registries with zero risk of fictional names attaching to real licensees.

Verified: tsc clean, lint clean, Atlas suite (12 tests) green, `/afsl-lookup` 200 and unknown-licence 404 regression-checked in dev.

https://claude.ai/code/session_0143tmNcofbgYFt1ufE8Gkmi

---
_Generated by [Claude Code](https://claude.ai/code/session_0143tmNcofbgYFt1ufE8Gkmi)_