### PR TITLE
feat(listings): lot-page experience — catalogue sections, save, vertical intel

### DIFF
--- a/__tests__/api/account-bookmarks.test.ts
+++ b/__tests__/api/account-bookmarks.test.ts
@@ -31,12 +31,14 @@ const listBookmarksMock = vi.fn();
 const addBookmarkMock = vi.fn();
 const removeBookmarkMock = vi.fn();
 const addAnonymousSaveMock = vi.fn();
+const removeAnonymousSaveMock = vi.fn();
 
 vi.mock("@/lib/bookmarks", () => ({
   listBookmarks: (...a: unknown[]) => listBookmarksMock(...a),
   addBookmark: (...a: unknown[]) => addBookmarkMock(...a),
   removeBookmark: (...a: unknown[]) => removeBookmarkMock(...a),
   addAnonymousSave: (...a: unknown[]) => addAnonymousSaveMock(...a),
+  removeAnonymousSave: (...a: unknown[]) => removeAnonymousSaveMock(...a),
 }));
 
 import { GET, POST, DELETE } from "@/app/api/account/bookmarks/route";
@@ -189,7 +191,7 @@ describe("/api/account/bookmarks", () => {
     });
 
     it("returns 400 on invalid type", async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: { id: "u1" } } });
+      // Body validation happens before auth — getUser is never reached.
       const res = await DELETE(
         jsonRequest("DELETE", { type: "nope", ref: "stake" }),
       );
@@ -197,7 +199,6 @@ describe("/api/account/bookmarks", () => {
     });
 
     it("returns 400 on missing ref", async () => {
-      mockGetUser.mockResolvedValueOnce({ data: { user: { id: "u1" } } });
       const res = await DELETE(jsonRequest("DELETE", { type: "broker" }));
       expect(res.status).toBe(400);
     });
@@ -216,6 +217,56 @@ describe("/api/account/bookmarks", () => {
         type: "broker",
         ref: "stake",
       });
+    });
+
+    it("removes the anonymous_saves row when an anonymous caller passes session_id", async () => {
+      mockGetUser.mockResolvedValueOnce({ data: { user: null } });
+      removeAnonymousSaveMock.mockResolvedValueOnce(true);
+      const res = await DELETE(
+        jsonRequest("DELETE", {
+          type: "listing",
+          ref: "riverina-aggregation-412ha",
+          session_id: "sess-123",
+        }),
+      );
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json).toEqual({ ok: true, anonymous: true });
+      expect(removeAnonymousSaveMock).toHaveBeenCalledWith({
+        sessionId: "sess-123",
+        type: "listing",
+        ref: "riverina-aggregation-412ha",
+      });
+      expect(removeBookmarkMock).not.toHaveBeenCalled();
+    });
+
+    it("rate-limits anonymous unsaves", async () => {
+      mockGetUser.mockResolvedValueOnce({ data: { user: null } });
+      isAllowedMock.mockResolvedValueOnce(false);
+      const res = await DELETE(
+        jsonRequest("DELETE", {
+          type: "listing",
+          ref: "riverina-aggregation-412ha",
+          session_id: "sess-123",
+        }),
+      );
+      expect(res.status).toBe(429);
+      expect(removeAnonymousSaveMock).not.toHaveBeenCalled();
+    });
+
+    it("prefers the authenticated path even when session_id is supplied", async () => {
+      mockGetUser.mockResolvedValueOnce({ data: { user: { id: "u1" } } });
+      removeBookmarkMock.mockResolvedValueOnce(true);
+      const res = await DELETE(
+        jsonRequest("DELETE", {
+          type: "listing",
+          ref: "riverina-aggregation-412ha",
+          session_id: "sess-123",
+        }),
+      );
+      expect(res.status).toBe(200);
+      expect(removeBookmarkMock).toHaveBeenCalled();
+      expect(removeAnonymousSaveMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/__tests__/api/invest-listings-resolver.test.ts
+++ b/__tests__/api/invest-listings-resolver.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/logger", () => ({
+  logger: vi.fn(() => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+const maybeSingleMock = vi.fn();
+const eqMock = vi.fn();
+
+// Self-returning query chain: from().select().eq().eq().maybeSingle()
+const chain: Record<string, unknown> = {};
+chain.select = vi.fn(() => chain);
+chain.eq = eqMock.mockImplementation(() => chain);
+chain.maybeSingle = maybeSingleMock;
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(async () => ({
+    from: vi.fn(() => chain),
+  })),
+}));
+
+import { GET } from "@/app/invest/listings/[slug]/route";
+
+function request(slug: string): [NextRequest, { params: Promise<{ slug: string }> }] {
+  return [
+    new NextRequest(`http://localhost/invest/listings/${slug}`),
+    { params: Promise.resolve({ slug }) },
+  ];
+}
+
+describe("/invest/listings/[slug] resolver", () => {
+  beforeEach(() => {
+    maybeSingleMock.mockReset();
+    eqMock.mockClear();
+  });
+
+  it("307s to the canonical vertical lot URL", async () => {
+    maybeSingleMock.mockResolvedValueOnce({
+      data: {
+        slug: "riverina-aggregation-412ha",
+        vertical: "farmland",
+        sub_category: null,
+        listing_kind: null,
+      },
+    });
+    const res = await GET(...request("riverina-aggregation-412ha"));
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe(
+      "http://localhost/invest/farmland/listings/riverina-aggregation-412ha",
+    );
+  });
+
+  it("routes listed securities by listing_kind, not sector vertical", async () => {
+    maybeSingleMock.mockResolvedValueOnce({
+      data: {
+        slug: "boss-energy-asx",
+        vertical: "uranium",
+        sub_category: null,
+        listing_kind: "listed_security",
+      },
+    });
+    const res = await GET(...request("boss-energy-asx"));
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe(
+      "http://localhost/invest/listed-securities/listings/boss-energy-asx",
+    );
+  });
+
+  it("only resolves active listings (stale bookmarks fall back to /invest)", async () => {
+    maybeSingleMock.mockResolvedValueOnce({ data: null });
+    const res = await GET(...request("sold-and-gone"));
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe("http://localhost/invest");
+    // The lookup itself must be status-guarded — the lot pages 404 on
+    // inactive rows, so redirecting there would dead-end the bookmark.
+    expect(eqMock).toHaveBeenCalledWith("status", "active");
+  });
+
+  it("falls back to /invest when the lookup throws", async () => {
+    maybeSingleMock.mockRejectedValueOnce(new Error("db down"));
+    const res = await GET(...request("anything"));
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe("http://localhost/invest");
+  });
+});

--- a/__tests__/components/BookmarksList.test.tsx
+++ b/__tests__/components/BookmarksList.test.tsx
@@ -56,6 +56,31 @@ describe("BookmarksList", () => {
     });
   });
 
+  describe("listing bookmarks", () => {
+    it("groups saved listings under 'Listings' and links via the slug resolver", () => {
+      render(
+        <BookmarksList
+          initialItems={[
+            {
+              id: 7,
+              bookmark_type: "listing",
+              ref: "riverina-aggregation-412ha",
+              label: "Riverina Aggregation",
+              note: null,
+              created_at: "2026-06-01T00:00:00Z",
+            },
+          ]}
+        />,
+      );
+      expect(screen.getByText("Listings")).toBeInTheDocument();
+      const link = screen.getByRole("link", { name: "Riverina Aggregation" });
+      expect(link).toHaveAttribute(
+        "href",
+        "/invest/listings/riverina-aggregation-412ha",
+      );
+    });
+  });
+
   describe("with items", () => {
     it("renders item labels as links", () => {
       render(<BookmarksList initialItems={SAMPLE_ITEMS} />);

--- a/__tests__/components/lot/LotPaperTrail.test.tsx
+++ b/__tests__/components/lot/LotPaperTrail.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "../setup";
+import LotPaperTrail from "@/components/invest/lot/LotPaperTrail";
+import { buildLotProfile } from "@/lib/listings/lot-profile";
+
+describe("LotPaperTrail", () => {
+  it("renders nothing when the listing has no evidence", () => {
+    const { container } = render(
+      <LotPaperTrail profile={buildLotProfile({ hectares: 100 })} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders a provenance timeline for structured events", () => {
+    const profile = buildLotProfile({
+      provenance_events: [
+        { year: 2019, label: "Acquired at auction", detail: "Shannons, Sydney" },
+        { when: "2023", label: "Concours restoration completed" },
+      ],
+    });
+    render(<LotPaperTrail profile={profile} />);
+
+    expect(screen.getByRole("heading", { name: "Paper trail" })).toBeInTheDocument();
+    expect(screen.getByText("Acquired at auction")).toBeInTheDocument();
+    expect(screen.getByText("Shannons, Sydney")).toBeInTheDocument();
+    expect(screen.getByText("2023")).toBeInTheDocument();
+  });
+
+  it("renders document status chips with seller-stated framing", () => {
+    const profile = buildLotProfile({
+      documents: [
+        { name: "Independent valuation", status: "verified" },
+        { name: "Water licence", status: "pending" },
+      ],
+    });
+    render(<LotPaperTrail profile={profile} />);
+
+    expect(screen.getByText("Independent valuation")).toBeInTheDocument();
+    expect(screen.getByText("Copy available")).toBeInTheDocument();
+    expect(screen.getByText("On request")).toBeInTheDocument();
+    expect(screen.getByText(/as stated by the seller/i)).toBeInTheDocument();
+    expect(screen.getByText(/request copies/i)).toBeInTheDocument();
+  });
+
+  it("renders scalar doc-ish facts from seed-shaped key_metrics", () => {
+    const profile = buildLotProfile({
+      provenance: "full build sheet and ownership history",
+      matching_numbers: true,
+    });
+    render(<LotPaperTrail profile={profile} />);
+
+    expect(screen.getByText("Provenance")).toBeInTheDocument();
+    expect(
+      screen.getByText("Full Build Sheet And Ownership History"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Matching Numbers")).toBeInTheDocument();
+    expect(screen.getByText("Yes")).toBeInTheDocument();
+  });
+});

--- a/__tests__/components/lot/LotSaveButton.test.tsx
+++ b/__tests__/components/lot/LotSaveButton.test.tsx
@@ -182,6 +182,30 @@ describe("LotSaveButton", () => {
     expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "true");
   });
 
+  it("reverts the authed optimistic state when the server answers a non-ok response", async () => {
+    mockUseUser.mockReturnValue({ user: { id: "user-1" }, loading: false });
+    mockFetch(async (url, init) => {
+      if (!init?.method || init.method === "GET") {
+        return new Response(JSON.stringify({ items: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      // fetch resolves (no throw) on server errors — the component must
+      // read res.ok / { ok } itself.
+      return new Response(JSON.stringify({ error: "boom" }), { status: 500 });
+    });
+
+    render(<LotSaveButton {...PROPS} />);
+    const button = screen.getByRole("button", { name: /save/i });
+
+    await userEvent.click(button);
+    await waitFor(() => expect(button).toHaveAttribute("aria-busy", "false"));
+
+    expect(button).toHaveAttribute("aria-pressed", "false");
+    expect(button).toHaveTextContent("Save");
+  });
+
   it("hydrates from the bookmarks API and deletes server-side for authed users", async () => {
     mockUseUser.mockReturnValue({ user: { id: "user-1" }, loading: false });
     const fetchFn = mockFetch(async (url, init) => {

--- a/__tests__/components/lot/LotSaveButton.test.tsx
+++ b/__tests__/components/lot/LotSaveButton.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, userEvent, mockUseUser } from "../setup";
+
+// "@/lib/hooks/useUser" and "@/lib/tracking" are mocked by ../setup
+// (mockUseUser is the overridable handle; trackEvent is already a vi.fn).
+vi.mock("@/lib/session", () => ({
+  getSessionId: vi.fn().mockReturnValue("sess-123"),
+}));
+
+import LotSaveButton from "@/components/invest/lot/LotSaveButton";
+import { trackEvent } from "@/lib/tracking";
+
+const mockTrackEvent = vi.mocked(trackEvent);
+
+const PROPS = {
+  slug: "riverina-aggregation-412ha",
+  title: "Riverina Aggregation",
+  vertical: "farmland",
+};
+
+function mockFetch(impl?: (url: string, init?: RequestInit) => Promise<Response>) {
+  const fn = vi.fn(
+    impl ??
+      (async () =>
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })),
+  );
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+describe("LotSaveButton", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockTrackEvent.mockClear();
+    mockUseUser.mockReturnValue({ user: null, loading: false });
+  });
+
+  it("saves optimistically for anonymous users and mirrors to localStorage", async () => {
+    const fetchFn = mockFetch();
+    render(<LotSaveButton {...PROPS} />);
+
+    const button = screen.getByRole("button", { name: /save/i });
+    expect(button).toHaveAttribute("aria-pressed", "false");
+
+    await userEvent.click(button);
+
+    expect(button).toHaveAttribute("aria-pressed", "true");
+    expect(button).toHaveTextContent("Saved");
+
+    await waitFor(() => {
+      const cached = JSON.parse(localStorage.getItem("inv_anon_saves") ?? "[]");
+      expect(cached).toContainEqual({ type: "listing", ref: PROPS.slug });
+    });
+
+    const post = fetchFn.mock.calls.find(([, init]) => init?.method === "POST");
+    expect(post).toBeTruthy();
+    const body = JSON.parse(String(post?.[1]?.body));
+    expect(body.type).toBe("listing");
+    expect(body.ref).toBe(PROPS.slug);
+    expect(body.session_id).toBe("sess-123");
+
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      "listing_save",
+      expect.objectContaining({ ref: PROPS.slug, vertical: "farmland", authed: false }),
+    );
+  });
+
+  it("does NOT revert the anonymous saved state when the server write fails", async () => {
+    mockFetch(async () => {
+      throw new Error("network");
+    });
+    render(<LotSaveButton {...PROPS} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    const button = screen.getByRole("button");
+    await waitFor(() => expect(button).toHaveAttribute("aria-busy", "false"));
+    // localStorage holds the anon truth; the star stays filled.
+    expect(button).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("shows the first-save hint once, and not on later mounts", async () => {
+    mockFetch();
+    const first = render(<LotSaveButton {...PROPS} />);
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(screen.getByRole("status")).toHaveTextContent(/saved on this device/i);
+    expect(localStorage.getItem("inv_lot_first_save_seen")).toBe("1");
+    first.unmount();
+
+    // A different lot, fresh mount: saving again must not re-show the hint.
+    render(<LotSaveButton {...PROPS} slug="another-lot" title="Another Lot" />);
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+    await waitFor(() =>
+      expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "true"),
+    );
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("hydrates saved state from localStorage for anonymous visitors", () => {
+    localStorage.setItem(
+      "inv_anon_saves",
+      JSON.stringify([{ type: "listing", ref: PROPS.slug }]),
+    );
+    mockFetch();
+    render(<LotSaveButton {...PROPS} />);
+    expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("hydrates from the bookmarks API and deletes server-side for authed users", async () => {
+    mockUseUser.mockReturnValue({ user: { id: "user-1" }, loading: false });
+    const fetchFn = mockFetch(async (url, init) => {
+      if (!init?.method || init.method === "GET") {
+        return new Response(
+          JSON.stringify({ items: [{ bookmark_type: "listing", ref: PROPS.slug }] }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    });
+
+    render(<LotSaveButton {...PROPS} />);
+    const button = screen.getByRole("button");
+    await waitFor(() => expect(button).toHaveAttribute("aria-pressed", "true"));
+
+    await userEvent.click(button);
+    await waitFor(() => {
+      const del = fetchFn.mock.calls.find(([, init]) => init?.method === "DELETE");
+      expect(del).toBeTruthy();
+    });
+    expect(button).toHaveAttribute("aria-pressed", "false");
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      "listing_unsave",
+      expect.objectContaining({ authed: true }),
+    );
+  });
+});

--- a/__tests__/components/lot/LotSaveButton.test.tsx
+++ b/__tests__/components/lot/LotSaveButton.test.tsx
@@ -123,6 +123,38 @@ describe("LotSaveButton", () => {
     expect(cached).not.toContainEqual({ type: "listing", ref: PROPS.slug });
   });
 
+  it("resets saved state when the slug changes during client-side navigation", () => {
+    localStorage.setItem(
+      "inv_anon_saves",
+      JSON.stringify([{ type: "listing", ref: PROPS.slug }]),
+    );
+    mockFetch();
+    const view = render(<LotSaveButton {...PROPS} />);
+    expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "true");
+
+    // Same component instance, new lot (related-listing navigation).
+    view.rerender(<LotSaveButton {...PROPS} slug="different-lot" title="Different Lot" />);
+    expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "false");
+
+    // …and back again.
+    view.rerender(<LotSaveButton {...PROPS} />);
+    expect(screen.getByRole("button")).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("ignores clicks until auth has resolved (no stale anonymous mirror for signed-in users)", async () => {
+    mockUseUser.mockReturnValue({ user: null, loading: true });
+    const fetchFn = mockFetch();
+    render(<LotSaveButton {...PROPS} />);
+
+    const button = screen.getByRole("button");
+    expect(button).toBeDisabled();
+    await userEvent.click(button);
+
+    expect(button).toHaveAttribute("aria-pressed", "false");
+    expect(fetchFn).not.toHaveBeenCalled();
+    expect(localStorage.getItem("inv_anon_saves")).toBeNull();
+  });
+
   it("keeps sibling instances for the same slug in sync (header pill + sticky bar)", async () => {
     const fetchFn = mockFetch();
     render(

--- a/__tests__/components/lot/LotSaveButton.test.tsx
+++ b/__tests__/components/lot/LotSaveButton.test.tsx
@@ -82,6 +82,78 @@ describe("LotSaveButton", () => {
     expect(button).toHaveAttribute("aria-pressed", "true");
   });
 
+  it("writes the localStorage mirror BEFORE the network call so a failed save survives reload", async () => {
+    mockFetch(async () => {
+      throw new Error("offline");
+    });
+    render(<LotSaveButton {...PROPS} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+    await waitFor(() =>
+      expect(screen.getByRole("button")).toHaveAttribute("aria-busy", "false"),
+    );
+
+    // The pressed button's promise ("saved on this device") must hold even
+    // though the POST never landed.
+    const cached = JSON.parse(localStorage.getItem("inv_anon_saves") ?? "[]");
+    expect(cached).toContainEqual({ type: "listing", ref: PROPS.slug });
+  });
+
+  it("deletes the anonymous server row on unsave (claim-on-signup must not resurrect it)", async () => {
+    localStorage.setItem(
+      "inv_anon_saves",
+      JSON.stringify([{ type: "listing", ref: PROPS.slug }]),
+    );
+    const fetchFn = mockFetch();
+    render(<LotSaveButton {...PROPS} />);
+
+    const button = screen.getByRole("button");
+    expect(button).toHaveAttribute("aria-pressed", "true");
+
+    await userEvent.click(button);
+    await waitFor(() => expect(button).toHaveAttribute("aria-busy", "false"));
+
+    expect(button).toHaveAttribute("aria-pressed", "false");
+    const del = fetchFn.mock.calls.find(([, init]) => init?.method === "DELETE");
+    expect(del).toBeTruthy();
+    const body = JSON.parse(String(del?.[1]?.body));
+    expect(body).toMatchObject({ type: "listing", ref: PROPS.slug, session_id: "sess-123" });
+
+    const cached = JSON.parse(localStorage.getItem("inv_anon_saves") ?? "[]");
+    expect(cached).not.toContainEqual({ type: "listing", ref: PROPS.slug });
+  });
+
+  it("keeps sibling instances for the same slug in sync (header pill + sticky bar)", async () => {
+    const fetchFn = mockFetch();
+    render(
+      <>
+        <LotSaveButton {...PROPS} />
+        <LotSaveButton {...PROPS} variant="bar" />
+      </>,
+    );
+
+    const [pill, bar] = screen.getAllByRole("button");
+    expect(pill).toHaveAttribute("aria-pressed", "false");
+    expect(bar).toHaveAttribute("aria-pressed", "false");
+
+    await userEvent.click(pill!);
+    await waitFor(() => expect(pill).toHaveAttribute("aria-busy", "false"));
+
+    // The sibling reflects the save without its own interaction…
+    expect(pill).toHaveAttribute("aria-pressed", "true");
+    expect(bar).toHaveAttribute("aria-pressed", "true");
+
+    // …and toggling from the sibling unsaves (DELETE) instead of re-saving.
+    await userEvent.click(bar!);
+    await waitFor(() => expect(bar).toHaveAttribute("aria-busy", "false"));
+    expect(pill).toHaveAttribute("aria-pressed", "false");
+    expect(bar).toHaveAttribute("aria-pressed", "false");
+
+    const methods = fetchFn.mock.calls.map(([, init]) => init?.method);
+    expect(methods.filter((m) => m === "POST")).toHaveLength(1);
+    expect(methods.filter((m) => m === "DELETE")).toHaveLength(1);
+  });
+
   it("shows the first-save hint once, and not on later mounts", async () => {
     mockFetch();
     const first = render(<LotSaveButton {...PROPS} />);

--- a/__tests__/components/lot/LotStickyActions.test.tsx
+++ b/__tests__/components/lot/LotStickyActions.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, mockUseUser } from "../setup";
+
+vi.mock("@/lib/session", () => ({
+  getSessionId: vi.fn().mockReturnValue("sess-123"),
+}));
+
+import LotStickyActions from "@/components/invest/lot/LotStickyActions";
+
+const PROPS = {
+  sentinelId: "lot-hero-sentinel",
+  priceLabel: "Asking",
+  priceValue: "$2.5M",
+  enquiryCta: "Enquire",
+  slug: "riverina-aggregation-412ha",
+  title: "Riverina Aggregation",
+  vertical: "farmland",
+};
+
+describe("LotStickyActions", () => {
+  beforeEach(() => {
+    mockUseUser.mockReturnValue({ user: null, loading: false });
+  });
+
+  it("is aria-hidden AND inert while off-screen so hidden controls leave the tab order", () => {
+    // jsdom has no IntersectionObserver — the bar stays in its hidden
+    // (pre-scroll) state, which is exactly the state under test.
+    const { container } = render(<LotStickyActions {...PROPS} />);
+    const bar = container.firstElementChild as HTMLElement;
+
+    expect(bar).toHaveAttribute("aria-hidden", "true");
+    // aria-hidden alone leaves Save/Enquire keyboard-focusable; inert is
+    // what actually removes the subtree from the tab order.
+    expect(bar).toHaveAttribute("inert");
+  });
+
+  it("renders the price and the enquiry anchor to the in-page form", () => {
+    const { container } = render(<LotStickyActions {...PROPS} />);
+    expect(container.textContent).toContain("$2.5M");
+    const anchor = container.querySelector('a[href="#enquire"]');
+    expect(anchor).not.toBeNull();
+    expect(anchor?.textContent).toBe("Enquire");
+  });
+});

--- a/__tests__/components/setup.tsx
+++ b/__tests__/components/setup.tsx
@@ -66,8 +66,22 @@ vi.mock("next/link", () => ({
 
 // Mock useUser hook (used by BookmarkButton and other auth-aware components).
 // Returns unauthenticated state to keep component tests Supabase-free.
+// Overridable per test for authed scenarios (vitest isolates module state
+// per test file, so overrides never leak across files):
+//   import { mockUseUser } from "../setup";
+//   mockUseUser.mockReturnValue({ user: { id: "u1" }, loading: false });
+// vi.hoisted so the vi.mock factory never sees a TDZ binding (see
+// CLAUDE.md § vi.mock hoisting); vitest disallows exporting the hoisted
+// binding itself, so the export is a separate reference.
+const hoistedUseUser = vi.hoisted(() => ({
+  mockUseUser: vi.fn((): { user: { id: string } | null; loading: boolean } => ({
+    user: null,
+    loading: false,
+  })),
+}));
+export const mockUseUser = hoistedUseUser.mockUseUser;
 vi.mock("@/lib/hooks/useUser", () => ({
-  useUser: () => ({ user: null, loading: false }),
+  useUser: () => hoistedUseUser.mockUseUser(),
 }));
 
 // Mock useShortlist hook (used by ShortlistButton and QuizPromptBar)

--- a/__tests__/lib/listing-kind.test.ts
+++ b/__tests__/lib/listing-kind.test.ts
@@ -112,6 +112,9 @@ describe("deriveListingKind", () => {
   it("maps buy-business / franchise to for_sale_business", () => {
     expect(deriveListingKind(deriveRow({ vertical: "buy-business" as InvestmentListing["vertical"] }))).toBe("for_sale_business");
     expect(deriveListingKind(deriveRow({ vertical: "franchise" as InvestmentListing["vertical"] }))).toBe("for_sale_business");
+    // The canonical DB union value — buy-business/franchise are the URL
+    // category slugs; rows fetched by the lot pages carry "business".
+    expect(deriveListingKind(deriveRow({ vertical: "business" as InvestmentListing["vertical"] }))).toBe("for_sale_business");
   });
 
   it("maps commercial / farmland / livestock to for_sale_asset", () => {

--- a/__tests__/lib/listing-kind.test.ts
+++ b/__tests__/lib/listing-kind.test.ts
@@ -458,6 +458,37 @@ describe("formatListingPrice", () => {
     expect(res).toEqual({ label: "Asking", value: "$2.5M" });
   });
 
+  it("falls back to key_metrics.min_investment_cents for franchise/business rows", () => {
+    const res = formatListingPrice(
+      priceRow({
+        listing_kind: "for_sale_business",
+        key_metrics: { min_investment_cents: 4_500_000 },
+      }),
+    );
+    expect(res).toEqual({ label: "Total investment from", value: "$45k" });
+  });
+
+  it("tolerates a drifted string min_investment_cents on franchise rows", () => {
+    const res = formatListingPrice(
+      priceRow({
+        listing_kind: "for_sale_business",
+        key_metrics: { min_investment_cents: "25000000" },
+      }),
+    );
+    expect(res).toEqual({ label: "Total investment from", value: "$250k" });
+  });
+
+  it("prefers asking_price_cents over the franchise min-investment fallback", () => {
+    const res = formatListingPrice(
+      priceRow({
+        listing_kind: "for_sale_business",
+        asking_price_cents: 9_900_000,
+        key_metrics: { min_investment_cents: 4_500_000 },
+      }),
+    );
+    expect(res).toEqual({ label: "Asking", value: "$99k" });
+  });
+
   it("returns null when nothing priceable", () => {
     expect(formatListingPrice(priceRow({ listing_kind: "for_sale_business" }))).toBeNull();
   });

--- a/__tests__/lib/listings/lot-profile.test.ts
+++ b/__tests__/lib/listings/lot-profile.test.ts
@@ -47,6 +47,21 @@ describe("buildLotProfile", () => {
     expect(hasPaperTrail(profile)).toBe(true);
   });
 
+  it("surfaces km.stage as a leading fact despite the card skip-list", () => {
+    const profile = buildLotProfile({
+      stage: "pre_construction",
+      hectares: 412,
+    });
+    expect(profile.facts[0]).toEqual({
+      key: "stage",
+      label: "Stage",
+      value: "Pre Construction",
+    });
+    // Still absent when the row has no stage.
+    const noStage = buildLotProfile({ hectares: 412 });
+    expect(noStage.facts.map((f) => f.key)).not.toContain("stage");
+  });
+
   it("parses structured modules and excludes them from facts", () => {
     const profile = buildLotProfile({
       hectares: 412,

--- a/__tests__/lib/listings/lot-profile.test.ts
+++ b/__tests__/lib/listings/lot-profile.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import { buildLotProfile, hasPaperTrail } from "@/lib/listings/lot-profile";
+
+describe("buildLotProfile", () => {
+  it("returns an empty profile for null/undefined/empty key_metrics", () => {
+    for (const km of [null, undefined, {}]) {
+      const profile = buildLotProfile(km);
+      expect(profile.facts).toEqual([]);
+      expect(profile.paperTrail).toEqual([]);
+      expect(profile.provenanceEvents).toEqual([]);
+      expect(profile.documents).toEqual([]);
+      expect(profile.comparables).toEqual([]);
+      expect(profile.holdingCosts).toEqual([]);
+      expect(profile.timeToSell).toBeUndefined();
+      expect(hasPaperTrail(profile)).toBe(false);
+    }
+  });
+
+  it("folds doc-ish scalar keys into the paper trail (seed-row shape)", () => {
+    // Mirrors the collectibles seed rows (GT-HO Phase III).
+    const profile = buildLotProfile({
+      year: 1971,
+      make: "Ford",
+      model: "Falcon GTHO Phase III",
+      matching_numbers: true,
+      transmission: "4-speed manual",
+      provenance: "full build sheet and ownership history",
+      documentation: "books and history file",
+    });
+
+    const trailLabels = profile.paperTrail.map((f) => f.label);
+    expect(trailLabels).toContain("Provenance");
+    expect(trailLabels).toContain("Documentation");
+    expect(trailLabels).toContain("Matching Numbers");
+    expect(
+      profile.paperTrail.find((f) => f.label === "Matching Numbers")?.detail,
+    ).toBe("Yes");
+
+    // Doc-ish keys must NOT also appear in the fact grid.
+    const factKeys = profile.facts.map((f) => f.key);
+    expect(factKeys).not.toContain("provenance");
+    expect(factKeys).not.toContain("documentation");
+    expect(factKeys).not.toContain("matching_numbers");
+    expect(factKeys).toContain("make");
+    expect(factKeys).toContain("transmission");
+
+    expect(hasPaperTrail(profile)).toBe(true);
+  });
+
+  it("parses structured modules and excludes them from facts", () => {
+    const profile = buildLotProfile({
+      hectares: 412,
+      provenance_events: [
+        { year: 2019, label: "Acquired", detail: "Private treaty" },
+        { when: "2022", label: "Irrigation upgrade" },
+      ],
+      documents: [
+        { name: "Independent valuation", status: "verified" },
+        { name: "Water licence", status: "pending" },
+        { name: "Soil report" },
+      ],
+      comparable_sales: [
+        { label: "380ha Riverina aggregation", price: "$3.8M", when: "Nov 2025" },
+      ],
+      holding_costs: [{ label: "Council rates", amount: "$11,200/yr" }],
+      typical_time_to_sell: "6-18 months",
+      liquidity_note: "Sells on a seasonal clock.",
+    });
+
+    expect(profile.provenanceEvents).toHaveLength(2);
+    expect(profile.provenanceEvents[0]?.when).toBe("2019");
+    expect(profile.provenanceEvents[1]?.when).toBe("2022");
+    expect(profile.documents).toHaveLength(3);
+    expect(profile.documents[0]?.status).toBe("verified");
+    expect(profile.documents[2]?.status).toBe("provided");
+    expect(profile.comparables[0]?.price).toBe("$3.8M");
+    expect(profile.holdingCosts[0]?.amount).toBe("$11,200/yr");
+    expect(profile.timeToSell).toBe("6-18 months");
+    expect(profile.liquidityNote).toBe("Sells on a seasonal clock.");
+
+    const factKeys = profile.facts.map((f) => f.key);
+    expect(factKeys).toEqual(["hectares"]);
+  });
+
+  it("drops malformed structured entries instead of throwing", () => {
+    const profile = buildLotProfile({
+      provenance_events: [
+        { label: "Valid event" },
+        { detail: "no label" },
+        "just a string",
+        42,
+        null,
+      ],
+      documents: [{ status: "verified" }, { name: "Title search" }],
+      comparable_sales: "not an array",
+      holding_costs: [{ amount: "$1" }],
+    });
+
+    expect(profile.provenanceEvents).toHaveLength(1);
+    expect(profile.provenanceEvents[0]?.label).toBe("Valid event");
+    expect(profile.documents).toHaveLength(1);
+    expect(profile.documents[0]?.name).toBe("Title search");
+    expect(profile.comparables).toEqual([]);
+    expect(profile.holdingCosts).toEqual([]);
+  });
+
+  it("coerces invalid document status to 'provided'", () => {
+    const profile = buildLotProfile({
+      documents: [{ name: "Survey", status: "notarised" }],
+    });
+    expect(profile.documents[0]?.status).toBe("provided");
+  });
+
+  it("ignores non-string typical_time_to_sell shapes", () => {
+    const profile = buildLotProfile({ typical_time_to_sell: { weird: true } });
+    expect(profile.timeToSell).toBeUndefined();
+  });
+});

--- a/__tests__/lib/listings/lot-transparency.test.ts
+++ b/__tests__/lib/listings/lot-transparency.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { buildLotProfile } from "@/lib/listings/lot-profile";
+import {
+  assessLotTransparency,
+  transparencyLevelLabel,
+} from "@/lib/listings/lot-transparency";
+
+const LONG_DESCRIPTION = "x".repeat(320);
+
+describe("assessLotTransparency", () => {
+  it("rates a bare listing as essential and lists what to request", () => {
+    const assessment = assessLotTransparency(
+      { description: "Short." },
+      buildLotProfile({}),
+    );
+
+    expect(assessment.level).toBe("essential");
+    expect(assessment.metCount).toBe(0);
+    expect(assessment.score).toBe(0);
+    const missing = assessment.checks.filter((c) => !c.met).map((c) => c.id);
+    expect(missing).toContain("pricing");
+    expect(missing).toContain("paper_trail");
+    expect(missing).toContain("costs");
+  });
+
+  it("rates a fully-documented listing as comprehensive", () => {
+    const profile = buildLotProfile({
+      a: 1,
+      b: 2,
+      c: 3,
+      d: 4,
+      provenance: "full history",
+      holding_costs: [{ label: "Rates", amount: "$1,000/yr" }],
+      typical_time_to_sell: "3-6 months",
+    });
+    const assessment = assessLotTransparency(
+      {
+        asking_price_cents: 100_000_00,
+        description: LONG_DESCRIPTION,
+        images: ["/a.jpg", "/b.jpg"],
+        location_state: "NSW",
+      },
+      profile,
+    );
+
+    expect(assessment.metCount).toBe(8);
+    expect(assessment.level).toBe("comprehensive");
+    expect(assessment.score).toBe(100);
+  });
+
+  it("rates a mid listing as documented", () => {
+    const assessment = assessLotTransparency(
+      {
+        price_display: "$2.4M",
+        description: LONG_DESCRIPTION,
+        images: ["/a.jpg", "/b.jpg"],
+        location_city: "Mudgee",
+      },
+      buildLotProfile({}),
+    );
+    expect(assessment.metCount).toBe(4);
+    expect(assessment.level).toBe("documented");
+    expect(assessment.score).toBe(50);
+  });
+
+  it("accepts price_display as pricing and city as location", () => {
+    const assessment = assessLotTransparency(
+      { price_display: "POA range $1-2M", location_city: "Orange" },
+      buildLotProfile({}),
+    );
+    const byId = Object.fromEntries(assessment.checks.map((c) => [c.id, c.met]));
+    expect(byId.pricing).toBe(true);
+    expect(byId.location).toBe(true);
+  });
+
+  it("has a label for every level", () => {
+    expect(transparencyLevelLabel("essential")).toBeTruthy();
+    expect(transparencyLevelLabel("documented")).toBeTruthy();
+    expect(transparencyLevelLabel("comprehensive")).toBeTruthy();
+  });
+});

--- a/__tests__/lib/listings/vertical-intel.test.ts
+++ b/__tests__/lib/listings/vertical-intel.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import {
+  intelForCategory,
+  DEFAULT_INTEL,
+  INTEL_SLUGS,
+} from "@/lib/listings/vertical-intel";
+import { LISTING_PAGE_SLUGS } from "@/lib/invest-listing-routes";
+
+describe("vertical-intel registry", () => {
+  it("returns DEFAULT_INTEL for unknown slugs", () => {
+    expect(intelForCategory("totally-made-up")).toBe(DEFAULT_INTEL);
+  });
+
+  it("resolves a complete entry for every canonical listings category", () => {
+    for (const slug of LISTING_PAGE_SLUGS) {
+      const intel = intelForCategory(slug);
+      expect(intel.noun.length, slug).toBeGreaterThan(0);
+      expect(intel.detailsHeading.length, slug).toBeGreaterThan(0);
+      expect(intel.aboutHeading.length, slug).toBeGreaterThan(0);
+      expect(intel.enquiryHeading.length, slug).toBeGreaterThan(0);
+      expect(intel.enquirySubcopy.length, slug).toBeGreaterThan(0);
+      expect(intel.dueDiligence.length, slug).toBeGreaterThanOrEqual(3);
+      expect(intel.typicalCosts.length, slug).toBeGreaterThanOrEqual(2);
+      expect(intel.liquidity.length, slug).toBeGreaterThan(20);
+      expect(intel.exitPaths.length, slug).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("registry copy never promises returns or appreciation", () => {
+    // Lean-lane editorial redline: factual due-diligence only. Guard the
+    // phrases most likely to creep in via future copy edits.
+    const banned =
+      /(guaranteed (return|income|profit)|will appreciate|can't lose|sure thing|risk-free)/i;
+    for (const slug of INTEL_SLUGS) {
+      const intel = intelForCategory(slug);
+      const corpus = [
+        intel.liquidity,
+        intel.riskNote ?? "",
+        ...intel.dueDiligence,
+        ...intel.typicalCosts,
+        ...intel.exitPaths,
+      ].join(" ");
+      expect(corpus, slug).not.toMatch(banned);
+    }
+  });
+
+  it("covers the high-traffic categories with bespoke (non-default) entries", () => {
+    for (const slug of [
+      "farmland",
+      "commercial-property",
+      "buy-business",
+      "water-rights",
+      "alternatives",
+    ]) {
+      expect(intelForCategory(slug), slug).not.toBe(DEFAULT_INTEL);
+    }
+  });
+});

--- a/app/account/bookmarks/BookmarksList.tsx
+++ b/app/account/bookmarks/BookmarksList.tsx
@@ -21,11 +21,12 @@ const TYPE_LABEL: Record<string, string> = {
   article: "Articles",
   broker: "Brokers",
   advisor: "Advisors",
+  listing: "Listings",
   scenario: "Scenarios",
   calculator: "Calculators",
 };
 
-const TYPE_ORDER = ["broker", "advisor", "article", "scenario", "calculator"];
+const TYPE_ORDER = ["broker", "advisor", "listing", "article", "scenario", "calculator"];
 
 function linkFor(type: string, ref: string): string {
   switch (type) {
@@ -35,6 +36,10 @@ function linkFor(type: string, ref: string): string {
       return `/broker/${ref}`;
     case "advisor":
       return `/advisor/${ref}`;
+    case "listing":
+      // Slug-only resolver — bookmarks store the listing slug, the route
+      // looks up the vertical and 307s to the canonical lot URL.
+      return `/invest/listings/${ref}`;
     case "scenario":
       return `/scenario/${ref}`;
     case "calculator":

--- a/app/api/account/bookmarks/route.ts
+++ b/app/api/account/bookmarks/route.ts
@@ -6,6 +6,7 @@ import {
   addBookmark,
   removeBookmark,
   addAnonymousSave,
+  removeAnonymousSave,
 } from "@/lib/bookmarks";
 import { isAllowed, ipKey } from "@/lib/rate-limit-db";
 import { logger } from "@/lib/logger";
@@ -20,7 +21,9 @@ export const runtime = "nodejs";
  *   GET    — authenticated user's bookmark list
  *   POST   — add a bookmark; works for anonymous users too
  *            (writes to anonymous_saves when no session user)
- *   DELETE — remove a bookmark (authenticated only)
+ *   DELETE — remove a bookmark; anonymous users pass session_id so the
+ *            anonymous_saves row is removed too (otherwise the claim-on-
+ *            signup flow would resurrect an unsaved item)
  */
 const BOOKMARK_TYPES = [
   "article",
@@ -42,6 +45,7 @@ const AddBookmarkBody = z.object({
 const RemoveBookmarkBody = z.object({
   type: z.enum(BOOKMARK_TYPES),
   ref: z.string().min(1),
+  session_id: z.string().max(100).nullish(),
 });
 
 async function getUser() {
@@ -95,14 +99,32 @@ export async function POST(request: NextRequest) {
 }
 
 export async function DELETE(request: NextRequest) {
-  const user = await getUser();
-  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
   const parsed = RemoveBookmarkBody.safeParse(await request.json().catch(() => ({})));
   if (!parsed.success) {
     return NextResponse.json({ error: "Invalid type or ref" }, { status: 400 });
   }
-  const { type, ref } = parsed.data;
-  const ok = await removeBookmark({ userId: user.id, type, ref });
-  return NextResponse.json({ ok });
+  const { type, ref, session_id: sessionId = null } = parsed.data;
+
+  const user = await getUser();
+  if (user) {
+    const ok = await removeBookmark({ userId: user.id, type, ref });
+    return NextResponse.json({ ok });
+  }
+
+  if (!sessionId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Anonymous unsave — same rate-limit bucket as anonymous saves.
+  if (
+    !(await isAllowed("bookmarks_write", ipKey(request), {
+      max: 30,
+      refillPerSec: 30 / 60,
+    }))
+  ) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+  const ok = await removeAnonymousSave({ sessionId, type, ref });
+  if (!ok) log.warn("anonymous unsave failed", { sessionId, type, ref });
+  return NextResponse.json({ ok, anonymous: true });
 }

--- a/app/api/account/bookmarks/route.ts
+++ b/app/api/account/bookmarks/route.ts
@@ -22,7 +22,14 @@ export const runtime = "nodejs";
  *            (writes to anonymous_saves when no session user)
  *   DELETE — remove a bookmark (authenticated only)
  */
-const BOOKMARK_TYPES = ["article", "broker", "advisor", "scenario", "calculator"] as const;
+const BOOKMARK_TYPES = [
+  "article",
+  "broker",
+  "advisor",
+  "scenario",
+  "calculator",
+  "listing",
+] as const;
 
 const AddBookmarkBody = z.object({
   type: z.enum(BOOKMARK_TYPES),

--- a/app/invest/alternatives/listings/[slug]/page.tsx
+++ b/app/invest/alternatives/listings/[slug]/page.tsx
@@ -1,13 +1,9 @@
-import Link from "next/link";
 import type { Metadata } from "next";
-import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
-import Icon from "@/components/Icon";
-import ListingImageGallery from "@/components/ListingImageGallery";
-import ListingCard, { type InvestmentListing } from "@/components/ListingCard";
-import ListingEnquiryForm from "@/components/ListingEnquiryForm";
-import ListingDecisionTools from "@/components/invest/ListingDecisionTools";
+import { SITE_URL, CURRENT_YEAR } from "@/lib/seo";
+import ListingDetailView from "@/components/invest/ListingDetailView";
 import ListingsEmptyState from "@/components/ListingsEmptyState";
 import SubCategoryListingsView from "@/components/SubCategoryListingsView";
+import { type InvestmentListing } from "@/components/ListingCard";
 import {
   fetchListingBySlug,
   fetchListingsBySubCategory,
@@ -15,15 +11,11 @@ import {
   ALTERNATIVES_SUB_CATEGORIES,
 } from "@/lib/investment-listings-query";
 import { getSubcategoryBySlug } from "@/lib/invest-categories";
-import ListingSchemaScripts from "@/components/ListingSchemaScripts";
 
 export const revalidate = 300;
 
 const CATEGORY_SLUG = "alternatives";
 const CATEGORY_LABEL = "Alternative Investments";
-// Alternatives listings live under vertical='fund' with sub_category
-// in ALTERNATIVES_SUB_CATEGORIES. When the trailing [slug] is a listing
-// slug (not a sub-category), we still look it up in the fund vertical.
 const VERTICAL = "fund" as const;
 
 export async function generateMetadata({
@@ -83,29 +75,12 @@ export async function generateMetadata({
   };
 }
 
-function formatCents(cents: number): string {
-  if (cents >= 1_000_000_00) return `$${(cents / 1_000_000_00).toFixed(1)}M`;
-  if (cents >= 1_000_00) return `$${(cents / 1_000_00).toFixed(0)}K`;
-  return `$${(cents / 100).toLocaleString("en-AU")}`;
-}
-
 export default async function AlternativesListingDetailPage({
   params,
 }: {
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-
-  // ── Resolution order ────────────────────────────────────────
-  // 1. Sub-category filter: if the slug names a known sub-category
-  //    of this vertical, show the filtered listings grid.
-  // 2. Single listing detail: if a listing exists with that slug,
-  //    show the detail page.
-  // 3. Empty state (200, NOT notFound): friendly "nothing here yet"
-  //    page with links back to the category and the submit form.
-  // This ordering means SubCategoryNav links always resolve (even
-  // with zero matching listings) while pre-existing listing URLs
-  // keep working.
 
   const subCat = getSubcategoryBySlug(CATEGORY_SLUG, slug);
   if (subCat) {
@@ -121,9 +96,6 @@ export default async function AlternativesListingDetailPage({
   }
 
   const listing = await fetchListingBySlug(VERTICAL, slug);
-
-  // Reject listings that aren't really alternatives (the fund
-  // vertical also covers private credit, infrastructure, etc.)
   if (
     !listing ||
     !listing.sub_category ||
@@ -137,194 +109,14 @@ export default async function AlternativesListingDetailPage({
     );
   }
 
-  const l = listing as InvestmentListing;
-  const relatedListings = await fetchRelatedListings(VERTICAL, slug, l.sub_category, 3);
-
-  const breadcrumb = breadcrumbJsonLd([
-    { name: "Home", url: `${SITE_URL}/` },
-    { name: "Invest", url: `${SITE_URL}/invest` },
-    { name: "Alternative Investments", url: `${SITE_URL}/invest/${CATEGORY_SLUG}` },
-    { name: "Listings", url: `${SITE_URL}/invest/${CATEGORY_SLUG}/listings` },
-    { name: l.title },
-  ]);
-
-  const km = (l.key_metrics ?? {}) as Record<string, unknown>;
-  const location = [l.location_city, l.location_state].filter(Boolean).join(", ");
+  const relatedListings = await fetchRelatedListings(VERTICAL, slug, listing.sub_category, 3);
 
   return (
-    <div>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <ListingSchemaScripts listing={l} vertical={CATEGORY_SLUG} />
-
-      {/* Compact header (E1) — breadcrumb + badges + title + location only,
-          so the gallery and metrics sit near the fold. */}
-      <section className="bg-white border-b border-slate-100 py-3 md:py-4">
-        <div className="container-custom">
-          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-2">
-            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" aria-hidden="true" />
-            <Link href="/invest" className="hover:text-slate-900 transition-colors">Invest</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" aria-hidden="true" />
-            <Link href={`/invest/${CATEGORY_SLUG}/listings`} className="hover:text-slate-900 transition-colors">{CATEGORY_LABEL}</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" aria-hidden="true" />
-            <span className="text-slate-900 font-medium truncate max-w-40">{l.title}</span>
-          </nav>
-
-          <div className="flex flex-wrap gap-2 mb-2">
-            {l.listing_type === "featured" && (
-              <span className="bg-amber-500 text-slate-900 text-xs font-bold px-2.5 py-0.5 rounded-full">Featured</span>
-            )}
-            {l.listing_type === "premium" && (
-              <span className="bg-yellow-400 text-slate-900 text-xs font-bold px-2.5 py-0.5 rounded-full">Premium</span>
-            )}
-            {l.firb_eligible && (
-              <span className="bg-blue-600 text-white text-xs font-bold px-2.5 py-0.5 rounded-full">FIRB Eligible</span>
-            )}
-            {l.sub_category && (
-              <span className="bg-slate-700 text-slate-200 text-xs font-semibold px-2.5 py-0.5 rounded-full capitalize">
-                {l.sub_category.replace(/_/g, " ")}
-              </span>
-            )}
-          </div>
-
-          <h1 className="text-2xl md:text-3xl font-extrabold mb-2 text-slate-900">{l.title}</h1>
-          {location && (
-            <div className="flex items-center gap-1.5 text-slate-600 text-sm">
-              <Icon name="map-pin" size={14} aria-hidden="true" />
-              {location}
-            </div>
-          )}
-        </div>
-      </section>
-
-      {/* Main content */}
-      <section className="py-6 md:py-8 bg-slate-50">
-        <div className="container-custom">
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
-            {/* Left: details */}
-            <div className="lg:col-span-2 space-y-6">
-              <ListingImageGallery images={l.images} alt={l.title} vertical={l.vertical} listingId={l.id} subCategory={l.sub_category} />
-              {/* Price card */}
-              <div className="bg-white border border-slate-200 rounded-xl p-4">
-                <div className="flex flex-wrap items-center justify-between gap-4">
-                  <div>
-                    <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1">Estimated Value</p>
-                    <p className="text-3xl font-extrabold text-slate-900">
-                      {l.price_display ?? (l.asking_price_cents ? formatCents(l.asking_price_cents) : "Price on application")}
-                    </p>
-                  </div>
-                </div>
-              </div>
-
-              {/* Key metrics */}
-              {Object.keys(km).length > 0 && (
-                <div className="bg-white border border-slate-200 rounded-xl p-6">
-                  <h2 className="text-base font-bold text-slate-900 mb-4">Key Metrics</h2>
-                  <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-                    {Object.entries(km).map(([key, value]) => (
-                      <div key={key} className="bg-slate-50 rounded-lg p-3">
-                        <p className="text-xs text-slate-500 capitalize mb-1">{key.replace(/_/g, " ")}</p>
-                        <p className="text-sm font-bold text-slate-900">
-                          {typeof value === "number" && key.includes("cents")
-                            ? formatCents(value)
-                            : String(value)}
-                        </p>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {/* Description */}
-              {l.description && (
-                <div className="bg-white border border-slate-200 rounded-xl p-6">
-                  <h2 className="text-base font-bold text-slate-900 mb-3">About This Investment</h2>
-                  <div className="prose prose-slate prose-sm max-w-none">
-                    {l.description.split("\n").map((para, i) => (
-                      <p key={i}>{para}</p>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {/* FIRB info */}
-              {l.firb_eligible && (
-                <div className="bg-blue-50 border border-blue-200 rounded-xl p-5 flex gap-4">
-                  <Icon name="globe" size={20} className="text-blue-600 shrink-0 mt-0.5" aria-hidden="true" />
-                  <div>
-                    <p className="font-bold text-blue-900 text-sm mb-1">FIRB Eligible</p>
-                    <p className="text-sm text-blue-700">
-                      This alternative investment is eligible for foreign investment under the Foreign Investment Review Board framework. FIRB approval may be required for foreign buyers. Our advisors can guide you through the process.
-                    </p>
-                    <Link href="/foreign-investment" className="inline-flex items-center gap-1 text-blue-700 font-semibold text-xs mt-2 hover:text-blue-900">
-                      Learn about FIRB <Icon name="arrow-right" size={11} aria-hidden="true" />
-                    </Link>
-                  </div>
-                </div>
-              )}
-            </div>
-
-            {/* Right: Enquiry form */}
-            <div className="space-y-5">
-              <div className="bg-white border border-slate-200 rounded-xl p-6 sticky top-20">
-                <h2 className="text-base font-bold text-slate-900 mb-1">Enquire About This Listing</h2>
-                <p className="text-xs text-slate-500 mb-4">
-                  Send a confidential enquiry directly to the listing representative.
-                </p>
-                <ListingEnquiryForm
-                  listingId={l.id}
-                  listingTitle={l.title}
-                  vertical="alternatives"
-                />
-              </div>
-              {/* Wave 5 — structure-aware after-tax return + FIRB estimate */}
-              <ListingDecisionTools listing={l} />
-
-
-              {/* Stats */}
-              <div className="bg-slate-50 border border-slate-200 rounded-xl p-4 flex gap-6">
-                <div className="text-center">
-                  <p className="text-lg font-bold text-slate-900">{l.views ?? 0}</p>
-                  <p className="text-xs text-slate-500">Views</p>
-                </div>
-                <div className="text-center">
-                  <p className="text-lg font-bold text-slate-900">{l.enquiries ?? 0}</p>
-                  <p className="text-xs text-slate-500">Enquiries</p>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          {/* Related listings */}
-          {relatedListings.length > 0 && (
-            <div className="mt-12">
-              <h2 className="text-xl font-extrabold text-slate-900 mb-6">Similar Alternative Investments</h2>
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-                {relatedListings.map((rel) => (
-                  <ListingCard key={rel.id} listing={rel} vertical="alternatives" />
-                ))}
-              </div>
-            </div>
-          )}
-        </div>
-      </section>
-
-      {/* List CTA */}
-      <section className="py-10 bg-white border-t border-slate-100">
-        <div className="container-custom text-center">
-          <p className="text-slate-500 text-sm mb-4">Looking for more opportunities?</p>
-          <Link
-            href={`/invest/${CATEGORY_SLUG}/listings`}
-            className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold px-6 py-3 rounded-xl transition-colors"
-          >
-            Browse All Alternative Investments
-            <Icon name="arrow-right" size={16} aria-hidden="true" />
-          </Link>
-        </div>
-      </section>
-    </div>
+    <ListingDetailView
+      listing={listing as InvestmentListing}
+      relatedListings={relatedListings as InvestmentListing[]}
+      categorySlug={CATEGORY_SLUG}
+      categoryLabel={CATEGORY_LABEL}
+    />
   );
 }

--- a/app/invest/buy-business/listings/[slug]/page.tsx
+++ b/app/invest/buy-business/listings/[slug]/page.tsx
@@ -1,20 +1,15 @@
-import Link from "next/link";
 import type { Metadata } from "next";
-import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
-import Icon from "@/components/Icon";
-import ListingImageGallery from "@/components/ListingImageGallery";
-import ListingCard, { type InvestmentListing } from "@/components/ListingCard";
-import ListingEnquiryForm from "@/components/ListingEnquiryForm";
-import ListingDecisionTools from "@/components/invest/ListingDecisionTools";
+import { SITE_URL, CURRENT_YEAR } from "@/lib/seo";
+import ListingDetailView from "@/components/invest/ListingDetailView";
 import ListingsEmptyState from "@/components/ListingsEmptyState";
 import SubCategoryListingsView from "@/components/SubCategoryListingsView";
+import { type InvestmentListing } from "@/components/ListingCard";
 import {
   fetchListingBySlug,
   fetchListingsBySubCategory,
   fetchRelatedListings,
 } from "@/lib/investment-listings-query";
 import { getSubcategoryBySlug } from "@/lib/invest-categories";
-import ListingSchemaScripts from "@/components/ListingSchemaScripts";
 
 export const revalidate = 300;
 
@@ -66,12 +61,6 @@ export async function generateMetadata({
   };
 }
 
-function formatCents(cents: number): string {
-  if (cents >= 1_000_000_00) return `$${(cents / 1_000_000_00).toFixed(1)}M`;
-  if (cents >= 1_000_00) return `$${(cents / 1_000_00).toFixed(0)}K`;
-  return `$${(cents / 100).toLocaleString("en-AU")}`;
-}
-
 export default async function BusinessListingDetailPage({
   params,
 }: {
@@ -102,206 +91,14 @@ export default async function BusinessListingDetailPage({
     );
   }
 
-  const l = listing as InvestmentListing;
   const relatedListings = await fetchRelatedListings(VERTICAL, slug, null, 3);
 
-  const breadcrumb = breadcrumbJsonLd([
-    { name: "Home", url: `${SITE_URL}/` },
-    { name: "Invest", url: `${SITE_URL}/invest` },
-    { name: "Buy a Business", url: `${SITE_URL}/invest/buy-business` },
-    { name: "Listings", url: `${SITE_URL}/invest/buy-business/listings` },
-    { name: l.title },
-  ]);
-
-  const km = l.key_metrics ?? {};
-  const location = [l.location_city, l.location_state].filter(Boolean).join(", ");
-
   return (
-    <div>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <ListingSchemaScripts listing={l} vertical={CATEGORY_SLUG} />
-
-      {/* Compact header (E1) — breadcrumb + badges + title + location only,
-          so the gallery and metrics sit near the fold. */}
-      <section className="bg-white border-b border-slate-100 py-3 md:py-4">
-        <div className="container-custom">
-          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-2">
-            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" />
-            <Link href="/invest" className="hover:text-slate-900 transition-colors">Invest</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" />
-            <Link href="/invest/buy-business/listings" className="hover:text-slate-900 transition-colors">Businesses for Sale</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" />
-            <span className="text-slate-900 font-medium truncate max-w-40">{l.title}</span>
-          </nav>
-
-          <div className="flex flex-wrap gap-2 mb-2">
-            {l.listing_type === "featured" && (
-              <span className="bg-amber-500 text-slate-900 text-xs font-bold px-2.5 py-0.5 rounded-full">Featured</span>
-            )}
-            {l.listing_type === "premium" && (
-              <span className="bg-yellow-400 text-slate-900 text-xs font-bold px-2.5 py-0.5 rounded-full">Premium</span>
-            )}
-            {l.firb_eligible && (
-              <span className="bg-blue-600 text-white text-xs font-bold px-2.5 py-0.5 rounded-full">FIRB Eligible</span>
-            )}
-            {l.industry && (
-              <span className="bg-slate-700 text-slate-200 text-xs font-semibold px-2.5 py-0.5 rounded-full capitalize">
-                {l.industry.replace(/_/g, " ")}
-              </span>
-            )}
-          </div>
-
-          <h1 className="text-2xl md:text-3xl font-extrabold mb-2 text-slate-900">{l.title}</h1>
-          {location && (
-            <div className="flex items-center gap-1.5 text-slate-600 text-sm">
-              <Icon name="map-pin" size={14} />
-              {location}
-            </div>
-          )}
-        </div>
-      </section>
-
-      {/* Main content */}
-      <section className="py-6 md:py-8 bg-slate-50">
-        <div className="container-custom">
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
-            {/* Left: details */}
-            <div className="lg:col-span-2 space-y-6">
-              <ListingImageGallery images={l.images} alt={l.title} vertical={l.vertical} listingId={l.id} subCategory={l.sub_category} />
-              {/* Price card */}
-              <div className="bg-white border border-slate-200 rounded-xl p-4">
-                <div className="flex flex-wrap items-center justify-between gap-4">
-                  <div>
-                    <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1">Asking Price</p>
-                    <p className="text-3xl font-extrabold text-slate-900">
-                      {l.price_display ?? (l.asking_price_cents ? formatCents(l.asking_price_cents) : "Price on application")}
-                    </p>
-                  </div>
-                  {l.annual_profit_cents && (
-                    <div className="text-right">
-                      <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1">Annual Net Profit</p>
-                      <p className="text-xl font-bold text-green-700">{formatCents(l.annual_profit_cents)}</p>
-                    </div>
-                  )}
-                </div>
-              </div>
-
-              {/* Key metrics */}
-              {Object.keys(km).length > 0 && (
-                <div className="bg-white border border-slate-200 rounded-xl p-6">
-                  <h2 className="text-base font-bold text-slate-900 mb-4">Key Metrics</h2>
-                  <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-                    {Object.entries(km).map(([key, value]) => (
-                      <div key={key} className="bg-slate-50 rounded-lg p-3">
-                        <p className="text-xs text-slate-500 capitalize mb-1">{key.replace(/_/g, " ")}</p>
-                        <p className="text-sm font-bold text-slate-900">
-                          {typeof value === "number" && key.includes("cents")
-                            ? formatCents(value)
-                            : String(value)}
-                        </p>
-                      </div>
-                    ))}
-                    {l.annual_revenue_cents && (
-                      <div className="bg-slate-50 rounded-lg p-3">
-                        <p className="text-xs text-slate-500 mb-1">Annual Revenue</p>
-                        <p className="text-sm font-bold text-slate-900">{formatCents(l.annual_revenue_cents)}</p>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              )}
-
-              {/* Description */}
-              {l.description && (
-                <div className="bg-white border border-slate-200 rounded-xl p-6">
-                  <h2 className="text-base font-bold text-slate-900 mb-3">About This Business</h2>
-                  <div className="prose prose-slate prose-sm max-w-none">
-                    {l.description.split("\n").map((para, i) => (
-                      <p key={i}>{para}</p>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {/* FIRB info */}
-              {l.firb_eligible && (
-                <div className="bg-blue-50 border border-blue-200 rounded-xl p-5 flex gap-4">
-                  <Icon name="globe" size={20} className="text-blue-600 shrink-0 mt-0.5" />
-                  <div>
-                    <p className="font-bold text-blue-900 text-sm mb-1">FIRB Eligible</p>
-                    <p className="text-sm text-blue-700">
-                      This business is eligible for foreign investment under the Foreign Investment Review Board framework. FIRB approval may be required for foreign buyers. Our advisors can guide you through the process.
-                    </p>
-                    <Link href="/foreign-investment" className="inline-flex items-center gap-1 text-blue-700 font-semibold text-xs mt-2 hover:text-blue-900">
-                      Learn about FIRB <Icon name="arrow-right" size={11} />
-                    </Link>
-                  </div>
-                </div>
-              )}
-            </div>
-
-            {/* Right: Enquiry form */}
-            <div className="space-y-5">
-              <div className="bg-white border border-slate-200 rounded-xl p-6 sticky top-20">
-                <h2 className="text-base font-bold text-slate-900 mb-1">Enquire About This Listing</h2>
-                <p className="text-xs text-slate-500 mb-4">
-                  Send a confidential enquiry directly to the listing representative.
-                </p>
-                <ListingEnquiryForm
-                  listingId={l.id}
-                  listingTitle={l.title}
-                  vertical="business"
-                />
-              </div>
-              {/* Wave 5 — structure-aware after-tax return + FIRB estimate */}
-              <ListingDecisionTools listing={l} />
-
-
-              {/* Stats */}
-              <div className="bg-slate-50 border border-slate-200 rounded-xl p-4 flex gap-6">
-                <div className="text-center">
-                  <p className="text-lg font-bold text-slate-900">{l.views ?? 0}</p>
-                  <p className="text-xs text-slate-500">Views</p>
-                </div>
-                <div className="text-center">
-                  <p className="text-lg font-bold text-slate-900">{l.enquiries ?? 0}</p>
-                  <p className="text-xs text-slate-500">Enquiries</p>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          {/* Related listings */}
-          {relatedListings.length > 0 && (
-            <div className="mt-12">
-              <h2 className="text-xl font-extrabold text-slate-900 mb-6">Similar Businesses in {l.location_state}</h2>
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-                {relatedListings.map((rel) => (
-                  <ListingCard key={rel.id} listing={rel} vertical="business" />
-                ))}
-              </div>
-            </div>
-          )}
-        </div>
-      </section>
-
-      {/* List CTA */}
-      <section className="py-10 bg-white border-t border-slate-100">
-        <div className="container-custom text-center">
-          <p className="text-slate-500 text-sm mb-4">Looking for more opportunities?</p>
-          <Link
-            href="/invest/buy-business/listings"
-            className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold px-6 py-3 rounded-xl transition-colors"
-          >
-            Browse All Businesses for Sale
-            <Icon name="arrow-right" size={16} />
-          </Link>
-        </div>
-      </section>
-    </div>
+    <ListingDetailView
+      listing={listing as InvestmentListing}
+      relatedListings={relatedListings as InvestmentListing[]}
+      categorySlug={CATEGORY_SLUG}
+      categoryLabel={CATEGORY_LABEL}
+    />
   );
 }

--- a/app/invest/commercial-property/listings/[slug]/page.tsx
+++ b/app/invest/commercial-property/listings/[slug]/page.tsx
@@ -1,20 +1,15 @@
-import Link from "next/link";
 import type { Metadata } from "next";
-import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
-import Icon from "@/components/Icon";
-import ListingImageGallery from "@/components/ListingImageGallery";
-import ListingCard, { type InvestmentListing } from "@/components/ListingCard";
-import ListingEnquiryForm from "@/components/ListingEnquiryForm";
-import ListingDecisionTools from "@/components/invest/ListingDecisionTools";
+import { SITE_URL, CURRENT_YEAR } from "@/lib/seo";
+import ListingDetailView from "@/components/invest/ListingDetailView";
 import ListingsEmptyState from "@/components/ListingsEmptyState";
 import SubCategoryListingsView from "@/components/SubCategoryListingsView";
+import { type InvestmentListing } from "@/components/ListingCard";
 import {
   fetchListingBySlug,
   fetchListingsBySubCategory,
   fetchRelatedListings,
 } from "@/lib/investment-listings-query";
 import { getSubcategoryBySlug } from "@/lib/invest-categories";
-import ListingSchemaScripts from "@/components/ListingSchemaScripts";
 
 export const revalidate = 300;
 
@@ -68,12 +63,6 @@ export async function generateMetadata({
   };
 }
 
-function formatCents(cents: number): string {
-  if (cents >= 1_000_000_00) return `$${(cents / 1_000_000_00).toFixed(1)}M`;
-  if (cents >= 1_000_00) return `$${(cents / 1_000_00).toFixed(0)}K`;
-  return `$${(cents / 100).toLocaleString("en-AU")}`;
-}
-
 export default async function CommercialListingDetailPage({
   params,
 }: {
@@ -103,163 +92,15 @@ export default async function CommercialListingDetailPage({
       />
     );
   }
-  const l = listing as InvestmentListing;
 
   const relatedListings = await fetchRelatedListings(VERTICAL, slug, null, 3);
-  const km = (l.key_metrics ?? {}) as Record<string, unknown>;
-  const location = [l.location_city, l.location_state].filter(Boolean).join(", ");
-
-  const breadcrumb = breadcrumbJsonLd([
-    { name: "Home", url: `${SITE_URL}/` },
-    { name: "Invest", url: `${SITE_URL}/invest` },
-    { name: "Commercial Property", url: `${SITE_URL}/invest/commercial-property` },
-    { name: "Listings", url: `${SITE_URL}/invest/commercial-property/listings` },
-    { name: l.title },
-  ]);
 
   return (
-    <div>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <ListingSchemaScripts listing={l} vertical={CATEGORY_SLUG} />
-
-      {/* Compact header (E1) — breadcrumb + badges + title + location only,
-          so the gallery and metrics sit near the fold. */}
-      <section className="bg-white border-b border-slate-100 py-3 md:py-4">
-        <div className="container-custom">
-          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-2">
-            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" />
-            <Link href="/invest/commercial-property/listings" className="hover:text-slate-900 transition-colors">Commercial Properties</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" />
-            <span className="text-slate-900 font-medium truncate max-w-40">{l.title}</span>
-          </nav>
-
-          <div className="flex flex-wrap gap-2 mb-2">
-            {l.listing_type === "featured" && (
-              <span className="bg-amber-500 text-slate-900 text-xs font-bold px-2.5 py-0.5 rounded-full">Featured</span>
-            )}
-            {l.firb_eligible && (
-              <span className="bg-blue-500 text-white text-xs font-bold px-2.5 py-0.5 rounded-full">FIRB Eligible</span>
-            )}
-            {l.industry && (
-              <span className="bg-blue-800 text-blue-100 text-xs font-semibold px-2.5 py-0.5 rounded-full capitalize">
-                {l.industry.replace(/_/g, " ")}
-              </span>
-            )}
-            {!!km.yield_percent && (
-              <span className="bg-green-600 text-white text-xs font-bold px-2.5 py-0.5 rounded-full">
-                {Number(km.yield_percent).toFixed(1)}% Yield
-              </span>
-            )}
-          </div>
-
-          <h1 className="text-2xl md:text-3xl font-extrabold mb-2 text-slate-900">{l.title}</h1>
-          {location && (
-            <div className="flex items-center gap-1.5 text-slate-600 text-sm">
-              <Icon name="map-pin" size={14} />
-              {location}
-            </div>
-          )}
-        </div>
-      </section>
-
-      <section className="py-6 md:py-8 bg-slate-50">
-        <div className="container-custom">
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
-            <div className="lg:col-span-2 space-y-6">
-              <ListingImageGallery images={l.images} alt={l.title} vertical={l.vertical} listingId={l.id} subCategory={l.sub_category} />
-              <div className="bg-white border border-slate-200 rounded-xl p-4">
-                <div className="flex flex-wrap items-center justify-between gap-4">
-                  <div>
-                    <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1">Asking Price</p>
-                    <p className="text-3xl font-extrabold text-slate-900">
-                      {l.price_display ?? (l.asking_price_cents ? formatCents(l.asking_price_cents) : "Price on application")}
-                    </p>
-                  </div>
-                  {!!km.yield_percent && (
-                    <div className="text-right">
-                      <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1">Net Yield</p>
-                      <p className="text-xl font-bold text-green-700">{Number(km.yield_percent).toFixed(1)}% p.a.</p>
-                    </div>
-                  )}
-                </div>
-              </div>
-
-              {Object.keys(km).length > 0 && (
-                <div className="bg-white border border-slate-200 rounded-xl p-6">
-                  <h2 className="text-base font-bold text-slate-900 mb-4">Property Details</h2>
-                  <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-                    {Object.entries(km).map(([key, value]) => (
-                      <div key={key} className="bg-slate-50 rounded-lg p-3">
-                        <p className="text-xs text-slate-500 capitalize mb-1">{key.replace(/_/g, " ")}</p>
-                        <p className="text-sm font-bold text-slate-900">{String(value)}</p>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {l.description && (
-                <div className="bg-white border border-slate-200 rounded-xl p-6">
-                  <h2 className="text-base font-bold text-slate-900 mb-3">About This Property</h2>
-                  <div className="prose prose-slate prose-sm max-w-none">
-                    {l.description.split("\n").map((para, i) => (
-                      <p key={i}>{para}</p>
-                    ))}
-                  </div>
-                </div>
-              )}
-            </div>
-
-            <div className="space-y-5">
-              <div className="bg-white border border-slate-200 rounded-xl p-6 sticky top-20">
-                <h2 className="text-base font-bold text-slate-900 mb-1">Enquire About This Property</h2>
-                <p className="text-xs text-slate-500 mb-4">Confidential enquiry to the listing agent.</p>
-                <ListingEnquiryForm listingId={l.id} listingTitle={l.title} vertical="commercial_property" />
-              </div>
-              {/* Wave 5 — structure-aware after-tax return + FIRB estimate */}
-              <ListingDecisionTools listing={l} />
-
-              <div className="bg-slate-50 border border-slate-200 rounded-xl p-4 flex gap-6">
-                <div className="text-center">
-                  <p className="text-lg font-bold text-slate-900">{l.views ?? 0}</p>
-                  <p className="text-xs text-slate-500">Views</p>
-                </div>
-                <div className="text-center">
-                  <p className="text-lg font-bold text-slate-900">{l.enquiries ?? 0}</p>
-                  <p className="text-xs text-slate-500">Enquiries</p>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          {relatedListings.length > 0 && (
-            <div className="mt-12">
-              <h2 className="text-xl font-extrabold text-slate-900 mb-6">Similar Commercial Properties</h2>
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-                {relatedListings.map((rel) => (
-                  <ListingCard key={rel.id} listing={rel} vertical="commercial_property" />
-                ))}
-              </div>
-            </div>
-          )}
-        </div>
-      </section>
-
-      <section className="py-10 bg-white border-t border-slate-100">
-        <div className="container-custom text-center">
-          <Link
-            href="/invest/commercial-property/listings"
-            className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold px-6 py-3 rounded-xl transition-colors"
-          >
-            Browse All Commercial Properties
-            <Icon name="arrow-right" size={16} />
-          </Link>
-        </div>
-      </section>
-    </div>
+    <ListingDetailView
+      listing={listing as InvestmentListing}
+      relatedListings={relatedListings as InvestmentListing[]}
+      categorySlug={CATEGORY_SLUG}
+      categoryLabel={CATEGORY_LABEL}
+    />
   );
 }

--- a/app/invest/farmland/listings/[slug]/page.tsx
+++ b/app/invest/farmland/listings/[slug]/page.tsx
@@ -1,20 +1,15 @@
-import Link from "next/link";
 import type { Metadata } from "next";
-import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
-import Icon from "@/components/Icon";
-import ListingImageGallery from "@/components/ListingImageGallery";
-import ListingCard, { type InvestmentListing } from "@/components/ListingCard";
-import ListingEnquiryForm from "@/components/ListingEnquiryForm";
-import ListingDecisionTools from "@/components/invest/ListingDecisionTools";
+import { SITE_URL, CURRENT_YEAR } from "@/lib/seo";
+import ListingDetailView from "@/components/invest/ListingDetailView";
 import ListingsEmptyState from "@/components/ListingsEmptyState";
 import SubCategoryListingsView from "@/components/SubCategoryListingsView";
+import { type InvestmentListing } from "@/components/ListingCard";
 import {
   fetchListingBySlug,
   fetchListingsBySubCategory,
   fetchRelatedListings,
 } from "@/lib/investment-listings-query";
 import { getSubcategoryBySlug } from "@/lib/invest-categories";
-import ListingSchemaScripts from "@/components/ListingSchemaScripts";
 
 export const revalidate = 300;
 
@@ -67,12 +62,6 @@ export async function generateMetadata({
   };
 }
 
-function formatCents(cents: number): string {
-  if (cents >= 1_000_000_00) return `$${(cents / 1_000_000_00).toFixed(1)}M`;
-  if (cents >= 1_000_00) return `$${(cents / 1_000_00).toFixed(0)}K`;
-  return `$${(cents / 100).toLocaleString("en-AU")}`;
-}
-
 export default async function FarmlandListingDetailPage({
   params,
 }: {
@@ -102,173 +91,15 @@ export default async function FarmlandListingDetailPage({
       />
     );
   }
-  const l = listing as InvestmentListing;
 
   const relatedListings = await fetchRelatedListings(VERTICAL, slug, null, 3);
-  const km = (l.key_metrics ?? {}) as Record<string, unknown>;
-  const location = [l.location_city, l.location_state].filter(Boolean).join(", ");
-
-  const breadcrumb = breadcrumbJsonLd([
-    { name: "Home", url: `${SITE_URL}/` },
-    { name: "Invest", url: `${SITE_URL}/invest` },
-    { name: "Farmland", url: `${SITE_URL}/invest/farmland` },
-    { name: "Listings", url: `${SITE_URL}/invest/farmland/listings` },
-    { name: l.title },
-  ]);
 
   return (
-    <div>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <ListingSchemaScripts listing={l} vertical={CATEGORY_SLUG} />
-
-      {/* Compact header (E1) — breadcrumb + badges + title + location only,
-          so the gallery and metrics sit near the fold. */}
-      <section className="bg-white border-b border-slate-100 py-3 md:py-4">
-        <div className="container-custom">
-          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-2">
-            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" />
-            <Link href="/invest/farmland/listings" className="hover:text-slate-900 transition-colors">Farmland Listings</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" />
-            <span className="text-slate-900 font-medium truncate max-w-40">{l.title}</span>
-          </nav>
-
-          <div className="flex flex-wrap gap-2 mb-2">
-            {l.listing_type === "featured" && (
-              <span className="bg-amber-500 text-slate-900 text-xs font-bold px-2.5 py-0.5 rounded-full">Featured</span>
-            )}
-            {l.firb_eligible && (
-              <span className="bg-blue-600 text-white text-xs font-bold px-2.5 py-0.5 rounded-full">FIRB Eligible</span>
-            )}
-            {l.sub_category && (
-              <span className="bg-green-800 text-green-100 text-xs font-semibold px-2.5 py-0.5 rounded-full capitalize">
-                {l.sub_category.replace(/_/g, " ")}
-              </span>
-            )}
-          </div>
-
-          <h1 className="text-2xl md:text-3xl font-extrabold mb-2 text-slate-900">{l.title}</h1>
-          {location && (
-            <div className="flex items-center gap-1.5 text-slate-600 text-sm">
-              <Icon name="map-pin" size={14} />
-              {location}
-            </div>
-          )}
-        </div>
-      </section>
-
-      <section className="py-6 md:py-8 bg-slate-50">
-        <div className="container-custom">
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
-            <div className="lg:col-span-2 space-y-6">
-              <ListingImageGallery images={l.images} alt={l.title} vertical={l.vertical} listingId={l.id} subCategory={l.sub_category} />
-              <div className="bg-white border border-slate-200 rounded-xl p-4">
-                <div className="flex flex-wrap items-center justify-between gap-4">
-                  <div>
-                    <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1">Asking Price</p>
-                    <p className="text-3xl font-extrabold text-slate-900">
-                      {l.price_display ?? (l.asking_price_cents ? formatCents(l.asking_price_cents) : "Price on application")}
-                    </p>
-                  </div>
-                  {!!km.hectares && (
-                    <div className="text-right">
-                      <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1">Property Size</p>
-                      <p className="text-xl font-bold text-green-700">{Number(km.hectares).toLocaleString("en-AU")} ha</p>
-                    </div>
-                  )}
-                </div>
-              </div>
-
-              {Object.keys(km).length > 0 && (
-                <div className="bg-white border border-slate-200 rounded-xl p-6">
-                  <h2 className="text-base font-bold text-slate-900 mb-4">Property Details</h2>
-                  <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-                    {Object.entries(km).map(([key, value]) => (
-                      <div key={key} className="bg-slate-50 rounded-lg p-3">
-                        <p className="text-xs text-slate-500 capitalize mb-1">{key.replace(/_/g, " ")}</p>
-                        <p className="text-sm font-bold text-slate-900">{String(value)}</p>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {l.description && (
-                <div className="bg-white border border-slate-200 rounded-xl p-6">
-                  <h2 className="text-base font-bold text-slate-900 mb-3">About This Property</h2>
-                  <div className="prose prose-slate prose-sm max-w-none">
-                    {l.description.split("\n").map((para, i) => (
-                      <p key={i}>{para}</p>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {l.firb_eligible && (
-                <div className="bg-blue-50 border border-blue-200 rounded-xl p-5 flex gap-4">
-                  <Icon name="globe" size={20} className="text-blue-600 shrink-0 mt-0.5" />
-                  <div>
-                    <p className="font-bold text-blue-900 text-sm mb-1">FIRB Eligible — Foreign Buyers Welcome</p>
-                    <p className="text-sm text-blue-700">
-                      This agricultural property is available to foreign investors. FIRB approval is required for acquisitions over $15M. Our advisors can guide you through the FIRB process.
-                    </p>
-                    <Link href="/foreign-investment" className="inline-flex items-center gap-1 text-blue-700 font-semibold text-xs mt-2 hover:text-blue-900">
-                      FIRB guide for farmland <Icon name="arrow-right" size={11} />
-                    </Link>
-                  </div>
-                </div>
-              )}
-            </div>
-
-            <div className="space-y-5">
-              <div className="bg-white border border-slate-200 rounded-xl p-6 sticky top-20">
-                <h2 className="text-base font-bold text-slate-900 mb-1">Enquire About This Property</h2>
-                <p className="text-xs text-slate-500 mb-4">Send a confidential enquiry to the selling agent.</p>
-                <ListingEnquiryForm listingId={l.id} listingTitle={l.title} vertical="farmland" />
-              </div>
-              {/* Wave 5 — structure-aware after-tax return + FIRB estimate */}
-              <ListingDecisionTools listing={l} />
-
-              <div className="bg-slate-50 border border-slate-200 rounded-xl p-4 flex gap-6">
-                <div className="text-center">
-                  <p className="text-lg font-bold text-slate-900">{l.views ?? 0}</p>
-                  <p className="text-xs text-slate-500">Views</p>
-                </div>
-                <div className="text-center">
-                  <p className="text-lg font-bold text-slate-900">{l.enquiries ?? 0}</p>
-                  <p className="text-xs text-slate-500">Enquiries</p>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          {relatedListings.length > 0 && (
-            <div className="mt-12">
-              <h2 className="text-xl font-extrabold text-slate-900 mb-6">Other Agricultural Properties</h2>
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-                {relatedListings.map((rel) => (
-                  <ListingCard key={rel.id} listing={rel} vertical="farmland" />
-                ))}
-              </div>
-            </div>
-          )}
-        </div>
-      </section>
-
-      <section className="py-10 bg-white border-t border-slate-100">
-        <div className="container-custom text-center">
-          <Link
-            href="/invest/farmland/listings"
-            className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold px-6 py-3 rounded-xl transition-colors"
-          >
-            Browse All Farmland Listings
-            <Icon name="arrow-right" size={16} />
-          </Link>
-        </div>
-      </section>
-    </div>
+    <ListingDetailView
+      listing={listing as InvestmentListing}
+      relatedListings={relatedListings as InvestmentListing[]}
+      categorySlug={CATEGORY_SLUG}
+      categoryLabel={CATEGORY_LABEL}
+    />
   );
 }

--- a/app/invest/franchise/listings/[slug]/page.tsx
+++ b/app/invest/franchise/listings/[slug]/page.tsx
@@ -1,20 +1,15 @@
-import Link from "next/link";
 import type { Metadata } from "next";
-import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
-import Icon from "@/components/Icon";
-import ListingImageGallery from "@/components/ListingImageGallery";
-import ListingCard, { type InvestmentListing } from "@/components/ListingCard";
-import ListingEnquiryForm from "@/components/ListingEnquiryForm";
-import ListingDecisionTools from "@/components/invest/ListingDecisionTools";
+import { SITE_URL, CURRENT_YEAR } from "@/lib/seo";
+import ListingDetailView from "@/components/invest/ListingDetailView";
 import ListingsEmptyState from "@/components/ListingsEmptyState";
 import SubCategoryListingsView from "@/components/SubCategoryListingsView";
+import { type InvestmentListing } from "@/components/ListingCard";
 import {
   fetchListingBySlug,
   fetchListingsBySubCategory,
   fetchRelatedListings,
 } from "@/lib/investment-listings-query";
 import { getSubcategoryBySlug } from "@/lib/invest-categories";
-import ListingSchemaScripts from "@/components/ListingSchemaScripts";
 
 export const revalidate = 300;
 
@@ -67,12 +62,6 @@ export async function generateMetadata({
   };
 }
 
-function formatCents(cents: number): string {
-  if (cents >= 1_000_000_00) return `$${(cents / 1_000_000_00).toFixed(1)}M`;
-  if (cents >= 1_000_00) return `$${(cents / 1_000_00).toFixed(0)}K`;
-  return `$${(cents / 100).toLocaleString("en-AU")}`;
-}
-
 export default async function FranchiseListingDetailPage({
   params,
 }: {
@@ -102,173 +91,15 @@ export default async function FranchiseListingDetailPage({
       />
     );
   }
-  const l = listing as InvestmentListing;
 
   const relatedListings = await fetchRelatedListings(VERTICAL, slug, null, 3);
-  const km = (l.key_metrics ?? {}) as Record<string, unknown>;
-  const location = [l.location_city, l.location_state].filter(Boolean).join(", ");
-
-  const breadcrumb = breadcrumbJsonLd([
-    { name: "Home", url: `${SITE_URL}/` },
-    { name: "Invest", url: `${SITE_URL}/invest` },
-    { name: "Franchise", url: `${SITE_URL}/invest/franchise` },
-    { name: "Listings", url: `${SITE_URL}/invest/franchise/listings` },
-    { name: l.title },
-  ]);
 
   return (
-    <div>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <ListingSchemaScripts listing={l} vertical={CATEGORY_SLUG} />
-
-      {/* Compact header (E1) — breadcrumb + badges + title + location only,
-          so the gallery and metrics sit near the fold. */}
-      <section className="bg-white border-b border-slate-100 py-3 md:py-4">
-        <div className="container-custom">
-          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-2">
-            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" />
-            <Link href="/invest/franchise/listings" className="hover:text-slate-900 transition-colors">Franchise Listings</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" />
-            <span className="text-slate-900 font-medium truncate max-w-40">{l.title}</span>
-          </nav>
-
-          <div className="flex flex-wrap gap-2 mb-2">
-            {l.listing_type === "featured" && (
-              <span className="bg-amber-500 text-slate-900 text-xs font-bold px-2.5 py-0.5 rounded-full">Featured</span>
-            )}
-            {l.industry && (
-              <span className="bg-purple-800 text-purple-100 text-xs font-semibold px-2.5 py-0.5 rounded-full capitalize">
-                {l.industry.replace(/_/g, " ")}
-              </span>
-            )}
-            {!!km.brand && (
-              <span className="bg-slate-700 text-slate-200 text-xs font-semibold px-2.5 py-0.5 rounded-full">
-                {String(km.brand)}
-              </span>
-            )}
-          </div>
-
-          <h1 className="text-2xl md:text-3xl font-extrabold mb-2 text-slate-900">{l.title}</h1>
-          {location && (
-            <div className="flex items-center gap-1.5 text-slate-600 text-sm">
-              <Icon name="map-pin" size={14} />
-              {location}
-            </div>
-          )}
-        </div>
-      </section>
-
-      <section className="py-6 md:py-8 bg-slate-50">
-        <div className="container-custom">
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
-            <div className="lg:col-span-2 space-y-6">
-              <ListingImageGallery images={l.images} alt={l.title} vertical={l.vertical} listingId={l.id} subCategory={l.sub_category} />
-              <div className="bg-white border border-slate-200 rounded-xl p-4">
-                <div className="flex flex-wrap items-center justify-between gap-4">
-                  <div>
-                    <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1">Total Investment From</p>
-                    <p className="text-3xl font-extrabold text-slate-900">
-                      {l.price_display ?? (l.asking_price_cents ? formatCents(l.asking_price_cents) : (km.min_investment_cents ? formatCents(km.min_investment_cents as number) : "Price on application"))}
-                    </p>
-                  </div>
-                  {!!km.royalty_percent && (
-                    <div className="text-right">
-                      <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1">Ongoing Royalty</p>
-                      <p className="text-xl font-bold text-slate-700">{String(km.royalty_percent)}%</p>
-                    </div>
-                  )}
-                </div>
-              </div>
-
-              {Object.keys(km).length > 0 && (
-                <div className="bg-white border border-slate-200 rounded-xl p-6">
-                  <h2 className="text-base font-bold text-slate-900 mb-4">Franchise Details</h2>
-                  <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-                    {Object.entries(km).map(([key, value]) => (
-                      <div key={key} className="bg-slate-50 rounded-lg p-3">
-                        <p className="text-xs text-slate-500 capitalize mb-1">{key.replace(/_/g, " ")}</p>
-                        <p className="text-sm font-bold text-slate-900">
-                          {typeof value === "number" && key.includes("cents") ? formatCents(value) : String(value)}
-                        </p>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {l.description && (
-                <div className="bg-white border border-slate-200 rounded-xl p-6">
-                  <h2 className="text-base font-bold text-slate-900 mb-3">About This Opportunity</h2>
-                  <div className="prose prose-slate prose-sm max-w-none">
-                    {l.description.split("\n").map((para, i) => (
-                      <p key={i}>{para}</p>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {/* Franchise Code note */}
-              <div className="bg-purple-50 border border-purple-200 rounded-xl p-5 flex gap-4">
-                <Icon name="star" size={20} className="text-purple-600 shrink-0 mt-0.5" />
-                <div>
-                  <p className="font-bold text-purple-900 text-sm mb-1">Australian Franchise Code of Conduct</p>
-                  <p className="text-sm text-purple-700">
-                    All Australian franchise agreements are governed by the mandatory Franchising Code of Conduct (ACCC). You are entitled to a 14-day review period and a cooling-off period of 7 days after signing.
-                  </p>
-                </div>
-              </div>
-            </div>
-
-            <div className="space-y-5">
-              <div className="bg-white border border-slate-200 rounded-xl p-6 sticky top-20">
-                <h2 className="text-base font-bold text-slate-900 mb-1">Request Franchise Information</h2>
-                <p className="text-xs text-slate-500 mb-4">Get a Franchise Disclosure Document and speak with the franchisor.</p>
-                <ListingEnquiryForm listingId={l.id} listingTitle={l.title} vertical="franchise" />
-              </div>
-              {/* Wave 5 — structure-aware after-tax return + FIRB estimate */}
-              <ListingDecisionTools listing={l} />
-
-              <div className="bg-slate-50 border border-slate-200 rounded-xl p-4 flex gap-6">
-                <div className="text-center">
-                  <p className="text-lg font-bold text-slate-900">{l.views ?? 0}</p>
-                  <p className="text-xs text-slate-500">Views</p>
-                </div>
-                <div className="text-center">
-                  <p className="text-lg font-bold text-slate-900">{l.enquiries ?? 0}</p>
-                  <p className="text-xs text-slate-500">Enquiries</p>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          {relatedListings.length > 0 && (
-            <div className="mt-12">
-              <h2 className="text-xl font-extrabold text-slate-900 mb-6">Other Franchise Opportunities</h2>
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-                {relatedListings.map((rel) => (
-                  <ListingCard key={rel.id} listing={rel} vertical="franchise" />
-                ))}
-              </div>
-            </div>
-          )}
-        </div>
-      </section>
-
-      <section className="py-10 bg-white border-t border-slate-100">
-        <div className="container-custom text-center">
-          <Link
-            href="/invest/franchise/listings"
-            className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold px-6 py-3 rounded-xl transition-colors"
-          >
-            Browse All Franchise Opportunities
-            <Icon name="arrow-right" size={16} />
-          </Link>
-        </div>
-      </section>
-    </div>
+    <ListingDetailView
+      listing={listing as InvestmentListing}
+      relatedListings={relatedListings as InvestmentListing[]}
+      categorySlug={CATEGORY_SLUG}
+      categoryLabel={CATEGORY_LABEL}
+    />
   );
 }

--- a/app/invest/infrastructure/listings/[slug]/page.tsx
+++ b/app/invest/infrastructure/listings/[slug]/page.tsx
@@ -1,13 +1,9 @@
-import Link from "next/link";
 import type { Metadata } from "next";
-import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
-import Icon from "@/components/Icon";
-import ListingImageGallery from "@/components/ListingImageGallery";
-import ListingCard, { type InvestmentListing } from "@/components/ListingCard";
-import ListingEnquiryForm from "@/components/ListingEnquiryForm";
-import ListingDecisionTools from "@/components/invest/ListingDecisionTools";
+import { SITE_URL, CURRENT_YEAR } from "@/lib/seo";
+import ListingDetailView from "@/components/invest/ListingDetailView";
 import ListingsEmptyState from "@/components/ListingsEmptyState";
 import SubCategoryListingsView from "@/components/SubCategoryListingsView";
+import { type InvestmentListing } from "@/components/ListingCard";
 import {
   fetchListingBySlug,
   fetchListingsBySubCategory,
@@ -15,16 +11,11 @@ import {
   INFRASTRUCTURE_SUB_CATEGORIES,
 } from "@/lib/investment-listings-query";
 import { getSubcategoryBySlug } from "@/lib/invest-categories";
-import ListingSchemaScripts from "@/components/ListingSchemaScripts";
 
 export const revalidate = 300;
 
 const CATEGORY_SLUG = "infrastructure";
 const CATEGORY_LABEL = "Infrastructure";
-// Infrastructure listings live under vertical='fund' with
-// sub_category='infrastructure'. The old code queried
-// vertical='infrastructure' which isn't a valid vertical and
-// always returned zero rows.
 const VERTICAL = "fund" as const;
 
 export async function generateMetadata({
@@ -78,12 +69,6 @@ export async function generateMetadata({
   };
 }
 
-function formatCents(cents: number): string {
-  if (cents >= 1_000_000_00) return `$${(cents / 1_000_000_00).toFixed(1)}M`;
-  if (cents >= 1_000_00) return `$${(cents / 1_000_00).toFixed(0)}K`;
-  return `$${(cents / 100).toLocaleString("en-AU")}`;
-}
-
 export default async function InfrastructureListingDetailPage({
   params,
 }: {
@@ -118,208 +103,14 @@ export default async function InfrastructureListingDetailPage({
     );
   }
 
-  const l = listing as InvestmentListing;
-  const relatedListings = await fetchRelatedListings(VERTICAL, slug, l.sub_category, 3);
-
-  const breadcrumb = breadcrumbJsonLd([
-    { name: "Home", url: `${SITE_URL}/` },
-    { name: "Invest", url: `${SITE_URL}/invest` },
-    { name: "Infrastructure", url: `${SITE_URL}/invest/infrastructure` },
-    { name: "Listings", url: `${SITE_URL}/invest/infrastructure/listings` },
-    { name: l.title },
-  ]);
-
-  const km = l.key_metrics ?? {};
-  const location = [l.location_city, l.location_state].filter(Boolean).join(", ");
+  const relatedListings = await fetchRelatedListings(VERTICAL, slug, listing.sub_category, 3);
 
   return (
-    <div>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <ListingSchemaScripts listing={l} vertical={CATEGORY_SLUG} />
-
-      {/* Compact header (E1) — breadcrumb + badges + title + location only,
-          so the gallery and metrics sit near the fold. */}
-      <section className="bg-white border-b border-slate-100 py-3 md:py-4">
-        <div className="container-custom">
-          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-2">
-            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" />
-            <Link href="/invest" className="hover:text-slate-900 transition-colors">Invest</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" />
-            <Link href="/invest/infrastructure/listings" className="hover:text-slate-900 transition-colors">Infrastructure</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" />
-            <span className="text-slate-900 font-medium truncate max-w-40">{l.title}</span>
-          </nav>
-
-          <div className="flex flex-wrap gap-2 mb-2">
-            {l.listing_type === "featured" && (
-              <span className="bg-amber-500 text-slate-900 text-xs font-bold px-2.5 py-0.5 rounded-full">Featured</span>
-            )}
-            {l.listing_type === "premium" && (
-              <span className="bg-yellow-400 text-slate-900 text-xs font-bold px-2.5 py-0.5 rounded-full">Premium</span>
-            )}
-            {l.firb_eligible && (
-              <span className="bg-blue-600 text-white text-xs font-bold px-2.5 py-0.5 rounded-full">FIRB Eligible</span>
-            )}
-            {l.sub_category && (
-              <span className="bg-slate-700 text-slate-200 text-xs font-semibold px-2.5 py-0.5 rounded-full capitalize">
-                {l.sub_category.replace(/_/g, " ")}
-              </span>
-            )}
-          </div>
-
-          <h1 className="text-2xl md:text-3xl font-extrabold mb-2 text-slate-900">{l.title}</h1>
-          {location && (
-            <div className="flex items-center gap-1.5 text-slate-600 text-sm">
-              <Icon name="map-pin" size={14} />
-              {location}
-            </div>
-          )}
-        </div>
-      </section>
-
-      {/* Main content */}
-      <section className="py-6 md:py-8 bg-slate-50">
-        <div className="container-custom">
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
-            {/* Left: details */}
-            <div className="lg:col-span-2 space-y-6">
-              <ListingImageGallery images={l.images} alt={l.title} vertical={l.vertical} listingId={l.id} subCategory={l.sub_category} />
-              {/* Price card */}
-              <div className="bg-white border border-slate-200 rounded-xl p-4">
-                <div className="flex flex-wrap items-center justify-between gap-4">
-                  <div>
-                    <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1">Investment Value</p>
-                    <p className="text-3xl font-extrabold text-slate-900">
-                      {l.price_display ?? (l.asking_price_cents ? formatCents(l.asking_price_cents) : "Price on application")}
-                    </p>
-                  </div>
-                  {l.annual_revenue_cents && (
-                    <div className="text-right">
-                      <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1">Annual Revenue</p>
-                      <p className="text-xl font-bold text-green-700">{formatCents(l.annual_revenue_cents)}</p>
-                    </div>
-                  )}
-                </div>
-              </div>
-
-              {/* Key metrics */}
-              {Object.keys(km).length > 0 && (
-                <div className="bg-white border border-slate-200 rounded-xl p-6">
-                  <h2 className="text-base font-bold text-slate-900 mb-4">Key Metrics</h2>
-                  <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-                    {Object.entries(km).map(([key, value]) => (
-                      <div key={key} className="bg-slate-50 rounded-lg p-3">
-                        <p className="text-xs text-slate-500 capitalize mb-1">{key.replace(/_/g, " ")}</p>
-                        <p className="text-sm font-bold text-slate-900">
-                          {typeof value === "number" && key.includes("cents")
-                            ? formatCents(value)
-                            : typeof value === "boolean"
-                            ? (value ? "Yes" : "No")
-                            : String(value)}
-                        </p>
-                      </div>
-                    ))}
-                    {l.annual_revenue_cents && (
-                      <div className="bg-slate-50 rounded-lg p-3">
-                        <p className="text-xs text-slate-500 mb-1">Annual Revenue</p>
-                        <p className="text-sm font-bold text-slate-900">{formatCents(l.annual_revenue_cents)}</p>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              )}
-
-              {/* Description */}
-              {l.description && (
-                <div className="bg-white border border-slate-200 rounded-xl p-6">
-                  <h2 className="text-base font-bold text-slate-900 mb-3">About This Investment</h2>
-                  <div className="prose prose-slate prose-sm max-w-none">
-                    {l.description.split("\n").map((para, i) => (
-                      <p key={i}>{para}</p>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {/* FIRB info */}
-              {l.firb_eligible && (
-                <div className="bg-blue-50 border border-blue-200 rounded-xl p-5 flex gap-4">
-                  <Icon name="globe" size={20} className="text-blue-600 shrink-0 mt-0.5" />
-                  <div>
-                    <p className="font-bold text-blue-900 text-sm mb-1">FIRB Eligible</p>
-                    <p className="text-sm text-blue-700">
-                      This infrastructure investment is eligible for foreign investment under the Foreign Investment Review Board framework. FIRB approval may be required for foreign investors. Our advisors can guide you through the process.
-                    </p>
-                    <Link href="/foreign-investment" className="inline-flex items-center gap-1 text-blue-700 font-semibold text-xs mt-2 hover:text-blue-900">
-                      Learn about FIRB <Icon name="arrow-right" size={11} />
-                    </Link>
-                  </div>
-                </div>
-              )}
-            </div>
-
-            {/* Right: Enquiry form */}
-            <div className="space-y-5">
-              <div className="bg-white border border-slate-200 rounded-xl p-6 sticky top-20">
-                <h2 className="text-base font-bold text-slate-900 mb-1">Enquire About This Investment</h2>
-                <p className="text-xs text-slate-500 mb-4">
-                  Send a confidential enquiry directly to the listing representative.
-                </p>
-                <ListingEnquiryForm
-                  listingId={l.id}
-                  listingTitle={l.title}
-                  vertical="infrastructure"
-                />
-              </div>
-              {/* Wave 5 — structure-aware after-tax return + FIRB estimate */}
-              <ListingDecisionTools listing={l} />
-
-
-              {/* Stats */}
-              <div className="bg-slate-50 border border-slate-200 rounded-xl p-4 flex gap-6">
-                <div className="text-center">
-                  <p className="text-lg font-bold text-slate-900">{l.views ?? 0}</p>
-                  <p className="text-xs text-slate-500">Views</p>
-                </div>
-                <div className="text-center">
-                  <p className="text-lg font-bold text-slate-900">{l.enquiries ?? 0}</p>
-                  <p className="text-xs text-slate-500">Enquiries</p>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          {/* Related listings */}
-          {relatedListings.length > 0 && (
-            <div className="mt-12">
-              <h2 className="text-xl font-extrabold text-slate-900 mb-6">Similar Infrastructure Investments</h2>
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-                {relatedListings.map((rel) => (
-                  <ListingCard key={rel.id} listing={rel} vertical="infrastructure" />
-                ))}
-              </div>
-            </div>
-          )}
-        </div>
-      </section>
-
-      {/* List CTA */}
-      <section className="py-10 bg-white border-t border-slate-100">
-        <div className="container-custom text-center">
-          <p className="text-slate-500 text-sm mb-4">Looking for more opportunities?</p>
-          <Link
-            href="/invest/infrastructure/listings"
-            className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold px-6 py-3 rounded-xl transition-colors"
-          >
-            Browse All Infrastructure Investments
-            <Icon name="arrow-right" size={16} />
-          </Link>
-        </div>
-      </section>
-    </div>
+    <ListingDetailView
+      listing={listing as InvestmentListing}
+      relatedListings={relatedListings as InvestmentListing[]}
+      categorySlug={CATEGORY_SLUG}
+      categoryLabel={CATEGORY_LABEL}
+    />
   );
 }

--- a/app/invest/listings/[slug]/route.ts
+++ b/app/invest/listings/[slug]/route.ts
@@ -32,6 +32,9 @@ export async function GET(
       .from("investment_listings")
       .select("slug, vertical, sub_category, listing_kind")
       .eq("slug", slug)
+      // The canonical lot pages only render active rows — redirecting an
+      // expired/sold slug there would land on a 404 instead of /invest.
+      .eq("status", "active")
       .maybeSingle();
 
     if (data) {

--- a/app/invest/listings/[slug]/route.ts
+++ b/app/invest/listings/[slug]/route.ts
@@ -30,7 +30,7 @@ export async function GET(
     const supabase = await createClient();
     const { data } = await supabase
       .from("investment_listings")
-      .select("slug, vertical, sub_category")
+      .select("slug, vertical, sub_category, listing_kind")
       .eq("slug", slug)
       .maybeSingle();
 

--- a/app/invest/listings/[slug]/route.ts
+++ b/app/invest/listings/[slug]/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { listingUrl } from "@/lib/listing-url";
+import { logger } from "@/lib/logger";
+
+const log = logger("invest:listing-resolver");
+
+/**
+ * Slug-only listing resolver.
+ *
+ * Canonical lot URLs are `/invest/<category>/listings/<slug>` (see
+ * `lib/listing-url.ts`), but some callers only hold the slug — account
+ * bookmarks store `ref = slug` with no vertical. This route looks the
+ * listing up and 307s to its canonical page, so those callers never have
+ * to duplicate the vertical→category mapping client-side.
+ *
+ * Unknown / removed slugs fall back to the marketplace root rather than a
+ * hard 404 — a stale bookmark should land somewhere useful.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> },
+) {
+  const { slug } = await params;
+  if (!slug || typeof slug !== "string") {
+    return NextResponse.redirect(new URL("/invest", request.url), 307);
+  }
+
+  try {
+    const supabase = await createClient();
+    const { data } = await supabase
+      .from("investment_listings")
+      .select("slug, vertical, sub_category")
+      .eq("slug", slug)
+      .maybeSingle();
+
+    if (data) {
+      return NextResponse.redirect(new URL(listingUrl(data), request.url), 307);
+    }
+  } catch (err) {
+    log.warn("listing resolve failed", {
+      slug,
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  return NextResponse.redirect(new URL("/invest", request.url), 307);
+}

--- a/app/invest/mining/listings/[slug]/page.tsx
+++ b/app/invest/mining/listings/[slug]/page.tsx
@@ -1,20 +1,15 @@
-import Link from "next/link";
 import type { Metadata } from "next";
-import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
-import Icon from "@/components/Icon";
-import ListingImageGallery from "@/components/ListingImageGallery";
-import ListingCard, { type InvestmentListing } from "@/components/ListingCard";
-import ListingEnquiryForm from "@/components/ListingEnquiryForm";
-import ListingDecisionTools from "@/components/invest/ListingDecisionTools";
+import { SITE_URL, CURRENT_YEAR } from "@/lib/seo";
+import ListingDetailView from "@/components/invest/ListingDetailView";
 import ListingsEmptyState from "@/components/ListingsEmptyState";
 import SubCategoryListingsView from "@/components/SubCategoryListingsView";
+import { type InvestmentListing } from "@/components/ListingCard";
 import {
   fetchListingBySlug,
   fetchListingsBySubCategory,
   fetchRelatedListings,
 } from "@/lib/investment-listings-query";
 import { getSubcategoryBySlug } from "@/lib/invest-categories";
-import ListingSchemaScripts from "@/components/ListingSchemaScripts";
 
 export const revalidate = 300;
 
@@ -67,12 +62,6 @@ export async function generateMetadata({
   };
 }
 
-function formatCents(cents: number): string {
-  if (cents >= 1_000_000_00) return `$${(cents / 1_000_000_00).toFixed(1)}M`;
-  if (cents >= 1_000_00) return `$${(cents / 1_000_00).toFixed(0)}K`;
-  return `$${(cents / 100).toLocaleString("en-AU")}`;
-}
-
 export default async function MiningOpportunityDetailPage({
   params,
 }: {
@@ -80,7 +69,6 @@ export default async function MiningOpportunityDetailPage({
 }) {
   const { slug } = await params;
 
-  // Sub-category filter first — SubCategoryNav generates these URLs.
   const subCat = getSubcategoryBySlug(CATEGORY_SLUG, slug);
   if (subCat) {
     const listings = await fetchListingsBySubCategory(VERTICAL, subCat.dbValue);
@@ -94,12 +82,8 @@ export default async function MiningOpportunityDetailPage({
     );
   }
 
-  // Then try as a single listing.
   const listing = await fetchListingBySlug(VERTICAL, slug);
   if (!listing) {
-    // Friendly empty state instead of 404 — matches user
-    // expectation that every URL under /invest/<cat>/listings/*
-    // resolves to a valid page.
     return (
       <ListingsEmptyState
         categoryLabel={CATEGORY_LABEL}
@@ -107,172 +91,15 @@ export default async function MiningOpportunityDetailPage({
       />
     );
   }
-  const l = listing as InvestmentListing;
 
   const relatedListings = await fetchRelatedListings(VERTICAL, slug, null, 3);
-  const km = (l.key_metrics ?? {}) as Record<string, unknown>;
-  const location = [l.location_city, l.location_state].filter(Boolean).join(", ");
-
-  const breadcrumb = breadcrumbJsonLd([
-    { name: "Home", url: `${SITE_URL}/` },
-    { name: "Invest", url: `${SITE_URL}/invest` },
-    { name: "Mining", url: `${SITE_URL}/invest/mining` },
-    { name: "Opportunities", url: `${SITE_URL}/invest/mining/listings` },
-    { name: l.title },
-  ]);
 
   return (
-    <div>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <ListingSchemaScripts listing={l} vertical={CATEGORY_SLUG} />
-
-      {/* Compact header (E1) — breadcrumb + badges + title + location only,
-          so the gallery and metrics sit near the fold. */}
-      <section className="bg-white border-b border-slate-100 py-3 md:py-4">
-        <div className="container-custom">
-          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-2">
-            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" />
-            <Link href="/invest/mining/listings" className="hover:text-slate-900 transition-colors">Mining Opportunities</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" />
-            <span className="text-slate-900 font-medium truncate max-w-40">{l.title}</span>
-          </nav>
-
-          <div className="flex flex-wrap gap-2 mb-2">
-            {l.listing_type === "featured" && (
-              <span className="bg-amber-500 text-slate-900 text-xs font-bold px-2.5 py-0.5 rounded-full">Featured</span>
-            )}
-            {l.firb_eligible && (
-              <span className="bg-blue-600 text-white text-xs font-bold px-2.5 py-0.5 rounded-full">FIRB Eligible</span>
-            )}
-            {!!km.commodity && (
-              <span className="bg-amber-700 text-amber-100 text-xs font-semibold px-2.5 py-0.5 rounded-full capitalize">
-                {String(km.commodity)}
-              </span>
-            )}
-            {!!km.stage && (
-              <span className="bg-slate-700 text-slate-200 text-xs font-semibold px-2.5 py-0.5 rounded-full capitalize">
-                {String(km.stage)}
-              </span>
-            )}
-          </div>
-
-          <h1 className="text-2xl md:text-3xl font-extrabold mb-2 text-slate-900">{l.title}</h1>
-          {location && (
-            <div className="flex items-center gap-1.5 text-slate-600 text-sm">
-              <Icon name="map-pin" size={14} />
-              {location}
-            </div>
-          )}
-        </div>
-      </section>
-
-      <section className="py-6 md:py-8 bg-slate-50">
-        <div className="container-custom">
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
-            <div className="lg:col-span-2 space-y-6">
-              <ListingImageGallery images={l.images} alt={l.title} vertical={l.vertical} listingId={l.id} subCategory={l.sub_category} />
-              {/* Price */}
-              <div className="bg-white border border-slate-200 rounded-xl p-4">
-                <div className="flex flex-wrap items-center justify-between gap-4">
-                  <div>
-                    <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1">Investment Required</p>
-                    <p className="text-3xl font-extrabold text-slate-900">
-                      {l.price_display ?? (l.asking_price_cents ? formatCents(l.asking_price_cents) : "Price on application")}
-                    </p>
-                  </div>
-                </div>
-              </div>
-
-              {/* Key metrics */}
-              {Object.keys(km).length > 0 && (
-                <div className="bg-white border border-slate-200 rounded-xl p-6">
-                  <h2 className="text-base font-bold text-slate-900 mb-4">Project Details</h2>
-                  <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-                    {Object.entries(km).map(([key, value]) => (
-                      <div key={key} className="bg-slate-50 rounded-lg p-3">
-                        <p className="text-xs text-slate-500 capitalize mb-1">{key.replace(/_/g, " ")}</p>
-                        <p className="text-sm font-bold text-slate-900 capitalize">{String(value)}</p>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {l.description && (
-                <div className="bg-white border border-slate-200 rounded-xl p-6">
-                  <h2 className="text-base font-bold text-slate-900 mb-3">About This Opportunity</h2>
-                  <div className="prose prose-slate prose-sm max-w-none">
-                    {l.description.split("\n").map((para, i) => (
-                      <p key={i}>{para}</p>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {l.firb_eligible && (
-                <div className="bg-blue-50 border border-blue-200 rounded-xl p-5 flex gap-4">
-                  <Icon name="globe" size={20} className="text-blue-600 shrink-0 mt-0.5" />
-                  <div>
-                    <p className="font-bold text-blue-900 text-sm mb-1">FIRB Eligible</p>
-                    <p className="text-sm text-blue-700">Foreign investment may be approved. Mining tenements are a sensitive sector — FIRB notification is required for foreign buyers.</p>
-                    <Link href="/foreign-investment" className="inline-flex items-center gap-1 text-blue-700 font-semibold text-xs mt-2 hover:text-blue-900">
-                      Learn about FIRB for mining <Icon name="arrow-right" size={11} />
-                    </Link>
-                  </div>
-                </div>
-              )}
-            </div>
-
-            <div className="space-y-5">
-              <div className="bg-white border border-slate-200 rounded-xl p-6 sticky top-20">
-                <h2 className="text-base font-bold text-slate-900 mb-1">Enquire About This Opportunity</h2>
-                <p className="text-xs text-slate-500 mb-4">Send a confidential enquiry to the project team.</p>
-                <ListingEnquiryForm listingId={l.id} listingTitle={l.title} vertical="mining" />
-              </div>
-              {/* Wave 5 — structure-aware after-tax return + FIRB estimate */}
-              <ListingDecisionTools listing={l} />
-
-              <div className="bg-slate-50 border border-slate-200 rounded-xl p-4 flex gap-6">
-                <div className="text-center">
-                  <p className="text-lg font-bold text-slate-900">{l.views ?? 0}</p>
-                  <p className="text-xs text-slate-500">Views</p>
-                </div>
-                <div className="text-center">
-                  <p className="text-lg font-bold text-slate-900">{l.enquiries ?? 0}</p>
-                  <p className="text-xs text-slate-500">Enquiries</p>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          {relatedListings.length > 0 && (
-            <div className="mt-12">
-              <h2 className="text-xl font-extrabold text-slate-900 mb-6">Other Mining Opportunities</h2>
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-                {relatedListings.map((rel) => (
-                  <ListingCard key={rel.id} listing={rel} vertical="mining" />
-                ))}
-              </div>
-            </div>
-          )}
-        </div>
-      </section>
-
-      <section className="py-10 bg-white border-t border-slate-100">
-        <div className="container-custom text-center">
-          <Link
-            href="/invest/mining/listings"
-            className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold px-6 py-3 rounded-xl transition-colors"
-          >
-            Browse All Mining Opportunities
-            <Icon name="arrow-right" size={16} />
-          </Link>
-        </div>
-      </section>
-    </div>
+    <ListingDetailView
+      listing={listing as InvestmentListing}
+      relatedListings={relatedListings as InvestmentListing[]}
+      categorySlug={CATEGORY_SLUG}
+      categoryLabel={CATEGORY_LABEL}
+    />
   );
 }

--- a/app/invest/private-credit/listings/[slug]/page.tsx
+++ b/app/invest/private-credit/listings/[slug]/page.tsx
@@ -1,13 +1,9 @@
-import Link from "next/link";
 import type { Metadata } from "next";
-import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
-import Icon from "@/components/Icon";
-import ListingImageGallery from "@/components/ListingImageGallery";
-import ListingCard, { type InvestmentListing } from "@/components/ListingCard";
-import ListingEnquiryForm from "@/components/ListingEnquiryForm";
-import ListingDecisionTools from "@/components/invest/ListingDecisionTools";
+import { SITE_URL, CURRENT_YEAR } from "@/lib/seo";
+import ListingDetailView from "@/components/invest/ListingDetailView";
 import ListingsEmptyState from "@/components/ListingsEmptyState";
 import SubCategoryListingsView from "@/components/SubCategoryListingsView";
+import { type InvestmentListing } from "@/components/ListingCard";
 import {
   fetchListingBySlug,
   fetchListingsBySubCategory,
@@ -15,16 +11,11 @@ import {
   PRIVATE_CREDIT_SUB_CATEGORIES,
 } from "@/lib/investment-listings-query";
 import { getSubcategoryBySlug } from "@/lib/invest-categories";
-import ListingSchemaScripts from "@/components/ListingSchemaScripts";
 
 export const revalidate = 300;
 
 const CATEGORY_SLUG = "private-credit";
 const CATEGORY_LABEL = "Private Credit";
-// Private-credit listings live under vertical='fund' with
-// sub_category='private_credit' (underscored). The old query
-// used vertical='private_credit' which isn't a valid vertical
-// and returned zero rows.
 const VERTICAL = "fund" as const;
 
 export async function generateMetadata({
@@ -78,12 +69,6 @@ export async function generateMetadata({
   };
 }
 
-function formatCents(cents: number): string {
-  if (cents >= 1_000_000_00) return `$${(cents / 1_000_000_00).toFixed(1)}M`;
-  if (cents >= 1_000_00) return `$${(cents / 1_000_00).toFixed(0)}K`;
-  return `$${(cents / 100).toLocaleString("en-AU")}`;
-}
-
 export default async function PrivateCreditListingDetailPage({
   params,
 }: {
@@ -118,200 +103,14 @@ export default async function PrivateCreditListingDetailPage({
     );
   }
 
-  const l = listing as InvestmentListing;
-  const relatedListings = await fetchRelatedListings(VERTICAL, slug, l.sub_category, 3);
-
-  const breadcrumb = breadcrumbJsonLd([
-    { name: "Home", url: `${SITE_URL}/` },
-    { name: "Invest", url: `${SITE_URL}/invest` },
-    { name: "Private Credit", url: `${SITE_URL}/invest/private-credit` },
-    { name: "Listings", url: `${SITE_URL}/invest/private-credit/listings` },
-    { name: l.title },
-  ]);
-
-  const km = l.key_metrics ?? {};
-  const location = [l.location_city, l.location_state].filter(Boolean).join(", ");
+  const relatedListings = await fetchRelatedListings(VERTICAL, slug, listing.sub_category, 3);
 
   return (
-    <div>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <ListingSchemaScripts listing={l} vertical={CATEGORY_SLUG} />
-
-      {/* Compact header (E1) — breadcrumb + badges + title + location only,
-          so the gallery and metrics sit near the fold. */}
-      <section className="bg-white border-b border-slate-100 py-3 md:py-4">
-        <div className="container-custom">
-          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-2">
-            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" />
-            <Link href="/invest" className="hover:text-slate-900 transition-colors">Invest</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" />
-            <Link href="/invest/private-credit/listings" className="hover:text-slate-900 transition-colors">Private Credit</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" />
-            <span className="text-slate-900 font-medium truncate max-w-40">{l.title}</span>
-          </nav>
-
-          <div className="flex flex-wrap gap-2 mb-2">
-            {l.listing_type === "featured" && (
-              <span className="bg-amber-500 text-slate-900 text-xs font-bold px-2.5 py-0.5 rounded-full">Featured</span>
-            )}
-            {l.listing_type === "premium" && (
-              <span className="bg-yellow-400 text-slate-900 text-xs font-bold px-2.5 py-0.5 rounded-full">Premium</span>
-            )}
-            {l.firb_eligible && (
-              <span className="bg-blue-600 text-white text-xs font-bold px-2.5 py-0.5 rounded-full">FIRB Eligible</span>
-            )}
-            {l.sub_category && (
-              <span className="bg-slate-700 text-slate-200 text-xs font-semibold px-2.5 py-0.5 rounded-full capitalize">
-                {l.sub_category.replace(/_/g, " ")}
-              </span>
-            )}
-          </div>
-
-          <h1 className="text-2xl md:text-3xl font-extrabold mb-2 text-slate-900">{l.title}</h1>
-          {location && (
-            <div className="flex items-center gap-1.5 text-slate-600 text-sm">
-              <Icon name="map-pin" size={14} />
-              {location}
-            </div>
-          )}
-        </div>
-      </section>
-
-      {/* Main content */}
-      <section className="py-6 md:py-8 bg-slate-50">
-        <div className="container-custom">
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
-            {/* Left: details */}
-            <div className="lg:col-span-2 space-y-6">
-              <ListingImageGallery images={l.images} alt={l.title} vertical={l.vertical} listingId={l.id} subCategory={l.sub_category} />
-              {/* Price card */}
-              <div className="bg-white border border-slate-200 rounded-xl p-4">
-                <div className="flex flex-wrap items-center justify-between gap-4">
-                  <div>
-                    <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1">Minimum Investment</p>
-                    <p className="text-3xl font-extrabold text-slate-900">
-                      {l.price_display ?? (l.asking_price_cents ? formatCents(l.asking_price_cents) : "On application")}
-                    </p>
-                  </div>
-                  {!!km.target_yield && (
-                    <div className="text-right">
-                      <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1">Target Yield</p>
-                      <p className="text-xl font-bold text-green-700">{String(km.target_yield)}</p>
-                    </div>
-                  )}
-                </div>
-              </div>
-
-              {/* Key metrics */}
-              {Object.keys(km).length > 0 && (
-                <div className="bg-white border border-slate-200 rounded-xl p-6">
-                  <h2 className="text-base font-bold text-slate-900 mb-4">Key Metrics</h2>
-                  <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-                    {Object.entries(km).map(([key, value]) => (
-                      <div key={key} className="bg-slate-50 rounded-lg p-3">
-                        <p className="text-xs text-slate-500 capitalize mb-1">{key.replace(/_/g, " ")}</p>
-                        <p className="text-sm font-bold text-slate-900">
-                          {typeof value === "number" && key.includes("cents")
-                            ? formatCents(value)
-                            : String(value)}
-                        </p>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {/* Description */}
-              {l.description && (
-                <div className="bg-white border border-slate-200 rounded-xl p-6">
-                  <h2 className="text-base font-bold text-slate-900 mb-3">About This Fund</h2>
-                  <div className="prose prose-slate prose-sm max-w-none">
-                    {l.description.split("\n").map((para, i) => (
-                      <p key={i}>{para}</p>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {/* FIRB info */}
-              {l.firb_eligible && (
-                <div className="bg-blue-50 border border-blue-200 rounded-xl p-5 flex gap-4">
-                  <Icon name="globe" size={20} className="text-blue-600 shrink-0 mt-0.5" />
-                  <div>
-                    <p className="font-bold text-blue-900 text-sm mb-1">FIRB Eligible</p>
-                    <p className="text-sm text-blue-700">
-                      This private credit fund is eligible for foreign investment under the Foreign Investment Review Board framework. FIRB approval may be required for foreign investors. Our advisors can guide you through the process.
-                    </p>
-                    <Link href="/foreign-investment" className="inline-flex items-center gap-1 text-blue-700 font-semibold text-xs mt-2 hover:text-blue-900">
-                      Learn about FIRB <Icon name="arrow-right" size={11} />
-                    </Link>
-                  </div>
-                </div>
-              )}
-            </div>
-
-            {/* Right: Enquiry form */}
-            <div className="space-y-5">
-              <div className="bg-white border border-slate-200 rounded-xl p-6 sticky top-20">
-                <h2 className="text-base font-bold text-slate-900 mb-1">Enquire About This Fund</h2>
-                <p className="text-xs text-slate-500 mb-4">
-                  Send a confidential enquiry directly to the fund manager.
-                </p>
-                <ListingEnquiryForm
-                  listingId={l.id}
-                  listingTitle={l.title}
-                  vertical="private_credit"
-                />
-              </div>
-              {/* Wave 5 — structure-aware after-tax return + FIRB estimate */}
-              <ListingDecisionTools listing={l} />
-
-
-              {/* Stats */}
-              <div className="bg-slate-50 border border-slate-200 rounded-xl p-4 flex gap-6">
-                <div className="text-center">
-                  <p className="text-lg font-bold text-slate-900">{l.views ?? 0}</p>
-                  <p className="text-xs text-slate-500">Views</p>
-                </div>
-                <div className="text-center">
-                  <p className="text-lg font-bold text-slate-900">{l.enquiries ?? 0}</p>
-                  <p className="text-xs text-slate-500">Enquiries</p>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          {/* Related listings */}
-          {relatedListings.length > 0 && (
-            <div className="mt-12">
-              <h2 className="text-xl font-extrabold text-slate-900 mb-6">Similar Private Credit Funds</h2>
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-                {relatedListings.map((rel) => (
-                  <ListingCard key={rel.id} listing={rel} vertical="private_credit" />
-                ))}
-              </div>
-            </div>
-          )}
-        </div>
-      </section>
-
-      {/* List CTA */}
-      <section className="py-10 bg-white border-t border-slate-100">
-        <div className="container-custom text-center">
-          <p className="text-slate-500 text-sm mb-4">Looking for more opportunities?</p>
-          <Link
-            href="/invest/private-credit/listings"
-            className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold px-6 py-3 rounded-xl transition-colors"
-          >
-            Browse All Private Credit Funds
-            <Icon name="arrow-right" size={16} />
-          </Link>
-        </div>
-      </section>
-    </div>
+    <ListingDetailView
+      listing={listing as InvestmentListing}
+      relatedListings={relatedListings as InvestmentListing[]}
+      categorySlug={CATEGORY_SLUG}
+      categoryLabel={CATEGORY_LABEL}
+    />
   );
 }

--- a/app/invest/renewable-energy/listings/[slug]/page.tsx
+++ b/app/invest/renewable-energy/listings/[slug]/page.tsx
@@ -1,20 +1,15 @@
-import Link from "next/link";
 import type { Metadata } from "next";
-import { breadcrumbJsonLd, SITE_URL, CURRENT_YEAR } from "@/lib/seo";
-import Icon from "@/components/Icon";
-import ListingImageGallery from "@/components/ListingImageGallery";
-import ListingCard, { type InvestmentListing } from "@/components/ListingCard";
-import ListingEnquiryForm from "@/components/ListingEnquiryForm";
-import ListingDecisionTools from "@/components/invest/ListingDecisionTools";
+import { SITE_URL, CURRENT_YEAR } from "@/lib/seo";
+import ListingDetailView from "@/components/invest/ListingDetailView";
 import ListingsEmptyState from "@/components/ListingsEmptyState";
 import SubCategoryListingsView from "@/components/SubCategoryListingsView";
+import { type InvestmentListing } from "@/components/ListingCard";
 import {
   fetchListingBySlug,
   fetchListingsBySubCategory,
   fetchRelatedListings,
 } from "@/lib/investment-listings-query";
 import { getSubcategoryBySlug } from "@/lib/invest-categories";
-import ListingSchemaScripts from "@/components/ListingSchemaScripts";
 
 export const revalidate = 300;
 
@@ -68,12 +63,6 @@ export async function generateMetadata({
   };
 }
 
-function formatCents(cents: number): string {
-  if (cents >= 1_000_000_00) return `$${(cents / 1_000_000_00).toFixed(1)}M`;
-  if (cents >= 1_000_00) return `$${(cents / 1_000_00).toFixed(0)}K`;
-  return `$${(cents / 100).toLocaleString("en-AU")}`;
-}
-
 export default async function EnergyProjectDetailPage({
   params,
 }: {
@@ -103,173 +92,15 @@ export default async function EnergyProjectDetailPage({
       />
     );
   }
-  const l = listing as InvestmentListing;
 
   const relatedListings = await fetchRelatedListings(VERTICAL, slug, null, 3);
-  const km = (l.key_metrics ?? {}) as Record<string, unknown>;
-  const location = [l.location_city, l.location_state].filter(Boolean).join(", ");
-
-  const breadcrumb = breadcrumbJsonLd([
-    { name: "Home", url: `${SITE_URL}/` },
-    { name: "Invest", url: `${SITE_URL}/invest` },
-    { name: "Renewable Energy", url: `${SITE_URL}/invest/renewable-energy` },
-    { name: "Projects", url: `${SITE_URL}/invest/renewable-energy/listings` },
-    { name: l.title },
-  ]);
 
   return (
-    <div>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
-      />
-      <ListingSchemaScripts listing={l} vertical={CATEGORY_SLUG} />
-
-      {/* Compact header (E1) — breadcrumb + badges + title + location only,
-          so the gallery and metrics sit near the fold. */}
-      <section className="bg-white border-b border-slate-100 py-3 md:py-4">
-        <div className="container-custom">
-          <nav aria-label="Breadcrumb" className="flex items-center gap-1.5 text-xs text-slate-500 mb-2">
-            <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" />
-            <Link href="/invest/renewable-energy/listings" className="hover:text-slate-900 transition-colors">Energy Projects</Link>
-            <Icon name="chevron-right" size={12} className="text-slate-300" />
-            <span className="text-slate-900 font-medium truncate max-w-40">{l.title}</span>
-          </nav>
-
-          <div className="flex flex-wrap gap-2 mb-2">
-            {l.listing_type === "featured" && (
-              <span className="bg-amber-500 text-slate-900 text-xs font-bold px-2.5 py-0.5 rounded-full">Featured</span>
-            )}
-            {l.firb_eligible && (
-              <span className="bg-blue-600 text-white text-xs font-bold px-2.5 py-0.5 rounded-full">FIRB Eligible</span>
-            )}
-            {!!km.technology && (
-              <span className="bg-teal-700 text-teal-100 text-xs font-semibold px-2.5 py-0.5 rounded-full capitalize">
-                {String(km.technology)}
-              </span>
-            )}
-            {!!km.stage && (
-              <span className="bg-slate-700 text-slate-200 text-xs font-semibold px-2.5 py-0.5 rounded-full capitalize">
-                {String(km.stage)}
-              </span>
-            )}
-          </div>
-
-          <h1 className="text-2xl md:text-3xl font-extrabold mb-2 text-slate-900">{l.title}</h1>
-          {location && (
-            <div className="flex items-center gap-1.5 text-slate-600 text-sm">
-              <Icon name="map-pin" size={14} />
-              {location}
-            </div>
-          )}
-        </div>
-      </section>
-
-      <section className="py-6 md:py-8 bg-slate-50">
-        <div className="container-custom">
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
-            <div className="lg:col-span-2 space-y-6">
-              <ListingImageGallery images={l.images} alt={l.title} vertical={l.vertical} listingId={l.id} subCategory={l.sub_category} />
-              <div className="bg-white border border-slate-200 rounded-xl p-4">
-                <div className="flex flex-wrap items-center justify-between gap-4">
-                  <div>
-                    <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1">Investment Required</p>
-                    <p className="text-3xl font-extrabold text-slate-900">
-                      {l.price_display ?? (l.asking_price_cents ? formatCents(l.asking_price_cents) : "Price on application")}
-                    </p>
-                  </div>
-                  {!!km.capacity_mw && (
-                    <div className="text-right">
-                      <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1">Project Capacity</p>
-                      <p className="text-xl font-bold text-teal-700">{String(km.capacity_mw)} MW</p>
-                    </div>
-                  )}
-                </div>
-              </div>
-
-              {Object.keys(km).length > 0 && (
-                <div className="bg-white border border-slate-200 rounded-xl p-6">
-                  <h2 className="text-base font-bold text-slate-900 mb-4">Project Details</h2>
-                  <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-                    {Object.entries(km).map(([key, value]) => (
-                      <div key={key} className="bg-slate-50 rounded-lg p-3">
-                        <p className="text-xs text-slate-500 capitalize mb-1">{key.replace(/_/g, " ")}</p>
-                        <p className="text-sm font-bold text-slate-900 capitalize">{String(value)}</p>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {l.description && (
-                <div className="bg-white border border-slate-200 rounded-xl p-6">
-                  <h2 className="text-base font-bold text-slate-900 mb-3">About This Project</h2>
-                  <div className="prose prose-slate prose-sm max-w-none">
-                    {l.description.split("\n").map((para, i) => (
-                      <p key={i}>{para}</p>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              <div className="bg-teal-50 border border-teal-200 rounded-xl p-5 flex gap-4">
-                <Icon name="zap" size={20} className="text-teal-600 shrink-0 mt-0.5" />
-                <div>
-                  <p className="font-bold text-teal-900 text-sm mb-1">Government Support Available</p>
-                  <p className="text-sm text-teal-700">
-                    Australian renewable energy projects may be eligible for ARENA grants, CEFC concessional finance, or state-based renewable energy zone (REZ) contracts. Ask the project team about government co-investment.
-                  </p>
-                </div>
-              </div>
-            </div>
-
-            <div className="space-y-5">
-              <div className="bg-white border border-slate-200 rounded-xl p-6 sticky top-20">
-                <h2 className="text-base font-bold text-slate-900 mb-1">Register Your Interest</h2>
-                <p className="text-xs text-slate-500 mb-4">Send a confidential enquiry to the project development team.</p>
-                <ListingEnquiryForm listingId={l.id} listingTitle={l.title} vertical="energy" />
-              </div>
-              {/* Wave 5 — structure-aware after-tax return + FIRB estimate */}
-              <ListingDecisionTools listing={l} />
-
-              <div className="bg-slate-50 border border-slate-200 rounded-xl p-4 flex gap-6">
-                <div className="text-center">
-                  <p className="text-lg font-bold text-slate-900">{l.views ?? 0}</p>
-                  <p className="text-xs text-slate-500">Views</p>
-                </div>
-                <div className="text-center">
-                  <p className="text-lg font-bold text-slate-900">{l.enquiries ?? 0}</p>
-                  <p className="text-xs text-slate-500">Enquiries</p>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          {relatedListings.length > 0 && (
-            <div className="mt-12">
-              <h2 className="text-xl font-extrabold text-slate-900 mb-6">Other Energy Projects</h2>
-              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-                {relatedListings.map((rel) => (
-                  <ListingCard key={rel.id} listing={rel} vertical="energy" />
-                ))}
-              </div>
-            </div>
-          )}
-        </div>
-      </section>
-
-      <section className="py-10 bg-white border-t border-slate-100">
-        <div className="container-custom text-center">
-          <Link
-            href="/invest/renewable-energy/listings"
-            className="inline-flex items-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold px-6 py-3 rounded-xl transition-colors"
-          >
-            Browse All Energy Projects
-            <Icon name="arrow-right" size={16} />
-          </Link>
-        </div>
-      </section>
-    </div>
+    <ListingDetailView
+      listing={listing as InvestmentListing}
+      relatedListings={relatedListings as InvestmentListing[]}
+      categorySlug={CATEGORY_SLUG}
+      categoryLabel={CATEGORY_LABEL}
+    />
   );
 }

--- a/components/BookmarkButton.tsx
+++ b/components/BookmarkButton.tsx
@@ -11,6 +11,14 @@ interface Props {
   className?: string;
 }
 
+/** fetch resolves on 4xx/5xx and the API can answer { ok: false } — treat
+ *  both as a failed write so authed optimistic state can be reverted. */
+async function responseOk(res: Response): Promise<boolean> {
+  if (!res.ok) return false;
+  const json = (await res.json().catch(() => ({ ok: false }))) as { ok?: boolean };
+  return json.ok === true;
+}
+
 /**
  * Save/unsave toggle that works for both authenticated and
  * anonymous visitors.
@@ -90,11 +98,14 @@ export default function BookmarkButton({ type, ref, label, className }: Props) {
         }
         const body: Record<string, unknown> = { type, ref, label };
         if (!user) body.session_id = getSessionId();
-        await fetch("/api/account/bookmarks", {
+        const res = await fetch("/api/account/bookmarks", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(body),
         });
+        if (user && !(await responseOk(res))) {
+          setSaved(!next);
+        }
       } else {
         if (!user) {
           // Drop the localStorage mirror first so the unsave survives a
@@ -114,11 +125,14 @@ export default function BookmarkButton({ type, ref, label, className }: Props) {
         }
         const body: Record<string, unknown> = { type, ref };
         if (!user) body.session_id = getSessionId();
-        await fetch("/api/account/bookmarks", {
+        const res = await fetch("/api/account/bookmarks", {
           method: "DELETE",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(body),
         });
+        if (user && !(await responseOk(res))) {
+          setSaved(!next);
+        }
       }
     } catch {
       // Anonymous state lives in localStorage (already written above);

--- a/components/BookmarkButton.tsx
+++ b/components/BookmarkButton.tsx
@@ -5,7 +5,7 @@ import { useUser } from "@/lib/hooks/useUser";
 import { getSessionId } from "@/lib/session";
 
 interface Props {
-  type: "article" | "broker" | "advisor" | "scenario" | "calculator";
+  type: "article" | "broker" | "advisor" | "scenario" | "calculator" | "listing";
   ref: string;
   label?: string;
   className?: string;

--- a/components/BookmarkButton.tsx
+++ b/components/BookmarkButton.tsx
@@ -32,7 +32,7 @@ async function responseOk(res: Response): Promise<boolean> {
  * button just fires the "save" event.
  */
 export default function BookmarkButton({ type, ref, label, className }: Props) {
-  const { user } = useUser();
+  const { user, loading: userLoading } = useUser();
   const [saved, setSaved] = useState(false);
   const [busy, setBusy] = useState(false);
 
@@ -74,7 +74,9 @@ export default function BookmarkButton({ type, ref, label, className }: Props) {
   }, [user, type, ref]);
 
   const toggle = async () => {
-    if (busy) return;
+    // Until auth resolves, a signed-in user looks anonymous — saving would
+    // write a stale inv_anon_saves mirror the authed unsave never cleans.
+    if (busy || userLoading) return;
     setBusy(true);
     const next = !saved;
     setSaved(next);
@@ -149,7 +151,7 @@ export default function BookmarkButton({ type, ref, label, className }: Props) {
       onClick={toggle}
       aria-label={saved ? "Remove bookmark" : "Save for later"}
       aria-pressed={saved}
-      disabled={busy}
+      disabled={busy || userLoading}
       aria-busy={busy}
       className={
         className ||

--- a/components/BookmarkButton.tsx
+++ b/components/BookmarkButton.tsx
@@ -72,16 +72,9 @@ export default function BookmarkButton({ type, ref, label, className }: Props) {
     setSaved(next);
     try {
       if (next) {
-        const body: Record<string, unknown> = { type, ref, label };
-        if (!user) body.session_id = getSessionId();
-        await fetch("/api/account/bookmarks", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(body),
-        });
         if (!user) {
-          // Mirror into localStorage so the star persists between
-          // page loads even before the user signs in.
+          // Mirror into localStorage BEFORE the network call so the star
+          // persists between page loads even if the server write fails.
           try {
             const cached = localStorage.getItem("inv_anon_saves");
             const list = cached
@@ -95,27 +88,42 @@ export default function BookmarkButton({ type, ref, label, className }: Props) {
             /* ignore */
           }
         }
-      } else if (user) {
+        const body: Record<string, unknown> = { type, ref, label };
+        if (!user) body.session_id = getSessionId();
+        await fetch("/api/account/bookmarks", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        });
+      } else {
+        if (!user) {
+          // Drop the localStorage mirror first so the unsave survives a
+          // failed network call, then delete the server row — otherwise
+          // claim-on-signup resurrects the unsaved item.
+          try {
+            const cached = localStorage.getItem("inv_anon_saves");
+            if (cached) {
+              const list = (
+                JSON.parse(cached) as Array<{ type: string; ref: string }>
+              ).filter((i) => !(i.type === type && i.ref === ref));
+              localStorage.setItem("inv_anon_saves", JSON.stringify(list));
+            }
+          } catch {
+            /* ignore */
+          }
+        }
+        const body: Record<string, unknown> = { type, ref };
+        if (!user) body.session_id = getSessionId();
         await fetch("/api/account/bookmarks", {
           method: "DELETE",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ type, ref }),
+          body: JSON.stringify(body),
         });
-      } else {
-        try {
-          const cached = localStorage.getItem("inv_anon_saves");
-          if (cached) {
-            const list = (
-              JSON.parse(cached) as Array<{ type: string; ref: string }>
-            ).filter((i) => !(i.type === type && i.ref === ref));
-            localStorage.setItem("inv_anon_saves", JSON.stringify(list));
-          }
-        } catch {
-          /* ignore */
-        }
       }
     } catch {
-      setSaved(!next);
+      // Anonymous state lives in localStorage (already written above);
+      // only revert when the server is the source of truth.
+      if (user) setSaved(!next);
     } finally {
       setBusy(false);
     }

--- a/components/ListingCard.tsx
+++ b/components/ListingCard.tsx
@@ -33,6 +33,7 @@ export type InvestmentListing = {
   listing_type?: string | null;
   firb_eligible?: boolean | null;
   siv_complying?: boolean | null;
+  external_url?: string | null;
   status?: string | null;
   views?: number | null;
   enquiries?: number | null;

--- a/components/invest/ListingDetailView.tsx
+++ b/components/invest/ListingDetailView.tsx
@@ -259,11 +259,44 @@ export default function ListingDetailView({
             </div>
 
             <div className="space-y-5">
-              <div id="enquire" className="bg-white border border-slate-200 rounded-xl p-6 lg:sticky lg:top-20 scroll-mt-24">
-                <h2 className="text-base font-bold text-slate-900 mb-1">{intel.enquiryHeading}</h2>
-                <p className="text-xs text-slate-500 mb-4">{intel.enquirySubcopy}</p>
-                <ListingEnquiryForm listingId={l.id} listingTitle={l.title} vertical={categorySlug} />
-              </div>
+              {/* externalCta kinds (listed securities) must not solicit
+                  enquiries — the sanctioned posture is factual listing +
+                  "buy via your own broker" referral. The card keeps the
+                  #enquire id so the mobile sticky bar's anchor lands here. */}
+              {kindMeta.externalCta ? (
+                <div id="enquire" className="bg-white border border-slate-200 rounded-xl p-6 lg:sticky lg:top-20 scroll-mt-24">
+                  <h2 className="text-base font-bold text-slate-900 mb-1">How to invest</h2>
+                  <p className="text-xs text-slate-500 mb-4">
+                    This is an ASX-listed security — you buy it on-market through
+                    your own broker, not by enquiry. Listing shown for general
+                    information only; not an offer or recommendation.
+                  </p>
+                  <Link
+                    href="/share-trading"
+                    className="inline-flex w-full items-center justify-center gap-2 bg-amber-500 hover:bg-amber-400 text-slate-900 font-bold px-4 py-2.5 rounded-xl transition-colors text-sm"
+                  >
+                    Compare share-trading platforms
+                    <Icon name="arrow-right" size={14} />
+                  </Link>
+                  {l.external_url && /^https?:\/\//.test(l.external_url) && (
+                    <a
+                      href={l.external_url}
+                      target="_blank"
+                      rel="noopener noreferrer nofollow"
+                      className="mt-3 inline-flex items-center gap-1 text-xs font-semibold text-slate-600 hover:text-slate-900"
+                    >
+                      Official company information
+                      <Icon name="external-link" size={12} />
+                    </a>
+                  )}
+                </div>
+              ) : (
+                <div id="enquire" className="bg-white border border-slate-200 rounded-xl p-6 lg:sticky lg:top-20 scroll-mt-24">
+                  <h2 className="text-base font-bold text-slate-900 mb-1">{intel.enquiryHeading}</h2>
+                  <p className="text-xs text-slate-500 mb-4">{intel.enquirySubcopy}</p>
+                  <ListingEnquiryForm listingId={l.id} listingTitle={l.title} vertical={categorySlug} />
+                </div>
+              )}
 
               <ListingDecisionTools listing={l} />
 

--- a/components/invest/ListingDetailView.tsx
+++ b/components/invest/ListingDetailView.tsx
@@ -22,6 +22,7 @@ import {
   deriveListingKind,
   listingKindMeta,
   formatListingPrice,
+  formatAudCompact,
   freshnessSignal,
   type FreshnessSignal,
 } from "@/lib/listing-kind";
@@ -85,9 +86,28 @@ export default function ListingDetailView({
   const highlightKey = intel.highlightMetricKeys.find(
     (key) => km[key] != null && km[key] !== "",
   );
-  const highlight = highlightKey
-    ? { label: humanizeTitle(highlightKey), value: formatMetricValue(highlightKey, km[highlightKey]) }
-    : null;
+  // Top-level annual_profit_cents wins the price-card highlight slot (the
+  // bespoke business/franchise pages always led with it); otherwise fall
+  // back to the vertical's preferred key_metrics highlight.
+  const highlight = l.annual_profit_cents
+    ? { label: "Annual Net Profit", value: formatAudCompact(l.annual_profit_cents) }
+    : highlightKey
+      ? { label: humanizeTitle(highlightKey), value: formatMetricValue(highlightKey, km[highlightKey]) }
+      : null;
+
+  // Financials stored as top-level columns (not key_metrics) — the facts
+  // grid is built from key_metrics, so fold these in or they vanish.
+  // Profit is excluded here because it always owns the highlight slot.
+  const facts = l.annual_revenue_cents
+    ? [
+        {
+          key: "annual_revenue_cents",
+          label: "Annual Revenue",
+          value: formatAudCompact(l.annual_revenue_cents),
+        },
+        ...profile.facts,
+      ]
+    : profile.facts;
 
   const breadcrumb = breadcrumbJsonLd([
     { name: "Home", url: `${SITE_URL}/` },
@@ -191,11 +211,11 @@ export default function ListingDetailView({
                 </div>
               </div>
 
-              {profile.facts.length > 0 && (
+              {facts.length > 0 && (
                 <div className="bg-white border border-slate-200 rounded-xl p-6">
                   <h2 className="text-base font-bold text-slate-900 mb-4">{intel.detailsHeading}</h2>
                   <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-                    {profile.facts.map((fact) => (
+                    {facts.map((fact) => (
                       <div key={fact.key} className="bg-slate-50 rounded-lg p-3">
                         <p className="text-xs text-slate-500 mb-1">{fact.label}</p>
                         <p className="text-sm font-bold text-slate-900">{fact.value}</p>

--- a/components/invest/ListingDetailView.tsx
+++ b/components/invest/ListingDetailView.tsx
@@ -120,6 +120,9 @@ export default function ListingDetailView({
             {l.listing_type === "featured" && (
               <span className="bg-amber-500 text-slate-900 text-xs font-bold px-2.5 py-0.5 rounded-full">Featured</span>
             )}
+            {l.listing_type === "premium" && (
+              <span className="bg-yellow-400 text-slate-900 text-xs font-bold px-2.5 py-0.5 rounded-full">Premium</span>
+            )}
             <span className={`text-xs font-semibold px-2.5 py-0.5 rounded-full border ${kindMeta.accent.badgeSubtle}`}>
               {kindMeta.label}
             </span>

--- a/components/invest/ListingDetailView.tsx
+++ b/components/invest/ListingDetailView.tsx
@@ -6,25 +6,50 @@ import ListingCard, { type InvestmentListing } from "@/components/ListingCard";
 import ListingEnquiryForm from "@/components/ListingEnquiryForm";
 import ListingDecisionTools from "@/components/invest/ListingDecisionTools";
 import ListingSchemaScripts from "@/components/ListingSchemaScripts";
+import LotSaveButton from "@/components/invest/lot/LotSaveButton";
+import LotStickyActions from "@/components/invest/lot/LotStickyActions";
+import LotFieldGuide from "@/components/invest/lot/LotFieldGuide";
+import LotPaperTrail from "@/components/invest/lot/LotPaperTrail";
+import LotTransparency from "@/components/invest/lot/LotTransparency";
+import LotHoldingCosts from "@/components/invest/lot/LotHoldingCosts";
+import LotLiquidityExit from "@/components/invest/lot/LotLiquidityExit";
+import LotComparables from "@/components/invest/lot/LotComparables";
+import LotListerCard from "@/components/invest/lot/LotListerCard";
+import { buildLotProfile } from "@/lib/listings/lot-profile";
+import { intelForCategory } from "@/lib/listings/vertical-intel";
+import { assessLotTransparency } from "@/lib/listings/lot-transparency";
+import {
+  deriveListingKind,
+  listingKindMeta,
+  formatListingPrice,
+  freshnessSignal,
+  type FreshnessSignal,
+} from "@/lib/listing-kind";
 import { humanizeTitle, formatMetricValue } from "@/lib/listing-format";
+import { GENERAL_ADVICE_WARNING } from "@/lib/compliance";
 
 /**
- * Shared single-listing detail view.
+ * Shared single-listing detail view — the "lot page".
  *
- * Generalised from the per-category bespoke detail pages
- * (`app/invest/<cat>/listings/[slug]/page.tsx`) so that the generic
- * `app/invest/[slug]/listings/[subcategory]` route can render a listing
- * detail for ANY category — including the ones with no bespoke page
- * (funds, private-equity, royalties, venture-capital, …) that previously
- * 500'd in production. Presentational only; the route fetches the listing
- * + related and passes them in.
+ * One canonical surface for every `/invest/<category>/listings/<slug>`
+ * detail render (bespoke category routes and the generic
+ * `[slug]/listings/[subcategory]` route both compose it). Per-vertical
+ * flavour — headings, enquiry nouns, FIRB notes, field-guide content —
+ * comes from `lib/listings/vertical-intel.ts`, NOT from forked JSX; the
+ * structured catalogue sections (paper trail, costs, liquidity, comps,
+ * transparency) come from `lib/listings/lot-profile.ts` +
+ * `lot-transparency.ts` and degrade gracefully on sparse rows.
+ *
+ * Design + compliance rationale: docs/plans/LISTINGS_LOT_EXPERIENCE.md.
  */
 
-function formatCents(cents: number): string {
-  if (cents >= 1_000_000_00) return `$${(cents / 1_000_000_00).toFixed(1)}M`;
-  if (cents >= 1_000_00) return `$${(cents / 1_000_00).toFixed(0)}K`;
-  return `$${(cents / 100).toLocaleString("en-AU")}`;
-}
+const HERO_SENTINEL_ID = "lot-hero-sentinel";
+
+const FRESHNESS_CHIP: Record<NonNullable<FreshnessSignal>, { label: string; className: string }> = {
+  new_this_week: { label: "New this week", className: "bg-emerald-50 text-emerald-700 border border-emerald-200" },
+  new_this_month: { label: "New this month", className: "bg-sky-50 text-sky-700 border border-sky-200" },
+  closing_soon: { label: "Closing soon", className: "bg-rose-50 text-rose-700 border border-rose-200" },
+};
 
 export interface ListingDetailViewProps {
   listing: InvestmentListing;
@@ -45,6 +70,25 @@ export default function ListingDetailView({
   const location = [l.location_city, l.location_state].filter(Boolean).join(", ");
   const listingsHref = `/invest/${categorySlug}/listings`;
 
+  const intel = intelForCategory(categorySlug);
+  const profile = buildLotProfile(km);
+  const transparency = assessLotTransparency(l, profile);
+  const kind = deriveListingKind(l);
+  const kindMeta = listingKindMeta(kind);
+  const price = formatListingPrice(l);
+  const fresh = freshnessSignal({
+    created_at: l.created_at ?? "",
+    expires_at: (l as { expires_at?: string }).expires_at,
+  });
+  const freshChip = fresh ? FRESHNESS_CHIP[fresh] : null;
+
+  const highlightKey = intel.highlightMetricKeys.find(
+    (key) => km[key] != null && km[key] !== "",
+  );
+  const highlight = highlightKey
+    ? { label: humanizeTitle(highlightKey), value: formatMetricValue(highlightKey, km[highlightKey]) }
+    : null;
+
   const breadcrumb = breadcrumbJsonLd([
     { name: "Home", url: `${SITE_URL}/` },
     { name: "Invest", url: `${SITE_URL}/invest` },
@@ -54,16 +98,17 @@ export default function ListingDetailView({
   ]);
 
   return (
-    <div>
+    <div className="pb-16 md:pb-0">
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
       />
       <ListingSchemaScripts listing={l} vertical={categorySlug} />
 
-      <section className="bg-white border-b border-slate-100 py-12">
+      {/* Compact header — breadcrumb + badges + title + save, gallery near the fold. */}
+      <section className="bg-white border-b border-slate-100 py-3 md:py-4">
         <div className="container-custom">
-          <nav className="flex items-center gap-1.5 text-xs text-slate-500 mb-4" aria-label="Breadcrumb">
+          <nav className="flex items-center gap-1.5 text-xs text-slate-500 mb-2" aria-label="Breadcrumb">
             <Link href="/" className="hover:text-slate-900 transition-colors">Home</Link>
             <Icon name="chevron-right" size={12} className="text-slate-300" />
             <Link href={listingsHref} className="hover:text-slate-900 transition-colors">{categoryLabel} Opportunities</Link>
@@ -71,56 +116,86 @@ export default function ListingDetailView({
             <span className="text-slate-900 font-medium truncate max-w-40">{l.title}</span>
           </nav>
 
-          <div className="flex flex-wrap gap-2 mb-3">
+          <div className="flex flex-wrap gap-2 mb-2">
             {l.listing_type === "featured" && (
               <span className="bg-amber-500 text-slate-900 text-xs font-bold px-2.5 py-0.5 rounded-full">Featured</span>
+            )}
+            <span className={`text-xs font-semibold px-2.5 py-0.5 rounded-full border ${kindMeta.accent.badgeSubtle}`}>
+              {kindMeta.label}
+            </span>
+            {freshChip && (
+              <span className={`text-xs font-semibold px-2.5 py-0.5 rounded-full ${freshChip.className}`}>
+                {freshChip.label}
+              </span>
             )}
             {l.firb_eligible && (
               <span className="bg-blue-600 text-white text-xs font-bold px-2.5 py-0.5 rounded-full">FIRB Eligible</span>
             )}
-            {!!km.commodity && (
-              <span className="bg-amber-700 text-amber-100 text-xs font-semibold px-2.5 py-0.5 rounded-full capitalize">{String(km.commodity)}</span>
-            )}
-            {!!km.stage && (
-              <span className="bg-slate-700 text-slate-200 text-xs font-semibold px-2.5 py-0.5 rounded-full capitalize">{String(km.stage)}</span>
+            {l.sub_category && (
+              <span className="bg-slate-700 text-slate-200 text-xs font-semibold px-2.5 py-0.5 rounded-full">
+                {humanizeTitle(l.sub_category)}
+              </span>
             )}
           </div>
 
-          <h1 className="text-2xl md:text-3xl font-extrabold mb-2 text-slate-900">{l.title}</h1>
-          {location && (
-            <div className="flex items-center gap-1.5 text-slate-600 text-sm">
-              <Icon name="map-pin" size={14} />
-              {location}
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="min-w-0">
+              <h1 className="text-2xl md:text-3xl font-extrabold mb-2 text-slate-900">{l.title}</h1>
+              {location && (
+                <div className="flex items-center gap-1.5 text-slate-600 text-sm">
+                  <Icon name="map-pin" size={14} />
+                  {location}
+                </div>
+              )}
             </div>
-          )}
+            <div className="hidden sm:block shrink-0">
+              <LotSaveButton slug={l.slug} title={l.title} vertical={l.vertical} />
+            </div>
+          </div>
         </div>
       </section>
 
-      <section className="py-10 bg-slate-50">
+      {/* Sticky-bar sentinel: the mobile action bar appears once this scrolls away. */}
+      <div id={HERO_SENTINEL_ID} aria-hidden className="h-px" />
+
+      <section className="py-6 md:py-8 bg-slate-50">
         <div className="container-custom">
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-            <div className="lg:col-span-2 space-y-6">
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-5 lg:gap-8">
+            <div className="lg:col-span-2 space-y-5">
               <ListingImageGallery images={l.images} alt={l.title} vertical={l.vertical} listingId={l.id} subCategory={l.sub_category} />
 
-              <div className="bg-white border border-slate-200 rounded-xl p-6">
+              <div className="bg-white border border-slate-200 rounded-xl p-5">
                 <div className="flex flex-wrap items-center justify-between gap-4">
                   <div>
-                    <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1">Investment Required</p>
-                    <p className="text-3xl font-extrabold text-slate-900">
-                      {l.price_display ?? (l.asking_price_cents ? formatCents(l.asking_price_cents) : "Price on application")}
+                    <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1">
+                      {price?.label ?? kindMeta.priceLabel}
                     </p>
+                    <p className="text-3xl font-extrabold text-slate-900">
+                      {price?.value ?? "Price on application"}
+                    </p>
+                  </div>
+                  {highlight && (
+                    <div className="text-right">
+                      <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-1">
+                        {highlight.label}
+                      </p>
+                      <p className="text-xl font-bold text-amber-700">{highlight.value}</p>
+                    </div>
+                  )}
+                  <div className="sm:hidden w-full">
+                    <LotSaveButton slug={l.slug} title={l.title} vertical={l.vertical} />
                   </div>
                 </div>
               </div>
 
-              {Object.keys(km).length > 0 && (
+              {profile.facts.length > 0 && (
                 <div className="bg-white border border-slate-200 rounded-xl p-6">
-                  <h2 className="text-base font-bold text-slate-900 mb-4">Opportunity Details</h2>
+                  <h2 className="text-base font-bold text-slate-900 mb-4">{intel.detailsHeading}</h2>
                   <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-                    {Object.entries(km).map(([key, value]) => (
-                      <div key={key} className="bg-slate-50 rounded-lg p-3">
-                        <p className="text-xs text-slate-500 mb-1">{humanizeTitle(key)}</p>
-                        <p className="text-sm font-bold text-slate-900">{formatMetricValue(key, value)}</p>
+                    {profile.facts.map((fact) => (
+                      <div key={fact.key} className="bg-slate-50 rounded-lg p-3">
+                        <p className="text-xs text-slate-500 mb-1">{fact.label}</p>
+                        <p className="text-sm font-bold text-slate-900">{fact.value}</p>
                       </div>
                     ))}
                   </div>
@@ -129,19 +204,29 @@ export default function ListingDetailView({
 
               {l.description && (
                 <div className="bg-white border border-slate-200 rounded-xl p-6">
-                  <h2 className="text-base font-bold text-slate-900 mb-3">About This Opportunity</h2>
+                  <h2 className="text-base font-bold text-slate-900 mb-3">{intel.aboutHeading}</h2>
                   <div className="prose prose-slate prose-sm max-w-none">
                     {l.description.split("\n").map((para, i) => (<p key={i}>{para}</p>))}
                   </div>
                 </div>
               )}
 
+              <LotFieldGuide intel={intel} categorySlug={categorySlug} categoryLabel={categoryLabel} />
+              <LotPaperTrail profile={profile} />
+              <LotTransparency assessment={transparency} />
+              <LotHoldingCosts profile={profile} intel={intel} />
+              <LotLiquidityExit profile={profile} intel={intel} />
+              <LotComparables profile={profile} />
+
               {l.firb_eligible && (
                 <div className="bg-blue-50 border border-blue-200 rounded-xl p-5 flex gap-4">
                   <Icon name="globe" size={20} className="text-blue-600 shrink-0 mt-0.5" />
                   <div>
                     <p className="font-bold text-blue-900 text-sm mb-1">FIRB Eligible</p>
-                    <p className="text-sm text-blue-700">Foreign investment may require FIRB approval for this asset class. Check the thresholds and notification rules before investing.</p>
+                    <p className="text-sm text-blue-700">
+                      {intel.firbNote ??
+                        "Foreign investment may require FIRB approval for this asset class. Check the thresholds and notification rules before investing."}
+                    </p>
                     <Link href="/foreign-investment" className="inline-flex items-center gap-1 text-blue-700 font-semibold text-xs mt-2 hover:text-blue-900">
                       Learn about FIRB <Icon name="arrow-right" size={11} />
                     </Link>
@@ -151,13 +236,15 @@ export default function ListingDetailView({
             </div>
 
             <div className="space-y-5">
-              <div className="bg-white border border-slate-200 rounded-xl p-6 sticky top-20">
-                <h2 className="text-base font-bold text-slate-900 mb-1">Enquire About This Opportunity</h2>
-                <p className="text-xs text-slate-500 mb-4">Send a confidential enquiry to the listing team.</p>
+              <div id="enquire" className="bg-white border border-slate-200 rounded-xl p-6 lg:sticky lg:top-20 scroll-mt-24">
+                <h2 className="text-base font-bold text-slate-900 mb-1">{intel.enquiryHeading}</h2>
+                <p className="text-xs text-slate-500 mb-4">{intel.enquirySubcopy}</p>
                 <ListingEnquiryForm listingId={l.id} listingTitle={l.title} vertical={categorySlug} />
               </div>
 
               <ListingDecisionTools listing={l} />
+
+              <LotListerCard km={km} noun={intel.noun} />
 
               <div className="bg-slate-50 border border-slate-200 rounded-xl p-4 flex gap-6">
                 <div className="text-center">
@@ -180,6 +267,13 @@ export default function ListingDetailView({
               </div>
             </div>
           )}
+
+          <p className="mt-10 text-xs text-slate-400 max-w-3xl">
+            {GENERAL_ADVICE_WARNING} Listings are general information provided
+            by sellers — not an offer, recommendation or endorsement by
+            Invest.com.au. Verify every claim independently before
+            transacting.
+          </p>
         </div>
       </section>
 
@@ -194,6 +288,16 @@ export default function ListingDetailView({
           </Link>
         </div>
       </section>
+
+      <LotStickyActions
+        sentinelId={HERO_SENTINEL_ID}
+        priceLabel={price?.label ?? kindMeta.priceLabel}
+        priceValue={price?.value ?? "POA"}
+        enquiryCta={kindMeta.externalCta ? "How to invest" : "Enquire"}
+        slug={l.slug}
+        title={l.title}
+        vertical={l.vertical}
+      />
     </div>
   );
 }

--- a/components/invest/lot/LotComparables.tsx
+++ b/components/invest/lot/LotComparables.tsx
@@ -1,0 +1,44 @@
+import Icon from "@/components/Icon";
+import type { LotProfile } from "@/lib/listings/lot-profile";
+
+/**
+ * Comparable sales — auction-catalogue market context from the listing's
+ * structured `comparable_sales[]`. Pure factual history with the
+ * past-performance caveat built in; hidden when the listing carries no
+ * comps.
+ */
+export default function LotComparables({ profile }: { profile: LotProfile }) {
+  if (profile.comparables.length === 0) return null;
+
+  return (
+    <div className="bg-white border border-slate-200 rounded-xl p-6">
+      <div className="flex items-center gap-2 mb-1">
+        <Icon name="bar-chart" size={16} className="text-slate-500" />
+        <h2 className="text-base font-bold text-slate-900">Recent comparable sales</h2>
+      </div>
+      <p className="text-xs text-slate-500 mb-4">
+        Market context stated by the seller — verify against independent sources.
+      </p>
+
+      <ul className="divide-y divide-slate-100">
+        {profile.comparables.map((comp, i) => (
+          <li key={`${comp.label}-${i}`} className="flex items-baseline justify-between gap-4 py-2.5">
+            <div className="min-w-0">
+              <p className="text-sm text-slate-800 truncate">{comp.label}</p>
+              <p className="text-xs text-slate-500">
+                {[comp.when, comp.source].filter(Boolean).join(" · ")}
+              </p>
+            </div>
+            {comp.price && (
+              <p className="text-sm font-bold text-slate-900 whitespace-nowrap">{comp.price}</p>
+            )}
+          </li>
+        ))}
+      </ul>
+
+      <p className="mt-4 text-xs text-slate-400">
+        Past sales are not an indicator of future prices.
+      </p>
+    </div>
+  );
+}

--- a/components/invest/lot/LotFieldGuide.tsx
+++ b/components/invest/lot/LotFieldGuide.tsx
@@ -1,0 +1,72 @@
+import Link from "next/link";
+import Icon from "@/components/Icon";
+import type { VerticalIntel } from "@/lib/listings/vertical-intel";
+
+/**
+ * "New to {category}?" collapsible field guide — the due-diligence
+ * checklist for first-time buyers in this asset class, rendered as a
+ * native `<details>` so it costs no client JS. Content comes from the
+ * vertical-intel registry: factual "what buyers check" items, never
+ * advice.
+ */
+export default function LotFieldGuide({
+  intel,
+  categorySlug,
+  categoryLabel,
+}: {
+  intel: VerticalIntel;
+  categorySlug: string;
+  categoryLabel: string;
+}) {
+  if (intel.dueDiligence.length === 0) return null;
+
+  return (
+    <details className="group bg-gradient-to-br from-slate-50 to-white border border-slate-200 rounded-xl open:shadow-sm">
+      <summary className="flex items-center gap-3 cursor-pointer select-none list-none p-5 [&::-webkit-details-marker]:hidden">
+        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-amber-100 text-amber-700">
+          <Icon name="book-open" size={18} />
+        </span>
+        <span className="flex-1">
+          <span className="block text-sm font-bold text-slate-900">
+            New to {categoryLabel.toLowerCase()}? What buyers check
+          </span>
+          <span className="block text-xs text-slate-500">
+            A first-timer&apos;s checklist for this asset class
+          </span>
+        </span>
+        <Icon
+          name="chevron-down"
+          size={18}
+          className="text-slate-400 transition-transform group-open:rotate-180"
+        />
+      </summary>
+      <div className="px-5 pb-5 pt-1">
+        <ul className="space-y-2.5">
+          {intel.dueDiligence.map((item) => (
+            <li key={item} className="flex gap-2.5 text-sm text-slate-700">
+              <Icon
+                name="check-circle"
+                size={16}
+                className="text-emerald-600 shrink-0 mt-0.5"
+              />
+              <span>{item}</span>
+            </li>
+          ))}
+        </ul>
+        {intel.riskNote && (
+          <p className="mt-4 flex gap-2 rounded-lg bg-amber-50 border border-amber-200 p-3 text-xs text-amber-900">
+            <Icon name="alert-triangle" size={14} className="shrink-0 mt-0.5 text-amber-600" />
+            <span>{intel.riskNote}</span>
+          </p>
+        )}
+        <Link
+          href={`/invest/${categorySlug}`}
+          className="mt-4 inline-flex items-center gap-1 text-xs font-semibold text-amber-700 hover:text-amber-900"
+        >
+          Read the {categoryLabel.toLowerCase()} guide
+          <Icon name="arrow-right" size={12} />
+        </Link>
+      </div>
+    </details>
+  );
+}

--- a/components/invest/lot/LotHoldingCosts.tsx
+++ b/components/invest/lot/LotHoldingCosts.tsx
@@ -1,0 +1,72 @@
+import Icon from "@/components/Icon";
+import type { LotProfile } from "@/lib/listings/lot-profile";
+import type { VerticalIntel } from "@/lib/listings/vertical-intel";
+
+/**
+ * "What it costs to hold" — the honesty panel alt-asset sellers usually
+ * skip. Structured `holding_costs[]` from the listing render as itemised
+ * rows; otherwise the vertical's typical-cost lines render with an
+ * explicit "ask for the full schedule" nudge, clearly labelled as
+ * class-level guidance rather than this asset's figures.
+ */
+export default function LotHoldingCosts({
+  profile,
+  intel,
+}: {
+  profile: LotProfile;
+  intel: VerticalIntel;
+}) {
+  const hasStated = profile.holdingCosts.length > 0;
+  if (!hasStated && intel.typicalCosts.length === 0) return null;
+
+  return (
+    <div className="bg-white border border-slate-200 rounded-xl p-6">
+      <div className="flex items-center gap-2 mb-1">
+        <Icon name="dollar-sign" size={16} className="text-slate-500" />
+        <h2 className="text-base font-bold text-slate-900">What it costs to hold</h2>
+      </div>
+      <p className="text-xs text-slate-500 mb-4">
+        {hasStated
+          ? "Ongoing costs stated by the seller."
+          : `Typical ongoing costs for ${intel.noun === "opportunity" ? "this asset class" : `a ${intel.noun} like this`} — the seller hasn't itemised costs for this listing.`}
+      </p>
+
+      {hasStated ? (
+        <ul className="divide-y divide-slate-100">
+          {profile.holdingCosts.map((cost, i) => (
+            <li key={`${cost.label}-${i}`} className="flex items-baseline justify-between gap-4 py-2">
+              <div className="min-w-0">
+                <p className="text-sm text-slate-800">{cost.label}</p>
+                {cost.note && <p className="text-xs text-slate-500">{cost.note}</p>}
+              </div>
+              {cost.amount && (
+                <p className="text-sm font-bold text-slate-900 whitespace-nowrap">{cost.amount}</p>
+              )}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <ul className="space-y-2">
+          {intel.typicalCosts.map((line) => (
+            <li key={line} className="flex gap-2.5 text-sm text-slate-700">
+              <Icon name="dollar-sign" size={14} className="text-slate-400 shrink-0 mt-0.5" />
+              {line}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <p className="mt-4 text-xs text-slate-400">
+        {hasStated
+          ? "Confirm every figure independently before committing."
+          : "General guide only — "}
+        {!hasStated && (
+          <a href="#enquire" className="font-semibold text-amber-700 hover:text-amber-900">
+            ask the seller for the full cost schedule
+          </a>
+        )}
+        {!hasStated && "."}
+      </p>
+    </div>
+  );
+}

--- a/components/invest/lot/LotLiquidityExit.tsx
+++ b/components/invest/lot/LotLiquidityExit.tsx
@@ -1,0 +1,63 @@
+import Icon from "@/components/Icon";
+import type { LotProfile } from "@/lib/listings/lot-profile";
+import type { VerticalIntel } from "@/lib/listings/vertical-intel";
+
+/**
+ * "Getting your money out" — honest liquidity + exit paths. The
+ * differentiating panel: comparison platforms compare the way in; this
+ * states the way out. Listing-level `typical_time_to_sell` /
+ * `liquidity_note` win over the vertical's class-level narrative.
+ */
+export default function LotLiquidityExit({
+  profile,
+  intel,
+}: {
+  profile: LotProfile;
+  intel: VerticalIntel;
+}) {
+  const narrative = profile.liquidityNote ?? intel.liquidity;
+  if (!narrative && !profile.timeToSell && intel.exitPaths.length === 0) return null;
+
+  return (
+    <div className="bg-white border border-slate-200 rounded-xl p-6">
+      <div className="flex items-center gap-2 mb-1">
+        <Icon name="arrow-left-right" size={16} className="text-slate-500" />
+        <h2 className="text-base font-bold text-slate-900">Getting your money out</h2>
+      </div>
+      <p className="text-xs text-slate-500 mb-4">
+        Liquidity and exit, stated plainly.
+      </p>
+
+      {profile.timeToSell && (
+        <div className="mb-4 inline-flex items-baseline gap-2 rounded-lg bg-slate-50 border border-slate-200 px-4 py-2.5">
+          <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+            Typical time to sell
+          </span>
+          <span className="text-lg font-extrabold text-slate-900">{profile.timeToSell}</span>
+        </div>
+      )}
+
+      {narrative && <p className="text-sm text-slate-700 mb-4">{narrative}</p>}
+
+      {intel.exitPaths.length > 0 && (
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-400 mb-2">
+            Realistic exit paths
+          </p>
+          <ul className="space-y-1.5">
+            {intel.exitPaths.map((path) => (
+              <li key={path} className="flex items-center gap-2 text-sm text-slate-700">
+                <Icon name="arrow-right" size={13} className="text-amber-600 shrink-0" />
+                {path}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <p className="mt-4 text-xs text-slate-400">
+        General guidance for the asset class — actual timeframes and options vary by asset and market conditions.
+      </p>
+    </div>
+  );
+}

--- a/components/invest/lot/LotListerCard.tsx
+++ b/components/invest/lot/LotListerCard.tsx
@@ -1,0 +1,73 @@
+import Icon from "@/components/Icon";
+
+/**
+ * "Listed by" sidebar card — surfaces whichever lister identity the
+ * listing's key_metrics carries (agency / dealer / brand / operator
+ * keys). Renders nothing when no identity is stated; makes no
+ * verification claims (the entity-profile layer with its verification
+ * ladder is a later, migration-gated phase — see
+ * docs/plans/LISTINGS_LOT_EXPERIENCE.md §8).
+ */
+
+const LISTER_KEYS = [
+  "agency",
+  "agent",
+  "dealer",
+  "broker_name",
+  "operator",
+  "manager",
+  "developer",
+  "listed_by",
+  "seller_name",
+  "brand",
+] as const;
+
+export function listerNameFromMetrics(
+  km: Record<string, unknown> | null | undefined,
+): string | null {
+  if (!km) return null;
+  for (const key of LISTER_KEYS) {
+    const value = km[key];
+    if (typeof value === "string" && value.trim().length > 1) {
+      return value.trim().slice(0, 80);
+    }
+  }
+  return null;
+}
+
+export default function LotListerCard({
+  km,
+  noun,
+}: {
+  km: Record<string, unknown> | null | undefined;
+  noun: string;
+}) {
+  const name = listerNameFromMetrics(km);
+  if (!name) return null;
+
+  return (
+    <div className="bg-white border border-slate-200 rounded-xl p-5">
+      <p className="text-xs font-semibold uppercase tracking-wide text-slate-400 mb-2">
+        Listed by
+      </p>
+      <div className="flex items-center gap-3">
+        <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-slate-100 text-slate-600 font-bold">
+          {name.charAt(0).toUpperCase()}
+        </span>
+        <div className="min-w-0">
+          <p className="text-sm font-bold text-slate-900 truncate">{name}</p>
+          <p className="text-xs text-slate-500">
+            Replies to enquiries about this {noun} go directly to the listing party.
+          </p>
+        </div>
+      </div>
+      <a
+        href="#enquire"
+        className="mt-3 inline-flex items-center gap-1 text-xs font-semibold text-amber-700 hover:text-amber-900"
+      >
+        Ask a question
+        <Icon name="arrow-right" size={12} />
+      </a>
+    </div>
+  );
+}

--- a/components/invest/lot/LotPaperTrail.tsx
+++ b/components/invest/lot/LotPaperTrail.tsx
@@ -1,0 +1,97 @@
+import Icon from "@/components/Icon";
+import {
+  hasPaperTrail,
+  type LotDocumentStatus,
+  type LotProfile,
+} from "@/lib/listings/lot-profile";
+
+/**
+ * Paper trail — provenance and documentation, the auction-catalogue
+ * section. Renders whichever evidence the listing carries:
+ *
+ *   - structured `provenance_events[]` → vertical timeline
+ *   - structured `documents[]`        → document list with status chips
+ *   - doc-ish scalar key_metrics      → stated-by-seller fact rows
+ *
+ * Everything here is seller-stated, and the footer says so — the
+ * platform's verification layer is a later phase; honesty about that *is*
+ * the trust feature.
+ */
+
+const DOC_STATUS: Record<LotDocumentStatus, { label: string; className: string }> = {
+  verified: { label: "Copy available", className: "bg-emerald-50 text-emerald-700 border-emerald-200" },
+  provided: { label: "Stated", className: "bg-slate-50 text-slate-600 border-slate-200" },
+  pending: { label: "On request", className: "bg-amber-50 text-amber-700 border-amber-200" },
+};
+
+export default function LotPaperTrail({ profile }: { profile: LotProfile }) {
+  if (!hasPaperTrail(profile)) return null;
+
+  return (
+    <div className="bg-white border border-slate-200 rounded-xl p-6">
+      <div className="flex items-center gap-2 mb-1">
+        <Icon name="file-text" size={16} className="text-slate-500" />
+        <h2 className="text-base font-bold text-slate-900">Paper trail</h2>
+      </div>
+      <p className="text-xs text-slate-500 mb-5">
+        Provenance and documentation, as stated by the seller.
+      </p>
+
+      {profile.provenanceEvents.length > 0 && (
+        <ol className="relative border-l-2 border-slate-200 ml-2 mb-5 space-y-4">
+          {profile.provenanceEvents.map((event, i) => (
+            <li key={`${event.label}-${i}`} className="ml-5">
+              <span className="absolute -left-[7px] mt-1 h-3 w-3 rounded-full border-2 border-white bg-amber-500" />
+              {event.when && (
+                <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                  {event.when}
+                </p>
+              )}
+              <p className="text-sm font-semibold text-slate-900">{event.label}</p>
+              {event.detail && <p className="text-sm text-slate-600">{event.detail}</p>}
+            </li>
+          ))}
+        </ol>
+      )}
+
+      {profile.documents.length > 0 && (
+        <ul className="space-y-2 mb-5">
+          {profile.documents.map((doc, i) => {
+            const status = DOC_STATUS[doc.status];
+            return (
+              <li
+                key={`${doc.name}-${i}`}
+                className="flex items-center justify-between gap-3 rounded-lg border border-slate-100 bg-slate-50/60 px-3 py-2"
+              >
+                <span className="flex items-center gap-2 text-sm text-slate-800 min-w-0">
+                  <Icon name="file-text" size={14} className="text-slate-400 shrink-0" />
+                  <span className="truncate">{doc.name}</span>
+                </span>
+                <span
+                  className={`shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-semibold ${status.className}`}
+                >
+                  {status.label}
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {profile.paperTrail.length > 0 && (
+        <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2.5 mb-5">
+          {profile.paperTrail.map((fact) => (
+            <div key={fact.label} className="flex items-baseline justify-between gap-3 border-b border-dotted border-slate-200 pb-1.5">
+              <dt className="text-xs text-slate-500">{fact.label}</dt>
+              <dd className="text-sm font-semibold text-slate-900 text-right">{fact.detail}</dd>
+            </div>
+          ))}
+        </dl>
+      )}
+
+      <p className="text-xs text-slate-400">
+        Request copies of any document via the enquiry form before relying on it.
+      </p>
+    </div>
+  );
+}

--- a/components/invest/lot/LotSaveButton.tsx
+++ b/components/invest/lot/LotSaveButton.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useUser } from "@/lib/hooks/useUser";
+import { getSessionId } from "@/lib/session";
+import { trackEvent } from "@/lib/tracking";
+
+/**
+ * Save/watch toggle for marketplace lot pages.
+ *
+ * Same persistence contract as `BookmarkButton` (user_bookmarks when
+ * authed, anonymous_saves + the `inv_anon_saves` localStorage mirror when
+ * not) with the lot-page treatment on top: a primary-feeling pill, a brief
+ * scale pulse on save, and a one-time "where did it go?" hint so the first
+ * save teaches the feature. Anonymous server writes fail soft until the
+ * `anonymous_saves` CHECK migration lands — localStorage keeps the state
+ * either way, which is why the anon path never reverts the star.
+ *
+ * Deliberately no confetti / streaks: the platform celebrates curiosity,
+ * not transactions (see docs/plans/LISTINGS_LOT_EXPERIENCE.md §1).
+ */
+
+const ANON_CACHE_KEY = "inv_anon_saves";
+const FIRST_SAVE_KEY = "inv_lot_first_save_seen";
+
+interface AnonSave {
+  type: string;
+  ref: string;
+}
+
+function readAnonCache(): AnonSave[] {
+  try {
+    const cached = localStorage.getItem(ANON_CACHE_KEY);
+    return cached ? (JSON.parse(cached) as AnonSave[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeAnonCache(list: AnonSave[]): void {
+  try {
+    localStorage.setItem(ANON_CACHE_KEY, JSON.stringify(list));
+  } catch {
+    /* storage unavailable — state stays in-memory */
+  }
+}
+
+export interface LotSaveButtonProps {
+  /** Listing slug — globally unique, used as the bookmark ref. */
+  slug: string;
+  title: string;
+  vertical: string;
+  /** "pill" (header) or "bar" (sticky mobile bar, compact). */
+  variant?: "pill" | "bar";
+}
+
+export default function LotSaveButton({
+  slug,
+  title,
+  vertical,
+  variant = "pill",
+}: LotSaveButtonProps) {
+  const { user } = useUser();
+  const [saved, setSaved] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [pulse, setPulse] = useState(false);
+  const [hint, setHint] = useState<string | null>(null);
+  const hintTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!user) {
+      if (readAnonCache().some((i) => i.type === "listing" && i.ref === slug)) {
+        setSaved(true);
+      }
+      return;
+    }
+    (async () => {
+      try {
+        const res = await fetch("/api/account/bookmarks", { cache: "no-store" });
+        if (!res.ok) return;
+        const json = (await res.json()) as {
+          items?: Array<{ bookmark_type: string; ref: string }>;
+        };
+        if (cancelled) return;
+        if (json.items?.some((i) => i.bookmark_type === "listing" && i.ref === slug)) {
+          setSaved(true);
+        }
+      } catch {
+        /* non-fatal — star stays empty */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [user, slug]);
+
+  useEffect(
+    () => () => {
+      if (hintTimer.current) clearTimeout(hintTimer.current);
+    },
+    [],
+  );
+
+  const showHint = (message: string) => {
+    setHint(message);
+    if (hintTimer.current) clearTimeout(hintTimer.current);
+    hintTimer.current = setTimeout(() => setHint(null), 4000);
+  };
+
+  const toggle = async () => {
+    if (busy) return;
+    setBusy(true);
+    const next = !saved;
+    setSaved(next);
+
+    if (next) {
+      setPulse(true);
+      setTimeout(() => setPulse(false), 350);
+      trackEvent("listing_save", { vertical, ref: slug, authed: Boolean(user) });
+      let firstSave = false;
+      try {
+        firstSave = !localStorage.getItem(FIRST_SAVE_KEY);
+        if (firstSave) localStorage.setItem(FIRST_SAVE_KEY, "1");
+      } catch {
+        /* ignore */
+      }
+      if (firstSave) {
+        showHint(
+          user
+            ? "Saved — find it any time in your account."
+            : "Saved on this device — sign in to keep it everywhere.",
+        );
+      }
+    } else {
+      trackEvent("listing_unsave", { vertical, ref: slug, authed: Boolean(user) });
+    }
+
+    try {
+      if (next) {
+        const body: Record<string, unknown> = {
+          type: "listing",
+          ref: slug,
+          label: title,
+        };
+        if (!user) body.session_id = getSessionId();
+        await fetch("/api/account/bookmarks", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        });
+        if (!user) {
+          const list = readAnonCache();
+          if (!list.some((i) => i.type === "listing" && i.ref === slug)) {
+            list.push({ type: "listing", ref: slug });
+            writeAnonCache(list);
+          }
+        }
+      } else if (user) {
+        await fetch("/api/account/bookmarks", {
+          method: "DELETE",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ type: "listing", ref: slug }),
+        });
+      } else {
+        writeAnonCache(
+          readAnonCache().filter((i) => !(i.type === "listing" && i.ref === slug)),
+        );
+      }
+    } catch {
+      // Anonymous saves live in localStorage regardless; only revert when
+      // the server is the source of truth.
+      if (user) setSaved(!next);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const compact = variant === "bar";
+
+  return (
+    <span className="relative inline-flex">
+      <button
+        type="button"
+        onClick={toggle}
+        disabled={busy}
+        aria-pressed={saved}
+        aria-busy={busy}
+        aria-label={saved ? `Remove ${title} from saved` : `Save ${title} for later`}
+        className={[
+          "inline-flex items-center justify-center gap-1.5 font-semibold rounded-full border transition-all duration-200",
+          compact ? "px-3 py-2 text-xs" : "px-4 py-2 text-sm",
+          saved
+            ? "bg-amber-50 border-amber-300 text-amber-800"
+            : "bg-white border-slate-300 text-slate-700 hover:border-amber-400 hover:text-amber-700",
+          pulse ? "scale-110" : "scale-100",
+        ].join(" ")}
+      >
+        <svg
+          className={compact ? "w-3.5 h-3.5" : "w-4 h-4"}
+          fill={saved ? "currentColor" : "none"}
+          stroke="currentColor"
+          strokeWidth={2}
+          viewBox="0 0 24 24"
+          aria-hidden
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"
+          />
+        </svg>
+        {saved ? "Saved" : "Save"}
+      </button>
+      <span aria-live="polite" className="sr-only">
+        {saved ? "Saved for later" : ""}
+      </span>
+      {hint && (
+        <span
+          role="status"
+          className="absolute right-0 top-full mt-2 z-30 w-56 rounded-lg bg-slate-900 text-white text-xs px-3 py-2 shadow-lg"
+        >
+          {hint}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/components/invest/lot/LotSaveButton.tsx
+++ b/components/invest/lot/LotSaveButton.tsx
@@ -74,7 +74,7 @@ export default function LotSaveButton({
   vertical,
   variant = "pill",
 }: LotSaveButtonProps) {
-  const { user } = useUser();
+  const { user, loading: userLoading } = useUser();
   const instanceId = useId();
   const [saved, setSaved] = useState(false);
   const [busy, setBusy] = useState(false);
@@ -103,14 +103,17 @@ export default function LotSaveButton({
     );
   };
 
+  // Hydrate from the membership test in BOTH directions — the component
+  // instance survives client-side navigation between lot pages, so a
+  // saved→unsaved slug change must clear the previous state, not just
+  // set it when found.
   useEffect(() => {
     let cancelled = false;
     if (!user) {
-      if (readAnonCache().some((i) => i.type === "listing" && i.ref === slug)) {
-        setSaved(true);
-      }
+      setSaved(readAnonCache().some((i) => i.type === "listing" && i.ref === slug));
       return;
     }
+    setSaved(false);
     (async () => {
       try {
         const res = await fetch("/api/account/bookmarks", { cache: "no-store" });
@@ -119,9 +122,9 @@ export default function LotSaveButton({
           items?: Array<{ bookmark_type: string; ref: string }>;
         };
         if (cancelled) return;
-        if (json.items?.some((i) => i.bookmark_type === "listing" && i.ref === slug)) {
-          setSaved(true);
-        }
+        setSaved(
+          Boolean(json.items?.some((i) => i.bookmark_type === "listing" && i.ref === slug)),
+        );
       } catch {
         /* non-fatal — star stays empty */
       }
@@ -145,7 +148,9 @@ export default function LotSaveButton({
   };
 
   const toggle = async () => {
-    if (busy) return;
+    // Until auth resolves, a signed-in user looks anonymous — saving would
+    // write a stale inv_anon_saves mirror the authed unsave never cleans.
+    if (busy || userLoading) return;
     setBusy(true);
     const next = !saved;
     setSaved(next);
@@ -246,7 +251,7 @@ export default function LotSaveButton({
       <button
         type="button"
         onClick={toggle}
-        disabled={busy}
+        disabled={busy || userLoading}
         aria-pressed={saved}
         aria-busy={busy}
         aria-label={saved ? `Remove ${title} from saved` : `Save ${title} for later`}

--- a/components/invest/lot/LotSaveButton.tsx
+++ b/components/invest/lot/LotSaveButton.tsx
@@ -191,6 +191,7 @@ export default function LotSaveButton({
     }
 
     try {
+      let res: Response;
       if (next) {
         const body: Record<string, unknown> = {
           type: "listing",
@@ -198,7 +199,7 @@ export default function LotSaveButton({
           label: title,
         };
         if (!user) body.session_id = getSessionId();
-        await fetch("/api/account/bookmarks", {
+        res = await fetch("/api/account/bookmarks", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(body),
@@ -208,11 +209,23 @@ export default function LotSaveButton({
         // without the server delete, claim-on-signup resurrects the save.
         const body: Record<string, unknown> = { type: "listing", ref: slug };
         if (!user) body.session_id = getSessionId();
-        await fetch("/api/account/bookmarks", {
+        res = await fetch("/api/account/bookmarks", {
           method: "DELETE",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(body),
         });
+      }
+      // fetch resolves on 4xx/5xx and the API can answer { ok: false } —
+      // for authed users the server is the source of truth, so a non-write
+      // must un-stick the optimistic state.
+      if (user) {
+        const ok =
+          res.ok &&
+          ((await res.json().catch(() => ({ ok: false }))) as { ok?: boolean }).ok === true;
+        if (!ok) {
+          setSaved(!next);
+          broadcast(!next);
+        }
       }
     } catch {
       // Anonymous saves live in localStorage regardless; only revert when

--- a/components/invest/lot/LotSaveButton.tsx
+++ b/components/invest/lot/LotSaveButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { useUser } from "@/lib/hooks/useUser";
 import { getSessionId } from "@/lib/session";
 import { trackEvent } from "@/lib/tracking";
@@ -22,6 +22,20 @@ import { trackEvent } from "@/lib/tracking";
 
 const ANON_CACHE_KEY = "inv_anon_saves";
 const FIRST_SAVE_KEY = "inv_lot_first_save_seen";
+
+/**
+ * Two LotSaveButtons can render for the same slug at once (header pill +
+ * mobile sticky bar). Each toggle broadcasts on this window event so the
+ * sibling stays in sync — otherwise the stale button mislabels itself and
+ * re-saves instead of unsaving.
+ */
+const SYNC_EVENT = "inv:lot-save-sync";
+
+interface LotSaveSyncDetail {
+  ref: string;
+  saved: boolean;
+  source: string;
+}
 
 interface AnonSave {
   type: string;
@@ -61,11 +75,33 @@ export default function LotSaveButton({
   variant = "pill",
 }: LotSaveButtonProps) {
   const { user } = useUser();
+  const instanceId = useId();
   const [saved, setSaved] = useState(false);
   const [busy, setBusy] = useState(false);
   const [pulse, setPulse] = useState(false);
   const [hint, setHint] = useState<string | null>(null);
   const hintTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Keep sibling instances for the same slug in sync (header pill +
+  // sticky bar both mount on mobile).
+  useEffect(() => {
+    const onSync = (e: Event) => {
+      const detail = (e as CustomEvent<LotSaveSyncDetail>).detail;
+      if (detail?.ref === slug && detail.source !== instanceId) {
+        setSaved(detail.saved);
+      }
+    };
+    window.addEventListener(SYNC_EVENT, onSync);
+    return () => window.removeEventListener(SYNC_EVENT, onSync);
+  }, [slug, instanceId]);
+
+  const broadcast = (nextSaved: boolean) => {
+    window.dispatchEvent(
+      new CustomEvent<LotSaveSyncDetail>(SYNC_EVENT, {
+        detail: { ref: slug, saved: nextSaved, source: instanceId },
+      }),
+    );
+  };
 
   useEffect(() => {
     let cancelled = false;
@@ -113,6 +149,7 @@ export default function LotSaveButton({
     setBusy(true);
     const next = !saved;
     setSaved(next);
+    broadcast(next);
 
     if (next) {
       setPulse(true);
@@ -136,6 +173,23 @@ export default function LotSaveButton({
       trackEvent("listing_unsave", { vertical, ref: slug, authed: Boolean(user) });
     }
 
+    // Anonymous state lives in localStorage first — the mirror is written
+    // BEFORE the network call so an offline/failed POST can't strand a
+    // pressed button whose save evaporates on reload.
+    if (!user) {
+      if (next) {
+        const list = readAnonCache();
+        if (!list.some((i) => i.type === "listing" && i.ref === slug)) {
+          list.push({ type: "listing", ref: slug });
+          writeAnonCache(list);
+        }
+      } else {
+        writeAnonCache(
+          readAnonCache().filter((i) => !(i.type === "listing" && i.ref === slug)),
+        );
+      }
+    }
+
     try {
       if (next) {
         const body: Record<string, unknown> = {
@@ -149,28 +203,24 @@ export default function LotSaveButton({
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(body),
         });
-        if (!user) {
-          const list = readAnonCache();
-          if (!list.some((i) => i.type === "listing" && i.ref === slug)) {
-            list.push({ type: "listing", ref: slug });
-            writeAnonCache(list);
-          }
-        }
-      } else if (user) {
+      } else {
+        // Authed: user_bookmarks row. Anonymous: the anonymous_saves row —
+        // without the server delete, claim-on-signup resurrects the save.
+        const body: Record<string, unknown> = { type: "listing", ref: slug };
+        if (!user) body.session_id = getSessionId();
         await fetch("/api/account/bookmarks", {
           method: "DELETE",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ type: "listing", ref: slug }),
+          body: JSON.stringify(body),
         });
-      } else {
-        writeAnonCache(
-          readAnonCache().filter((i) => !(i.type === "listing" && i.ref === slug)),
-        );
       }
     } catch {
       // Anonymous saves live in localStorage regardless; only revert when
       // the server is the source of truth.
-      if (user) setSaved(!next);
+      if (user) {
+        setSaved(!next);
+        broadcast(!next);
+      }
     } finally {
       setBusy(false);
     }

--- a/components/invest/lot/LotStickyActions.tsx
+++ b/components/invest/lot/LotStickyActions.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { trackEvent } from "@/lib/tracking";
+import LotSaveButton from "@/components/invest/lot/LotSaveButton";
+
+/**
+ * Mobile sticky action bar for lot pages: price + Save + Enquire, pinned to
+ * the bottom edge once the reader scrolls past the page header (an
+ * IntersectionObserver sentinel rendered by ListingDetailView). Hidden on
+ * md+ where the sidebar enquiry card is always visible.
+ *
+ * "Enquire" is an in-page anchor to `#enquire` (the sidebar form) so the
+ * bar adds zero new lead plumbing — it shortens the path to the existing
+ * one.
+ */
+export interface LotStickyActionsProps {
+  sentinelId: string;
+  priceLabel: string;
+  priceValue: string;
+  enquiryCta: string;
+  slug: string;
+  title: string;
+  vertical: string;
+}
+
+export default function LotStickyActions({
+  sentinelId,
+  priceLabel,
+  priceValue,
+  enquiryCta,
+  slug,
+  title,
+  vertical,
+}: LotStickyActionsProps) {
+  const [visible, setVisible] = useState(false);
+  const observerRef = useRef<IntersectionObserver | null>(null);
+
+  useEffect(() => {
+    const sentinel = document.getElementById(sentinelId);
+    if (!sentinel || typeof IntersectionObserver === "undefined") return;
+    observerRef.current = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (entry) setVisible(!entry.isIntersecting);
+      },
+      { rootMargin: "0px" },
+    );
+    observerRef.current.observe(sentinel);
+    return () => observerRef.current?.disconnect();
+  }, [sentinelId]);
+
+  return (
+    <div
+      aria-hidden={!visible}
+      className={[
+        "fixed inset-x-0 bottom-0 z-40 md:hidden border-t border-slate-200 bg-white/95 backdrop-blur",
+        "transition-transform duration-300",
+        visible ? "translate-y-0" : "translate-y-full",
+      ].join(" ")}
+      style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
+    >
+      <div className="flex items-center gap-3 px-4 py-2.5">
+        <div className="min-w-0 flex-1">
+          <p className="text-[10px] font-semibold uppercase tracking-wide text-slate-500">
+            {priceLabel}
+          </p>
+          <p className="text-base font-extrabold text-slate-900 truncate">{priceValue}</p>
+        </div>
+        <LotSaveButton slug={slug} title={title} vertical={vertical} variant="bar" />
+        <a
+          href="#enquire"
+          onClick={() => trackEvent("listing_sticky_enquire", { vertical, ref: slug })}
+          className="inline-flex items-center justify-center rounded-full bg-amber-500 hover:bg-amber-400 text-slate-900 text-sm font-bold px-5 py-2.5 transition-colors"
+        >
+          {enquiryCta}
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/components/invest/lot/LotStickyActions.tsx
+++ b/components/invest/lot/LotStickyActions.tsx
@@ -53,6 +53,9 @@ export default function LotStickyActions({
   return (
     <div
       aria-hidden={!visible}
+      // `inert` (React 19) removes the off-screen bar's Save/Enquire from
+      // the tab order — aria-hidden alone leaves them keyboard-focusable.
+      inert={!visible}
       className={[
         "fixed inset-x-0 bottom-0 z-40 md:hidden border-t border-slate-200 bg-white/95 backdrop-blur",
         "transition-transform duration-300",

--- a/components/invest/lot/LotTransparency.tsx
+++ b/components/invest/lot/LotTransparency.tsx
@@ -1,0 +1,82 @@
+import Icon from "@/components/Icon";
+import {
+  transparencyLevelLabel,
+  type LotTransparency as Assessment,
+} from "@/lib/listings/lot-transparency";
+
+/**
+ * Listing-transparency meter: what this listing states vs what's worth
+ * requesting, with a segment bar per check. Buyer-framed completeness —
+ * presence of information only, never an opinion on the asset — so it can
+ * render on every lot without implying a recommendation.
+ */
+export default function LotTransparency({ assessment }: { assessment: Assessment }) {
+  const stated = assessment.checks.filter((c) => c.met);
+  const missing = assessment.checks.filter((c) => !c.met);
+
+  return (
+    <div className="bg-white border border-slate-200 rounded-xl p-6">
+      <div className="flex flex-wrap items-center justify-between gap-2 mb-1">
+        <div className="flex items-center gap-2">
+          <Icon name="clipboard-list" size={16} className="text-slate-500" />
+          <h2 className="text-base font-bold text-slate-900">Listing transparency</h2>
+        </div>
+        <span className="text-xs font-semibold text-slate-600">
+          {transparencyLevelLabel(assessment.level)} · {assessment.metCount}/{assessment.total}
+        </span>
+      </div>
+      <p className="text-xs text-slate-500 mb-4">
+        How much of the full picture this listing states up front.
+      </p>
+
+      <div className="flex gap-1 mb-5" role="img" aria-label={`${assessment.metCount} of ${assessment.total} information checks stated`}>
+        {assessment.checks.map((check) => (
+          <span
+            key={check.id}
+            className={`h-1.5 flex-1 rounded-full ${check.met ? "bg-emerald-500" : "bg-slate-200"}`}
+          />
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
+        {stated.length > 0 && (
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-400 mb-2">
+              Stated in this listing
+            </p>
+            <ul className="space-y-1.5">
+              {stated.map((check) => (
+                <li key={check.id} className="flex items-center gap-2 text-sm text-slate-700">
+                  <Icon name="check-circle" size={14} className="text-emerald-600 shrink-0" />
+                  {check.label}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        {missing.length > 0 && (
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-400 mb-2">
+              Worth requesting
+            </p>
+            <ul className="space-y-1.5">
+              {missing.map((check) => (
+                <li key={check.id} className="flex items-center gap-2 text-sm text-slate-500">
+                  <Icon name="plus-circle" size={14} className="text-slate-400 shrink-0" />
+                  {check.label}
+                </li>
+              ))}
+            </ul>
+            <a
+              href="#enquire"
+              className="mt-3 inline-flex items-center gap-1 text-xs font-semibold text-amber-700 hover:text-amber-900"
+            >
+              Request these details
+              <Icon name="arrow-right" size={12} />
+            </a>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/docs/plans/LISTINGS_LOT_EXPERIENCE.md
+++ b/docs/plans/LISTINGS_LOT_EXPERIENCE.md
@@ -1,0 +1,193 @@
+# Listings Lot Experience — master build plan
+
+**Status:** Phase 1 executed (this PR) · Phases 2+ sequenced, founder-gated
+**Owner:** Fin (founder) · **Author:** Claude session · **Created:** 2026-06-11
+
+**Related:**
+`docs/plans/LISTINGS_MARKETPLACE_CONSOLIDATION.md` (D1–D7 system-of-record decisions) ·
+`docs/strategy/REGULATORY-AVOID-LIST.md` (lean-lane redlines) ·
+`lib/listing-verticals.ts` / `lib/invest-listing-routes.ts` (vertical + route SSOTs) ·
+`lib/listing-kind.ts` (kind meta SSOT) · `lib/listing-format.ts` (metric display SSOT)
+
+---
+
+## 1. Vision
+
+A listing on invest.com.au should feel like a **catalogued lot at a good auction
+house**, not a classified ad: provenance, paper trail, honest costs, honest
+liquidity, market context — presented with consumer-fintech polish on a phone.
+
+The strategic position (from the 2026-06-11 ideation thread): the reason
+alternative assets don't appear on financial platforms is missing **trust
+infrastructure**. Our lean regulatory lane (factual listing + lead routing, no
+client money, no custody, no fractionalisation) is the moat, not the
+constraint — we can be the catalogue, the comps record, and the verification
+layer without ever touching the transaction.
+
+### Design principles
+
+1. **Trust is the delight.** For money products, the Robinhood-style dopamine
+   loop is the wrong import (and an ASIC gamification red flag). What we
+   celebrate is *curiosity and understanding* — saving, comparing, learning —
+   never the transaction itself. No confetti on enquiries.
+2. **Honesty panels are the differentiator.** Holding costs, time-to-sell,
+   exit paths. The platform that says "this takes 9 months to sell" is the one
+   whose other claims you believe.
+3. **Every listing gets the full experience.** Sections degrade gracefully:
+   structured `key_metrics` light up rich modules; sparse rows fall back to
+   per-vertical editorial intelligence so nothing ever renders as an empty
+   shell.
+4. **One canonical surface.** The 11 bespoke detail pages and the generic
+   route converge on a single `ListingDetailView` — per-vertical flavour
+   lives in a registry, not in forked JSX.
+5. **Compliance is wired in, not bolted on.** `GENERAL_ADVICE_WARNING`,
+   "general information only — not an offer or recommendation" (the
+   listed-securities precedent), past-sales caveats, and licence-mode gates
+   (`SHOW_GENERIC_VERIFIED`) ship inside the components.
+
+---
+
+## 2. Information architecture (the lot page, top to bottom)
+
+| Zone | Module | Data source | Fallback |
+|---|---|---|---|
+| Header | Breadcrumb · kind badge · FIRB/SIV chips · title · location · **Save** | listing row + `LISTING_KIND_META` | — |
+| Hero | Image gallery | `images[]` | vertical hero image (existing) |
+| Price card | Price + per-vertical highlight metric (farmland → hectares, mining → commodity…) | `formatListingPrice` + intel registry | "Price on application" |
+| Facts | Key-metrics grid | `listingDisplayMetrics` (full set) | hidden |
+| Story | About section | `description` | hidden |
+| **Field guide** | "New to {category}? What buyers check" — due-diligence checklist + guide link | intel registry | registry default |
+| **Paper trail** | Provenance timeline (structured) or doc-fact list (scalar keys: provenance, documentation, grading…) | `lot-profile` parser | hidden + transparency nudge |
+| **Transparency** | Listing-completeness meter: what's stated, what to request | `lot-transparency` scorer | always renders |
+| **Costs** | Holding-cost grid (structured) or typical-costs editorial | parser → registry | registry |
+| **Liquidity & exit** | Time-to-sell + liquidity narrative + exit paths | parser → registry | registry |
+| **Comps** | Comparable-sales table + past-sales caveat | `comparable_sales[]` in `key_metrics` | hidden |
+| FIRB | Eligibility explainer (vertical-specific note) | `firb_eligible` + registry | generic copy |
+| Sidebar | Enquiry form (`#enquire`) · decision tools (after-tax, FIRB fee) · lister card · view counts | existing components | — |
+| Mobile | **Sticky action bar**: price + Save + Enquire (appears after hero scrolls past) | client island | — |
+| Footer | Related lots · category CTA · compliance notice | existing | — |
+
+### The save moment
+
+Saving is the platform's first commitment gesture, so it gets the care:
+instant optimistic toggle, a one-time "Saved — find it any time in My Options"
+hint on first ever save, `aria-live` announcement, and event tracking. Works
+logged-out (localStorage mirror + anonymous_saves once the CHECK lands) and
+logged-in (user_bookmarks — **no constraint, works today**).
+
+---
+
+## 3. Data model strategy
+
+**No new tables in Phase 1.** Everything rides `investment_listings.key_metrics`
+(JSONB) with documented conventions, parsed defensively:
+
+```jsonc
+{
+  // structured modules (all optional, all arrays tolerant of bad entries)
+  "provenance_events": [{ "year": 2019, "label": "Acquired at Shannons auction" }],
+  "documents":         [{ "name": "Independent valuation", "status": "verified" }],
+  "comparable_sales":  [{ "label": "380ha Riverina aggregation", "price": "$3.8M", "when": "Nov 2025" }],
+  "holding_costs":     [{ "label": "Storage & insurance", "amount": "$2,400/yr" }],
+  "typical_time_to_sell": "6–18 months",
+  // scalar doc-ish keys fold into the paper trail automatically
+  "provenance": "full build sheet and ownership history",
+  "matching_numbers": true
+}
+```
+
+Existing seed rows (e.g. the GT-HO collectibles) already carry doc-ish scalars,
+so the paper trail lights up on real data from day one.
+
+**Schema changes in this PR (file only — founder runs `db push` per DB rules):**
+`20260611140000_anonymous_saves_listing_type.sql` extends the
+`anonymous_saves.bookmark_type` CHECK with `'listing'`. Until applied, anonymous
+listing-saves persist in localStorage only (the existing mirror pattern);
+authed saves are unaffected. Fails soft everywhere.
+
+**Phase 2+ (founder-gated, from the consolidation plan):** `owner_user_id`
+ownership migration, `listing_entities` (org profiles with vertical-aware
+labels), entity follows/drop alerts, sold-price archive columns. Each is
+designed in the ideation thread; none block Phase 1.
+
+---
+
+## 4. Component breakdown
+
+```
+lib/listings/
+  lot-profile.ts        parser: key_metrics → typed LotProfile (zod, never throws)
+  vertical-intel.ts     per-category editorial registry (headings, nouns, FIRB
+                        notes, highlight metrics, due diligence, costs,
+                        liquidity, exit paths) + DEFAULT fallback
+  lot-transparency.ts   completeness scorer → level + present/missing items
+
+components/invest/lot/
+  LotSaveButton.tsx     client · optimistic save w/ anon fallback + first-save hint
+  LotStickyActions.tsx  client · mobile bottom bar (IntersectionObserver sentinel)
+  LotFieldGuide.tsx     server · <details> due-diligence explainer
+  LotPaperTrail.tsx     server · provenance timeline / doc-fact list
+  LotTransparency.tsx   server · completeness meter + request-docs nudge
+  LotHoldingCosts.tsx   server · structured grid or editorial typical costs
+  LotLiquidityExit.tsx  server · liquidity narrative + exit paths
+  LotComparables.tsx    server · comps table + caveat
+  LotListerCard.tsx     server · lister identity from key_metrics (entity layer later)
+
+components/invest/ListingDetailView.tsx   composes all of the above (v2)
+```
+
+Route consolidation: 9 of the 11 bespoke
+`app/invest/<cat>/listings/[slug]/page.tsx` detail branches swap their forked
+JSX for the shared view (metadata + subcategory branches stay bespoke — those
+genuinely differ).
+
+**Deliberately NOT migrated: `startups` and `pre-ipo`.** Their bespoke pages
+carry the s708 wholesale gating (`WholesaleAttestationGate` around raise
+terms, wholesale-only notices, risk warnings) that the shared view does not
+yet compose. Removing that gating autonomously would violate the avoid-list.
+They join the shared surface only when it gains gate-aware slots, designed
+under the s708 workstream (consolidation plan D4) with founder + legal
+sign-off.
+
+---
+
+## 5. Compliance redlines (checked against REGULATORY-AVOID-LIST)
+
+- Factual presentation only; no appreciation/return promises anywhere in
+  registry copy. Comps carry "Past sales are not an indicator of future
+  prices."
+- No transaction mechanics: enquiry remains the only action (lead routing).
+- "Verified" language gates behind `SHOW_GENERIC_VERIFIED`.
+- Capital-markets verticals (startups, pre-ipo, funds) keep their existing
+  posture; registry entries for them are risk-forward and change no gating.
+  The s708 wholesale gate remains a separate, legal-gated workstream (D4).
+- No engagement streaks/leaderboards on money actions (ASIC INFO 251-adjacent
+  gamification concern). Delight = clarity + responsiveness only.
+
+## 6. Analytics
+
+`trackEvent` on: `listing_save` / `listing_unsave` (vertical, listing id,
+authed flag), `listing_sticky_enquire` (mobile bar tap). Enquiry submission
+events already exist in `ListingEnquiryForm`.
+
+## 7. Test plan
+
+- `lot-profile`: rich seed-shaped km, structured arrays, malformed entries
+  skipped, empty km.
+- `vertical-intel`: every `LISTING_PAGE_SLUGS` slug resolves with non-empty
+  required fields; unknown slug → DEFAULT.
+- `lot-transparency`: sparse vs documented vs comprehensive; missing-items
+  correctness.
+- Components (jsdom): LotSaveButton toggle + anon localStorage path +
+  aria-pressed; LotPaperTrail structured/scalar variants; LotFieldGuide render.
+
+## 8. Sequencing after this PR
+
+1. Founder: `supabase db push` for the bookmark-type migration (Tier-E ledger
+   rules apply — reconcile M05 drift first).
+2. Entity profiles (`listing_entities`) per the ideation design — needs the
+   ownership migration window.
+3. Follows + drop alerts (rides the rate-alert mailer engine).
+4. Sold archive + comps capture (the data moat), then category pilots
+   (water rights / whisky casks / heritage plates) with asset-passport
+   schemas per vertical.

--- a/lib/bookmarks.ts
+++ b/lib/bookmarks.ts
@@ -16,6 +16,7 @@
  * empty result so the bookmark star never breaks the page.
  */
 
+// eslint-disable-next-line no-restricted-imports -- anonymous paths (anonymous_saves has deny-all-anon RLS, no JWT available) + cross-user claim replay (claimAnonymousSaves); both documented exceptions in CLAUDE.md § "Two Supabase clients"
 import { createAdminClient } from "@/lib/supabase/admin";
 import { logger } from "@/lib/logger";
 
@@ -26,7 +27,12 @@ export type BookmarkType =
   | "broker"
   | "advisor"
   | "scenario"
-  | "calculator";
+  | "calculator"
+  // Marketplace listings (lot pages). NOTE: `anonymous_saves` carries a
+  // CHECK constraint on bookmark_type — anonymous listing-saves fail soft
+  // (localStorage only) until 20260611140000_anonymous_saves_listing_type
+  // is applied. `user_bookmarks` has no CHECK, so authed saves work now.
+  | "listing";
 
 export interface BookmarkRow {
   id: number;

--- a/lib/bookmarks.ts
+++ b/lib/bookmarks.ts
@@ -136,6 +136,31 @@ export async function addAnonymousSave(input: {
   }
 }
 
+/**
+ * Remove an anonymous save (the unsave half of `addAnonymousSave`).
+ * Without this, an anonymous save that the visitor later unsaves
+ * lingers server-side and `claimAnonymousSaves` resurrects it into
+ * `user_bookmarks` when they sign in.
+ */
+export async function removeAnonymousSave(input: {
+  sessionId: string;
+  type: BookmarkType;
+  ref: string;
+}): Promise<boolean> {
+  try {
+    const supabase = createAdminClient();
+    const { error } = await supabase
+      .from("anonymous_saves")
+      .delete()
+      .eq("session_id", input.sessionId)
+      .eq("bookmark_type", input.type)
+      .eq("ref", input.ref);
+    return !error;
+  } catch {
+    return false;
+  }
+}
+
 export async function listAnonymousSaves(
   sessionId: string,
 ): Promise<Array<Pick<BookmarkRow, "bookmark_type" | "ref" | "label" | "created_at">>> {

--- a/lib/listing-kind.ts
+++ b/lib/listing-kind.ts
@@ -52,7 +52,7 @@ export function deriveListingKind(row: DerivableListing): ListingKind {
 
   if (v === "royalties" || km["stage"] === "royalty" || km["royalty_type"]) return "royalty";
 
-  if (["buy-business", "franchise"].includes(v)) return "for_sale_business";
+  if (["business", "buy-business", "franchise"].includes(v)) return "for_sale_business";
   if (["commercial_property", "commercial-property", "farmland", "livestock"].includes(v)) return "for_sale_asset";
   if (["startups", "startup", "pre_ipo", "pre-ipo"].includes(v)) return "equity_raise";
 

--- a/lib/listing-kind.ts
+++ b/lib/listing-kind.ts
@@ -383,10 +383,23 @@ export function formatListingPrice(l: DerivableListing & { price_display?: strin
     return { label: meta.priceLabel, value: l.price_display };
   }
 
+  const km = (l.key_metrics ?? {}) as Record<string, unknown>;
+
+  // Franchise / business rows often state only a minimum entry cost
+  // (key_metrics.min_investment_cents — already in cents). The bespoke
+  // franchise page rendered it as "Total Investment From"; without this
+  // branch those rows regress to "Price on application".
+  if (kind === "for_sale_business" && !l.asking_price_cents) {
+    const rawMinCents = km["min_investment_cents"];
+    const minCents = typeof rawMinCents === "number" ? rawMinCents : Number(rawMinCents);
+    if (Number.isFinite(minCents) && minCents > 0) {
+      return { label: "Total investment from", value: formatAudCompact(minCents) };
+    }
+  }
+
   // Fund / project equity: prefer min_investment from key_metrics when
   // it's set and no asking_price was; this is the case for most fund
   // and project rows whose "price" is really a min-commitment.
-  const km = (l.key_metrics ?? {}) as Record<string, unknown>;
   const minInvest = km["min_investment_aud"] ?? km["min_commit_aud"] ?? km["min_investment"];
   if ((kind === "fund" || kind === "project_equity") && minInvest != null && !l.asking_price_cents) {
     return { label: meta.priceLabel, value: typeof minInvest === "number" ? formatAudCompact(minInvest * 100) : String(minInvest) };

--- a/lib/listings/lot-profile.ts
+++ b/lib/listings/lot-profile.ts
@@ -1,0 +1,205 @@
+import { z } from "zod";
+import {
+  humanizeTitle,
+  formatMetricValue,
+  listingDisplayMetrics,
+  type DisplayMetric,
+} from "@/lib/listing-format";
+
+/**
+ * Lot profile — the structured "catalogue entry" view of a listing's
+ * `key_metrics` JSONB.
+ *
+ * The marketplace stores everything bespoke about a listing in
+ * `investment_listings.key_metrics`. This module is the single place that
+ * turns that free-form blob into the typed sections the lot page renders:
+ *
+ *   - **Structured modules** (all optional): `provenance_events[]`,
+ *     `documents[]`, `comparable_sales[]`, `holding_costs[]`,
+ *     `typical_time_to_sell`, `liquidity_note`. Sellers/admins opt in by
+ *     writing these conventions; each array item is validated individually
+ *     and bad entries are dropped, never thrown.
+ *   - **Doc-ish scalars**: existing rows (e.g. the collectibles seeds) carry
+ *     keys like `provenance`, `documentation`, `matching_numbers`,
+ *     `service`. Those fold into the "paper trail" section automatically so
+ *     the lot page lights up on real data without re-seeding.
+ *   - **Facts**: whatever remains renders through the existing
+ *     `listingDisplayMetrics` SSOT (skip-list + humanisation), so the fact
+ *     grid stays consistent with cards.
+ *
+ * Parsing is total: any input shape returns a usable (possibly empty)
+ * profile.
+ */
+
+export interface ProvenanceEvent {
+  when?: string;
+  label: string;
+  detail?: string;
+}
+
+export type LotDocumentStatus = "provided" | "verified" | "pending";
+
+export interface LotDocument {
+  name: string;
+  status: LotDocumentStatus;
+  note?: string;
+}
+
+export interface ComparableSale {
+  label: string;
+  price?: string;
+  when?: string;
+  source?: string;
+}
+
+export interface HoldingCost {
+  label: string;
+  amount?: string;
+  note?: string;
+}
+
+export interface PaperTrailFact {
+  label: string;
+  detail: string;
+}
+
+export interface LotProfile {
+  /** Curated key-metrics grid (price/yield/noise already skipped). */
+  facts: DisplayMetric[];
+  /** Doc-ish scalar keys folded into provenance/paper-trail facts. */
+  paperTrail: PaperTrailFact[];
+  provenanceEvents: ProvenanceEvent[];
+  documents: LotDocument[];
+  comparables: ComparableSale[];
+  holdingCosts: HoldingCost[];
+  timeToSell?: string;
+  liquidityNote?: string;
+}
+
+const asText = z
+  .union([z.string(), z.number()])
+  .transform((v) => String(v).trim())
+  .pipe(z.string().min(1).max(300));
+
+const ProvenanceEventSchema = z.object({
+  when: asText.optional(),
+  year: asText.optional(),
+  label: asText,
+  detail: asText.optional(),
+});
+
+const DocumentSchema = z.object({
+  name: asText,
+  status: z.enum(["provided", "verified", "pending"]).catch("provided"),
+  note: asText.optional(),
+});
+
+const ComparableSchema = z.object({
+  label: asText,
+  price: asText.optional(),
+  when: asText.optional(),
+  source: asText.optional(),
+});
+
+const HoldingCostSchema = z.object({
+  label: asText,
+  amount: asText.optional(),
+  note: asText.optional(),
+});
+
+/** Reserved structured keys — consumed by this parser, never shown in the
+ *  generic fact grid. */
+const STRUCTURED_KEYS = new Set([
+  "provenance_events",
+  "documents",
+  "comparable_sales",
+  "holding_costs",
+  "typical_time_to_sell",
+  "liquidity_note",
+]);
+
+/** Scalar keys that read as evidence/paper-trail rather than specs. Matched
+ *  as whole key or by stem so seeded data (`provenance`, `documentation`,
+ *  `history_file`, `service`, `grading`…) is picked up without listing every
+ *  variant. */
+const PAPER_TRAIL_KEY =
+  /(provenance|document|history|certificat|grading|graded|registration|rego\b|licen[cs]e|permit|valuation|survey|inspection|warranty|service|restoration|books|build_sheet|matching_numbers|title_search|coa\b)/i;
+
+function parseItems<T>(value: unknown, schema: z.ZodType<T>): T[] {
+  if (!Array.isArray(value)) return [];
+  const out: T[] = [];
+  for (const item of value) {
+    const parsed = schema.safeParse(item);
+    if (parsed.success) out.push(parsed.data);
+    if (out.length >= 20) break;
+  }
+  return out;
+}
+
+function parseScalarText(value: unknown, max = 200): string | undefined {
+  const parsed = asText.safeParse(value);
+  if (!parsed.success) return undefined;
+  return parsed.data.slice(0, max);
+}
+
+/** Max entries surfaced in the detail-page fact grid. */
+const FACT_LIMIT = 12;
+
+export function buildLotProfile(
+  km: Record<string, unknown> | null | undefined,
+): LotProfile {
+  const metrics = km ?? {};
+
+  const provenanceEvents = parseItems(
+    metrics.provenance_events,
+    ProvenanceEventSchema,
+  ).map((e) => ({
+    when: e.when ?? e.year,
+    label: e.label,
+    detail: e.detail,
+  }));
+
+  const documents = parseItems(metrics.documents, DocumentSchema);
+  const comparables = parseItems(metrics.comparable_sales, ComparableSchema);
+  const holdingCosts = parseItems(metrics.holding_costs, HoldingCostSchema);
+
+  const paperTrail: PaperTrailFact[] = [];
+  const factSource: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(metrics)) {
+    if (STRUCTURED_KEYS.has(key)) continue;
+    if (value == null || value === "") continue;
+    if (
+      PAPER_TRAIL_KEY.test(key) &&
+      (typeof value === "string" ||
+        typeof value === "boolean" ||
+        typeof value === "number")
+    ) {
+      paperTrail.push({
+        label: humanizeTitle(key),
+        detail: formatMetricValue(key, value),
+      });
+      continue;
+    }
+    factSource[key] = value;
+  }
+
+  return {
+    facts: listingDisplayMetrics(factSource, FACT_LIMIT),
+    paperTrail: paperTrail.slice(0, 12),
+    provenanceEvents,
+    documents,
+    comparables,
+    holdingCosts,
+    timeToSell: parseScalarText(metrics.typical_time_to_sell, 80),
+    liquidityNote: parseScalarText(metrics.liquidity_note, 280),
+  };
+}
+
+/** True when the lot has any provenance/document evidence to show. */
+export function hasPaperTrail(profile: LotProfile): boolean {
+  return (
+    profile.paperTrail.length > 0 ||
+    profile.provenanceEvents.length > 0 ||
+    profile.documents.length > 0
+  );
+}

--- a/lib/listings/lot-profile.ts
+++ b/lib/listings/lot-profile.ts
@@ -183,8 +183,22 @@ export function buildLotProfile(
     factSource[key] = value;
   }
 
+  // `stage` sits on the card formatter's skip-list (derivation input —
+  // the kind badge reflects it on compact cards), but on the lot page
+  // "exploration / construction / operating" is substantive detail the
+  // old Object.entries renders always showed. Surface it explicitly.
+  const facts = listingDisplayMetrics(factSource, FACT_LIMIT);
+  const stage = parseScalarText(metrics.stage, 40);
+  if (stage) {
+    facts.unshift({
+      key: "stage",
+      label: "Stage",
+      value: humanizeTitle(stage),
+    });
+  }
+
   return {
-    facts: listingDisplayMetrics(factSource, FACT_LIMIT),
+    facts,
     paperTrail: paperTrail.slice(0, 12),
     provenanceEvents,
     documents,

--- a/lib/listings/lot-transparency.ts
+++ b/lib/listings/lot-transparency.ts
@@ -1,0 +1,110 @@
+import { hasPaperTrail, type LotProfile } from "@/lib/listings/lot-profile";
+
+/**
+ * Listing-transparency assessment — the buyer-facing completeness meter on
+ * the lot page.
+ *
+ * Frames completeness from the buyer's side ("what this listing states /
+ * what's worth requesting") rather than scoring the seller. The checks are
+ * deliberately factual — presence of information, never quality of the
+ * asset — so the meter can render on every listing without implying any
+ * recommendation.
+ */
+
+export type TransparencyLevel = "essential" | "documented" | "comprehensive";
+
+export interface TransparencyCheck {
+  id: string;
+  /** Buyer-framed label, e.g. "Pricing stated". */
+  label: string;
+  met: boolean;
+}
+
+export interface LotTransparency {
+  level: TransparencyLevel;
+  /** 0–100, met/total rounded. */
+  score: number;
+  checks: TransparencyCheck[];
+  metCount: number;
+  total: number;
+}
+
+export interface TransparencyInput {
+  asking_price_cents?: number | null;
+  price_display?: string | null;
+  description?: string | null;
+  images?: string[] | null;
+  location_state?: string | null;
+  location_city?: string | null;
+}
+
+const LEVEL_LABELS: Record<TransparencyLevel, string> = {
+  essential: "Essentials stated",
+  documented: "Well documented",
+  comprehensive: "Comprehensively documented",
+};
+
+export function transparencyLevelLabel(level: TransparencyLevel): string {
+  return LEVEL_LABELS[level];
+}
+
+export function assessLotTransparency(
+  listing: TransparencyInput,
+  profile: LotProfile,
+): LotTransparency {
+  const checks: TransparencyCheck[] = [
+    {
+      id: "pricing",
+      label: "Pricing stated",
+      met: Boolean(listing.price_display) || Boolean(listing.asking_price_cents),
+    },
+    {
+      id: "description",
+      label: "Detailed description",
+      met: (listing.description ?? "").trim().length >= 300,
+    },
+    {
+      id: "photos",
+      label: "Photos provided",
+      met: (listing.images ?? []).length >= 2,
+    },
+    {
+      id: "location",
+      label: "Location stated",
+      met: Boolean(listing.location_state) || Boolean(listing.location_city),
+    },
+    {
+      id: "facts",
+      label: "Key facts itemised",
+      met: profile.facts.length >= 4,
+    },
+    {
+      id: "paper_trail",
+      label: "Provenance / documents noted",
+      met: hasPaperTrail(profile),
+    },
+    {
+      id: "costs",
+      label: "Holding costs disclosed",
+      met: profile.holdingCosts.length >= 1,
+    },
+    {
+      id: "liquidity",
+      label: "Time-to-sell guidance",
+      met: Boolean(profile.timeToSell) || Boolean(profile.liquidityNote),
+    },
+  ];
+
+  const metCount = checks.filter((c) => c.met).length;
+  const total = checks.length;
+  const level: TransparencyLevel =
+    metCount >= 7 ? "comprehensive" : metCount >= 4 ? "documented" : "essential";
+
+  return {
+    level,
+    score: Math.round((metCount / total) * 100),
+    checks,
+    metCount,
+    total,
+  };
+}

--- a/lib/listings/vertical-intel.ts
+++ b/lib/listings/vertical-intel.ts
@@ -1,0 +1,569 @@
+/**
+ * Per-category editorial intelligence for the lot (listing detail) page.
+ *
+ * One registry entry per `/invest/<slug>/listings` category carrying the
+ * copy that used to be forked across the bespoke detail pages (headings,
+ * enquiry nouns, FIRB notes) plus the "field guide" content that makes a
+ * sparse listing still feel substantive: what buyers typically check,
+ * typical holding costs, an honest liquidity picture, and realistic exit
+ * paths.
+ *
+ * Editorial redlines (REGULATORY-AVOID-LIST · lean lane):
+ *   - Factual/general information only — describe what buyers *check* and
+ *     what costs *exist*, never what will perform or what anyone should do.
+ *   - No return promises, no "expected to appreciate", no urgency framing.
+ *   - Capital-markets entries (startups, pre-ipo, funds, private-equity,
+ *     venture flavours) stay risk-forward and change no gating posture.
+ *
+ * Keyed by route category slug (see `lib/invest-listing-routes.ts`).
+ * Unknown slugs get DEFAULT_INTEL so the lot page never renders empty.
+ */
+
+export interface VerticalIntel {
+  /** "property" / "project" / "company" / "business" / "asset". */
+  noun: string;
+  detailsHeading: string;
+  aboutHeading: string;
+  enquiryHeading: string;
+  enquirySubcopy: string;
+  /** key_metrics keys promoted next to the price (first present wins). */
+  highlightMetricKeys: string[];
+  /** Vertical-specific FIRB sentence (falls back to generic copy). */
+  firbNote?: string;
+  /** "What buyers typically check" — factual due-diligence checklist. */
+  dueDiligence: string[];
+  /** Typical ongoing-cost lines when the listing states none. */
+  typicalCosts: string[];
+  /** Honest liquidity narrative for the asset class. */
+  liquidity: string;
+  /** Realistic ways out of the position. */
+  exitPaths: string[];
+  /** Extra risk-forward line for higher-risk verticals. */
+  riskNote?: string;
+}
+
+const DEFAULT_INTEL: VerticalIntel = {
+  noun: "opportunity",
+  detailsHeading: "Opportunity Details",
+  aboutHeading: "About This Opportunity",
+  enquiryHeading: "Enquire About This Opportunity",
+  enquirySubcopy: "Send a confidential enquiry to the listing team.",
+  highlightMetricKeys: [],
+  dueDiligence: [
+    "Verify the seller's identity and ABN before sharing personal details",
+    "Ask for every claim in the listing to be backed by a document",
+    "Get independent legal and financial advice before committing funds",
+    "Confirm how and where your money is held during the transaction",
+  ],
+  typicalCosts: [
+    "Legal and due-diligence fees at purchase",
+    "Ongoing holding or management costs — ask for a full schedule",
+    "Selling costs when you exit (agent, broker or auction fees)",
+  ],
+  liquidity:
+    "Private-market assets rarely sell quickly. Plan on months, not days, to find a buyer at fair value.",
+  exitPaths: ["Private sale", "Specialist broker or agent", "Auction"],
+};
+
+const INTEL: Record<string, VerticalIntel> = {
+  "buy-business": {
+    noun: "business",
+    detailsHeading: "Key Metrics",
+    aboutHeading: "About This Business",
+    enquiryHeading: "Enquire About This Business",
+    enquirySubcopy: "Send a confidential enquiry to the broker or owner.",
+    highlightMetricKeys: ["annual_ebitda", "annual_profit", "years_established"],
+    firbNote:
+      "Foreign buyers may need FIRB approval depending on the deal size and sector. Check the current thresholds before signing.",
+    dueDiligence: [
+      "Three years of financials, verified by your own accountant",
+      "Whether profit depends on the current owner staying involved",
+      "Lease terms, key contracts and whether they transfer with the sale",
+      "Why the owner is selling — and whether staff and customers know",
+    ],
+    typicalCosts: [
+      "Stamp duty and legal fees at purchase (varies by state)",
+      "Working capital from day one — most sales exclude it",
+      "Transition costs: training, rebranding, systems",
+    ],
+    liquidity:
+      "Small businesses typically take 6–12 months to sell, and many never find a buyer at the asking price.",
+    exitPaths: ["Trade sale to a competitor", "Sale via business broker", "Management or staff buyout"],
+  },
+  franchise: {
+    noun: "franchise",
+    detailsHeading: "Franchise Details",
+    aboutHeading: "About This Franchise",
+    enquiryHeading: "Enquire About This Franchise",
+    enquirySubcopy: "Send a confidential enquiry to the franchisor or broker.",
+    highlightMetricKeys: ["initial_investment", "franchise_term_years", "sites"],
+    dueDiligence: [
+      "The disclosure document and franchise agreement, reviewed by a franchise lawyer",
+      "Earnings claims tested against existing franchisees you contact yourself",
+      "Territory rights, renewal terms and what happens at end of term",
+      "Total entry cost including fit-out, stock and working capital — not just the franchise fee",
+    ],
+    typicalCosts: [
+      "Ongoing royalties and marketing levies (usually % of revenue)",
+      "Mandatory refurbishment cycles in the agreement",
+      "Equipment and POS systems specified by the franchisor",
+    ],
+    liquidity:
+      "Reselling a franchise needs franchisor consent and an approved buyer — exits routinely take 6–12 months.",
+    exitPaths: ["Resale to a franchisor-approved buyer", "Sale back to the franchisor (if offered)", "End-of-term non-renewal"],
+  },
+  mining: {
+    noun: "project",
+    detailsHeading: "Project Details",
+    aboutHeading: "About This Project",
+    enquiryHeading: "Enquire About This Project",
+    enquirySubcopy: "Send a confidential enquiry to the project team.",
+    highlightMetricKeys: ["commodity", "jorc_resource", "tenement_area"],
+    firbNote:
+      "Mining tenements are a sensitive sector — foreign buyers generally need FIRB notification regardless of value.",
+    dueDiligence: [
+      "Tenement standing: granted vs application, expiry and annual commitments",
+      "JORC resource statements vs exploration targets — they are not the same thing",
+      "Environmental bonds, rehabilitation liabilities and native-title status",
+      "Whether stated metallurgy and infrastructure access are verified or assumed",
+    ],
+    typicalCosts: [
+      "Annual tenement rent and minimum expenditure commitments",
+      "Environmental bonding and compliance reporting",
+      "Care-and-maintenance costs if the project pauses",
+    ],
+    liquidity:
+      "Project-level mining interests trade infrequently and prices swing with the commodity cycle. Exits can take years in a weak market.",
+    exitPaths: ["Trade sale to a producer or explorer", "Joint-venture farm-out", "Vend into a listed vehicle"],
+    riskNote:
+      "Exploration-stage projects are speculative: most never reach production.",
+  },
+  farmland: {
+    noun: "property",
+    detailsHeading: "Property Details",
+    aboutHeading: "About This Property",
+    enquiryHeading: "Enquire About This Property",
+    enquirySubcopy: "Send a confidential enquiry to the selling agent.",
+    highlightMetricKeys: ["hectares", "water_entitlement_ml", "rainfall_mm"],
+    firbNote:
+      "Foreign buyers generally need FIRB approval for agricultural land above the cumulative $15M threshold — check your position before bidding.",
+    dueDiligence: [
+      "Water entitlements: volume, security class and whether they're included in the sale",
+      "Soil tests, carrying capacity and rainfall history — not just the marketing figures",
+      "Access, easements and any leases or agistment agreements in place",
+      "Chemical-use and contamination history for cropping country",
+    ],
+    typicalCosts: [
+      "Council rates and (state-dependent) land tax",
+      "Fencing, weed and pest control — ongoing, not optional",
+      "Insurance and any water-delivery charges",
+    ],
+    liquidity:
+      "Rural property sells on a seasonal clock: well-priced country can move in a campaign, but 6–18 months is common for larger holdings.",
+    exitPaths: ["Private treaty via rural agency", "Auction or expression-of-interest campaign", "Sale-and-leaseback to an operator"],
+  },
+  "commercial-property": {
+    noun: "property",
+    detailsHeading: "Property Details",
+    aboutHeading: "About This Property",
+    enquiryHeading: "Enquire About This Property",
+    enquirySubcopy: "Send a confidential enquiry to the selling agent.",
+    highlightMetricKeys: ["net_lettable_area_sqm", "wale", "occupancy_pct"],
+    firbNote:
+      "Foreign buyers of commercial property face FIRB thresholds that vary by property type and buyer country — confirm before contracting.",
+    dueDiligence: [
+      "Lease audit: WALE, incentives, make-good clauses and arrears history",
+      "Tenant covenant strength — who actually pays the rent",
+      "Outgoings recoveries, capex history and building condition reports",
+      "Zoning, permitted use and anything affecting re-letting",
+    ],
+    typicalCosts: [
+      "Land tax, rates and insurance (check what's recoverable from tenants)",
+      "Property management fees",
+      "Capex and incentives at each lease expiry",
+    ],
+    liquidity:
+      "Commercial sales commonly run 3–9 months from listing to settlement, longer when credit is tight or the asset has vacancy.",
+    exitPaths: ["On-market campaign via commercial agency", "Off-market sale to a syndicate or private buyer", "Auction for sub-$5M assets"],
+  },
+  "renewable-energy": {
+    noun: "project",
+    detailsHeading: "Project Details",
+    aboutHeading: "About This Project",
+    enquiryHeading: "Register Your Interest",
+    enquirySubcopy: "Send a confidential enquiry to the project team.",
+    highlightMetricKeys: ["capacity_mw", "ppa_term_years", "technology"],
+    dueDiligence: [
+      "Grid connection status: agreed, applied-for, or aspirational",
+      "Offtake/PPA terms and counterparty strength",
+      "Development approvals, land tenure and community standing",
+      "Curtailment and marginal-loss-factor history for the region",
+    ],
+    typicalCosts: [
+      "O&M contracts and inverter/turbine replacement reserves",
+      "Land lease payments and council rates",
+      "Insurance and network charges",
+    ],
+    liquidity:
+      "Operating projects with contracted revenue attract institutional buyers; development-stage assets can take years to exit.",
+    exitPaths: ["Sale to an infrastructure fund or utility", "Refinance and hold", "Portfolio aggregation sale"],
+  },
+  startups: {
+    noun: "company",
+    detailsHeading: "Company Details",
+    aboutHeading: "About This Company",
+    enquiryHeading: "Express Interest",
+    enquirySubcopy: "Send a confidential enquiry to the founding team.",
+    highlightMetricKeys: ["stage", "arr", "team_size"],
+    dueDiligence: [
+      "The actual security on offer (ordinary shares, preference shares, SAFE) and your rights in it",
+      "Burn rate, runway and the assumptions behind revenue claims",
+      "Cap table: who owns what, and what happens to you in the next raise",
+      "Founder vesting and key-person dependency",
+    ],
+    typicalCosts: [
+      "Follow-on raises will dilute you if you don't participate",
+      "Legal review of the share subscription documents",
+      "No income: returns, if any, arrive only at an exit event",
+    ],
+    liquidity:
+      "There is generally no market for private startup shares. Expect to hold for 5–10 years, with a real chance of total loss.",
+    exitPaths: ["Trade sale or acquisition", "IPO (rare)", "Secondary sale if the company permits one"],
+    riskNote:
+      "Early-stage investing is high risk: most startups fail. Only invest what you can afford to lose entirely.",
+  },
+  alternatives: {
+    noun: "asset",
+    detailsHeading: "Asset Details",
+    aboutHeading: "About This Asset",
+    enquiryHeading: "Enquire About This Asset",
+    enquirySubcopy: "Send a confidential enquiry to the seller or dealer.",
+    highlightMetricKeys: ["year", "grading", "rarity"],
+    dueDiligence: [
+      "Provenance: ownership history and supporting documents, not just the story",
+      "Independent authentication or grading from a recognised body",
+      "Condition report and any restoration work disclosed in writing",
+      "Where the asset is held now, and who insures it until settlement",
+    ],
+    typicalCosts: [
+      "Specialist insurance (often ~1% of value per year)",
+      "Storage in appropriate conditions",
+      "Authentication, valuation and selling commissions at exit",
+    ],
+    liquidity:
+      "Collectable markets are thin and taste-driven. Selling well can take months and usually means auction-house commissions of 10–25%.",
+    exitPaths: ["Specialist auction house", "Dealer consignment", "Private sale to a collector"],
+    riskNote:
+      "Collectables produce no income and prices depend entirely on what the next buyer will pay.",
+  },
+  "private-credit": {
+    noun: "opportunity",
+    detailsHeading: "Facility Details",
+    aboutHeading: "About This Opportunity",
+    enquiryHeading: "Request the Information Memorandum",
+    enquirySubcopy: "Send a confidential enquiry to the manager.",
+    highlightMetricKeys: ["target_yield_pct", "ltv", "term_months"],
+    dueDiligence: [
+      "What sits behind the headline yield: borrower quality, security and ranking",
+      "LVR methodology and who valued the collateral",
+      "Manager track record through a full credit cycle, including losses",
+      "Redemption terms — and what happens when redemptions are frozen",
+    ],
+    typicalCosts: [
+      "Management and performance fees netted from the stated yield",
+      "Early-withdrawal restrictions or penalties",
+      "Tax: distributions are generally income, not capital gains",
+    ],
+    liquidity:
+      "Private credit is hold-to-maturity in practice. Redemption windows can close exactly when you most want out.",
+    exitPaths: ["Hold to facility maturity", "Scheduled redemption window", "Secondary transfer if the manager allows"],
+    riskNote:
+      "Higher yield means higher risk of borrower default — these are not bank deposits.",
+  },
+  infrastructure: {
+    noun: "project",
+    detailsHeading: "Project Details",
+    aboutHeading: "About This Project",
+    enquiryHeading: "Enquire About This Project",
+    enquirySubcopy: "Send a confidential enquiry to the manager.",
+    highlightMetricKeys: ["asset_type", "concession_term_years", "target_yield_pct"],
+    dueDiligence: [
+      "Revenue model: contracted, regulated or patronage-exposed",
+      "Concession/lease terms and end-of-term hand-back obligations",
+      "Gearing levels and refinancing dates",
+      "Counterparty and regulatory-reset risk",
+    ],
+    typicalCosts: [
+      "Management fees within the holding vehicle",
+      "Lifecycle capex obligations",
+      "Debt-service ahead of any distributions",
+    ],
+    liquidity:
+      "Unlisted infrastructure stakes change hands slowly and in large parcels; exits are negotiated, not instant.",
+    exitPaths: ["Sale to an infrastructure fund", "Stake transfer at refinancing events", "Hold through concession term"],
+  },
+  funds: {
+    noun: "fund",
+    detailsHeading: "Fund Details",
+    aboutHeading: "About This Fund",
+    enquiryHeading: "Request Fund Information",
+    enquirySubcopy: "Send a confidential enquiry to the fund manager.",
+    highlightMetricKeys: ["aum_billions", "mer_bps", "strategy"],
+    dueDiligence: [
+      "Read the PDS or IM in full — especially fees, gates and redemption terms",
+      "Whether the fund is registered with ASIC and who the responsible entity is",
+      "Manager track record net of fees, over periods that include drawdowns",
+      "How the underlying assets are valued and how often",
+    ],
+    typicalCosts: [
+      "Management fees (MER) and any performance fees",
+      "Buy/sell spreads on entry and exit",
+      "Indirect costs disclosed deep in the PDS",
+    ],
+    liquidity:
+      "Unlisted fund liquidity is set by the manager: monthly or quarterly windows are common, and gates can suspend redemptions entirely.",
+    exitPaths: ["Redemption via the manager's window", "Transfer if the constitution permits", "Wind-up distributions"],
+    riskNote:
+      "Consider the PDS and target market determination before deciding. Past performance is not an indicator of future performance.",
+  },
+  "pre-ipo": {
+    noun: "company",
+    detailsHeading: "Company Details",
+    aboutHeading: "About This Company",
+    enquiryHeading: "Express Interest",
+    enquirySubcopy: "Send a confidential enquiry to the offer team.",
+    highlightMetricKeys: ["stage", "target_listing_window", "last_round_valuation"],
+    dueDiligence: [
+      "The basis for the valuation — and how it compares to the last priced round",
+      "Whether 'pre-IPO' has a committed timetable or is aspirational",
+      "Escrow terms that lock your shares after any float",
+      "Your information rights as a minority holder if the IPO never happens",
+    ],
+    typicalCosts: [
+      "Placement or broker fees built into the entry price",
+      "Legal review of the subscription documents",
+      "No income while you wait for a liquidity event",
+    ],
+    liquidity:
+      "If the IPO is delayed or shelved — which happens often — there may be no way to sell for years.",
+    exitPaths: ["IPO and post-escrow sale", "Trade sale of the company", "Negotiated secondary sale"],
+    riskNote:
+      "Pre-IPO offers are typically restricted to wholesale/sophisticated investors and carry a real risk the listing never occurs.",
+  },
+  "private-equity": {
+    noun: "opportunity",
+    detailsHeading: "Deal Details",
+    aboutHeading: "About This Opportunity",
+    enquiryHeading: "Request the Information Memorandum",
+    enquirySubcopy: "Send a confidential enquiry to the sponsor.",
+    highlightMetricKeys: ["sector", "ebitda", "hold_period_years"],
+    dueDiligence: [
+      "The sponsor's realised (not paper) track record",
+      "Fee stack: management, performance, transaction and monitoring fees",
+      "Leverage in the deal structure and covenant headroom",
+      "Alignment: how much of the sponsor's own money is in",
+    ],
+    typicalCosts: [
+      "Committed-capital fees even before money is drawn",
+      "Capital calls on your schedule, not yours",
+      "Carried interest on exit profits",
+    ],
+    liquidity:
+      "PE commitments are typically locked for 7–10 years. Secondary sales exist but usually at a discount.",
+    exitPaths: ["Sponsor-led exit (trade sale/IPO)", "Secondary-market sale at a discount", "Fund wind-down distributions"],
+    riskNote:
+      "Generally wholesale-investor territory: concentrated, leveraged and illiquid.",
+  },
+  royalties: {
+    noun: "royalty",
+    detailsHeading: "Royalty Details",
+    aboutHeading: "About This Royalty",
+    enquiryHeading: "Enquire About This Royalty",
+    enquirySubcopy: "Send a confidential enquiry to the seller.",
+    highlightMetricKeys: ["royalty_rate", "underlying_asset", "remaining_term"],
+    dueDiligence: [
+      "The legal instrument: what exactly the royalty attaches to and for how long",
+      "Payment history and the counterparty's ability to keep paying",
+      "What happens on sale, insolvency or shut-in of the underlying asset",
+      "Audit rights to verify the revenue you're paid on",
+    ],
+    typicalCosts: [
+      "Legal review of the royalty deed",
+      "Ongoing audit/verification of payments",
+      "Tax treatment varies — get specific advice",
+    ],
+    liquidity:
+      "Royalty interests are bespoke contracts with few natural buyers; exits are negotiated and slow.",
+    exitPaths: ["Sale to a royalty aggregator", "Buy-back by the operator", "Hold to expiry"],
+  },
+  "listed-securities": {
+    noun: "security",
+    detailsHeading: "Security Details",
+    aboutHeading: "About This Security",
+    enquiryHeading: "How to Invest",
+    enquirySubcopy: "This security trades on the ASX — buy via your own broker.",
+    highlightMetricKeys: ["asx_ticker", "market_cap", "sector"],
+    dueDiligence: [
+      "Recent ASX announcements and financial reports on the company page",
+      "Liquidity: average daily volume vs the parcel you'd want to sell",
+      "How this listing's theme exposure matches what the company actually earns",
+    ],
+    typicalCosts: [
+      "Brokerage on each trade",
+      "Buy/sell spread, wider on small caps",
+    ],
+    liquidity:
+      "Listed on the ASX — generally saleable any trading day, though small caps can gap on thin volume.",
+    exitPaths: ["Sell on-market via your broker"],
+    riskNote:
+      "Factual listing only — not an offer or recommendation. Invest via your own broker after your own research.",
+  },
+  "digital-infrastructure": {
+    noun: "asset",
+    detailsHeading: "Asset Details",
+    aboutHeading: "About This Asset",
+    enquiryHeading: "Enquire About This Asset",
+    enquirySubcopy: "Send a confidential enquiry to the operator.",
+    highlightMetricKeys: ["asset_type", "capacity", "contract_term_years"],
+    dueDiligence: [
+      "Customer contracts: term, churn history and concentration",
+      "Power costs and supply security (the real cost driver)",
+      "Technology-refresh obligations and obsolescence risk",
+      "Connectivity/network position vs competitors",
+    ],
+    typicalCosts: [
+      "Power and cooling (often the largest line)",
+      "Maintenance and equipment refresh cycles",
+      "Insurance and security compliance",
+    ],
+    liquidity:
+      "Operating digital-infrastructure assets attract institutional interest but sell through long negotiated processes.",
+    exitPaths: ["Sale to a data-centre or fibre platform", "Sale-and-leaseback", "Refinance and hold"],
+  },
+  "income-assets": {
+    noun: "asset",
+    detailsHeading: "Asset Details",
+    aboutHeading: "About This Asset",
+    enquiryHeading: "Enquire About This Asset",
+    enquirySubcopy: "Send a confidential enquiry to the seller.",
+    highlightMetricKeys: ["net_yield_pct", "contract_term_years", "operator"],
+    dueDiligence: [
+      "The contract behind the income: who pays, for how long, with what outs",
+      "Whether the stated yield is gross or net of all costs",
+      "Counterparty strength and replacement risk if they walk",
+      "What the asset is worth without the income contract",
+    ],
+    typicalCosts: [
+      "Management or servicing fees against the income stream",
+      "Maintenance/insurance obligations that sit with you",
+      "Re-contracting costs at term end",
+    ],
+    liquidity:
+      "Income assets sell on their remaining contract term — shorter tail, smaller buyer pool, slower exit.",
+    exitPaths: ["Sale with contract in place", "Sale to the income counterparty", "Run off the contract and sell the residual asset"],
+  },
+  bullion: {
+    noun: "holding",
+    detailsHeading: "Holding Details",
+    aboutHeading: "About This Holding",
+    enquiryHeading: "Enquire About This Holding",
+    enquirySubcopy: "Send a confidential enquiry to the dealer.",
+    highlightMetricKeys: ["metal", "weight", "purity"],
+    dueDiligence: [
+      "Accredited refiner bars (e.g. LBMA-listed) vs generic — it affects resale",
+      "Where the metal is held: allocated, unallocated or in your possession",
+      "Premium over spot you're paying now vs the spread you'll get back",
+      "Audit and insurance arrangements for vaulted metal",
+    ],
+    typicalCosts: [
+      "Vault storage and insurance (typically 0.5–1%/yr)",
+      "Dealer spread on both buy and sell",
+      "Transport and assay if you take delivery",
+    ],
+    liquidity:
+      "Recognised bars and coins are among the more liquid physical assets — reputable dealers quote daily — but spreads widen in stressed markets.",
+    exitPaths: ["Sell back to a bullion dealer", "Private sale", "Consign to auction for numismatic pieces"],
+  },
+  "water-rights": {
+    noun: "entitlement",
+    detailsHeading: "Entitlement Details",
+    aboutHeading: "About This Entitlement",
+    enquiryHeading: "Enquire About This Entitlement",
+    enquirySubcopy: "Send a confidential enquiry to the water broker.",
+    highlightMetricKeys: ["volume_ml", "security_class", "catchment"],
+    dueDiligence: [
+      "Register search confirming ownership, encumbrances and the exact entitlement class",
+      "Allocation history for that class and catchment across wet and dry years",
+      "Carryover rules and delivery constraints in the relevant system",
+      "Your broker's standing under the water-markets intermediaries code",
+    ],
+    typicalCosts: [
+      "Annual entitlement and delivery fees to the water authority",
+      "Broker commission on trades",
+      "Registry transfer fees",
+    ],
+    liquidity:
+      "Major catchments (e.g. southern Murray–Darling) trade actively in season; smaller systems can be very thin. Allocation water moves faster than permanent entitlement.",
+    exitPaths: ["Permanent transfer via a licensed water broker", "Annual allocation trade while you hold", "Sale bundled with land"],
+    riskNote:
+      "Water entitlements are property rights, not financial products — but values swing hard with rainfall and policy.",
+  },
+  "carbon-credits": {
+    noun: "project",
+    detailsHeading: "Project Details",
+    aboutHeading: "About This Project",
+    enquiryHeading: "Enquire About This Project",
+    enquirySubcopy: "Send a confidential enquiry to the project proponent.",
+    highlightMetricKeys: ["method", "accus_issued", "project_term_years"],
+    dueDiligence: [
+      "Registration status with the Clean Energy Regulator and the method used",
+      "Issuance history vs forward projections (projections are not credits)",
+      "Permanence obligations and reversal risk for sequestration projects",
+      "Whether you're being offered the land/project interest or the units themselves",
+    ],
+    typicalCosts: [
+      "Audit and reporting costs across the project life",
+      "Land management obligations for vegetation methods",
+      "Brokerage on any unit sales",
+    ],
+    liquidity:
+      "ACCU spot markets exist but project-level interests are bespoke and slow to trade.",
+    exitPaths: ["Sell issued units via accredited brokers", "Sell the project interest", "Contract forward delivery"],
+    riskNote:
+      "ACCUs are financial products — dealing in the units themselves involves licensed intermediaries. This page is general information only.",
+  },
+  "sda-housing": {
+    noun: "property",
+    detailsHeading: "Property Details",
+    aboutHeading: "About This Property",
+    enquiryHeading: "Enquire About This Property",
+    enquirySubcopy: "Send a confidential enquiry to the provider.",
+    highlightMetricKeys: ["sda_category", "sil_provider", "enrolment_status"],
+    dueDiligence: [
+      "SDA enrolment status and design category certification — in writing",
+      "Tenancy: actual participant demand in that location, not state-wide stats",
+      "The SIL provider relationship and what happens if they exit",
+      "Vacancy assumptions behind any income projections",
+    ],
+    typicalCosts: [
+      "Specialist property management (higher than standard residential)",
+      "Compliance, audit and certification renewals",
+      "Higher fit-out maintenance obligations",
+    ],
+    liquidity:
+      "A purpose-built SDA dwelling has a narrow resale market — investors who understand the scheme — and can take many months to sell.",
+    exitPaths: ["Sale to another SDA investor", "Sale to a specialist fund", "Conversion to mainstream rental (usually at lower income)"],
+    riskNote:
+      "Income depends on government policy settings and participant demand; neither is guaranteed.",
+  },
+};
+
+/** Resolve the registry entry for a category slug (DEFAULT for unknowns). */
+export function intelForCategory(slug: string): VerticalIntel {
+  return INTEL[slug] ?? DEFAULT_INTEL;
+}
+
+/** Slugs with a dedicated registry entry (exported for tests). */
+export const INTEL_SLUGS: readonly string[] = Object.keys(INTEL);
+
+export { DEFAULT_INTEL };

--- a/scripts/check-jsonld-coverage.mjs
+++ b/scripts/check-jsonld-coverage.mjs
@@ -52,6 +52,9 @@ const WRAPPER_COMPONENTS = [
   "CountryHubTemplate",
   "ListingSchemaScripts",
   "ListingProductSchema",
+  // Shared lot page — renders breadcrumb JSON-LD + ListingSchemaScripts
+  // for every /invest/<cat>/listings/<slug> detail route.
+  "ListingDetailView",
   "ForeignInvestmentLocalizedPage",
   "ForeignInvestmentSubPage",
   "JsonLd",

--- a/supabase/migrations/20260611140000_anonymous_saves_listing_type.sql
+++ b/supabase/migrations/20260611140000_anonymous_saves_listing_type.sql
@@ -6,6 +6,11 @@
 -- persist in localStorage only (the existing BookmarkButton mirror
 -- pattern) and the server insert is silently skipped.
 --
+-- The drop is by DETECTED name, not a hard-coded one: environments that
+-- predate the baseline squash may carry the constraint under a different
+-- auto-generated name (e.g. anonymous_saves_type_check), and dropping a
+-- hard-coded name there would abort the migration.
+--
 -- Rollback strategy: recreate the constraint without 'listing' after
 -- deleting any rows with bookmark_type = 'listing':
 --   DELETE FROM public.anonymous_saves WHERE bookmark_type = 'listing';
@@ -14,25 +19,39 @@
 --     CHECK (bookmark_type = ANY (ARRAY['article','broker','advisor','scenario','calculator']));
 
 DO $$
+DECLARE
+  stale record;
 BEGIN
-  IF EXISTS (
-    SELECT 1
-    FROM information_schema.constraint_column_usage ccu
-    JOIN pg_constraint c ON c.conname = ccu.constraint_name
-    WHERE ccu.table_schema = 'public'
-      AND ccu.table_name = 'anonymous_saves'
-      AND ccu.column_name = 'bookmark_type'
+  -- Drop every CHECK on bookmark_type that does not yet allow 'listing',
+  -- whatever it happens to be named in this environment.
+  FOR stale IN
+    SELECT c.conname
+    FROM pg_constraint c
+    JOIN pg_class t ON t.oid = c.conrelid
+    JOIN pg_namespace n ON n.oid = t.relnamespace
+    WHERE n.nspname = 'public'
+      AND t.relname = 'anonymous_saves'
       AND c.contype = 'c'
+      AND pg_get_constraintdef(c.oid) LIKE '%bookmark_type%'
       AND pg_get_constraintdef(c.oid) NOT LIKE '%listing%'
-  ) THEN
-    ALTER TABLE public.anonymous_saves
-      DROP CONSTRAINT anonymous_saves_bookmark_type_check;
-  END IF;
+  LOOP
+    EXECUTE format(
+      'ALTER TABLE public.anonymous_saves DROP CONSTRAINT %I',
+      stale.conname
+    );
+  END LOOP;
 
+  -- Re-add under the canonical name unless a listing-aware CHECK on
+  -- bookmark_type already exists (idempotent re-run / drifted name).
   IF NOT EXISTS (
     SELECT 1
-    FROM pg_constraint
-    WHERE conname = 'anonymous_saves_bookmark_type_check'
+    FROM pg_constraint c
+    JOIN pg_class t ON t.oid = c.conrelid
+    JOIN pg_namespace n ON n.oid = t.relnamespace
+    WHERE n.nspname = 'public'
+      AND t.relname = 'anonymous_saves'
+      AND c.contype = 'c'
+      AND pg_get_constraintdef(c.oid) LIKE '%bookmark_type%'
   ) THEN
     ALTER TABLE public.anonymous_saves
       ADD CONSTRAINT anonymous_saves_bookmark_type_check

--- a/supabase/migrations/20260611140000_anonymous_saves_listing_type.sql
+++ b/supabase/migrations/20260611140000_anonymous_saves_listing_type.sql
@@ -1,0 +1,48 @@
+-- Extend anonymous_saves.bookmark_type CHECK with 'listing' so anonymous
+-- visitors can save marketplace lot pages server-side (the lot-page save
+-- button; authed saves use user_bookmarks, which has no type CHECK).
+--
+-- Until this is applied the feature fails soft: anonymous listing-saves
+-- persist in localStorage only (the existing BookmarkButton mirror
+-- pattern) and the server insert is silently skipped.
+--
+-- Rollback strategy: recreate the constraint without 'listing' after
+-- deleting any rows with bookmark_type = 'listing':
+--   DELETE FROM public.anonymous_saves WHERE bookmark_type = 'listing';
+--   ALTER TABLE public.anonymous_saves DROP CONSTRAINT anonymous_saves_bookmark_type_check;
+--   ALTER TABLE public.anonymous_saves ADD CONSTRAINT anonymous_saves_bookmark_type_check
+--     CHECK (bookmark_type = ANY (ARRAY['article','broker','advisor','scenario','calculator']));
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.constraint_column_usage ccu
+    JOIN pg_constraint c ON c.conname = ccu.constraint_name
+    WHERE ccu.table_schema = 'public'
+      AND ccu.table_name = 'anonymous_saves'
+      AND ccu.column_name = 'bookmark_type'
+      AND c.contype = 'c'
+      AND pg_get_constraintdef(c.oid) NOT LIKE '%listing%'
+  ) THEN
+    ALTER TABLE public.anonymous_saves
+      DROP CONSTRAINT anonymous_saves_bookmark_type_check;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'anonymous_saves_bookmark_type_check'
+  ) THEN
+    ALTER TABLE public.anonymous_saves
+      ADD CONSTRAINT anonymous_saves_bookmark_type_check
+      CHECK (bookmark_type = ANY (ARRAY[
+        'article'::text,
+        'broker'::text,
+        'advisor'::text,
+        'scenario'::text,
+        'calculator'::text,
+        'listing'::text
+      ]));
+  END IF;
+END $$;


### PR DESCRIPTION
Executes Phase 1 of `docs/plans/LISTINGS_LOT_EXPERIENCE.md` (committed in this PR): listing detail pages become catalogued "lot pages" with structured trust sections, a save-to-watchlist moment, and a mobile sticky action bar — built schema-free on `key_metrics` conventions plus a per-vertical editorial registry, so every existing row (including current seeds) renders the full experience today.

## What's in the lot page now
- **Paper trail** — provenance timeline / document status chips / doc-ish scalar facts (`provenance`, `matching_numbers`, …) with explicit seller-stated framing
- **Listing transparency meter** — buyer-framed "stated vs worth requesting" checks, linked to the enquiry form
- **What it costs to hold / Getting your money out** — honest holding-cost, liquidity and exit-path panels with class-level fallbacks per vertical
- **Comparable sales** — with the past-performance caveat baked in
- **Field guide** — per-category "what buyers check" due-diligence checklist (`lib/listings/vertical-intel.ts`, guard-tested against promissory copy)
- **Save** (anon + authed) with a one-time first-save hint; **sticky mobile bar** (price · Save · Enquire)
- Kind + freshness badges, per-vertical headings/FIRB notes, `GENERAL_ADVICE_WARNING` + not-an-offer footer

## Consolidation
9 bespoke `app/invest/<cat>/listings/[slug]` pages now compose the shared `ListingDetailView` (~1,790 lines of forked JSX deleted). **`startups` and `pre-ipo` are deliberately not migrated** — their pages carry the s708 wholesale gating (`WholesaleAttestationGate`, wholesale notices) that the shared view doesn't compose yet; they follow under the D4 workstream with founder + legal sign-off.

## ⚠️ Migration shipped, not applied (founder-pushed per DB rules)
`20260611140000_anonymous_saves_listing_type.sql` extends the `anonymous_saves.bookmark_type` CHECK with `'listing'`. Until applied, anonymous listing-saves persist in localStorage only (existing mirror pattern) and the server insert fails soft; **authed saves work immediately** (`user_bookmarks` has no type CHECK). Nothing breaks if the push waits — note the standing M05 ledger-drift reconciliation gate before any `db push`.

## Tests
42 new tests (lot-profile parser, vertical-intel registry incl. no-promissory-copy guard, transparency scorer, LotSaveButton incl. anon fail-soft + authed delete, LotPaperTrail). Full component suite (184 files / 1,647 tests) green after the `setup.tsx` change that makes `mockUseUser` an overridable `vi.hoisted` handle (default behaviour unchanged). `type-check` and `lint` clean.

Founder QA suggestion: open any farmland or alternatives lot on a phone — the collectibles seed rows (GT-HO etc.) light up the paper trail without any data changes.

https://claude.ai/code/session_014BbPNUuda1bCvnkM782p9c

---
_Generated by [Claude Code](https://claude.ai/code/session_014BbPNUuda1bCvnkM782p9c)_