### PR TITLE
feat(cgt): scenario library — 18 worked CGT discount pages

### DIFF
--- a/__tests__/lib/cgt-scenarios.test.ts
+++ b/__tests__/lib/cgt-scenarios.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import {
+  CGT_SCENARIOS,
+  cgtScenario,
+  cgtScenarioOutcomes,
+  relatedCgtScenarios,
+} from "@/lib/cgt-scenarios";
+
+describe("cgt scenario grid", () => {
+  it("has unique slugs and resolves round-trip", () => {
+    expect(CGT_SCENARIOS.length).toBe(18);
+    expect(new Set(CGT_SCENARIOS.map((s) => s.slug)).size).toBe(18);
+    for (const s of CGT_SCENARIOS) {
+      expect(cgtScenario(s.slug)).toEqual(s);
+    }
+    expect(cgtScenario("nope")).toBeNull();
+  });
+
+  it("outcomes match the engine: 50k at 37% saves 9,250 via the discount", () => {
+    const s = cgtScenario("50k-gain-at-37pc")!;
+    const { shortHold, longHold } = cgtScenarioOutcomes(s);
+    expect(shortHold.taxWithDiscount).toBeCloseTo(18_500, 0);
+    expect(longHold.taxWithDiscount).toBeCloseTo(9_250, 0);
+    expect(longHold.taxSaved).toBeCloseTo(9_250, 0);
+    expect(longHold.discountedGain).toBeCloseTo(25_000, 0);
+  });
+
+  it("super hold uses the 15% rate and one-third discount", () => {
+    const s = cgtScenario("100k-gain-at-45pc")!;
+    const { superHold } = cgtScenarioOutcomes(s);
+    // 100k × (1 − 1/3) = 66,667 assessable × 15% ≈ 10,000
+    expect(superHold.discountedGain).toBeCloseTo(66_666.67, 0);
+    expect(superHold.taxWithDiscount).toBeCloseTo(10_000, -1);
+  });
+
+  it("long hold never costs more than short hold across the grid", () => {
+    for (const s of CGT_SCENARIOS) {
+      const { shortHold, longHold } = cgtScenarioOutcomes(s);
+      expect(longHold.taxWithDiscount).toBeLessThan(shortHold.taxWithDiscount);
+      expect(longHold.taxSaved).toBeGreaterThan(0);
+    }
+  });
+
+  it("related scenarios exclude self and stay within the grid", () => {
+    const s = CGT_SCENARIOS[0]!;
+    const related = relatedCgtScenarios(s);
+    expect(related.length).toBeGreaterThan(0);
+    for (const r of related) {
+      expect(r.slug).not.toBe(s.slug);
+      expect(cgtScenario(r.slug)).not.toBeNull();
+    }
+  });
+});

--- a/app/cgt-calculator/[scenario]/page.tsx
+++ b/app/cgt-calculator/[scenario]/page.tsx
@@ -1,0 +1,204 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import Icon from "@/components/Icon";
+import JsonLd from "@/components/JsonLd";
+import ComplianceFooter from "@/components/ComplianceFooter";
+import { absoluteUrl, breadcrumbJsonLd, CURRENT_YEAR } from "@/lib/seo";
+import { faqJsonLd } from "@/lib/schema-markup";
+import {
+  CGT_SCENARIOS,
+  cgtScenario,
+  cgtScenarioOutcomes,
+  relatedCgtScenarios,
+  formatMoney,
+  type CgtScenario,
+} from "@/lib/cgt-scenarios";
+
+export const revalidate = 86400;
+// Small, fully known grid — prerender everything.
+export function generateStaticParams() {
+  return CGT_SCENARIOS.map((s) => ({ scenario: s.slug }));
+}
+export const dynamicParams = false;
+
+function headline(s: CgtScenario): string {
+  return `CGT on a $${s.gainLabel} gain at ${s.rateLabel}%`;
+}
+
+export async function generateMetadata({ params }: { params: Promise<{ scenario: string }> }): Promise<Metadata> {
+  const { scenario: slug } = await params;
+  const s = cgtScenario(slug);
+  if (!s) notFound();
+  const { shortHold, longHold } = cgtScenarioOutcomes(s);
+  return {
+    title: `CGT on a $${s.gainLabel} Capital Gain at ${s.rateLabel}% — Held Under vs Over 12 Months (${CURRENT_YEAR})`,
+    description: `A $${s.gainLabel} capital gain at a ${s.rateLabel}% marginal rate: ${formatMoney(shortHold.taxWithDiscount)} tax if sold within 12 months, ${formatMoney(longHold.taxWithDiscount)} after — the 50% discount saves ${formatMoney(longHold.taxSaved)}.`,
+    alternates: { canonical: absoluteUrl(`/cgt-calculator/${s.slug}`) },
+  };
+}
+
+export default async function CgtScenarioPage({ params }: { params: Promise<{ scenario: string }> }) {
+  const { scenario: slug } = await params;
+  const s = cgtScenario(slug);
+  if (!s) notFound();
+
+  const { shortHold, longHold, superHold } = cgtScenarioOutcomes(s);
+  const related = relatedCgtScenarios(s);
+
+  const faqs = [
+    {
+      q: `How much CGT do I pay on a $${s.gainLabel} gain at the ${s.rateLabel}% marginal rate?`,
+      a: `Sold within 12 months of buying, the whole gain is assessable: about ${formatMoney(shortHold.taxWithDiscount)} at a flat ${s.rateLabel}% marginal rate. Held longer than 12 months, the 50% CGT discount halves the assessable gain and the tax falls to about ${formatMoney(longHold.taxWithDiscount)} — a saving of ${formatMoney(longHold.taxSaved)}.`,
+    },
+    {
+      q: "Does the 12-month clock matter that much?",
+      a: `In this scenario it's worth ${formatMoney(longHold.taxSaved)}. Selling even a day before the 12-month mark forfeits the entire discount — if you're close to the anniversary, the date you sign the contract (not settlement) is what counts.`,
+    },
+  ];
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-slate-50 via-white to-white">
+      <JsonLd
+        data={breadcrumbJsonLd([
+          { name: "Home", url: absoluteUrl("/") },
+          { name: "CGT calculator", url: absoluteUrl("/cgt-calculator") },
+          { name: headline(s), url: absoluteUrl(`/cgt-calculator/${s.slug}`) },
+        ])}
+      />
+      <JsonLd data={faqJsonLd(faqs)} />
+
+      <div className="max-w-2xl mx-auto px-4 py-10 md:py-14">
+        <nav aria-label="Breadcrumb" className="text-xs text-slate-500 mb-6">
+          <Link href="/" className="hover:text-slate-700 transition-colors">Home</Link>
+          <span className="mx-1.5 text-slate-300">/</span>
+          <Link href="/cgt-calculator" className="hover:text-slate-700 transition-colors">CGT calculator</Link>
+          <span className="mx-1.5 text-slate-300">/</span>
+          <span className="text-slate-600 font-medium">${s.gainLabel} at {s.rateLabel}%</span>
+        </nav>
+
+        <h1 className="text-3xl md:text-4xl font-extrabold text-slate-900 leading-tight mb-3">
+          CGT on a ${s.gainLabel} gain at a {s.rateLabel}% marginal rate
+        </h1>
+        <p className="text-slate-600 text-sm md:text-base leading-relaxed mb-6">
+          The single biggest lever is the calendar: hold past 12 months and half the gain
+          disappears from your assessable income. Here is exactly what that does to the bill.
+        </p>
+
+        {/* Headline saving */}
+        <div className="rounded-2xl border-2 border-amber-200 bg-gradient-to-br from-amber-50 to-white p-5 mb-6 text-center">
+          <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1">
+            The 12-month discount is worth
+          </p>
+          <p className="text-4xl font-extrabold text-slate-900 tabular-nums">{formatMoney(longHold.taxSaved)}</p>
+          <p className="text-xs text-slate-500 mt-1.5">
+            on this gain at this rate — {formatMoney(shortHold.taxWithDiscount)} vs {formatMoney(longHold.taxWithDiscount)}
+          </p>
+        </div>
+
+        {/* Comparison table */}
+        <section aria-labelledby="cgt-outcomes" className="mb-6">
+          <h2 id="cgt-outcomes" className="text-sm font-bold text-slate-900 mb-2.5">
+            ${s.gainLabel} gross gain, three ways
+          </h2>
+          <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white">
+            <table className="w-full text-sm min-w-[520px]">
+              <thead>
+                <tr className="border-b border-slate-200 bg-slate-50 text-xs font-bold uppercase tracking-wide text-slate-600">
+                  <th scope="col" className="px-3 py-2.5 text-left">Situation</th>
+                  <th scope="col" className="px-3 py-2.5 text-right">Assessable gain</th>
+                  <th scope="col" className="px-3 py-2.5 text-right">Tax</th>
+                  <th scope="col" className="px-3 py-2.5 text-right">Effective rate</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr className="border-b border-slate-100">
+                  <td className="px-3 py-2.5 font-semibold text-slate-800">Sold within 12 months</td>
+                  <td className="px-3 py-2.5 text-right tabular-nums text-slate-700">{formatMoney(shortHold.discountedGain)}</td>
+                  <td className="px-3 py-2.5 text-right tabular-nums font-bold text-red-600">{formatMoney(shortHold.taxWithDiscount)}</td>
+                  <td className="px-3 py-2.5 text-right tabular-nums text-slate-700">{shortHold.effectiveRateWithDiscount.toFixed(1)}%</td>
+                </tr>
+                <tr className="border-b border-slate-100">
+                  <td className="px-3 py-2.5 font-semibold text-slate-800">Held &gt; 12 months (individual)</td>
+                  <td className="px-3 py-2.5 text-right tabular-nums text-slate-700">{formatMoney(longHold.discountedGain)}</td>
+                  <td className="px-3 py-2.5 text-right tabular-nums font-bold text-emerald-700">{formatMoney(longHold.taxWithDiscount)}</td>
+                  <td className="px-3 py-2.5 text-right tabular-nums text-slate-700">{longHold.effectiveRateWithDiscount.toFixed(1)}%</td>
+                </tr>
+                <tr>
+                  <td className="px-3 py-2.5 font-semibold text-slate-800">Held &gt; 12 months in super (15%)</td>
+                  <td className="px-3 py-2.5 text-right tabular-nums text-slate-700">{formatMoney(superHold.discountedGain)}</td>
+                  <td className="px-3 py-2.5 text-right tabular-nums font-bold text-emerald-700">{formatMoney(superHold.taxWithDiscount)}</td>
+                  <td className="px-3 py-2.5 text-right tabular-nums text-slate-700">{superHold.effectiveRateWithDiscount.toFixed(1)}%</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <p className="mt-2.5 text-[0.7rem] leading-relaxed text-slate-500">
+            Assumptions: a single asset, flat marginal rate of {s.rateLabel}% (excludes the
+            Medicare levy), no capital losses or other offsets, individual 50% discount and super
+            one-third discount as legislated. Illustrative general information — not tax advice;
+            your return depends on your full circumstances.
+          </p>
+        </section>
+
+        {/* Interactive cross-link */}
+        <section className="rounded-2xl border border-emerald-200 bg-emerald-50/60 p-5 mb-6">
+          <h2 className="text-base font-bold text-slate-900 mb-2 flex items-center gap-2">
+            <Icon name="trending-up" size={16} className="text-emerald-600" />
+            Your numbers won&apos;t be this round
+          </h2>
+          <p className="text-sm text-slate-700 leading-relaxed mb-3">
+            Put your actual cost base, sale price and bracket into the interactive calculator —
+            or talk timing with a professional before you sign anything.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-2.5">
+            <Link
+              href="/cgt-calculator"
+              className="inline-flex items-center justify-center gap-1.5 rounded-xl bg-emerald-600 hover:bg-emerald-700 px-4 py-2.5 text-sm font-semibold text-white transition-colors"
+            >
+              Open the CGT calculator
+            </Link>
+            <Link
+              href="/advisors/accountants"
+              className="inline-flex items-center justify-center gap-1.5 rounded-xl border border-emerald-300 px-4 py-2.5 text-sm font-semibold text-emerald-800 hover:bg-emerald-100 transition-colors"
+            >
+              Find a tax professional
+            </Link>
+          </div>
+        </section>
+
+        {/* FAQ */}
+        <section className="mb-8 space-y-5">
+          <h2 className="text-lg font-bold text-slate-900">Common questions</h2>
+          {faqs.map((f) => (
+            <div key={f.q}>
+              <h3 className="text-sm font-semibold text-slate-800 mb-1">{f.q}</h3>
+              <p className="text-sm text-slate-600 leading-relaxed">{f.a}</p>
+            </div>
+          ))}
+        </section>
+
+        {/* Related scenarios */}
+        {related.length > 0 && (
+          <section className="mb-8">
+            <h2 className="text-sm font-bold text-slate-900 mb-2.5">Other scenarios</h2>
+            <ul className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+              {related.map((r) => (
+                <li key={r.slug}>
+                  <Link
+                    href={`/cgt-calculator/${r.slug}`}
+                    className="block rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm font-medium text-slate-800 hover:border-amber-300 hover:bg-amber-50/50 transition-colors"
+                  >
+                    ${r.gainLabel} gain at {r.rateLabel}%
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        <ComplianceFooter variant="calculator" />
+      </div>
+    </div>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -26,6 +26,7 @@ import { superFundsMeta, allSuperFunds } from "@/lib/super-funds";
 import { ghostTickersMeta, allGhostTickers } from "@/lib/ghost-tickers";
 import { postcodeAtlasMeta, allPostcodes } from "@/lib/postcode-atlas";
 import { FEE_DRAG_SCENARIOS } from "@/lib/fee-drag";
+import { CGT_SCENARIOS } from "@/lib/cgt-scenarios";
 
 const log = logger("sitemap");
 
@@ -826,6 +827,14 @@ async function buildShard4(): Promise<MetadataRoute.Sitemap> {
   // extract; excluded while the bundled dataset is the synthetic preview.
   // Postcode Wealth Atlas — per-postcode pages over the ATO extract;
   // excluded while the bundled dataset is the synthetic preview.
+  // CGT scenario pages — pure-math static pages, always included.
+  const cgtScenarioPages: MetadataRoute.Sitemap = CGT_SCENARIOS.map((s) => ({
+    url: `${base}/cgt-calculator/${s.slug}`,
+    lastModified: new Date(),
+    changeFrequency: "yearly" as const,
+    priority: 0.55,
+  }));
+
   // Fee-drag scenario pages — pure-math static pages, always included.
   const feeDragPages: MetadataRoute.Sitemap = FEE_DRAG_SCENARIOS.map((s) => ({
     url: `${base}/super/fee-drag/${s.slug}`,
@@ -1006,6 +1015,7 @@ async function buildShard4(): Promise<MetadataRoute.Sitemap> {
     ...ghostTickerPages,
     ...postcodePages,
     ...feeDragPages,
+    ...cgtScenarioPages,
   ];
 }
 

--- a/docs/strategy/FIN_NOTEBOOK.md
+++ b/docs/strategy/FIN_NOTEBOOK.md
@@ -1325,6 +1325,13 @@ Brainstormed list of self-contained builds (each one Claude session, no founder 
 10. **"Is X regulated?" checker pages** — AFSL/ACL/unlicensed status pages for every entity in the AFSL register cache.
 11–25. (lower-confidence ideas — regenerate from this list's spirit when reached: state-by-state stamp duty matrices, visa-by-visa investment right pages, SMSF cost benchmarks by balance, dividend calendar pages, broker outage log, term-deposit ladder builders, CGT scenario library, currency-corridor remittance pages, super contribution deadline pages, advisor fee benchmarks by region, FIRB application timeline tracker, bond yield explainers, IPO archive, LIC NTA discount tracker, robo-advisor comparison matrix.)
 
+**Loop status (2026-06-11 PM session):**
+- #6-as-attempted (AFSL permalinks): already existed (parallel session) — shipped the Atlas↔AFSL adviser cross-link instead (#1551, merged).
+- #9 (broker fee-history): already exists — `broker/[slug]/changelog` + `broker_data_changes` + market-pulse cover it. Marked done.
+- #8 (glossary i18n): deferred — 195 terms × 3 locales of hand-authored translations; needs founder sign-off on translation approach before it's worth building.
+- CGT scenario library (from the 11–25 tail): ✅ SHIPPED — 18 prerendered worked-example pages at `/cgt-calculator/[scenario]` over the existing `computeCgt` engine; pure math, live immediately, same posture as fee-drag.
+- Remaining buildable-without-data items are thinning; most of the tail now waits on founder-run ingests (the four `data:*` commands) or founder decisions.
+
 **Pattern established (#1, #2):** file-backed JSON in `data/` + typed lib loader + alias-driven CSV ingest script + hub/detail ISR routes + synthetic preview with `meta.sample` → banner + noindex until real extract lands → one-command hydration, ships as PR diff. Egress from build sandboxes is blocked for AU data portals — run ingests locally.
 
 ## Open commitments / revisit-by dates

--- a/lib/cgt-scenarios.ts
+++ b/lib/cgt-scenarios.ts
@@ -1,0 +1,97 @@
+/**
+ * CGT scenario grid behind /cgt-calculator/[scenario] — programmatic
+ * worked examples over the existing pure engine (lib/calculators/cgt).
+ * Pure math, nothing to ingest: every page is fully static and
+ * indexable from day one, same posture as lib/fee-drag.
+ *
+ * Each scenario is one (gain, marginal rate) pair; the page tells the
+ * one story that matters — what the 12-month discount does to the tax
+ * bill — plus the super-holder variant.
+ */
+
+import { computeCgt, type CgtResult } from "@/lib/calculators/cgt";
+import { formatMoney } from "@/lib/fee-drag";
+
+export { formatMoney };
+
+export interface CgtScenario {
+  slug: string;
+  gain: number;
+  /** e.g. "50k" — for headlines. */
+  gainLabel: string;
+  /** Marginal rate as a fraction, e.g. 0.37. */
+  marginalRate: number;
+  /** e.g. "37" — for headlines and slugs. */
+  rateLabel: string;
+}
+
+const GAINS: { gain: number; label: string }[] = [
+  { gain: 10_000, label: "10k" },
+  { gain: 25_000, label: "25k" },
+  { gain: 50_000, label: "50k" },
+  { gain: 100_000, label: "100k" },
+  { gain: 250_000, label: "250k" },
+  { gain: 500_000, label: "500k" },
+];
+
+/** Resident marginal rates (excl. Medicare levy) — matches the engine's
+ * framing; the rate is an input, not tax advice about the reader's bracket. */
+const RATES: { rate: number; label: string }[] = [
+  { rate: 0.3, label: "30" },
+  { rate: 0.37, label: "37" },
+  { rate: 0.45, label: "45" },
+];
+
+export const CGT_SCENARIOS: CgtScenario[] = GAINS.flatMap(({ gain, label }) =>
+  RATES.map(({ rate, label: rateLabel }) => ({
+    slug: `${label}-gain-at-${rateLabel}pc`,
+    gain,
+    gainLabel: label,
+    marginalRate: rate,
+    rateLabel,
+  })),
+);
+
+const index = new Map(CGT_SCENARIOS.map((s) => [s.slug, s]));
+
+export function cgtScenario(slug: string): CgtScenario | null {
+  return index.get(slug) ?? null;
+}
+
+export interface CgtScenarioOutcomes {
+  /** Sold within 12 months — no discount. */
+  shortHold: CgtResult;
+  /** Held > 12 months — 50% individual discount. */
+  longHold: CgtResult;
+  /** Held > 12 months inside super — 1/3 discount. */
+  superHold: CgtResult;
+}
+
+export function cgtScenarioOutcomes(s: CgtScenario): CgtScenarioOutcomes {
+  return {
+    shortHold: computeCgt({ gain: s.gain, marginalRate: s.marginalRate, held12Months: false }),
+    longHold: computeCgt({ gain: s.gain, marginalRate: s.marginalRate, held12Months: true }),
+    superHold: computeCgt({
+      gain: s.gain,
+      // Super funds pay 15% on investment earnings; the marginal-rate input
+      // models that flat rate rather than the member's personal bracket.
+      marginalRate: 0.15,
+      held12Months: true,
+      holder: "super",
+    }),
+  };
+}
+
+/** Same gain at other rates + same rate at neighbouring gains. */
+export function relatedCgtScenarios(s: CgtScenario, limit = 6): CgtScenario[] {
+  const sameGain = CGT_SCENARIOS.filter((o) => o.gain === s.gain && o.slug !== s.slug);
+  const sameRate = CGT_SCENARIOS.filter((o) => o.marginalRate === s.marginalRate && o.slug !== s.slug).sort(
+    (a, b) => Math.abs(a.gain - s.gain) - Math.abs(b.gain - s.gain),
+  );
+  const merged: CgtScenario[] = [];
+  for (const o of [...sameGain, ...sameRate]) {
+    if (!merged.some((m) => m.slug === o.slug)) merged.push(o);
+    if (merged.length >= limit) break;
+  }
+  return merged;
+}


### PR DESCRIPTION
Loop continuation on the 25-item backlog: the CGT scenario library — 18 fully prerendered worked-example pages at `/cgt-calculator/[scenario]` (six gain sizes × three marginal rates), each built on the existing `computeCgt` engine and telling the story that matters: what the 12-month discount does to the bill (e.g. $50k at 37%: **$18,500 vs $9,250**).

Same posture as the fee-drag set: pure math, nothing to hydrate, live and indexable on merge. Three-way comparison per page (short hold / individual long hold / super 15% + one-third discount), per-page FAQ JSON-LD, assumptions verbatim (flat marginal rate, excludes Medicare levy, no losses/offsets — general information, not tax advice), cross-links to the interactive calculator and accountant directory. Sitemap shard 4.

Also: FIN_NOTEBOOK loop statuses — AFSL permalinks and the broker fee-history tracker turned out to already exist (marked done); glossary i18n deferred pending founder sign-off on translation approach.

Checks: tsc clean · lint clean · 5 unit tests incl. engine sanity and a grid-wide "long hold never costs more" invariant · server-render QA (exact figures, super row, 404s, existing calculator intact at 200).

https://claude.ai/code/session_0143tmNcofbgYFt1ufE8Gkmi

---
_Generated by [Claude Code](https://claude.ai/code/session_0143tmNcofbgYFt1ufE8Gkmi)_