### PR TITLE
revert: feat(journey): Feel layer v2 completion (#1561) — restore green main

### DIFF
--- a/__tests__/components/BookmarksList.test.tsx
+++ b/__tests__/components/BookmarksList.test.tsx
@@ -31,11 +31,10 @@ const SAMPLE_ITEMS = [
 
 describe("BookmarksList", () => {
   describe("empty state", () => {
-    it("shows the journey-aware EmptyState heading when there are no bookmarks", () => {
+    it("shows the EmptyState heading when there are no bookmarks", () => {
       render(<BookmarksList initialItems={[]} />);
-      // Fresh visitor (no journey milestones in this jsdom) → Stage 1: Curious.
       expect(
-        screen.getByText(/Stage 1: Curious — nothing saved yet/),
+        screen.getByText("Your reading list is empty"),
       ).toBeInTheDocument();
     });
 

--- a/app/account/bookmarks/BookmarksList.tsx
+++ b/app/account/bookmarks/BookmarksList.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { journeySnapshot } from "@/lib/journey";
 import { useMemo, useState } from "react";
 import Link from "next/link";
 import EmptyState from "@/components/directory/EmptyState";
@@ -64,17 +63,11 @@ export default function BookmarksList({ initialItems }: Props) {
   }, [items]);
 
   if (items.length === 0) {
-    // Journey-aware zero state: name the stage and point at the next step
-    // instead of presenting a void.
-    const journey = journeySnapshot();
     return (
       <EmptyState
         icon="file-text"
-        title={`Stage ${journey.stage.level}: ${journey.stage.name} — nothing saved yet`}
-        body={
-          journey.stage.nextHint ??
-          "Tap the bookmark icon on any article, broker or advisor page to save it here for later."
-        }
+        title="Your reading list is empty"
+        body="Tap the bookmark icon on any article, broker or advisor page to save it here for later."
         ctas={[
           { label: "Browse brokers", href: "/compare" },
           { label: "Explore guides", href: "/learn", variant: "secondary" },

--- a/app/find-advisor/page.tsx
+++ b/app/find-advisor/page.tsx
@@ -5,7 +5,6 @@ import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import Image from "next/image";
 import { ProgressBar } from "@/components/ui/ProgressBar";
-import { fireJourneyMoment } from "@/components/journey/journeyMoment";
 import { Button } from "@/components/ui/Button";
 import { Input } from "@/components/ui/Input";
 import { Select } from "@/components/ui/Select";
@@ -331,9 +330,6 @@ export default function FindAdvisorPage() {
 }
 
 function FindAdvisorQuiz() {
-  // Journey milestone: completing the matching flow = investor profile done.
-  // (Declared early so hook order is stable; fires once when step 6 confirms.)
-
   const searchParams = useSearchParams();
   const needParam = searchParams.get("need");
   const handoffToken = searchParams.get("handoff");
@@ -450,9 +446,6 @@ function FindAdvisorQuiz() {
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [submitted, setSubmitted] = useState(!!savedMatch);
-  useEffect(() => {
-    if (quiz.step === 6 && submitted) fireJourneyMoment("profile_complete");
-  }, [quiz.step, submitted]);
   // ADV-008: whether the "Resume your quiz" banner should still show. Hidden
   // once the user resumes or dismisses it.
   const [showResumePrompt, setShowResumePrompt] = useState(!!resumableQuiz);

--- a/components/ClaimAnonymousOnAuth.tsx
+++ b/components/ClaimAnonymousOnAuth.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useRef } from "react";
 import { useUser } from "@/lib/hooks/useUser";
 import { getSessionId } from "@/lib/session";
-import { useToast } from "@/components/Toast";
 
 /**
  * Global trigger that fires /api/account/claim-anonymous once
@@ -25,7 +24,6 @@ import { useToast } from "@/components/Toast";
  */
 export default function ClaimAnonymousOnAuth() {
   const { user, loading } = useUser();
-  const { toast } = useToast();
   const fired = useRef(false);
 
   useEffect(() => {
@@ -56,17 +54,7 @@ export default function ClaimAnonymousOnAuth() {
         if (!res.ok) return;
         try {
           sessionStorage.setItem(`inv_claimed_${user.id}`, "1");
-          // Sync moment: tell the user their pre-auth saves made it home.
-          const cached = localStorage.getItem("inv_anon_saves");
-          const count = cached ? (JSON.parse(cached) as unknown[]).length : 0;
           localStorage.removeItem("inv_anon_saves");
-          if (count > 0) {
-            toast(
-              count === 1 ? "Your saved item is now in your account" : `Your ${count} saves are now in your account`,
-              "success",
-              3000,
-            );
-          }
         } catch {
           /* ignore */
         }
@@ -75,7 +63,7 @@ export default function ClaimAnonymousOnAuth() {
         // Non-blocking — the user can still use the site
         // without their pre-auth state migrated.
       });
-  }, [user, loading, toast]);
+  }, [user, loading]);
 
   return null;
 }


### PR DESCRIPTION
Restores green main. `65a282b0` reverted the Feel layer #1557 (bundle budget +58.5 kB) but missed #1561, whose imports of the deleted `@/lib/journey` / `@/components/journey/journeyMoment` have failed `tsc` on every main commit since (the auto-revert workflow then misfired at the innocent #1555 — closed as misdiagnosed with diagnosis). This completes the revert: 4 files, pure Feel-layer wiring, mechanically exact inverse of #1561. Verified locally: `tsc --noEmit` exits 0. Feel layer v1+v2 re-lands together once the bundle optimisations from the original revert message are done. Founder-approved in session.

https://claude.ai/code/session_01M6yzew4xrq9NVrmZHbRrj4

---
_Generated by [Claude Code](https://claude.ai/code/session_01M6yzew4xrq9NVrmZHbRrj4)_