### PR TITLE
fix(cards): stop price/fee clipping, kill slashed zero, fill the return slot

### DIFF
--- a/__tests__/lib/listing-format.test.ts
+++ b/__tests__/lib/listing-format.test.ts
@@ -73,6 +73,15 @@ describe("listingDisplayMetrics", () => {
     expect(metrics.map((m) => m.key)).toEqual(["bedrooms", "build_year", "scheme"]);
   });
 
+  it("skips sub_category (already shown in the card's category line) and target-yield", () => {
+    const metrics = listingDisplayMetrics({
+      sub_category: "subsea_cable",
+      target_yield_pct: "7-9",
+      route: "Perth Singapore Jakarta",
+    });
+    expect(metrics.map((m) => m.key)).toEqual(["route"]);
+  });
+
   it("returns [] for nullish metrics", () => {
     expect(listingDisplayMetrics(null)).toEqual([]);
     expect(listingDisplayMetrics(undefined)).toEqual([]);
@@ -125,6 +134,18 @@ describe("listingHeadlineStat", () => {
         }),
       ),
     ).toEqual({ label: "Per credit", value: "$1k", tone: "neutral" });
+  });
+
+  it("shows a project's target IRR given as a string range (en-dashed)", () => {
+    expect(
+      listingHeadlineStat(row({ listing_kind: "project_equity", key_metrics: { target_irr: "12-15%" } })),
+    ).toEqual({ label: "Target IRR", value: "12–15%", tone: "positive" });
+  });
+
+  it("shows a target yield range, appending % when the string omits it", () => {
+    expect(
+      listingHeadlineStat(row({ listing_kind: "project_equity", key_metrics: { target_yield_pct: "7-9" } })),
+    ).toEqual({ label: "Target yield", value: "7–9%", tone: "positive" });
   });
 
   it("returns null when the listing has no headline metric", () => {

--- a/__tests__/lib/listing-kind.test.ts
+++ b/__tests__/lib/listing-kind.test.ts
@@ -529,6 +529,17 @@ describe("formatListingPrice", () => {
     ).toEqual({ label: "Asking", value: "$1.495M" });
   });
 
+  it("ignores a '$Xmin (wholesale only)' price_display, using the structured min commitment", () => {
+    const res = formatListingPrice(
+      priceRow({
+        listing_kind: "project_equity",
+        price_display: "$3M min (wholesale only)",
+        key_metrics: { min_commit_aud: 3000000 },
+      }),
+    );
+    expect(res).toEqual({ label: "Min commitment", value: "$3M" });
+  });
+
   it("returns null when nothing priceable", () => {
     expect(formatListingPrice(priceRow({ listing_kind: "for_sale_business" }))).toBeNull();
   });

--- a/app/advisors/AdvisorsClient.tsx
+++ b/app/advisors/AdvisorsClient.tsx
@@ -1436,23 +1436,21 @@ export default function AdvisorsClient({ professionals, initialType, initialStat
                       </div>
                     )}
 
-                    {/* Fees + Availability stat grid */}
-                    <div className="grid grid-cols-2 gap-2 mt-3">
-                      <div className="rounded-lg bg-slate-50 border border-slate-100 px-2.5 py-1.5">
+                    {/* Fees gets the full width (up to 2 lines, no mid-word clip);
+                        availability is a compact status pill alongside it. */}
+                    <div className="mt-3 flex items-start justify-between gap-2 rounded-lg bg-slate-50 border border-slate-100 px-2.5 py-2">
+                      <div className="min-w-0">
                         <div className="iv2-mini text-[0.55rem] text-slate-500">Fees</div>
-                        <div className="text-[0.68rem] font-bold text-slate-800 truncate" title={feeText}>{feeText}</div>
+                        <div className="text-[0.72rem] font-bold leading-snug text-slate-800 line-clamp-2" title={feeText}>{feeText}</div>
                       </div>
-                      <div className="rounded-lg bg-slate-50 border border-slate-100 px-2.5 py-1.5">
-                        <div className="iv2-mini text-[0.55rem] text-slate-500">Availability</div>
-                        <div className={`text-[0.68rem] font-bold flex items-center gap-1 ${
-                          availability === "open" ? "text-emerald-700" : availability === "waitlist" ? "text-amber-700" : "text-red-600"
-                        }`}>
-                          <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${
-                            availability === "open" ? "bg-emerald-500" : availability === "waitlist" ? "bg-amber-500" : "bg-red-500"
-                          }`} />
-                          {availability === "open" ? "Accepting" : availability === "waitlist" ? "Waitlist" : "Closed"}
-                        </div>
-                      </div>
+                      <span className={`mt-0.5 shrink-0 inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[0.58rem] font-bold ${
+                        availability === "open" ? "bg-emerald-100 text-emerald-700" : availability === "waitlist" ? "bg-amber-100 text-amber-700" : "bg-red-100 text-red-600"
+                      }`}>
+                        <span className={`w-1.5 h-1.5 rounded-full ${
+                          availability === "open" ? "bg-emerald-500" : availability === "waitlist" ? "bg-amber-500" : "bg-red-500"
+                        }`} />
+                        {availability === "open" ? "Accepting" : availability === "waitlist" ? "Waitlist" : "Closed"}
+                      </span>
                     </div>
 
                     {/* Offer */}

--- a/app/globals.css
+++ b/app/globals.css
@@ -156,7 +156,7 @@ body {
   font-family: var(--font-display);
   font-weight: 800;
   letter-spacing: -0.04em;
-  font-feature-settings: "tnum", "zero";
+  font-feature-settings: "tnum";
   line-height: 1;
 }
 

--- a/components/InvestListingCard.tsx
+++ b/components/InvestListingCard.tsx
@@ -383,7 +383,19 @@ export default function InvestListingCard({
           <div className="flex items-end justify-between gap-3">
             <div className="min-w-0">
               <div className="iv2-mini">{price.label}</div>
-              <div className="iv2-bignum whitespace-nowrap text-2xl text-ink-900">{price.value}</div>
+              <div
+                className={`iv2-bignum truncate text-ink-900 ${
+                  price.value.length > 18
+                    ? "text-sm"
+                    : price.value.length > 13
+                      ? "text-base"
+                      : price.value.length > 9
+                        ? "text-xl"
+                        : "text-2xl"
+                }`}
+              >
+                {price.value}
+              </div>
             </div>
             {headline && (
               <div className="shrink-0 text-right">

--- a/lib/listing-format.ts
+++ b/lib/listing-format.ts
@@ -14,7 +14,7 @@
  * detail view) — don't hand-roll `.replace(/_/g, " ")` at call sites.
  */
 
-import { deriveListingKind, formatAudCompact, type DerivableListing } from "@/lib/listing-kind";
+import { formatAudCompact, type DerivableListing } from "@/lib/listing-kind";
 import { metricNumber } from "@/lib/listings/vertical-metrics";
 
 /**
@@ -46,14 +46,15 @@ const METRIC_SKIP = new Set([
   // Yield / return — shown as the headline stat beside the price (see
   // listingHeadlineStat), so never repeated as a chip.
   "net_yield_pct", "gross_yield_pct", "yield_pct", "yield_percent", "distribution_yield", "yield",
-  "target_irr_pct", "target_irr", "irr",
+  "target_irr_pct", "target_irr", "irr", "target_yield_pct", "target_yield",
   // Per-unit price — shown as the headline stat for environmental units.
   "spot_price_aud", "unit_price_aud",
   // Price / ticket — shown as the hero price.
   "min_investment_aud", "min_commit_aud", "min_investment", "asking_price",
   "asking_price_aud", "price", "price_aud",
   // Identifiers / derivation inputs / eligibility flags (rendered elsewhere).
-  "asx_ticker", "commodity", "structure", "stage", "royalty_type",
+  // `sub_category` is already shown in the card's category line — skip the dup.
+  "asx_ticker", "commodity", "structure", "stage", "royalty_type", "sub_category",
   "wholesale_only", "s708_required", "accredited_only", "open_to_retail",
   "retail_eligible",
 ]);
@@ -196,6 +197,18 @@ function formatPct(n: number): string {
   return `${Number.isInteger(n) ? n.toFixed(0) : n.toFixed(1)}%`;
 }
 
+/** Format an IRR/yield that may be a number (11.2) or a string range
+ *  ("7-9", "12-15%"): numbers → "11.2%"; strings get an en-dash and a
+ *  trailing % ("7-9" → "7–9%"). Null when blank/unparseable. */
+function formatReturnRange(raw: unknown): string | null {
+  if (typeof raw === "number") return Number.isFinite(raw) ? formatPct(raw) : null;
+  if (typeof raw !== "string") return null;
+  const s = raw.trim();
+  if (!s) return null;
+  const dashed = s.replace(/\s*[-–]\s*/g, "–");
+  return /%/.test(dashed) ? dashed : `${dashed}%`;
+}
+
 function perUnitLabel(km: Record<string, unknown>): string {
   return String(km["unit_type"] ?? "").toLowerCase().includes("credit") ? "Per credit" : "Per unit";
 }
@@ -214,17 +227,7 @@ function perUnitLabel(km: Record<string, unknown>): string {
 export function listingHeadlineStat(
   l: DerivableListing & { sub_category?: string | null },
 ): HeadlineStat | null {
-  const kind = deriveListingKind(l);
   const km = (l.key_metrics ?? {}) as Record<string, unknown>;
-
-  // Funds: forward-looking target IRR, with distribution yield as a fallback.
-  if (kind === "fund") {
-    const irr = pickMetricNumber(km, ["target_irr_pct"]);
-    if (irr != null) return { label: "Target IRR", value: formatPct(irr), tone: "positive" };
-    const dist = pickMetricNumber(km, ["distribution_yield", "yield_percent", "net_yield_pct"]);
-    if (dist != null) return { label: "Distribution", value: formatPct(dist), tone: "positive" };
-    return null;
-  }
 
   // Per-unit environmental assets (ACCUs, biodiversity credits): the buyer's
   // unit economics — prefer an explicit spot/unit price, else derive it from
@@ -238,11 +241,17 @@ export function listingHeadlineStat(
     return { label: perUnitLabel(km), value: formatAudCompact(Math.round(l.asking_price_cents / units)), tone: "neutral" };
   }
 
-  // Yield-bearing tangibles / projects / royalties / listed securities.
-  const yld = pickMetricNumber(km, ["net_yield_pct", "gross_yield_pct", "yield_percent", "yield_pct", "distribution_yield", "yield"]);
-  if (yld != null) {
-    return { label: km["net_yield_pct"] != null ? "Net yield" : "Yield", value: formatPct(yld), tone: "positive" };
-  }
+  // Return metric — IRR (target) then yield (net / target / distribution).
+  // Accepts numeric values AND string ranges ("12-15%", "7-9"), so project
+  // listings whose returns are forecast bands still get a headline stat.
+  const irr = formatReturnRange(km["target_irr_pct"] ?? km["target_irr"] ?? km["irr"]);
+  if (irr) return { label: "Target IRR", value: irr, tone: "positive" };
+  const net = formatReturnRange(km["net_yield_pct"]);
+  if (net) return { label: "Net yield", value: net, tone: "positive" };
+  const target = formatReturnRange(km["target_yield_pct"] ?? km["target_yield"]);
+  if (target) return { label: "Target yield", value: target, tone: "positive" };
+  const other = formatReturnRange(km["gross_yield_pct"] ?? km["yield_percent"] ?? km["yield_pct"] ?? km["distribution_yield"] ?? km["yield"]);
+  if (other) return { label: km["distribution_yield"] != null ? "Distribution" : "Yield", value: other, tone: "positive" };
 
   return null;
 }

--- a/lib/listing-kind.ts
+++ b/lib/listing-kind.ts
@@ -362,7 +362,7 @@ export function freshnessSignal(l: Pick<InvestmentListing, "created_at" | "expir
  *  second stat (price + yield / per-unit / tax-perks). When a clean numeric
  *  price is derivable we ignore these — the return metric belongs in its own
  *  slot (see `listingHeadlineStat`), not crammed into the big price number. */
-const COMPOUND_PRICE_DISPLAY = /yield|\/\s*(?:credit|unit)|·|≈|=|tax|cgt|esvclp|esic|upfront|exempt|stacked/i;
+const COMPOUND_PRICE_DISPLAY = /yield|\/\s*(?:credit|unit)|·|≈|=|tax|cgt|esvclp|esic|upfront|exempt|stacked|wholesale|\bmin\b|\bonly\b|\(/i;
 
 /** Drop a redundant leading "AUD" / "A$" — the whole marketplace is AUD, so
  *  `formatAudCompact` omits it and free-text overrides shouldn't re-add it. */


### PR DESCRIPTION
Round-two polish on the `/invest` and `/advisors` directory cards — they still read as cut-off and cheap. Styling/formatting only (no data writes, no routes).

## The "weird 0"
`.iv2-bignum` set `font-feature-settings: "tnum", "zero"` — the `"zero"` forces a **slashed zero**, which looked broken in `$5,000` / `$250k` / `$500k`. Dropped it (kept tabular figures).

## Invest cards (`/invest`)
- **Prices stop clipping.** Long descriptive `price_display` strings like `$3M min (wholesale only)` (which the earlier compound-detector missed — no "wholesale"/"min"/paren tokens) now resolve to the clean structured number `$3M` from `key_metrics.min_commit_aud`, dropping the qualifier. The price font also **scales down** for any genuinely long value (e.g. `NASDAQ: EQIX (parent)`) so it never clips mid-word.
- **Right side filled.** `listingHeadlineStat` now accepts **string ranges** (`12-15%`, `7-9`), so project listings show `Target IRR 12–15%` / `Target yield 7–9%` instead of an empty slot.
- **Dropped the redundant `Subsea Cable sub category` chip** (already in the category line).

## Advisor cards (`/advisors`)
- **Fees stop clipping.** The Fees box is now full-width with up to **2 lines** (no more `SMSF setup wit…`), and **Availability** is a compact status pill beside it.

## Verification
- `type-check` clean, `lint` clean, **104 tests pass** (incl. new coverage: compound `$Xmin (wholesale only)` → `$3M`, IRR/yield string ranges, `sub_category` skip).

https://claude.ai/code/session_01KMTVeHKD2GpG1huECg5FRF

---
_Generated by [Claude Code](https://claude.ai/code/session_01KMTVeHKD2GpG1huECg5FRF)_