### PR TITLE
fix(booking): resolve [slotId]/[token] route-slug collision crashing the server

### DIFF
--- a/__tests__/api/booking-slot-checkout.test.ts
+++ b/__tests__/api/booking-slot-checkout.test.ts
@@ -39,7 +39,7 @@ vi.mock("@/lib/url", () => ({
   getSiteUrl: (_host: unknown) => "https://invest.com.au",
 }));
 
-import { POST } from "@/app/api/booking/[slotId]/checkout/route";
+import { POST } from "@/app/api/booking/[token]/checkout/route";
 
 // ─── Builder helper ───────────────────────────────────────────────────────────
 
@@ -58,10 +58,11 @@ function makeBuilder(data: unknown = null, error: unknown = null) {
 }
 
 // The route awaits params as a Promise (Next.js dynamic route convention)
-type RouteParams = { params: Promise<{ slotId: string }> };
+type RouteParams = { params: Promise<{ token: string }> };
 
 function makeParams(slotId: string): RouteParams {
-  return { params: Promise.resolve({ slotId }) };
+  // The route segment is named `token`; for checkout its value is the slot id.
+  return { params: Promise.resolve({ token: slotId }) };
 }
 
 const FUTURE_DATE = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
@@ -100,7 +101,7 @@ const VALID_BODY = {
 
 // ─── Rate limiting ────────────────────────────────────────────────────────────
 
-describe("POST /api/booking/[slotId]/checkout — rate limiting", () => {
+describe("POST /api/booking/[token]/checkout — rate limiting", () => {
   beforeEach(() => vi.clearAllMocks());
 
   it("returns 429 when rate limited", async () => {
@@ -115,7 +116,7 @@ describe("POST /api/booking/[slotId]/checkout — rate limiting", () => {
 
 // ─── slotId validation ────────────────────────────────────────────────────────
 
-describe("POST /api/booking/[slotId]/checkout — slotId validation", () => {
+describe("POST /api/booking/[token]/checkout — slotId validation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIsRateLimited.mockResolvedValue(false);
@@ -145,7 +146,7 @@ describe("POST /api/booking/[slotId]/checkout — slotId validation", () => {
 
 // ─── Body validation ──────────────────────────────────────────────────────────
 
-describe("POST /api/booking/[slotId]/checkout — body validation", () => {
+describe("POST /api/booking/[token]/checkout — body validation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIsRateLimited.mockResolvedValue(false);
@@ -189,7 +190,7 @@ describe("POST /api/booking/[slotId]/checkout — body validation", () => {
 
 // ─── Slot lookups ─────────────────────────────────────────────────────────────
 
-describe("POST /api/booking/[slotId]/checkout — slot state checks", () => {
+describe("POST /api/booking/[token]/checkout — slot state checks", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIsRateLimited.mockResolvedValue(false);
@@ -227,7 +228,7 @@ describe("POST /api/booking/[slotId]/checkout — slot state checks", () => {
 
 // ─── Advisor lookups ──────────────────────────────────────────────────────────
 
-describe("POST /api/booking/[slotId]/checkout — advisor checks", () => {
+describe("POST /api/booking/[token]/checkout — advisor checks", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIsRateLimited.mockResolvedValue(false);
@@ -268,7 +269,7 @@ describe("POST /api/booking/[slotId]/checkout — advisor checks", () => {
 
 // ─── Checkout creation ────────────────────────────────────────────────────────
 
-describe("POST /api/booking/[slotId]/checkout — Stripe checkout", () => {
+describe("POST /api/booking/[token]/checkout — Stripe checkout", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIsRateLimited.mockResolvedValue(false);
@@ -351,7 +352,7 @@ describe("POST /api/booking/[slotId]/checkout — Stripe checkout", () => {
   });
 });
 
-describe("POST /api/booking/[slotId]/checkout — optional topic field", () => {
+describe("POST /api/booking/[token]/checkout — optional topic field", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIsRateLimited.mockResolvedValue(false);

--- a/app/api/booking/[token]/checkout/route.ts
+++ b/app/api/booking/[token]/checkout/route.ts
@@ -17,10 +17,13 @@ const BodySchema = z.object({
   topic: z.string().max(500).optional(),
 });
 
-type Params = { params: Promise<{ slotId: string }> };
+// The dynamic segment is named `token` to match the sibling
+// /api/booking/[token]/{cancel,reschedule} routes (Next.js requires one slug
+// name per path position). For checkout the value is the numeric slot id.
+type Params = { params: Promise<{ token: string }> };
 
 /**
- * POST /api/booking/[slotId]/checkout
+ * POST /api/booking/[token]/checkout
  *
  * Creates a Stripe Checkout session for a paid advisor session booking.
  * The slot is NOT claimed until the webhook confirms payment — prevents
@@ -37,7 +40,7 @@ export async function POST(req: NextRequest, { params }: Params): Promise<Respon
     return NextResponse.json({ error: "Too many requests." }, { status: 429 });
   }
 
-  const { slotId: slotIdRaw } = await params;
+  const { token: slotIdRaw } = await params;
   const slotId = Number.parseInt(slotIdRaw, 10);
   if (!Number.isFinite(slotId) || slotId <= 0) {
     return NextResponse.json({ error: "Invalid slot." }, { status: 400 });


### PR DESCRIPTION
**Hotfix — restores the staging deploy (site-wide 500).**

## Root cause
Merged `main` crashed the Next.js server at init with:
```
Error: You cannot use different slug names for the same dynamic path ('slotId' !== 'token').
```
Next.js forbids two different slug names at the same dynamic path position. **#1570** added `app/api/booking/[token]/cancel` + `/reschedule` next to the pre-existing `app/api/booking/[slotId]/checkout`, so `booking/[slotId]` vs `booking/[token]` collided → the route table fails to build → the whole server function fails to start → **Netlify returns a plain 500 on every route** (homepage included).

This is the same conflict that failed the a11y/E2E webServer checks on #1578. It surfaced in production when the latest deploy first included #1570's routes.

## Fix
Unify the segment under `[token]` (the name the sibling booking routes already use): move checkout to `app/api/booking/[token]/checkout` and read `params.token`. The URL is **unchanged** (`/api/booking/<slotId>/checkout`; the value is still the numeric slot id), so `BookingWidget` and all callers are unaffected. 2 files.

## Verification
- Route-slug conflict detector now reports **zero** same-parent collisions across the whole `app/` tree (this was the only one).
- The checkout route's **21 tests pass**; lint + pre-push type-check clean.
- The crash was reproduced locally pre-fix; its structural trigger is removed, so it cannot recur.

https://claude.ai/code/session_01KMTVeHKD2GpG1huECg5FRF

---
_Generated by [Claude Code](https://claude.ai/code/session_01KMTVeHKD2GpG1huECg5FRF)_