### PR TITLE
fix(advisor-portal): self-heal NULL auth_user_id so advisors can reach their portal

### DIFF
--- a/__tests__/lib/portal-gate.test.ts
+++ b/__tests__/lib/portal-gate.test.ts
@@ -16,6 +16,11 @@ vi.mock("@/lib/account-kinds", () => ({
   setActiveKind: (k: string) => mockSetActiveKind(k),
 }));
 
+const mockLinkProfessionalAuthUser = vi.fn();
+vi.mock("@/lib/professional-auth-link", () => ({
+  linkProfessionalAuthUser: (...a: unknown[]) => mockLinkProfessionalAuthUser(...a),
+}));
+
 // redirect() throws in Next; emulate so we can assert on it.
 const mockRedirect = vi.fn((url: string) => {
   throw new Error(`REDIRECT:${url}`);
@@ -29,8 +34,9 @@ import { enforcePortalKind } from "@/lib/portal-gate";
 describe("enforcePortalKind", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetUser.mockResolvedValue({ data: { user: { id: "u1" } } });
+    mockGetUser.mockResolvedValue({ data: { user: { id: "u1", email: "pro@example.com" } } });
     mockSetActiveKind.mockResolvedValue(undefined);
+    mockLinkProfessionalAuthUser.mockResolvedValue(0); // default: nothing to heal
   });
 
   it("allows a brand-new 0-kind user into the investor workspace (AJ-10)", async () => {
@@ -110,5 +116,34 @@ describe("enforcePortalKind", () => {
     mockGetKindsForUser.mockResolvedValue([]);
     mockSetActiveKind.mockRejectedValue(new Error("blocked"));
     await expect(enforcePortalKind("investor")).resolves.toBeUndefined();
+  });
+
+  // P0: ~98% of active advisors have a NULL auth_user_id, so the membership
+  // view reports zero kinds and the gate would lock them out of their own
+  // portal. The gate self-heals the link on email match and re-resolves.
+  it("self-heals an unlinked advisor (NULL auth_user_id) and lets them into the portal", async () => {
+    mockGetActiveKind.mockResolvedValue(null);
+    // First resolve: view still reports no kinds (unlinked). After the heal
+    // links the row, the second resolve surfaces the advisor kind.
+    mockGetKindsForUser
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ kind: "advisor" }]);
+    mockLinkProfessionalAuthUser.mockResolvedValue(1);
+
+    await expect(enforcePortalKind("advisor")).resolves.toBeUndefined();
+
+    expect(mockLinkProfessionalAuthUser).toHaveBeenCalledWith("u1", "pro@example.com");
+    expect(mockGetKindsForUser).toHaveBeenCalledTimes(2); // re-resolved after heal
+    expect(mockSetActiveKind).toHaveBeenCalledWith("advisor");
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
+  it("still bounces to the chooser when self-heal finds no matching professional", async () => {
+    mockGetActiveKind.mockResolvedValue(null);
+    mockGetKindsForUser.mockResolvedValue([]); // never resolves a kind
+    mockLinkProfessionalAuthUser.mockResolvedValue(0); // nothing to heal
+
+    await expect(enforcePortalKind("advisor")).rejects.toThrow(/select-workspace/);
+    expect(mockGetKindsForUser).toHaveBeenCalledTimes(1); // no re-resolve when 0 linked
   });
 });

--- a/__tests__/lib/professional-auth-link.test.ts
+++ b/__tests__/lib/professional-auth-link.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockCreateAdminClient = vi.fn();
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => mockCreateAdminClient(),
+}));
+vi.mock("@/lib/logger", () => ({
+  logger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+import { linkProfessionalAuthUser } from "@/lib/professional-auth-link";
+
+/** Build a chainable PostgREST-style admin stub whose terminal `.select()`
+ *  resolves to `result`, capturing each call's arguments for assertions. */
+function buildAdmin(result: { data: unknown; error: unknown }) {
+  const calls: Record<string, unknown[]> = {};
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const builder: any = {};
+  for (const m of ["update", "is", "eq", "in"]) {
+    builder[m] = vi.fn((...args: unknown[]) => {
+      calls[m] = args;
+      return builder;
+    });
+  }
+  builder.select = vi.fn((...args: unknown[]) => {
+    calls.select = args;
+    return Promise.resolve(result);
+  });
+  const from = vi.fn((...args: unknown[]) => {
+    calls.from = args;
+    return builder;
+  });
+  return { client: { from }, calls };
+}
+
+describe("linkProfessionalAuthUser", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("links an unlinked professional on email match and returns the count", async () => {
+    const { client, calls } = buildAdmin({ data: [{ id: 42 }], error: null });
+    mockCreateAdminClient.mockReturnValue(client);
+
+    const n = await linkProfessionalAuthUser("auth-uuid-1", "advisor@example.com");
+
+    expect(n).toBe(1);
+    expect(calls.from).toEqual(["professionals"]);
+    // Sets the link + a login timestamp.
+    expect((calls.update[0] as Record<string, unknown>).auth_user_id).toBe("auth-uuid-1");
+    expect((calls.update[0] as Record<string, unknown>).last_login_at).toBeTypeOf("string");
+    // Only ever fills a NULL link (no takeover), scoped by verified email + live status.
+    expect(calls.is).toEqual(["auth_user_id", null]);
+    expect(calls.eq).toEqual(["email", "advisor@example.com"]);
+    expect(calls.in).toEqual(["status", ["active", "pending"]]);
+  });
+
+  it("returns 0 and never queries when userId or email is missing", async () => {
+    expect(await linkProfessionalAuthUser(null, "a@b.com")).toBe(0);
+    expect(await linkProfessionalAuthUser("u1", null)).toBe(0);
+    expect(await linkProfessionalAuthUser("u1", "")).toBe(0);
+    expect(mockCreateAdminClient).not.toHaveBeenCalled();
+  });
+
+  it("returns 0 when no row matched (already linked or not a professional)", async () => {
+    const { client } = buildAdmin({ data: [], error: null });
+    mockCreateAdminClient.mockReturnValue(client);
+    expect(await linkProfessionalAuthUser("u1", "nobody@example.com")).toBe(0);
+  });
+
+  it("fails soft (returns 0) on a database error", async () => {
+    const { client } = buildAdmin({ data: null, error: { message: "boom" } });
+    mockCreateAdminClient.mockReturnValue(client);
+    expect(await linkProfessionalAuthUser("u1", "a@b.com")).toBe(0);
+  });
+
+  it("never throws even if the admin client blows up", async () => {
+    mockCreateAdminClient.mockImplementation(() => {
+      throw new Error("no service role key");
+    });
+    await expect(linkProfessionalAuthUser("u1", "a@b.com")).resolves.toBe(0);
+  });
+});

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -6,6 +6,7 @@ import {
   getKindsForUser,
   setActiveKind,
 } from "@/lib/account-kinds";
+import { linkProfessionalAuthUser } from "@/lib/professional-auth-link";
 import { attributeSignupByToken } from "@/lib/pro-affiliate/track";
 
 const log = logger("auth-callback");
@@ -46,6 +47,11 @@ async function postAuthRedirectUrl(origin: string, fallbackNext: string): Promis
     const supabase = await createClient();
     const { data: { user } } = await supabase.auth.getUser();
     if (!user) return new URL(fallbackNext, origin);
+    // Self-heal the professional ↔ auth-user link before resolving kinds, so a
+    // magic-link/password login by an advisor whose professionals row was never
+    // linked (NULL auth_user_id) routes straight to /advisor-portal instead of
+    // the empty-handed investor fallback. No-op for non-professionals.
+    await linkProfessionalAuthUser(user.id, user.email);
     const memberships = await getKindsForUser(user.id);
     const { redirect, setKind } = chooseCallbackRedirect(memberships, fallbackNext);
     if (setKind) await setActiveKind(setKind);

--- a/lib/portal-gate.ts
+++ b/lib/portal-gate.ts
@@ -35,6 +35,7 @@ import {
   setActiveKind,
   type WorkspaceKind,
 } from "@/lib/account-kinds";
+import { linkProfessionalAuthUser } from "@/lib/professional-auth-link";
 
 const CHOOSER = "/account/select-workspace";
 
@@ -79,11 +80,27 @@ export async function enforcePortalKind(
     redirect(`/auth/login?next=${encodeURIComponent(next)}`);
   }
 
-  const [active, memberships] = await Promise.all([
+  const [active, initialMemberships] = await Promise.all([
     getActiveKind(),
     getKindsForUser(user.id),
   ]);
-  const holdsExpected = memberships.some((m) => m.kind === expected);
+  let memberships = initialMemberships;
+  let holdsExpected = memberships.some((m) => m.kind === expected);
+
+  // Self-heal an unlinked professional. Rows created via the application/
+  // approval flow carry a NULL auth_user_id, so the membership view — which
+  // keys off auth_user_id — reports zero kinds and the gate would bounce a
+  // legitimate advisor out of their own portal (≈98% of active advisors were
+  // unlinked as of 2026-06). Link on the email Supabase verified for this
+  // session and re-resolve before making any redirect decision. No-op for a
+  // visitor who isn't a professional, so non-pro behaviour is unchanged.
+  if (!holdsExpected) {
+    const linked = await linkProfessionalAuthUser(user.id, user.email);
+    if (linked > 0) {
+      memberships = await getKindsForUser(user.id);
+      holdsExpected = memberships.some((m) => m.kind === expected);
+    }
+  }
 
   if (active === expected && holdsExpected) {
     return; // happy path

--- a/lib/professional-auth-link.ts
+++ b/lib/professional-auth-link.ts
@@ -1,0 +1,75 @@
+// eslint-disable-next-line no-restricted-imports -- self-heal links a professionals row that has no auth_user_id yet, so it cannot be scoped to auth.uid() and RLS would deny the write (CLAUDE.md §"Two Supabase clients")
+import { createAdminClient } from "@/lib/supabase/admin";
+import { logger } from "@/lib/logger";
+
+const log = logger("professional-auth-link");
+
+/**
+ * Self-heal the link between a Supabase auth user and their `professionals` row.
+ *
+ * Professional rows created through the application/approval flow
+ * (`/advisor-apply`, admin approval, legacy imports) carry a NULL
+ * `auth_user_id` — they were never connected to a Supabase auth user. But the
+ * portal gate (`enforcePortalKind`) and the `account_kind_membership` view both
+ * key off `auth_user_id`, so an unlinked professional can authenticate yet
+ * appear to hold *zero* workspace kinds and get bounced straight out of their
+ * own portal. As of 2026-06, ~177 of 180 active advisors (98%) were unlinked —
+ * i.e. locked out of `/advisor-portal` and every revenue action behind it.
+ *
+ * This links the row on a verified-email match so the membership view starts
+ * reporting the kind. Call it at the auth boundary — the login callback and the
+ * portal gate — right before kinds are resolved.
+ *
+ * Safety:
+ *  - Only ever fills a NULL `auth_user_id`; it never re-points an existing link,
+ *    so it cannot transfer one professional's identity onto another account.
+ *  - Matches on the email Supabase already verified for this session
+ *    (magic-link click / password / signup), so email ownership is proven.
+ *  - `professionals.email` is effectively unique and the partial unique index
+ *    `professionals_auth_user_id_unique` guards `auth_user_id`, so at most one
+ *    row is linked per call (a unique-violation just fails the write closed).
+ *  - Idempotent and best-effort: safe to call on every request; never throws.
+ *
+ * Mirrors the inline self-heal that already exists in
+ * `app/api/advisor-auth/session/route.ts` — hoisted into a shared helper so it
+ * also runs at the boundaries that fire *before* that endpoint is ever reached.
+ *
+ * @returns the number of rows newly linked (0 when already linked / no match).
+ */
+export async function linkProfessionalAuthUser(
+  userId: string | null | undefined,
+  email: string | null | undefined,
+): Promise<number> {
+  if (!userId || !email) return 0;
+  try {
+    const admin = createAdminClient();
+    const { data, error } = await admin
+      .from("professionals")
+      .update({
+        auth_user_id: userId,
+        last_login_at: new Date().toISOString(),
+      })
+      .is("auth_user_id", null)
+      .eq("email", email)
+      .in("status", ["active", "pending"])
+      .select("id");
+    if (error) {
+      log.warn("linkProfessionalAuthUser update failed", {
+        userId,
+        error: error.message,
+      });
+      return 0;
+    }
+    const linked = data?.length ?? 0;
+    if (linked > 0) {
+      log.info("self-healed professional auth link on login", { userId, linked });
+    }
+    return linked;
+  } catch (err) {
+    log.warn("linkProfessionalAuthUser threw", {
+      userId,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return 0;
+  }
+}

--- a/supabase/migrations/20260613113000_backfill_professionals_auth_user_id.sql
+++ b/supabase/migrations/20260613113000_backfill_professionals_auth_user_id.sql
@@ -1,0 +1,51 @@
+-- 20260613113000_backfill_professionals_auth_user_id.sql
+--
+-- Backfill professionals.auth_user_id by verified-email match against auth.users.
+--
+-- WHY
+--   Professional rows created through the application/approval flow
+--   (/advisor-apply, admin approval, legacy imports) were never linked to a
+--   Supabase auth user — auth_user_id IS NULL. The portal gate
+--   (enforcePortalKind) and the account_kind_membership view both key off
+--   auth_user_id, so these professionals authenticate yet appear to hold zero
+--   workspace kinds and are bounced out of /advisor-portal. As of 2026-06,
+--   ~177 of 180 active advisors (98%) were unlinked.
+--
+--   The application now self-heals this link on login
+--   (lib/professional-auth-link.ts, called from the auth callback and the
+--   portal gate). This one-shot backfill additionally links every professional
+--   who ALREADY has a matching Supabase auth user, so they are unblocked
+--   immediately without having to trigger a fresh login.
+--
+-- SAFETY
+--   * Only fills a NULL auth_user_id — never re-points an existing link, so it
+--     cannot transfer one professional's identity onto another account.
+--   * Links only when the email maps to exactly ONE auth user, and only when
+--     that auth user is not already linked to another professional, respecting
+--     the partial unique index professionals_auth_user_id_unique.
+--   * Case-insensitive email match (auth emails are normalised to lower case).
+--   * Pure DML, no schema change; RLS unaffected.
+--
+-- IDEMPOTENT
+--   The `auth_user_id IS NULL` predicate makes re-runs no-ops.
+--
+-- ROLLBACK
+--   No automatic rollback (the link is corrective). To undo a specific link,
+--   set that row's auth_user_id back to NULL by id:
+--     UPDATE public.professionals SET auth_user_id = NULL WHERE id = <id>;
+
+UPDATE public.professionals AS p
+SET auth_user_id = u.id
+FROM auth.users AS u
+WHERE p.auth_user_id IS NULL
+  AND p.status IN ('active', 'pending')
+  AND p.email IS NOT NULL
+  AND lower(u.email) = lower(p.email)
+  -- the email must resolve to exactly one auth user
+  AND (
+    SELECT count(*) FROM auth.users u2 WHERE lower(u2.email) = lower(p.email)
+  ) = 1
+  -- and that auth user must not already be linked to another professional
+  AND NOT EXISTS (
+    SELECT 1 FROM public.professionals x WHERE x.auth_user_id = u.id
+  );


### PR DESCRIPTION
## The bug (P0 — blocks all advisor revenue)

Surfaced by the AI-journey audit in #1573. The portal gate (`enforcePortalKind`) and the `account_kind_membership` view both key off `professionals.auth_user_id`, but rows created via the application/approval flow (`/advisor-apply`, admin approval, legacy imports) carry a **NULL `auth_user_id`**. As of 2026-06, **177 of 180 active advisors (98%)** were unlinked — each can authenticate yet appears to hold *zero* workspace kinds, so the gate bounces them to `/account/select-workspace` and they never reach `/advisor-portal`. That blocks every advisor revenue action: leads, billing, bidding.

Root cause: an inline self-heal already exists in `app/api/advisor-auth/session/route.ts`, but it only runs **after** the client portal page calls that endpoint — and the **server-side layout gate redirects the advisor away first**, so it never fires for the people who need it.

## The fix

Hoist the self-heal into a shared, tested helper (`lib/professional-auth-link.ts`) and run it at the two auth boundaries that execute *first*:

- **`app/auth/callback`** — link before resolving kinds, so a magic-link / password login routes straight to `/advisor-portal` instead of the investor fallback.
- **`lib/portal-gate`** — in the `!holdsExpected` branch, link + re-resolve before redirecting to the chooser (defensive layer for sessions that bypass the callback).

Safety:
- Only ever fills a **NULL** `auth_user_id` — never re-points an existing link, so no identity takeover.
- Matches on the email **Supabase already verified** for the session.
- `professionals.email` is unique and `professionals_auth_user_id_unique` guards the column, so ≤1 row links per call.
- Idempotent, best-effort, never throws.

## Backfill migration (file-only — needs your `supabase db push`)

`supabase/migrations/20260613113000_backfill_professionals_auth_user_id.sql` links every professional who **already** has a matching Supabase auth user, so they're unblocked without a fresh login. Per the DB Migration Rules it is **not applied** here — apply after review. Idempotent: only fills NULL links, only for emails resolving to exactly one auth user not already linked. Most of the 177 likely have no auth user yet → they get linked by the self-heal on their next login.

## Verification
- `linkProfessionalAuthUser` unit suite: links on match; no-ops on missing args / no row / already linked; fails soft on DB error; never throws.
- Gate self-heal cases: heals an unlinked advisor and admits them; still bounces to the chooser when no professional matches.
- `tsc --noEmit` clean · `eslint --max-warnings 0` clean · pre-push hook (type-check + rate-limit audit + changed-tests) green.

## Residual (follow-up — needs a founder product call)
Advisors who only ever used the **legacy approval-email `?token=` / `advisor_session` cookie** have *no* Supabase auth user at all, so the server-side gate still can't admit them. The clean fix is to point the approval email at the magic-link login (approvals then create a Supabase user, which the self-heal links). Flagged for your decision rather than changing auth issuance unilaterally.

## Merge tier
**Tier C** (auth + a migration). Opened as a draft for your review — not self-merged.

https://claude.ai/code/session_01D9yjtP4ponSkrt5eM7ivYz

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9yjtP4ponSkrt5eM7ivYz)_