### PR TITLE
fix(ui): directory card polish — listing price/yield split + advisor rating & actions

### DIFF
--- a/__tests__/components/InvestListingCard.test.tsx
+++ b/__tests__/components/InvestListingCard.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import type { InvestmentListing } from "@/lib/types";
+
+// Keep the test scoped to the card's own DOM — stub next primitives and the
+// client-only children (enquire/shortlist/match/claim) to no-ops.
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: unknown }) => (
+    <a href={typeof href === "string" ? href : "#"}>{children}</a>
+  ),
+}));
+vi.mock("next/image", () => ({
+  // The hero image is irrelevant to these assertions — render nothing.
+  default: () => null,
+}));
+vi.mock("@/components/marketplace/EnquireButton", () => ({ default: () => <button>Enquire</button> }));
+vi.mock("@/components/invest/ListingShortlistButton", () => ({ default: () => null }));
+vi.mock("@/components/invest/MatchScorePill", () => ({ default: () => null }));
+vi.mock("@/components/invest/ListingClaimLink", () => ({ default: () => null }));
+
+import InvestListingCard from "@/components/InvestListingCard";
+
+function makeListing(over: Partial<InvestmentListing> = {}): InvestmentListing {
+  return {
+    id: 1,
+    slug: "demo",
+    title: "Demo Listing",
+    vertical: "commercial_property",
+    sub_category: null,
+    listing_kind: "for_sale_asset",
+    key_metrics: {},
+    asking_price_cents: null,
+    price_display: null,
+    created_at: "2026-01-01T00:00:00Z",
+    location_state: null,
+    location_city: null,
+    industry: null,
+    images: [],
+    firb_eligible: false,
+    siv_complying: false,
+    listing_type: "standard",
+    views: 0,
+    expires_at: null,
+    description: "",
+    ...over,
+  } as unknown as InvestmentListing;
+}
+
+describe("InvestListingCard — price + headline stat layout", () => {
+  it("renders the SDA price and yield as two separate stats, not one mashed string", () => {
+    render(
+      <InvestListingCard
+        listing={makeListing({
+          title: "SDA Melbourne — Fully-Accessible 3BR",
+          vertical: "commercial_property",
+          listing_kind: "for_sale_asset",
+          asking_price_cents: 85_000_000,
+          // The legacy overloaded override — must NOT reach the big number.
+          price_display: "AUD $850,000 — Net yield 11.2%",
+          key_metrics: { net_yield_pct: 11.2, bedrooms: 3, build_year: 2025, smsf_eligible: true },
+        })}
+      />,
+    );
+
+    // Price renders as a clean compact figure; yield is its own labelled stat.
+    expect(screen.getByText("$850k")).toBeInTheDocument();
+    expect(screen.getByText("Net yield")).toBeInTheDocument();
+    expect(screen.getByText("11.2%")).toBeInTheDocument();
+
+    // The overloaded string is gone — no "AUD $850,000 …" anywhere.
+    expect(screen.queryByText(/AUD \$850,000/)).not.toBeInTheDocument();
+
+    // …and price + yield are in distinct elements.
+    expect(screen.getByText("$850k")).not.toBe(screen.getByText("11.2%"));
+  });
+
+  it("renders a true boolean as a presence chip without a leading 'Yes'", () => {
+    render(
+      <InvestListingCard
+        listing={makeListing({
+          key_metrics: { bedrooms: 3, build_year: 2025, smsf_eligible: true },
+        })}
+      />,
+    );
+    expect(screen.getByText("SMSF eligible")).toBeInTheDocument();
+    expect(screen.queryByText(/Yes\s+SMSF eligible/)).not.toBeInTheDocument();
+  });
+
+  it("shows a fund's min investment and a forward-looking target IRR", () => {
+    render(
+      <InvestListingCard
+        listing={makeListing({
+          title: "Australia Tech ESVCLP Fund IV",
+          vertical: "fund",
+          listing_kind: "fund",
+          // asking_price_cents stays null (base default) — funds price off min.
+          price_display: "Min $250,000 · 10% upfront tax offset + 100% CGT exempt",
+          key_metrics: { min_investment_aud: 250000, target_irr_pct: 22 },
+        })}
+      />,
+    );
+    expect(screen.getByText("$250k")).toBeInTheDocument();
+    expect(screen.getByText("Target IRR")).toBeInTheDocument();
+    expect(screen.getByText("22%")).toBeInTheDocument();
+    expect(screen.queryByText(/upfront tax offset/)).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/lib/listing-format.test.ts
+++ b/__tests__/lib/listing-format.test.ts
@@ -3,7 +3,9 @@ import {
   humanizeTitle,
   formatMetricValue,
   listingDisplayMetrics,
+  listingHeadlineStat,
 } from "@/lib/listing-format";
+import type { InvestmentListing } from "@/lib/types";
 
 describe("humanizeTitle", () => {
   it("title-cases snake_case and preserves domain acronyms", () => {
@@ -44,9 +46,19 @@ describe("listingDisplayMetrics", () => {
     expect(
       listingDisplayMetrics({ bedrooms: 3, build_year: 2025, sil_provider: "Confidential" }),
     ).toEqual([
-      { key: "bedrooms", label: "bedrooms", value: "3" },
-      { key: "build_year", label: "build year", value: "2025" },
-      { key: "sil_provider", label: "SIL provider", value: "Confidential" },
+      { key: "bedrooms", label: "bedrooms", value: "3", bool: false },
+      { key: "build_year", label: "build year", value: "2025", bool: false },
+      { key: "sil_provider", label: "SIL provider", value: "Confidential", bool: false },
+    ]);
+  });
+
+  it("renders a true boolean as a label-only presence chip and drops false ones", () => {
+    expect(
+      listingDisplayMetrics({ smsf_eligible: true, lrba_compatible: false, bedrooms: 3 }),
+    ).toEqual([
+      { key: "smsf_eligible", label: "SMSF eligible", value: "", bool: true },
+      // lrba_compatible: false is dropped entirely (no "No LRBA compatible").
+      { key: "bedrooms", label: "bedrooms", value: "3", bool: false },
     ]);
   });
 
@@ -64,5 +76,58 @@ describe("listingDisplayMetrics", () => {
   it("returns [] for nullish metrics", () => {
     expect(listingDisplayMetrics(null)).toEqual([]);
     expect(listingDisplayMetrics(undefined)).toEqual([]);
+  });
+});
+
+describe("listingHeadlineStat", () => {
+  type Row = Parameters<typeof listingHeadlineStat>[0];
+  function row(over: Partial<Row>): Row {
+    return {
+      vertical: "commercial_property" as InvestmentListing["vertical"],
+      listing_kind: null,
+      asking_price_cents: null,
+      key_metrics: {},
+      sub_category: null,
+      ...over,
+    } as Row;
+  }
+
+  it("returns a fund's forward-looking target IRR", () => {
+    expect(
+      listingHeadlineStat(row({ listing_kind: "fund", key_metrics: { target_irr_pct: 22 } })),
+    ).toEqual({ label: "Target IRR", value: "22%", tone: "positive" });
+  });
+
+  it("returns net yield for a yield-bearing asset, one decimal when meaningful", () => {
+    expect(
+      listingHeadlineStat(row({ listing_kind: "for_sale_asset", key_metrics: { net_yield_pct: 11.2 } })),
+    ).toEqual({ label: "Net yield", value: "11.2%", tone: "positive" });
+    expect(
+      listingHeadlineStat(row({ listing_kind: "for_sale_asset", key_metrics: { net_yield_pct: 11 } }))?.value,
+    ).toBe("11%");
+  });
+
+  it("uses an explicit spot price for per-unit environmental assets", () => {
+    expect(
+      listingHeadlineStat(
+        row({ listing_kind: "for_sale_asset", key_metrics: { units: 100, spot_price_aud: 35, unit_type: "ACCU" } }),
+      ),
+    ).toEqual({ label: "Per unit", value: "$35", tone: "neutral" });
+  });
+
+  it("derives per-credit price from asking_price_cents / credits", () => {
+    expect(
+      listingHeadlineStat(
+        row({
+          listing_kind: "for_sale_asset",
+          asking_price_cents: 5_000_000,
+          key_metrics: { credits: 50, unit_type: "biodiversity_credit" },
+        }),
+      ),
+    ).toEqual({ label: "Per credit", value: "$1k", tone: "neutral" });
+  });
+
+  it("returns null when the listing has no headline metric", () => {
+    expect(listingHeadlineStat(row({ listing_kind: "project_equity", key_metrics: {} }))).toBeNull();
   });
 });

--- a/__tests__/lib/listing-kind.test.ts
+++ b/__tests__/lib/listing-kind.test.ts
@@ -397,6 +397,12 @@ describe("formatAudCompact", () => {
   it("rounds small amounts", () => {
     expect(formatAudCompact(99)).toBe("$1");
   });
+
+  it("keeps one decimal for sub-$10k thousands, rounds larger ones", () => {
+    expect(formatAudCompact(350_000)).toBe("$3.5k"); // $3,500 — not "$4k"
+    expect(formatAudCompact(300_000)).toBe("$3k"); // $3,000 — drops .0
+    expect(formatAudCompact(1_200_000)).toBe("$12k"); // $12,000 rounds
+  });
 });
 
 describe("formatListingPrice", () => {
@@ -490,6 +496,37 @@ describe("formatListingPrice", () => {
       }),
     );
     expect(res).toEqual({ label: "Asking", value: "$99k" });
+  });
+
+  it("ignores a compound price_display (price + yield) in favour of the numeric price", () => {
+    const res = formatListingPrice(
+      priceRow({
+        listing_kind: "for_sale_asset",
+        asking_price_cents: 85_000_000,
+        price_display: "AUD $850,000 — Net yield 11.2%",
+        key_metrics: { net_yield_pct: 11.2 },
+      }),
+    );
+    expect(res).toEqual({ label: "Asking", value: "$850k" });
+  });
+
+  it("ignores a compound min-investment price_display for funds", () => {
+    const res = formatListingPrice(
+      priceRow({
+        listing_kind: "fund",
+        price_display: "Min $250,000 · 10% upfront tax offset + 100% CGT exempt",
+        key_metrics: { min_investment_aud: 250000 },
+      }),
+    );
+    expect(res).toEqual({ label: "Min investment", value: "$250k" });
+  });
+
+  it("keeps a simple price_display but strips a redundant AUD prefix", () => {
+    expect(
+      formatListingPrice(
+        priceRow({ listing_kind: "for_sale_asset", asking_price_cents: 50_000_000, price_display: "AUD $1.495M" }),
+      ),
+    ).toEqual({ label: "Asking", value: "$1.495M" });
   });
 
   it("returns null when nothing priceable", () => {

--- a/app/advisors/AdvisorsClient.tsx
+++ b/app/advisors/AdvisorsClient.tsx
@@ -1328,32 +1328,32 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
                           Fast reply
                         </span>
                       )}
-                    </div>
-
-                    {/* top-right rating + actions */}
-                    <div className="absolute top-3 right-3 flex items-center gap-1">
                       {pro.rating > 0 && pro.review_count > 0 && (
-                        <span className="shrink-0 text-[0.62rem] font-bold px-2 py-0.5 rounded-full bg-black/55 backdrop-blur text-white border border-white/20 flex items-center gap-1">
-                          <svg className="w-2.5 h-2.5 text-amber-400" fill="currentColor" viewBox="0 0 20 20">
-                            <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
-                          </svg>
+                        <span className="shrink-0 inline-flex items-center gap-1 rounded-full bg-white/95 px-2 py-0.5 text-[0.62rem] font-bold text-ink-900 shadow-sm backdrop-blur">
+                          <Icon name="star" size={9} className="text-amber-500" />
                           {pro.rating}
-                          <span className="opacity-70 font-semibold">({pro.review_count})</span>
+                          <span className="font-semibold text-slate-500">({pro.review_count})</span>
                         </span>
                       )}
+                    </div>
+
+                    {/* top-right actions: save + compare (distinct glyphs) */}
+                    <div className="absolute top-3 right-3 flex items-center gap-1">
                       <BookmarkButton
                         type="advisor"
                         ref={pro.slug}
                         label={pro.name}
+                        iconOnly
                         className="shrink-0 p-1.5 rounded-lg bg-black/45 backdrop-blur text-white/90 hover:text-white hover:bg-black/60 transition-colors"
                       />
                       <button
                         onClick={(e) => { e.preventDefault(); toggleShortlist(pro.slug); }}
                         disabled={!inShortlist(pro.slug) && shortlistCount >= shortlistMax}
-                        title={inShortlist(pro.slug) ? "Remove from compare" : shortlistCount >= shortlistMax ? "Compare list full" : "Save to compare"}
+                        title={inShortlist(pro.slug) ? "Remove from compare" : shortlistCount >= shortlistMax ? "Compare list full" : "Add to compare"}
+                        aria-label={inShortlist(pro.slug) ? "Remove from compare" : "Add to compare"}
                         className={`shrink-0 p-1.5 rounded-lg backdrop-blur transition-colors ${inShortlist(pro.slug) ? "text-slate-900 bg-amber-500 hover:bg-amber-400" : shortlistCount >= shortlistMax ? "text-white/40 bg-black/30 cursor-not-allowed" : "text-white/90 bg-black/45 hover:text-white hover:bg-black/60"}`}
                       >
-                        <Icon name={inShortlist(pro.slug) ? "bookmark-check" : "bookmark"} size={15} />
+                        <Icon name="scale" size={15} />
                       </button>
                     </div>
 

--- a/components/BookmarkButton.tsx
+++ b/components/BookmarkButton.tsx
@@ -12,6 +12,10 @@ interface Props {
   ref: string;
   label?: string;
   className?: string;
+  /** Render just the bookmark glyph (no "Save"/"Saved" text) — for dense
+   *  card overlays where it sits beside other icon-only actions. The
+   *  aria-label still announces the action. */
+  iconOnly?: boolean;
 }
 
 /** fetch resolves on 4xx/5xx and the API can answer { ok: false } — treat
@@ -34,7 +38,7 @@ async function responseOk(res: Response): Promise<boolean> {
  * claim trigger is handled by ClaimAnonymousOnAuth — this
  * button just fires the "save" event.
  */
-export default function BookmarkButton({ type, ref, label, className }: Props) {
+export default function BookmarkButton({ type, ref, label, className, iconOnly }: Props) {
   const { user, loading: userLoading } = useUser();
   const { toast } = useToast();
   const [saved, setSaved] = useState(false);
@@ -181,7 +185,7 @@ export default function BookmarkButton({ type, ref, label, className }: Props) {
           d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"
         />
       </svg>
-      {saved ? "Saved" : "Save"}
+      {!iconOnly && (saved ? "Saved" : "Save")}
     </button>
   );
 }

--- a/components/InvestListingCard.tsx
+++ b/components/InvestListingCard.tsx
@@ -9,7 +9,7 @@ import {
   formatListingPrice,
   freshnessSignal,
 } from "@/lib/listing-kind";
-import { humanizeTitle, listingDisplayMetrics } from "@/lib/listing-format";
+import { humanizeTitle, listingDisplayMetrics, listingHeadlineStat } from "@/lib/listing-format";
 import Icon from "@/components/Icon";
 import EnquireButton from "@/components/marketplace/EnquireButton";
 import ListingShortlistButton from "@/components/invest/ListingShortlistButton";
@@ -118,6 +118,7 @@ export default function InvestListingCard({
   const meta = listingKindMeta(kind);
   const fresh = freshnessSignal(listing);
   const price = formatListingPrice(listing);
+  const headline = listingHeadlineStat(listing);
   const location = formatLocation(listing.location_state, listing.location_city);
   const stripColor = KIND_STRIP[kind];
 
@@ -146,14 +147,23 @@ export default function InvestListingCard({
     </span>
   );
 
-  // Inline metric line ("3 bedrooms · 2025 build year · SIL provider").
+  // Inline metric line ("3 bedrooms · 2025 build year · ✓ SMSF eligible").
   const metricLine = displayMetrics.length > 0 && (
     <p className="text-xs leading-relaxed text-slate-600">
       {displayMetrics.map((m, i) => (
         <span key={m.key}>
           {i > 0 && <span className="text-slate-300"> · </span>}
-          <span className="font-bold text-ink-800">{m.value}</span>{" "}
-          <span className="text-slate-500">{m.label}</span>
+          {m.bool ? (
+            <span className="font-semibold text-ink-700">
+              <Icon name="check" size={11} className="mr-0.5 inline align-[-1px] text-emerald-600" />
+              {m.label}
+            </span>
+          ) : (
+            <>
+              <span className="font-bold text-ink-800">{m.value}</span>{" "}
+              <span className="text-slate-500">{m.label}</span>
+            </>
+          )}
         </span>
       ))}
     </p>
@@ -256,7 +266,16 @@ export default function InvestListingCard({
           {price ? (
             <div>
               <div className="iv2-mini">{price.label}</div>
-              <div className="iv2-bignum text-xl text-ink-900">{price.value}</div>
+              <div className="iv2-bignum whitespace-nowrap text-xl text-ink-900">{price.value}</div>
+              {headline && (
+                <div
+                  className={`mt-0.5 text-xs font-semibold ${
+                    headline.tone === "positive" ? "text-emerald-600" : "text-slate-500"
+                  }`}
+                >
+                  {headline.label} <span className="tabular-nums">{headline.value}</span>
+                </div>
+              )}
             </div>
           ) : (
             <span />
@@ -359,13 +378,25 @@ export default function InvestListingCard({
           </p>
         )}
 
-        {/* Price — the hero number */}
+        {/* Price + headline return stat — two distinct slots, never concatenated */}
         {price && (
-          <div className="flex items-end justify-between gap-2">
-            <div>
+          <div className="flex items-end justify-between gap-3">
+            <div className="min-w-0">
               <div className="iv2-mini">{price.label}</div>
-              <div className="iv2-bignum text-2xl text-ink-900">{price.value}</div>
+              <div className="iv2-bignum whitespace-nowrap text-2xl text-ink-900">{price.value}</div>
             </div>
+            {headline && (
+              <div className="shrink-0 text-right">
+                <div className="iv2-mini">{headline.label}</div>
+                <div
+                  className={`iv2-bignum whitespace-nowrap text-xl ${
+                    headline.tone === "positive" ? "text-emerald-600" : "text-ink-700"
+                  }`}
+                >
+                  {headline.value}
+                </div>
+              </div>
+            )}
           </div>
         )}
 

--- a/lib/listing-format.ts
+++ b/lib/listing-format.ts
@@ -14,6 +14,9 @@
  * detail view) — don't hand-roll `.replace(/_/g, " ")` at call sites.
  */
 
+import { deriveListingKind, formatAudCompact, type DerivableListing } from "@/lib/listing-kind";
+import { metricNumber } from "@/lib/listings/vertical-metrics";
+
 /**
  * Domain abbreviations that must stay uppercased when they appear as a
  * standalone token. Lowercased here; matched case-insensitively. Kept
@@ -25,9 +28,9 @@ const ACRONYMS = new Set([
   // Australian states / territories
   "nsw", "vic", "qld", "wa", "sa", "nt", "act", "tas",
   // Disability accommodation / NDIS
-  "sda", "sil", "ndis", "ohc",
+  "sda", "sil", "ndis", "ohc", "ndia", "sroa",
   // Schemes / tax / investor structures
-  "bcs", "esvclp", "esic", "siv", "firb", "cgt", "smsf", "fhog", "reit", "spv",
+  "bcs", "esvclp", "esic", "siv", "firb", "cgt", "smsf", "fhog", "reit", "spv", "lrba",
   // Finance / deal terms
   "asx", "im", "pds", "irr", "mer", "aum", "ppa", "jorc", "ebitda", "roi",
   "npv", "etf", "ipo", "nav", "ltv", "icr", "wale", "p2p",
@@ -40,8 +43,12 @@ const ACRONYMS = new Set([
 /** Field keys we never surface as a metric chip on a card: shown elsewhere
  *  (price line), used only for kind derivation, or pure noise. */
 const METRIC_SKIP = new Set([
-  // Yield / return — already shown on the price line for yield-bearing kinds.
-  "net_yield_pct", "gross_yield_pct", "yield_pct", "distribution_yield", "yield",
+  // Yield / return — shown as the headline stat beside the price (see
+  // listingHeadlineStat), so never repeated as a chip.
+  "net_yield_pct", "gross_yield_pct", "yield_pct", "yield_percent", "distribution_yield", "yield",
+  "target_irr_pct", "target_irr", "irr",
+  // Per-unit price — shown as the headline stat for environmental units.
+  "spot_price_aud", "unit_price_aud",
   // Price / ticket — shown as the hero price.
   "min_investment_aud", "min_commit_aud", "min_investment", "asking_price",
   "asking_price_aud", "price", "price_aud",
@@ -126,8 +133,12 @@ export interface DisplayMetric {
   key: string;
   /** Lowercase-with-acronyms label, e.g. "build year", "SIL provider". */
   label: string;
-  /** Presentable value, e.g. "2025", "Biodiversity credit", "12.5%". */
+  /** Presentable value, e.g. "2025", "Biodiversity credit", "12.5%". Empty
+   *  string for a presence chip (see `bool`). */
   value: string;
+  /** True when this is a present-and-true boolean, rendered as a label-only
+   *  presence chip ("SMSF eligible") rather than a "Yes <label>" value pair. */
+  bool?: boolean;
 }
 
 /**
@@ -144,8 +155,94 @@ export function listingDisplayMetrics(
   for (const [key, value] of Object.entries(km)) {
     if (value == null || value === "") continue;
     if (METRIC_SKIP.has(key)) continue;
-    out.push({ key, label: humanizeMetricLabel(key), value: formatMetricValue(key, value) });
+    // Booleans read badly as "Yes <label>" / "No <label>". Surface a true
+    // boolean as a label-only presence chip; drop false ones entirely rather
+    // than render "No SMSF eligible".
+    const isBool = typeof value === "boolean" || value === "true" || value === "false";
+    if (isBool) {
+      if (value !== true && value !== "true") continue;
+      out.push({ key, label: humanizeMetricLabel(key), value: "", bool: true });
+    } else {
+      out.push({ key, label: humanizeMetricLabel(key), value: formatMetricValue(key, value), bool: false });
+    }
     if (out.length >= limit) break;
   }
   return out;
+}
+
+// ─── Headline return stat (the card's second number) ──────────────────────
+
+export interface HeadlineStat {
+  /** Small label above the figure, e.g. "Net yield", "Target IRR", "Per credit". */
+  label: string;
+  /** The figure itself, e.g. "11.2%", "22%", "$1k". */
+  value: string;
+  /** `positive` → green (a yield / return); `neutral` → ink (a unit price). */
+  tone: "positive" | "neutral";
+}
+
+function pickMetricNumber(km: Record<string, unknown>, keys: string[]): number | null {
+  for (const k of keys) {
+    if (km[k] != null && km[k] !== "") {
+      const n = metricNumber(km[k]);
+      if (n != null) return n;
+    }
+  }
+  return null;
+}
+
+/** "11.2%", but "22%" — keep one decimal only when it carries information. */
+function formatPct(n: number): string {
+  return `${Number.isInteger(n) ? n.toFixed(0) : n.toFixed(1)}%`;
+}
+
+function perUnitLabel(km: Record<string, unknown>): string {
+  return String(km["unit_type"] ?? "").toLowerCase().includes("credit") ? "Per credit" : "Per unit";
+}
+
+/**
+ * The card's secondary "return" stat — the number a retail investor actually
+ * compares listings on (yield / IRR / unit price), rendered in its OWN slot
+ * beside the ticket price rather than concatenated into it. Read structurally
+ * from `key_metrics`; never parsed out of free-text `price_display`. Null when
+ * the listing has no meaningful headline metric (the card shows price alone).
+ *
+ *   - Funds            → "Target IRR 22%" (kept labelled forward-looking)
+ *   - Per-unit assets  → "Per credit $1k" (explicit unit price, or price ÷ units)
+ *   - Yield-bearing    → "Net yield 11.2%" (property / project / royalty / listed)
+ */
+export function listingHeadlineStat(
+  l: DerivableListing & { sub_category?: string | null },
+): HeadlineStat | null {
+  const kind = deriveListingKind(l);
+  const km = (l.key_metrics ?? {}) as Record<string, unknown>;
+
+  // Funds: forward-looking target IRR, with distribution yield as a fallback.
+  if (kind === "fund") {
+    const irr = pickMetricNumber(km, ["target_irr_pct"]);
+    if (irr != null) return { label: "Target IRR", value: formatPct(irr), tone: "positive" };
+    const dist = pickMetricNumber(km, ["distribution_yield", "yield_percent", "net_yield_pct"]);
+    if (dist != null) return { label: "Distribution", value: formatPct(dist), tone: "positive" };
+    return null;
+  }
+
+  // Per-unit environmental assets (ACCUs, biodiversity credits): the buyer's
+  // unit economics — prefer an explicit spot/unit price, else derive it from
+  // the ticket price over the unit count.
+  const explicitUnit = pickMetricNumber(km, ["spot_price_aud", "unit_price_aud"]);
+  if (explicitUnit != null && explicitUnit > 0) {
+    return { label: perUnitLabel(km), value: formatAudCompact(Math.round(explicitUnit * 100)), tone: "neutral" };
+  }
+  const units = pickMetricNumber(km, ["credits", "units"]);
+  if (units != null && units > 0 && l.asking_price_cents != null && l.asking_price_cents > 0) {
+    return { label: perUnitLabel(km), value: formatAudCompact(Math.round(l.asking_price_cents / units)), tone: "neutral" };
+  }
+
+  // Yield-bearing tangibles / projects / royalties / listed securities.
+  const yld = pickMetricNumber(km, ["net_yield_pct", "gross_yield_pct", "yield_percent", "yield_pct", "distribution_yield", "yield"]);
+  if (yld != null) {
+    return { label: km["net_yield_pct"] != null ? "Net yield" : "Yield", value: formatPct(yld), tone: "positive" };
+  }
+
+  return null;
 }

--- a/lib/listing-kind.ts
+++ b/lib/listing-kind.ts
@@ -358,33 +358,26 @@ export function freshnessSignal(l: Pick<InvestmentListing, "created_at" | "expir
   return null;
 }
 
-/** Returns a price-display string for a listing, picking the right
- *  prefix for its kind. Falls back to `price_display` when set on the
- *  row (sellers can override), else formats `asking_price_cents`.
- *  Accepts the structural `DerivableListing` shape so callers holding
- *  raw DB rows (string vertical, drifted values) don't need a cast. */
-export function formatListingPrice(l: DerivableListing & { price_display?: string | null }): {
-  label: string;   // "Asking" / "Min investment" / "Raising" / "Market cap"
-  value: string;   // "$2.5M" / "$100k" / "ASX: TLS"
-} | null {
-  const kind = deriveListingKind(l);
-  const meta = listingKindMeta(kind);
+/** Free-text `price_display` strings that overload the price slot with a
+ *  second stat (price + yield / per-unit / tax-perks). When a clean numeric
+ *  price is derivable we ignore these — the return metric belongs in its own
+ *  slot (see `listingHeadlineStat`), not crammed into the big price number. */
+const COMPOUND_PRICE_DISPLAY = /yield|\/\s*(?:credit|unit)|·|≈|=|tax|cgt|esvclp|esic|upfront|exempt|stacked/i;
 
-  // Listed securities: show the ticker + market cap when available.
-  if (kind === "listed_security") {
-    const km = (l.key_metrics ?? {}) as Record<string, unknown>;
-    const ticker = km["asx_ticker"];
-    if (ticker) return { label: "ASX", value: String(ticker).toUpperCase() };
-    return null;
-  }
+/** Drop a redundant leading "AUD" / "A$" — the whole marketplace is AUD, so
+ *  `formatAudCompact` omits it and free-text overrides shouldn't re-add it. */
+function stripAudPrefix(s: string): string {
+  return s.replace(/^\s*(?:aud|au\$|a\$)\s*/i, "").trim();
+}
 
-  // Sellers can override the auto-formatted price via price_display.
-  if (l.price_display) {
-    return { label: meta.priceLabel, value: l.price_display };
-  }
-
-  const km = (l.key_metrics ?? {}) as Record<string, unknown>;
-
+/** The structured, kind-aware numeric price (asking / min-commitment),
+ *  formatted compactly. Null when the row carries no priceable number. */
+function numericListingPrice(
+  l: DerivableListing,
+  kind: ListingKind,
+  meta: ListingKindMeta,
+  km: Record<string, unknown>,
+): { label: string; value: string } | null {
   // Franchise / business rows often state only a minimum entry cost
   // (key_metrics.min_investment_cents — already in cents). The bespoke
   // franchise page rendered it as "Total Investment From"; without this
@@ -412,6 +405,42 @@ export function formatListingPrice(l: DerivableListing & { price_display?: strin
   return null;
 }
 
+/** Returns a price-display string for a listing, picking the right prefix for
+ *  its kind. A seller's `price_display` override is honoured for simple values
+ *  ("$1.495M", "POA"); a *compound* override (price + yield/units/tax-perks) is
+ *  dropped in favour of the structured number when one exists, so the big price
+ *  number stays a single clean figure. Accepts the structural `DerivableListing`
+ *  shape so callers holding raw DB rows don't need a cast. */
+export function formatListingPrice(l: DerivableListing & { price_display?: string | null }): {
+  label: string;   // "Asking" / "Min investment" / "Raising" / "Market cap"
+  value: string;   // "$2.5M" / "$100k" / "ASX: TLS"
+} | null {
+  const kind = deriveListingKind(l);
+  const meta = listingKindMeta(kind);
+
+  // Listed securities: show the ticker + market cap when available.
+  if (kind === "listed_security") {
+    const km = (l.key_metrics ?? {}) as Record<string, unknown>;
+    const ticker = km["asx_ticker"];
+    if (ticker) return { label: "ASX", value: String(ticker).toUpperCase() };
+    return null;
+  }
+
+  const km = (l.key_metrics ?? {}) as Record<string, unknown>;
+  const numeric = numericListingPrice(l, kind, meta, km);
+
+  // Honour a seller override unless it's a compound string we can replace with
+  // a clean structured number.
+  if (l.price_display) {
+    const compound = COMPOUND_PRICE_DISPLAY.test(l.price_display);
+    if (!compound || !numeric) {
+      return { label: meta.priceLabel, value: stripAudPrefix(l.price_display) };
+    }
+  }
+
+  return numeric;
+}
+
 /** "$2.5M" / "$100k" / "$300" — compact AUD formatter. Input is cents. */
 export function formatAudCompact(cents: number): string {
   const dollars = cents / 100;
@@ -420,7 +449,10 @@ export function formatAudCompact(cents: number): string {
     return `$${m >= 10 ? m.toFixed(0) : m.toFixed(1).replace(/\.0$/, "")}M`;
   }
   if (dollars >= 1_000) {
-    return `$${Math.round(dollars / 1_000)}k`;
+    const k = dollars / 1_000;
+    // Sub-$10k keeps one decimal so e.g. $3,500 reads "$3.5k", not "$4k";
+    // larger amounts round to whole thousands.
+    return `$${k < 10 ? k.toFixed(1).replace(/\.0$/, "") : Math.round(k)}k`;
   }
   return `$${Math.round(dollars).toLocaleString("en-AU")}`;
 }

--- a/supabase/migrations/20260613154522_fix_overloaded_price_display.sql
+++ b/supabase/migrations/20260613154522_fix_overloaded_price_display.sql
@@ -1,0 +1,61 @@
+-- Fix overloaded `price_display` strings on wave-4 seed listings.
+--
+-- These rows crammed price + return-metric (yield / per-unit / tax-perks) into a
+-- single `price_display` string, which the card rendered as one oversized,
+-- wrapping number (e.g. "AUD $850,000 — Net yield 11.2%"). The card now renders
+-- the ticket price from asking_price_cents / key_metrics and the return metric
+-- from key_metrics (net_yield_pct / target_irr_pct / spot_price_aud / units) in
+-- its own slot — see lib/listing-format.ts::listingHeadlineStat — so these
+-- overloaded overrides must be cleared to let the structured fields drive the
+-- display.
+--
+-- Also corrects a price inconsistency on the biodiversity row: asking_price_cents
+-- was $25,000 while the listing represents 50 credits at ~$1,000/credit =
+-- $50,000 (the overloaded string was masking the wrong number).
+--
+-- Data-only, idempotent (each UPDATE guards on the current value), forward-only.
+-- Rollback: restore the prior `price_display` strings from this migration's git
+-- history, and set asking_price_cents = 2500000 on the biodiversity row.
+
+BEGIN;
+
+-- SDA housing — yield now renders from key_metrics.net_yield_pct.
+UPDATE investment_listings SET price_display = NULL
+ WHERE slug IN (
+   'sda-melbourne-fully-accessible-3br',
+   'sda-brisbane-hpa-4br',
+   'sda-perth-improved-livability',
+   'sda-syd-robust-2br'
+ )
+   AND price_display IS NOT NULL;
+
+-- ESVCLP funds — "Min investment" renders from key_metrics.min_investment_aud;
+-- the tax-offset / CGT story lives in the description + detail page.
+UPDATE investment_listings SET price_display = NULL
+ WHERE slug IN (
+   'esvclp-australia-tech-fund-iv',
+   'esvclp-aussie-climate-fund-ii',
+   'esvclp-medtech-impact-iii'
+ )
+   AND price_display IS NOT NULL;
+
+-- Carbon / environmental units — per-unit price renders from
+-- key_metrics.spot_price_aud (or asking_price_cents / units).
+UPDATE investment_listings SET price_display = NULL
+ WHERE slug IN (
+   'accu-generic-spot-100-units',
+   'accu-hir-vegetation-1000-units',
+   'vcu-verra-redd-1000-units',
+   'accu-savanna-burning-500-units'
+ )
+   AND price_display IS NOT NULL;
+
+-- Biodiversity credits — clear the overloaded string AND correct the total to
+-- match 50 credits x ~$1,000/credit; the card then derives "$1k per credit".
+UPDATE investment_listings
+   SET price_display = NULL,
+       asking_price_cents = 5000000
+ WHERE slug = 'biodiversity-credits-nsw-50-units'
+   AND asking_price_cents = 2500000;
+
+COMMIT;


### PR DESCRIPTION
Two related directory-card UX fixes — both "the cards look cheap / confusing." Styling + structured-rendering only; no change to *what's* shown.

---

## 1. Invest listing cards (`/invest`)

The big price number was rendering an **overloaded `price_display` string**, not a clean figure:

| Listing | Was rendered in the giant price slot |
|---|---|
| SDA housing | `AUD $850,000 — Net yield 11.2%` |
| ESVCLP fund | `Min $250,000 · 10% upfront tax offset + 100% CGT exempt` |
| Biodiversity | `AUD $50,000 (≈ $1k/credit)` |

In the 800-weight display font this wrapped to two lines and fused two unrelated numbers at the same weight. The card's price row was already a `justify-between` flex with an empty right side — the second stat slot was never wired, so the yield got crammed into the price string.

- **`listingHeadlineStat()`** — new SSOT for the card's secondary return stat, read structurally from `key_metrics` (net yield / target IRR / per-unit), rendered in its own slot beside the ticket price.
- **`formatListingPrice()`** — honours simple overrides (`$1.495M`, `POA`); drops compound ones in favour of the structured number; strips a redundant `AUD`.
- **`formatAudCompact()`** — one decimal under $10k (`$3,500` → `$3.5k`, not `$4k`).
- **`listingDisplayMetrics()`** — true booleans → presence chips (`SMSF eligible`), false ones dropped, instead of `Yes SMSF eligible`.
- **Migration** — clears the overloaded `price_display` seed strings and corrects the biodiversity total ($25k → $50k for 50 credits @ ~$1k). ⚠️ **Human-apply** via the migration runbook; not auto-applied on this PR. The rendering fix already corrects the visual without it (only the biodiversity number waits on the apply).

## 2. Advisor cards (`/advisors`)

The rating was a tiny hand-inlined `<svg>` star on a murky translucent-black chip, and the top-right crammed two near-identical bookmark glyphs (`BookmarkButton` with a "Save" label, beside the compare button's bookmark icon).

- Rating → clean **white pill top-left**: amber `<Icon name="star">`, bold ink score, muted review count (consistent with the shared icon set).
- Top-right → two **distinct** actions: icon-only bookmark (Save) + a `scale` glyph (compare) — no longer duplicate-looking.
- `BookmarkButton` gains an additive `iconOnly` prop; existing call sites keep their label.

---

## Testing
- `type-check` clean; `lint` clean.
- 84 unit/DOM tests for the listing modules (incl. a new `InvestListingCard` render test), 16 `AdvisorsClient` tests, plus the full `__tests__/lib` suite — all green.

## Compliance
Forecast returns stay labelled **"Target IRR"** / **"Net yield"**; advisor ratings/reviews are unchanged — display relocation only.

https://claude.ai/code/session_01KMTVeHKD2GpG1huECg5FRF