### PR TITLE
fix(db): rename gm08 seed migration to resolve version collision

### DIFF
--- a/supabase/migrations/20260613120000_gm08_questions_intents_seed.sql
+++ b/supabase/migrations/20260613120000_gm08_questions_intents_seed.sql
@@ -1,5 +1,15 @@
 -- ============================================================================
--- Migration: 20260611160000_gm08_questions_intents_seed.sql
+-- Migration: 20260613120000_gm08_questions_intents_seed.sql
+--
+-- RENAMED 2026-06-13 from 20260611160000_gm08_questions_intents_seed.sql to
+-- resolve a version collision: 20260611160000 was also used by
+-- 20260611160000_advisor_standing_orders.sql. Supabase keys the ledger on the
+-- 14-digit version, so the duplicate caused this seed to be silently skipped on
+-- push (only one 20260611160000 entry can exist). Re-timestamped to a unique,
+-- later version so it applies cleanly. Content is unchanged and idempotent, so
+-- re-applying is a no-op even if a prior partial apply occurred. Before pushing,
+-- run `supabase migration list` to confirm file↔ledger sync (DB Migration Rules).
+--
 -- Purpose: Seed `get_matched_questions` and `intent_taxonomy` to mirror the
 --          code-defined canonical sets in lib/getmatched/fallbacks.ts
 --          (FALLBACK_QUESTIONS + FALLBACK_INTENTS), one-for-one, INCLUDING the


### PR DESCRIPTION
## Why

`20260611160000_gm08_questions_intents_seed.sql` shared its 14-digit version with `20260611160000_advisor_standing_orders.sql`. Supabase keys its migration ledger on the version, so only one `20260611160000` entry can exist — the **gm08 seed was silently skipped on push**, leaving `get_matched_questions` / `intent_taxonomy` unseeded in prod (the matching flow runs entirely on code fallbacks).

## Fix

Re-timestamp gm08 to a unique `20260613120000` (`git mv`, content unchanged) so it applies on the next push. The seed is idempotent (`INSERT … ON CONFLICT (slug) DO UPDATE`), so re-applying is a no-op even if a prior partial apply occurred.

**File-only per DB Migration Rules — not applied here.** Before pushing, run `supabase migration list` to confirm file↔ledger sync (if it shows a mismatch, that's Tier E → stop + review). Prereq for the migration push covering #1562's listing migrations + #1575's advisor backfill.

https://claude.ai/code/session_01D9yjtP4ponSkrt5eM7ivYz

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9yjtP4ponSkrt5eM7ivYz)_