### PR TITLE
feat(journey): Feel layer v2 completion — claim-sync, journey-aware zero state, profile milestone

### DIFF
--- a/__tests__/components/BookmarksList.test.tsx
+++ b/__tests__/components/BookmarksList.test.tsx
@@ -31,10 +31,11 @@ const SAMPLE_ITEMS = [
 
 describe("BookmarksList", () => {
   describe("empty state", () => {
-    it("shows the EmptyState heading when there are no bookmarks", () => {
+    it("shows the journey-aware EmptyState heading when there are no bookmarks", () => {
       render(<BookmarksList initialItems={[]} />);
+      // Fresh visitor (no journey milestones in this jsdom) → Stage 1: Curious.
       expect(
-        screen.getByText("Your reading list is empty"),
+        screen.getByText(/Stage 1: Curious — nothing saved yet/),
       ).toBeInTheDocument();
     });
 

--- a/app/account/bookmarks/BookmarksList.tsx
+++ b/app/account/bookmarks/BookmarksList.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { journeySnapshot } from "@/lib/journey";
 import { useMemo, useState } from "react";
 import Link from "next/link";
 import EmptyState from "@/components/directory/EmptyState";
@@ -63,11 +64,17 @@ export default function BookmarksList({ initialItems }: Props) {
   }, [items]);
 
   if (items.length === 0) {
+    // Journey-aware zero state: name the stage and point at the next step
+    // instead of presenting a void.
+    const journey = journeySnapshot();
     return (
       <EmptyState
         icon="file-text"
-        title="Your reading list is empty"
-        body="Tap the bookmark icon on any article, broker or advisor page to save it here for later."
+        title={`Stage ${journey.stage.level}: ${journey.stage.name} — nothing saved yet`}
+        body={
+          journey.stage.nextHint ??
+          "Tap the bookmark icon on any article, broker or advisor page to save it here for later."
+        }
         ctas={[
           { label: "Browse brokers", href: "/compare" },
           { label: "Explore guides", href: "/learn", variant: "secondary" },

--- a/app/find-advisor/page.tsx
+++ b/app/find-advisor/page.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import Image from "next/image";
 import { ProgressBar } from "@/components/ui/ProgressBar";
+import { fireJourneyMoment } from "@/components/journey/journeyMoment";
 import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
 import { Select } from "@/components/ui/Select";
@@ -330,6 +331,9 @@ export default function FindAdvisorPage() {
 }
 
 function FindAdvisorQuiz() {
+  // Journey milestone: completing the matching flow = investor profile done.
+  // (Declared early so hook order is stable; fires once when step 6 confirms.)
+
   const searchParams = useSearchParams();
   const needParam = searchParams.get("need");
   const handoffToken = searchParams.get("handoff");
@@ -446,6 +450,9 @@ function FindAdvisorQuiz() {
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [submitted, setSubmitted] = useState(!!savedMatch);
+  useEffect(() => {
+    if (quiz.step === 6 && submitted) fireJourneyMoment("profile_complete");
+  }, [quiz.step, submitted]);
   // ADV-008: whether the "Resume your quiz" banner should still show. Hidden
   // once the user resumes or dismisses it.
   const [showResumePrompt, setShowResumePrompt] = useState(!!resumableQuiz);

--- a/components/ClaimAnonymousOnAuth.tsx
+++ b/components/ClaimAnonymousOnAuth.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from "react";
 import { useUser } from "@/lib/hooks/useUser";
 import { getSessionId } from "@/lib/session";
+import { useToast } from "@/components/Toast";
 
 /**
  * Global trigger that fires /api/account/claim-anonymous once
@@ -24,6 +25,7 @@ import { getSessionId } from "@/lib/session";
  */
 export default function ClaimAnonymousOnAuth() {
   const { user, loading } = useUser();
+  const { toast } = useToast();
   const fired = useRef(false);
 
   useEffect(() => {
@@ -54,7 +56,17 @@ export default function ClaimAnonymousOnAuth() {
         if (!res.ok) return;
         try {
           sessionStorage.setItem(`inv_claimed_${user.id}`, "1");
+          // Sync moment: tell the user their pre-auth saves made it home.
+          const cached = localStorage.getItem("inv_anon_saves");
+          const count = cached ? (JSON.parse(cached) as unknown[]).length : 0;
           localStorage.removeItem("inv_anon_saves");
+          if (count > 0) {
+            toast(
+              count === 1 ? "Your saved item is now in your account" : `Your ${count} saves are now in your account`,
+              "success",
+              3000,
+            );
+          }
         } catch {
           /* ignore */
         }
@@ -63,7 +75,7 @@ export default function ClaimAnonymousOnAuth() {
         // Non-blocking — the user can still use the site
         // without their pre-auth state migrated.
       });
-  }, [user, loading]);
+  }, [user, loading, toast]);
 
   return null;
 }


### PR DESCRIPTION
Completes the Feel-layer v2 backlog items that need no product decisions — all five journey milestones now have live wire points:

- **Claim-sync moment** — when a new account claims pre-auth saves, a toast confirms it ("Your N saves are now in your account"); the count comes from the local `inv_anon_saves` cache read just before it's cleared.
- **Journey-aware zero state** — `/account/bookmarks` empty state now names the visitor's stage and points at the stage's next step instead of presenting a void.
- **`profile_complete` milestone** — the find-advisor step-6 confirmation fires the fifth and final milestone, tipping the stage ladder to *Decision-ready*.

Remaining v2 items deliberately left for product decisions: streak UI (needs a check-in surface choice) and lifecycle-journey visualisation (needs hub placement) — both noted in FIN_NOTEBOOK.

Checks: tsc clean · lint clean · journey + find-advisor suites green (50 tests).

https://claude.ai/code/session_0143tmNcofbgYFt1ufE8Gkmi

---
_Generated by [Claude Code](https://claude.ai/code/session_0143tmNcofbgYFt1ufE8Gkmi)_