### PR TITLE
feat(journey): the Feel layer v1+v2 — milestone moments, header stage chip, article dwell

### DIFF
--- a/__tests__/lib/journey.test.ts
+++ b/__tests__/lib/journey.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  recordMilestone,
+  journeySnapshot,
+  journeyStageFor,
+  JOURNEY_MILESTONE_LABELS,
+} from "@/lib/journey";
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("journey milestones", () => {
+  it("first recording is new, repeat is idempotent", () => {
+    const first = recordMilestone("first_save");
+    expect(first.isNew).toBe(true);
+    expect(first.count).toBe(1);
+    const again = recordMilestone("first_save");
+    expect(again.isNew).toBe(false);
+    expect(again.count).toBe(1);
+  });
+
+  it("stages advance with distinct milestones and cap at the ladder top", () => {
+    expect(journeyStageFor(0).name).toBe("Curious");
+    const r1 = recordMilestone("first_save");
+    expect(r1.stage.name).toBe("Explorer");
+    expect(r1.stageAdvanced).toBe(true);
+    const r2 = recordMilestone("first_compare");
+    expect(r2.stage.name).toBe("Comparer");
+    recordMilestone("quiz_complete");
+    recordMilestone("first_article");
+    const r5 = recordMilestone("profile_complete");
+    expect(r5.stage.name).toBe("Decision-ready");
+    expect(r5.stage.nextHint).toBeNull();
+    expect(r5.count).toBe(Object.keys(JOURNEY_MILESTONE_LABELS).length);
+  });
+
+  it("snapshot reflects stored state and survives corrupt storage", () => {
+    recordMilestone("quiz_complete");
+    expect(journeySnapshot().milestones).toContain("quiz_complete");
+    window.localStorage.setItem("inv_journey", "{not json");
+    expect(journeySnapshot().count).toBe(0);
+  });
+});

--- a/app/article/[slug]/page.tsx
+++ b/app/article/[slug]/page.tsx
@@ -32,6 +32,7 @@ import LinkifiedText from "@/components/LinkifiedText";
 import FloatingRightCTA from "@/components/FloatingRightCTA";
 import ArticleShareRow from "@/components/ArticleShareRow";
 import ArticleBookmarkButton from "@/components/ArticleBookmarkButton";
+import ArticleJourneyPing from "@/components/journey/ArticleJourneyPing";
 import { isFlagEnabled } from "@/lib/feature-flags";
 import { pillarPathForCategory, linkDensityForCategory } from "@/lib/keyword-linking";
 import NextActions from "@/components/NextActions";
@@ -425,6 +426,7 @@ export default async function ArticlePage({
               <div className="flex-1 min-w-0">
                 <ArticleShareRow title={a.title} url={absoluteUrl(pagePath)} />
               </div>
+              <ArticleJourneyPing />
               <ArticleBookmarkButton slug={a.slug} title={a.title} />
             </div>
 

--- a/app/quiz/_components/QuizTopMatch.tsx
+++ b/app/quiz/_components/QuizTopMatch.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useEffect } from "react";
+import { fireJourneyMoment } from "@/components/journey/journeyMoment";
 import type { Broker } from "@/lib/types";
 import { trackClick, getAffiliateLink, getBenefitCta, renderStars, AFFILIATE_REL } from "@/lib/tracking";
 import { SHOW_RATINGS } from "@/lib/compliance-config";
@@ -21,6 +23,11 @@ interface Props {
 }
 
 export default function QuizTopMatch({ topMatch, answers, getMatchReasons }: Props) {
+  // Reaching a personalised result is a journey milestone (first time only).
+  useEffect(() => {
+    fireJourneyMoment("quiz_complete");
+  }, []);
+
   if (!topMatch.broker) return null;
   const broker = topMatch.broker;
 

--- a/app/shortlist/compare/CompareClient.tsx
+++ b/app/shortlist/compare/CompareClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { fireJourneyMoment } from "@/components/journey/journeyMoment";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
@@ -96,6 +97,11 @@ const METRICS: ComparisonMetric[] = [
 ];
 
 export default function CompareClient() {
+  // First side-by-side comparison is a journey milestone.
+  useEffect(() => {
+    fireJourneyMoment("first_compare");
+  }, []);
+
   const searchParams = useSearchParams();
   const [brokers, setBrokers] = useState<Broker[]>([]);
   const [loading, setLoading] = useState(true);

--- a/components/ArticleBookmarkButton.tsx
+++ b/components/ArticleBookmarkButton.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { fireJourneyMoment } from "@/components/journey/journeyMoment";
 import { useEffect, useState } from "react";
 
 interface Props {
@@ -38,6 +39,9 @@ export default function ArticleBookmarkButton({ slug, title }: Props) {
           action: next ? "add" : "remove",
         }),
       });
+      if (res.ok && next) {
+        fireJourneyMoment("first_save");
+      }
       if (!res.ok) {
         if (res.status === 401) {
           window.location.href = `/auth/login?next=${encodeURIComponent(window.location.pathname)}`;

--- a/components/BookmarkButton.tsx
+++ b/components/BookmarkButton.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useState } from "react";
 import { useUser } from "@/lib/hooks/useUser";
 import { getSessionId } from "@/lib/session";
+import { useToast } from "@/components/Toast";
+import { fireJourneyMoment } from "@/components/journey/journeyMoment";
 
 interface Props {
   type: "article" | "broker" | "advisor" | "scenario" | "calculator";
@@ -25,6 +27,7 @@ interface Props {
  */
 export default function BookmarkButton({ type, ref, label, className }: Props) {
   const { user } = useUser();
+  const { toast } = useToast();
   const [saved, setSaved] = useState(false);
   const [busy, setBusy] = useState(false);
 
@@ -79,6 +82,9 @@ export default function BookmarkButton({ type, ref, label, className }: Props) {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(body),
         });
+        // Journey moment on the first-ever save; quiet toast thereafter.
+        const moment = fireJourneyMoment("first_save");
+        if (!moment.isNew) toast(label ? `Saved ${label}` : "Saved to your shortlist", "success");
         if (!user) {
           // Mirror into localStorage so the star persists between
           // page loads even before the user signs in.

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -8,6 +8,7 @@ import { CURRENT_YEAR } from "@/lib/seo";
 import Icon from "@/components/Icon";
 import NotificationBell from "@/components/notifications/NotificationBell";
 import ThemeToggle from "@/components/ThemeToggle";
+import JourneyChip from "@/components/journey/JourneyChip";
 import WorkspaceSwitcher from "@/components/WorkspaceSwitcher";
 import { MegaMenu } from "@/components/MegaMenu";
 import type { MegaMenuSidebar } from "@/components/MegaMenu";
@@ -502,6 +503,7 @@ export default function Header() {
 
           {/* Desktop CTA + Theme */}
           <div className="hidden lg:flex items-center gap-3">
+            <JourneyChip />
             <WorkspaceSwitcher />
             <ThemeToggle />
             <NotificationBell />

--- a/components/journey/ArticleJourneyPing.tsx
+++ b/components/journey/ArticleJourneyPing.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+/**
+ * Fires the `first_article` milestone after genuine dwell on an article
+ * (25s with the tab visible) — "read", not merely "opened". Renders
+ * nothing; mount once on article pages.
+ */
+
+import { useEffect } from "react";
+import { fireJourneyMoment } from "@/components/journey/journeyMoment";
+
+const DWELL_MS = 25_000;
+
+export default function ArticleJourneyPing() {
+  useEffect(() => {
+    let elapsed = 0;
+    let last = Date.now();
+    const tick = window.setInterval(() => {
+      const now = Date.now();
+      if (document.visibilityState === "visible") {
+        elapsed += now - last;
+        if (elapsed >= DWELL_MS) {
+          window.clearInterval(tick);
+          fireJourneyMoment("first_article");
+        }
+      }
+      last = now;
+    }, 1_000);
+    return () => window.clearInterval(tick);
+  }, []);
+
+  return null;
+}

--- a/components/journey/JourneyChip.tsx
+++ b/components/journey/JourneyChip.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+/**
+ * Persistent journey identity in the header: a small chip showing the
+ * visitor's current stage once they've reached their first milestone.
+ * Invisible for brand-new visitors (no clutter before there's a story),
+ * hydration-safe (renders nothing until mounted), and live — updates on
+ * the `inv:journey` event fired whenever a milestone records.
+ */
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { journeySnapshot } from "@/lib/journey";
+
+export default function JourneyChip() {
+  const [snap, setSnap] = useState<{ count: number; stageName: string; total: number } | null>(null);
+
+  useEffect(() => {
+    const read = () => {
+      const s = journeySnapshot();
+      setSnap(s.count > 0 ? { count: s.count, stageName: s.stage.name, total: 5 } : null);
+    };
+    read();
+    window.addEventListener("inv:journey", read);
+    return () => window.removeEventListener("inv:journey", read);
+  }, []);
+
+  if (!snap) return null;
+
+  return (
+    <Link
+      href="/account/bookmarks"
+      className="hidden xl:inline-flex items-center gap-1.5 rounded-full border border-amber-200 bg-amber-50 px-3 py-1.5 text-xs font-semibold text-amber-800 hover:bg-amber-100 transition-colors"
+      title={`Journey stage: ${snap.stageName} (${snap.count}/${snap.total} milestones)`}
+    >
+      <span aria-hidden>⭐</span>
+      {snap.stageName}
+    </Link>
+  );
+}

--- a/components/journey/journeyMoment.tsx
+++ b/components/journey/journeyMoment.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+/**
+ * Imperative "journey moment" — the celebration card for milestone
+ * events (first save, first compare, quiz done). Follows the house
+ * imperative-toast pattern (components/Toast.tsx) so any client
+ * component can fire it without providers or layout changes.
+ *
+ * Feel: a spring-in card (bottom-centre, thumb territory on mobile)
+ * with the milestone, stage-progress dots, and one next-step line —
+ * celebration that immediately hands back momentum. Confetti only on
+ * stage advances, and never when the user prefers reduced motion.
+ */
+
+import {
+  recordMilestone,
+  JOURNEY_MILESTONE_LABELS,
+  type JourneyMilestone,
+  type MilestoneResult,
+} from "@/lib/journey";
+
+const CARD_ID = "__journey_moment";
+
+function prefersReducedMotion(): boolean {
+  return typeof window !== "undefined" && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+function renderCard(result: MilestoneResult): void {
+  document.getElementById(CARD_ID)?.remove();
+
+  const card = document.createElement("div");
+  card.id = CARD_ID;
+  card.setAttribute("role", "status");
+  card.setAttribute("aria-live", "polite");
+  card.className =
+    "fixed bottom-6 left-1/2 -translate-x-1/2 z-[60] w-[calc(100%-2rem)] max-w-sm rounded-2xl border-2 border-amber-200 bg-white shadow-xl p-4 toast-enter";
+
+  const reduced = prefersReducedMotion();
+
+  // Stage-progress dots: filled per milestone reached.
+  const dots = Array.from({ length: result.totalMilestones })
+    .map(
+      (_, i) =>
+        `<span class="inline-block w-1.5 h-1.5 rounded-full ${i < result.count ? "bg-amber-500" : "bg-slate-200"}"></span>`,
+    )
+    .join("");
+
+  const confetti =
+    result.stageAdvanced && !reduced
+      ? `<div class="confetti-container confetti-active" aria-hidden="true">${Array.from({ length: 12 })
+          .map(
+            (_, i) =>
+              `<span class="confetti-particle" style="--confetti-delay:${(i * 0.05).toFixed(2)}s; left:${8 + i * 7}%"></span>`,
+          )
+          .join("")}</div>`
+      : "";
+
+  card.innerHTML = `
+    ${confetti}
+    <div class="flex items-start gap-3">
+      <div class="w-9 h-9 rounded-xl bg-amber-100 flex items-center justify-center shrink-0 text-base" aria-hidden="true">⭐</div>
+      <div class="min-w-0">
+        <p class="text-sm font-bold text-slate-900 leading-snug">${JOURNEY_MILESTONE_LABELS[result.milestone]}</p>
+        <p class="text-xs text-slate-500 mt-0.5">Stage ${result.stage.level}: ${result.stage.name}</p>
+        <div class="flex items-center gap-1 mt-1.5">${dots}</div>
+        ${result.stage.nextHint ? `<p class="text-xs text-slate-600 mt-1.5 leading-relaxed">${result.stage.nextHint}</p>` : ""}
+      </div>
+    </div>`;
+
+  document.body.appendChild(card);
+  const ttl = reduced ? 3200 : 4200;
+  window.setTimeout(() => {
+    card.classList.remove("toast-enter");
+    card.classList.add("toast-exit");
+    window.setTimeout(() => card.remove(), 250);
+  }, ttl);
+}
+
+/**
+ * Record the milestone and, when it's genuinely new, show the moment.
+ * Returns the result so callers can fall back to a quiet toast for
+ * repeat actions. Safe to call from any client event handler.
+ */
+export function fireJourneyMoment(milestone: JourneyMilestone): MilestoneResult {
+  const result = recordMilestone(milestone);
+  if (result.isNew && typeof document !== "undefined") {
+    renderCard(result);
+  }
+  return result;
+}

--- a/components/layout/Navigation.tsx
+++ b/components/layout/Navigation.tsx
@@ -9,6 +9,7 @@ import dynamic from "next/dynamic";
 import AccountButton from "@/components/layout/AccountButton";
 import { useUser } from "@/lib/hooks/useUser";
 import ThemeToggle from "@/components/ThemeToggle";
+import JourneyChip from "@/components/journey/JourneyChip";
 
 const SearchOverlay = dynamic(() => import("@/components/SearchOverlay"), { ssr: false });
 const LocationFlagButton = dynamic(() => import("@/components/layout/LocationFlagButton"), { ssr: false });
@@ -772,6 +773,7 @@ export function Navigation() {
 
           {/* Desktop CTA area */}
           <div className="hidden lg:flex items-center gap-2">
+            <JourneyChip />
             <LocationFlagButton />
             <ThemeToggle />
             <button

--- a/docs/strategy/FIN_NOTEBOOK.md
+++ b/docs/strategy/FIN_NOTEBOOK.md
@@ -1334,6 +1334,26 @@ Brainstormed list of self-contained builds (each one Claude session, no founder 
 
 **Pattern established (#1, #2):** file-backed JSON in `data/` + typed lib loader + alias-driven CSV ingest script + hub/detail ISR routes + synthetic preview with `meta.sample` → banner + noindex until real extract lands → one-command hydration, ships as PR diff. Egress from build sandboxes is blocked for AU data portals — run ingests locally.
 
+### 2026-06-11 — The Feel layer (founder directive: consumer-fintech energy)
+
+Directive: retail investor opens this on their phone and FEELS something — Robinhood/Revolut/Coinbase stickiness, not compliance-grey boxes. Compliance inversion that makes this safe for an AU comparison site: celebrate curiosity and decision-quality, never transactions (no trade-confetti conduct risk — we don't execute trades anyway).
+
+**v1 SHIPPED (journey layer):**
+- `lib/journey.ts` — PII-free localStorage milestone model (`inv_journey`): first_save / first_compare / quiz_complete / first_article / profile_complete → 5 named stages (Curious → Explorer → Comparer → Shortlister → Decision-ready), idempotent, SSR-safe, unit-tested.
+- `components/journey/journeyMoment.tsx` — imperative celebration card (house toast pattern, no providers): milestone + stage + progress dots + next-step hint; confetti only on stage advance and never under prefers-reduced-motion.
+- Wired: BookmarkButton (first save = the moment; repeats = quiet "Saved" toast — was previously SILENT), compare page (first_compare), quiz top-match (quiz_complete).
+
+**v2 backlog (in priority order):**
+1. Header stage chip ("N saved · Explorer") in the right cluster — persistent identity.
+2. Wire `first_article` (article pages currently only fire first_save via bookmark).
+3. Claim-sync moment: "your N saves are now in your account" on ClaimAnonymousOnAuth.
+4. Streak UI — lib/streak.ts math is DONE, no UI consumes it (daily check-in surface, at-risk nudge).
+5. Profile-completion meter on /account using the milestone model.
+6. Saved-state empty pages: /account/bookmarks zero-state should sell the journey, not show a void.
+7. Lifecycle journeys (lib/lifecycle-journeys.ts, 6 journeys, no UI) → stage visualisation on hub pages.
+
+Where delight lives: the save tap, the quiz reveal (shine/pulse exists), the first compare. Where trust builds: dated-stat badges, register links, "not advice" framing at decision moments — keep these adjacent to every celebration so excitement and honesty travel together.
+
 ## Open commitments / revisit-by dates
 
 Time-bound items that need a check-in at a specific date. Don't delete — strike through and timestamp when resolved so we keep the trail.

--- a/lib/journey.ts
+++ b/lib/journey.ts
@@ -101,6 +101,9 @@ export function recordMilestone(milestone: JourneyMilestone): MilestoneResult {
   if (isNew) {
     state.milestones[milestone] = new Date().toISOString();
     writeState(state);
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new Event("inv:journey"));
+    }
   }
   const count = Object.keys(state.milestones).length;
   return {

--- a/lib/journey.ts
+++ b/lib/journey.ts
@@ -1,0 +1,120 @@
+/**
+ * The Journey layer — client-side milestone model behind the delight
+ * moments (first save, first compare, quiz done…). Design notes in
+ * docs/strategy/FIN_NOTEBOOK.md ("Feel layer").
+ *
+ * Principles:
+ * - Celebrates curiosity and decision-quality, never transactions —
+ *   the compliance-safe inverse of trade-confetti. Copy stays factual.
+ * - PII-free and schema-free: a tiny localStorage event log under the
+ *   `inv_` prefix convention. No network, no cookies, no identity.
+ * - Pure + SSR-safe: storage access is guarded; the math is testable.
+ */
+
+export type JourneyMilestone =
+  | "first_save"
+  | "first_compare"
+  | "quiz_complete"
+  | "first_article"
+  | "profile_complete";
+
+export interface JourneyStage {
+  /** 1-based stage index. */
+  level: number;
+  name: string;
+  /** What reaching the NEXT stage takes — the nudge copy. */
+  nextHint: string | null;
+}
+
+/** Stage ladder: named identity per level of engagement. */
+const STAGES: { name: string; nextHint: string | null }[] = [
+  { name: "Curious", nextHint: "Save anything that catches your eye to start your shortlist." },
+  { name: "Explorer", nextHint: "Save one more and compare them side by side." },
+  { name: "Comparer", nextHint: "Two minutes of quiz questions sharpens every match on the site." },
+  { name: "Shortlister", nextHint: "Read one guide on your shortlisted picks — it all compounds." },
+  { name: "Decision-ready", nextHint: null },
+];
+
+export const JOURNEY_MILESTONE_LABELS: Record<JourneyMilestone, string> = {
+  first_save: "First save on your shortlist",
+  first_compare: "First side-by-side comparison",
+  quiz_complete: "Quiz complete — matches personalised",
+  first_article: "First guide read",
+  profile_complete: "Investor profile complete",
+};
+
+const STORAGE_KEY = "inv_journey";
+
+interface JourneyState {
+  /** Milestone → ISO timestamp of first occurrence. */
+  milestones: Partial<Record<JourneyMilestone, string>>;
+}
+
+function readState(): JourneyState {
+  if (typeof window === "undefined") return { milestones: {} };
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { milestones: {} };
+    const parsed = JSON.parse(raw) as JourneyState;
+    return parsed && typeof parsed === "object" && parsed.milestones ? parsed : { milestones: {} };
+  } catch {
+    return { milestones: {} };
+  }
+}
+
+function writeState(state: JourneyState): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // Storage full/blocked — the journey quietly degrades to stateless.
+  }
+}
+
+export function journeyStageFor(milestoneCount: number): JourneyStage {
+  const idx = Math.min(milestoneCount, STAGES.length - 1);
+  const stage = STAGES[idx]!;
+  return { level: idx + 1, name: stage.name, nextHint: stage.nextHint };
+}
+
+export interface MilestoneResult {
+  /** True the first time this milestone is ever recorded. */
+  isNew: boolean;
+  milestone: JourneyMilestone;
+  /** Stage after recording. */
+  stage: JourneyStage;
+  /** True when this milestone tipped the user into a new stage. */
+  stageAdvanced: boolean;
+  /** Total distinct milestones reached. */
+  count: number;
+  totalMilestones: number;
+}
+
+/**
+ * Record a milestone (idempotent). Returns enough for the caller to
+ * decide between a full celebration (isNew) and a quiet acknowledgement.
+ */
+export function recordMilestone(milestone: JourneyMilestone): MilestoneResult {
+  const state = readState();
+  const isNew = !state.milestones[milestone];
+  const prevCount = Object.keys(state.milestones).length;
+  if (isNew) {
+    state.milestones[milestone] = new Date().toISOString();
+    writeState(state);
+  }
+  const count = Object.keys(state.milestones).length;
+  return {
+    isNew,
+    milestone,
+    stage: journeyStageFor(count),
+    stageAdvanced: isNew && journeyStageFor(count).level > journeyStageFor(prevCount).level,
+    count,
+    totalMilestones: Object.keys(JOURNEY_MILESTONE_LABELS).length,
+  };
+}
+
+export function journeySnapshot(): { count: number; stage: JourneyStage; milestones: JourneyMilestone[] } {
+  const state = readState();
+  const milestones = Object.keys(state.milestones) as JourneyMilestone[];
+  return { count: milestones.length, stage: journeyStageFor(milestones.length), milestones };
+}


### PR DESCRIPTION
First two slices of the founder's "feel layer" directive: make the platform feel alive for a first-time retail investor — Robinhood/Revolut energy with the compliance inversion that makes it safe here: **celebrate curiosity and decision-quality, never transactions.**

## v1 — milestone moments
- **`lib/journey.ts`** — PII-free, schema-free milestone model in localStorage (`inv_journey`): five milestones (first save, first compare, quiz complete, first article, profile complete) → five named stages: *Curious → Explorer → Comparer → Shortlister → Decision-ready*. Idempotent, SSR-safe, unit-tested; dispatches `inv:journey` for live UI updates.
- **`components/journey/journeyMoment.tsx`** — imperative celebration card (house toast pattern, no providers): milestone, stage identity, progress dots, next-step hint. Confetti only on stage advances, never under `prefers-reduced-motion`.
- **Wiring:** saving was previously **silent**. First-ever save fires the moment ("First save on your shortlist · Stage 2: Explorer"); repeats get a quiet "Saved" toast. Compare page fires `first_compare`; quiz top-match fires `quiz_complete`.

## v2 — persistent identity + honest reading milestone
- **`JourneyChip`** in the live header (`components/layout/Navigation.tsx`): "⭐ Explorer" appears only after the first milestone, live-updates on the `inv:journey` event, links to bookmarks. (Discovery en route: `components/Header.tsx` is legacy — only costs pages use it; chip mounted in both.)
- **`ArticleJourneyPing`**: `first_article` fires after 25s of *visible* dwell — read, not opened. `ArticleBookmarkButton` (articles' own save control) now records `first_save` too.

Design map + remaining v2 backlog (claim-sync moment, streak UI over the dormant `lib/streak.ts`, profile meter, zero-state redesigns) in `FIN_NOTEBOOK.md`.

## Checks
tsc clean · lint clean · 3 unit tests (idempotency, stage ladder, corrupt-storage resilience) · browser-verified: celebration card on first save (390px), chip render/absence on the live Navigation (1440px), zero page errors.

https://claude.ai/code/session_0143tmNcofbgYFt1ufE8Gkmi