### PR TITLE
fix/feat(home+advisor-portal): JWT dashboard auth, schema-drift fixes, Decision Cockpit Phase 0

### DIFF
--- a/__tests__/api/advisor-dashboard.test.ts
+++ b/__tests__/api/advisor-dashboard.test.ts
@@ -19,7 +19,14 @@ vi.mock("@/lib/logger", () => ({
   logger: vi.fn(() => ({ error: vi.fn(), info: vi.fn(), warn: vi.fn() })),
 }));
 
+// The route now delegates auth to the shared resolver (JWT + legacy cookie);
+// mock it at the boundary instead of the underlying session lookup.
+vi.mock("@/lib/require-advisor-session", () => ({
+  requireAdvisorSession: vi.fn(),
+}));
+
 import { GET } from "@/app/api/advisor-dashboard/route";
+import { requireAdvisorSession } from "@/lib/require-advisor-session";
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -108,6 +115,8 @@ function makeReview(rating: number) {
 describe("GET /api/advisor-dashboard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: authenticated as ADVISOR_ID. The 401 tests override to null.
+    vi.mocked(requireAdvisorSession).mockResolvedValue(ADVISOR_ID);
     // advisor_bookings is fetched via createAdminClient — default to empty result
     adminFromMock.mockImplementation(() => {
       const b = createChainableBuilder("advisor_bookings");
@@ -120,8 +129,7 @@ describe("GET /api/advisor-dashboard", () => {
   });
 
   it("returns 401 when no advisor_session cookie", async () => {
-    // Session lookup returns null (no cookie → no session)
-    mockFrom.mockImplementation(() => createChainableBuilder("advisor_sessions"));
+    vi.mocked(requireAdvisorSession).mockResolvedValue(null);
 
     const res = await GET(makeGet());
     expect(res.status).toBe(401);
@@ -129,35 +137,15 @@ describe("GET /api/advisor-dashboard", () => {
     expect(data.error).toMatch(/not authenticated/i);
   });
 
-  it("returns 401 when session token is invalid", async () => {
-    mockFrom.mockImplementation((table: string) => {
-      if (table === "advisor_sessions") {
-        return createChainableBuilder("advisor_sessions");
-      }
-      return createChainableBuilder(table);
-    });
+  it("returns 401 when the shared resolver rejects the session", async () => {
+    vi.mocked(requireAdvisorSession).mockResolvedValue(null);
 
     const res = await GET(makeGet(SESSION_TOKEN));
     expect(res.status).toBe(401);
   });
 
-  it("returns 401 when session is expired", async () => {
-    mockFrom.mockImplementation((table: string) => {
-      if (table === "advisor_sessions") {
-        const builder = createChainableBuilder("advisor_sessions");
-        builder.single = vi.fn(() =>
-          Promise.resolve({
-            data: {
-              professional_id: ADVISOR_ID,
-              expires_at: new Date(Date.now() - 86400000).toISOString(), // yesterday
-            },
-            error: null,
-          }),
-        );
-        return builder;
-      }
-      return createChainableBuilder(table);
-    });
+  it("returns 401 when the session has expired (resolver returns null)", async () => {
+    vi.mocked(requireAdvisorSession).mockResolvedValue(null);
 
     const res = await GET(makeGet(SESSION_TOKEN));
     expect(res.status).toBe(401);

--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -233,12 +233,6 @@ export default async function HomePage() {
           latest rate changes in a single card (was three stacked strips). */}
       <HomeMarketToday />
 
-      {/* Social feed — personalised for logged-in users; streams in
-          dynamically so the ISR shell remains cacheable. */}
-      <Suspense fallback={null}>
-        <HomeFeedSection />
-      </Suspense>
-
       <ScrollFadeIn>
         <HomeRouteCards
           listingCount={totalListingCount}
@@ -296,6 +290,14 @@ export default async function HomePage() {
       <ScrollFadeIn>
         <CountryToolsStripWrapper />
       </ScrollFadeIn>
+
+      {/* Social/activity feed — personalised for logged-in users; streams in
+          dynamically so the ISR shell stays cacheable. Sits low on the page so
+          the hero + product bands (compare / listings / experts) lead, instead
+          of a 20-row feed wall in the hero's slot. */}
+      <Suspense fallback={null}>
+        <HomeFeedSection />
+      </Suspense>
 
       <ScrollFadeIn>
         <HomeFridayBriefing />

--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -229,6 +229,14 @@ export default async function HomePage() {
       {/* Temporarily hidden for the next few months. Keep the component intact
           so the homepage AI concierge entry can be restored without rebuilding it. */}
 
+      {/* Decision Cockpit (Phase 0) — personalised activity feed for logged-in
+          users, directly under the hero (renders null for anonymous visitors,
+          who get the marketing hero alone). Streams in via Suspense so the ISR
+          shell stays cacheable. See docs/plans/DECISION_COCKPIT.md. */}
+      <Suspense fallback={null}>
+        <HomeFeedSection />
+      </Suspense>
+
       {/* One "Today's market" band — Invest Score gauge, standout rate and
           latest rate changes in a single card (was three stacked strips). */}
       <HomeMarketToday />
@@ -290,14 +298,6 @@ export default async function HomePage() {
       <ScrollFadeIn>
         <CountryToolsStripWrapper />
       </ScrollFadeIn>
-
-      {/* Social/activity feed — personalised for logged-in users; streams in
-          dynamically so the ISR shell stays cacheable. Sits low on the page so
-          the hero + product bands (compare / listings / experts) lead, instead
-          of a 20-row feed wall in the hero's slot. */}
-      <Suspense fallback={null}>
-        <HomeFeedSection />
-      </Suspense>
 
       <ScrollFadeIn>
         <HomeFridayBriefing />

--- a/app/advisor/[slug]/page.tsx
+++ b/app/advisor/[slug]/page.tsx
@@ -220,7 +220,7 @@ export default async function AdvisorProfilePage({ params }: { params: Promise<{
     id: string;
     name: string;
     issuer: string | null;
-    issued_year: number | null;
+    issued_at: string | null;
     credential_url: string | null;
   };
   type AdvisorCaseStudy = {
@@ -247,7 +247,7 @@ export default async function AdvisorProfilePage({ params }: { params: Promise<{
         .order("sort_order"),
       supabase
         .from("advisor_certifications")
-        .select("id, name, issuer, issued_year, credential_url")
+        .select("id, name, issuer, issued_at, credential_url")
         .eq("professional_id", pro.id),
       supabase
         .from("advisor_case_studies")
@@ -540,7 +540,7 @@ export default async function AdvisorProfilePage({ params }: { params: Promise<{
                       <div className="flex flex-col gap-px">
                         <span className="text-[13px] font-bold text-slate-900">{cert.name}</span>
                         <span className="text-[11px] text-slate-500">
-                          {[cert.issuer, cert.issued_year].filter(Boolean).join(" · ")}
+                          {[cert.issuer, cert.issued_at ? new Date(cert.issued_at).getFullYear() : null].filter(Boolean).join(" · ")}
                         </span>
                       </div>
                     );

--- a/app/api/advisor-dashboard/route.ts
+++ b/app/api/advisor-dashboard/route.ts
@@ -1,26 +1,17 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
-// advisor_bookings is non-anon RLS; this route authenticates via the custom
-// advisor_session cookie (no Supabase JWT), so its booking read uses the
+// advisor_bookings is non-anon RLS; the booking read below uses the
 // service-role client, scoped in-query to the validated advisorId.
 import { createAdminClient } from "@/lib/supabase/admin";
+import { requireAdvisorSession } from "@/lib/require-advisor-session";
 import { deriveProfileCompleteness } from "@/lib/advisor-portal/profile-completeness";
 
-async function getAdvisorId(request: NextRequest): Promise<number | null> {
-  const sessionToken = request.cookies.get("advisor_session")?.value;
-  if (!sessionToken) return null;
-  const supabase = await createClient();
-  const { data } = await supabase
-    .from("advisor_sessions")
-    .select("professional_id, expires_at")
-    .eq("session_token", sessionToken)
-    .single();
-  if (!data || new Date(data.expires_at) < new Date()) return null;
-  return data.professional_id;
-}
-
 export async function GET(request: NextRequest) {
-  const advisorId = await getAdvisorId(request);
+  // Accept BOTH auth schemes — the Supabase JWT minted by magic-link/password
+  // login AND the legacy advisor_session cookie — via the shared resolver. The
+  // previous cookie-only check 401'd every advisor who logged in with a JWT,
+  // which blanked the dashboard stats and tripped the load-error banner.
+  const advisorId = await requireAdvisorSession(request);
   if (!advisorId)
     return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
 

--- a/app/article/[slug]/page.tsx
+++ b/app/article/[slug]/page.tsx
@@ -150,7 +150,23 @@ export default async function ArticlePage({
     : Promise.resolve({ data: null });
 
   const crossCategoryPromise = (a.tags && a.tags.length > 0)
-    ? supabase.from("articles").select("slug, title, category, read_time, id, tags").eq("status", "published").neq("category", a.category || "").neq("slug", slug).overlaps("tags", a.tags).order("published_at", { ascending: false }).limit(3)
+    ? (async () => {
+        const { data } = await supabase
+          .from("articles")
+          .select("slug, title, category, read_time, id, tags")
+          .eq("status", "published")
+          .neq("category", a.category || "")
+          .neq("slug", slug)
+          .order("published_at", { ascending: false })
+          .limit(40);
+        // articles.tags is jsonb, so PostgREST array-overlap (&&) errors;
+        // filter the tag overlap in JS instead.
+        const selfTags = (a.tags as string[]) || [];
+        const matched = ((data as { tags?: unknown }[]) || [])
+          .filter((r) => Array.isArray(r.tags) && (r.tags as string[]).some((t) => selfTags.includes(t)))
+          .slice(0, 3);
+        return { data: matched };
+      })()
     : Promise.resolve({ data: null });
 
   const [relatedBrokersRes, fxBrokersRes, allActiveBrokersRes, relatedArticlesRes, crossCategoryRes, linkInjectionEnabled] = await Promise.all([

--- a/app/glossary/[term]/page.tsx
+++ b/app/glossary/[term]/page.tsx
@@ -60,9 +60,19 @@ export default async function GlossaryTermPage({ params }: { params: Promise<{ t
   const termWords = entry.term.toLowerCase().split(/\s+/).filter((w) => w.length > 3);
   const categoryTag = entry.category?.toLowerCase().replace(/\s+/g, "-").replace(/&/g, "").replace(/\//g, "-") || "";
   const searchTags = [...termWords, categoryTag].filter(Boolean);
-  const { data: relatedArticles } = searchTags.length > 0
-    ? await supabase.from("articles").select("slug, title, read_time").eq("status", "published").overlaps("tags", searchTags).limit(3)
-    : { data: [] };
+  const relatedArticles = await (async (): Promise<{ slug: string; title: string; read_time: number }[]> => {
+    if (searchTags.length === 0) return [];
+    const { data } = await supabase
+      .from("articles")
+      .select("slug, title, read_time, tags")
+      .eq("status", "published")
+      .order("published_at", { ascending: false })
+      .limit(60);
+    // articles.tags is jsonb — filter overlap in JS (PostgREST && errors).
+    return ((data as { slug: string; title: string; read_time: number; tags?: unknown }[]) || [])
+      .filter((r) => Array.isArray(r.tags) && (r.tags as string[]).some((t) => searchTags.includes(t)))
+      .slice(0, 3);
+  })();
 
 
   // WebPage + Speakable + DefinedTerm (mainEntity). Speakable selectors point

--- a/app/how-to/[slug]/page.tsx
+++ b/app/how-to/[slug]/page.tsx
@@ -92,12 +92,19 @@ export default async function HowToGuidePage({
 
   // Fetch related articles based on guide slug keywords
   const guideKeywords = guide.slug.split("-").filter((w) => w.length > 3);
-  const { data: relatedArticlesData } = await supabase
-    .from("articles")
-    .select("slug, title, category, read_time")
-    .eq("status", "published")
-    .overlaps("tags", guideKeywords)
-    .limit(4);
+  const { data: relatedArticlesData } = await (async () => {
+    const { data } = await supabase
+      .from("articles")
+      .select("slug, title, category, read_time, tags")
+      .eq("status", "published")
+      .order("published_at", { ascending: false })
+      .limit(60);
+    // articles.tags is jsonb — filter overlap in JS (PostgREST && errors).
+    const matched = ((data as { tags?: unknown }[]) || [])
+      .filter((r) => Array.isArray(r.tags) && (r.tags as string[]).some((t) => guideKeywords.includes(t)))
+      .slice(0, 4);
+    return { data: matched };
+  })();
   const relatedArticles = (relatedArticlesData as { slug: string; title: string; category: string; read_time: number }[]) || [];
 
   // JSON-LD

--- a/components/HomeFeedSection.tsx
+++ b/components/HomeFeedSection.tsx
@@ -4,8 +4,8 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import HomeFeedTabs from "@/components/HomeFeedTabs";
 import { rankFeedEvents, type FeedEvent } from "@/lib/feed-ranking";
 
-const INITIAL_LIMIT = 20;
-const FETCH_LIMIT = 40; // fetch 2× to allow ranking without losing pagination accuracy
+const INITIAL_LIMIT = 6; // homepage teaser — "load more" + the /feed page carry the rest
+const FETCH_LIMIT = 24; // fetch wider than we show so ranking has a pool to sort
 
 export default async function HomeFeedSection() {
   const supabase = await createClient();

--- a/components/HomeFeedTabs.tsx
+++ b/components/HomeFeedTabs.tsx
@@ -2,10 +2,12 @@
 
 import { useState, useRef, useCallback, useEffect } from "react";
 import Link from "next/link";
+import Icon from "@/components/Icon";
 import {
   FEED_TAB_LABELS,
   feedEventHref,
   type FeedEvent,
+  type FeedEventType,
   type FeedTab,
 } from "@/lib/feed-ranking";
 
@@ -32,20 +34,17 @@ const DEFAULT_TAB_STATE: TabState = {
   loaded: false,
 };
 
-function eventIcon(type: FeedEvent["event_type"]): string {
-  switch (type) {
-    case "rate_change":
-      return "📈";
-    case "advisor_post":
-      return "💬";
-    case "community_thread":
-      return "🗣️";
-    case "article":
-      return "📄";
-    case "deal":
-      return "🎁";
-  }
-}
+/** Per-event-type visual identity — house Icon + tinted badge, never emoji. */
+const EVENT_META: Record<
+  FeedEventType,
+  { icon: string; label: string; badge: string; ring: string }
+> = {
+  rate_change: { icon: "trending-up", label: "Rate", badge: "bg-emerald-50 text-emerald-600", ring: "ring-emerald-100" },
+  advisor_post: { icon: "message-circle", label: "Advisor", badge: "bg-blue-50 text-blue-600", ring: "ring-blue-100" },
+  community_thread: { icon: "help-circle", label: "Community", badge: "bg-violet-50 text-violet-600", ring: "ring-violet-100" },
+  article: { icon: "file-text", label: "Insight", badge: "bg-amber-50 text-amber-600", ring: "ring-amber-100" },
+  deal: { icon: "party-popper", label: "Deal", badge: "bg-rose-50 text-rose-600", ring: "ring-rose-100" },
+};
 
 function timeAgo(iso: string): string {
   const secs = Math.floor((Date.now() - new Date(iso).getTime()) / 1000);
@@ -57,42 +56,104 @@ function timeAgo(iso: string): string {
   return `${Math.floor(hrs / 24)}d ago`;
 }
 
-function FeedEventCard({ event }: { event: FeedEvent }) {
+/** <1h old — kept out of the render body so the purity lint stays happy. */
+function isFresh(iso: string): boolean {
+  return Date.now() - new Date(iso).getTime() < 3_600_000;
+}
+
+function initials(name: string): string {
+  return name
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((w) => w[0]?.toUpperCase() ?? "")
+    .join("");
+}
+
+/** Leading visual: actor photo → initials → category icon badge. */
+function EventVisual({ event }: { event: FeedEvent }) {
+  const meta = EVENT_META[event.event_type];
+  if (event.image_url) {
+    return (
+      <span className="relative shrink-0">
+        {/* eslint-disable-next-line @next/next/no-img-element -- remote, unknown-host feed thumbnails */}
+        <img src={event.image_url} alt="" className="h-10 w-10 rounded-lg object-cover ring-1 ring-slate-200" />
+        <span className={`absolute -bottom-1 -right-1 grid h-5 w-5 place-items-center rounded-md ring-2 ring-white ${meta.badge}`}>
+          <Icon name={meta.icon} size={12} />
+        </span>
+      </span>
+    );
+  }
+  if (event.actor_name) {
+    return (
+      <span className={`grid h-10 w-10 shrink-0 place-items-center rounded-lg text-xs font-bold ring-1 ${meta.badge} ${meta.ring}`}>
+        {initials(event.actor_name)}
+      </span>
+    );
+  }
+  return (
+    <span className={`grid h-10 w-10 shrink-0 place-items-center rounded-lg ${meta.badge}`}>
+      <Icon name={meta.icon} size={18} />
+    </span>
+  );
+}
+
+function FeedEventCard({ event, index }: { event: FeedEvent; index: number }) {
   const href = feedEventHref(event);
+  const meta = EVENT_META[event.event_type];
+  const fresh = isFresh(event.published_at);
   return (
     <Link
       href={href}
-      className="block group px-4 py-3.5 border-b border-slate-100 hover:bg-slate-50 transition-colors last:border-0"
+      className="group relative flex items-start gap-3 rounded-xl border border-slate-200 bg-white p-3.5 shadow-sm transition-all hover:-translate-y-0.5 hover:border-slate-300 hover:shadow-md"
+      style={{ animation: "fadeInUp 0.4s ease-out both", animationDelay: `${Math.min(index, 6) * 55}ms` }}
     >
-      <div className="flex items-start gap-3">
-        <span className="text-lg shrink-0 mt-0.5" aria-hidden="true">
-          {eventIcon(event.event_type)}
-        </span>
-        <div className="min-w-0 flex-1">
-          <p className="text-sm font-medium text-slate-800 group-hover:text-blue-700 leading-snug line-clamp-2">
-            {event.headline}
-          </p>
-          {event.summary && event.event_type === "advisor_post" && (
-            <p className="text-xs text-slate-500 mt-0.5 line-clamp-2">
-              {event.summary}
-            </p>
-          )}
-          <div className="flex items-center gap-2 mt-1">
-            {event.actor_name && (
-              <span className="text-[11px] text-slate-500 font-medium">
-                {event.actor_name}
+      <EventVisual event={event} />
+      <div className="min-w-0 flex-1">
+        <div className="mb-1 flex items-center gap-2">
+          <span className={`inline-flex items-center rounded-md px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${meta.badge}`}>
+            {meta.label}
+          </span>
+          {fresh && (
+            <span className="inline-flex items-center gap-1 text-[10px] font-semibold text-emerald-600">
+              <span className="relative flex h-1.5 w-1.5">
+                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75" />
+                <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-emerald-500" />
               </span>
-            )}
-            <span className="text-[11px] text-slate-500">
-              {timeAgo(event.published_at)}
+              New
             </span>
-          </div>
+          )}
         </div>
-        <span className="text-slate-300 group-hover:text-blue-400 shrink-0 mt-1" aria-hidden="true">
-          →
-        </span>
+        <p className="line-clamp-2 text-sm font-semibold leading-snug text-slate-900 group-hover:text-blue-700">
+          {event.headline}
+        </p>
+        {event.summary && (
+          <p className="mt-0.5 line-clamp-1 text-xs text-slate-500">{event.summary}</p>
+        )}
+        <div className="mt-1.5 flex items-center gap-1.5 text-[11px] text-slate-400">
+          {event.actor_name && <span className="font-medium text-slate-500">{event.actor_name}</span>}
+          {event.actor_name && <span aria-hidden="true">·</span>}
+          <span>{timeAgo(event.published_at)}</span>
+        </div>
       </div>
+      <Icon
+        name="arrow-right"
+        size={16}
+        className="mt-1 shrink-0 text-slate-300 transition-all group-hover:translate-x-0.5 group-hover:text-blue-500"
+      />
     </Link>
+  );
+}
+
+function CardSkeleton() {
+  return (
+    <div className="flex items-start gap-3 rounded-xl border border-slate-200 bg-white p-3.5">
+      <div className="h-10 w-10 shrink-0 animate-pulse rounded-lg bg-slate-100" />
+      <div className="min-w-0 flex-1 space-y-2 py-0.5">
+        <div className="h-3 w-16 animate-pulse rounded bg-slate-100" />
+        <div className="h-3.5 w-full animate-pulse rounded bg-slate-100" />
+        <div className="h-3 w-2/3 animate-pulse rounded bg-slate-100" />
+      </div>
+    </div>
   );
 }
 
@@ -183,16 +244,32 @@ export default function HomeFeedTabs({ initialEvents, initialCursor }: Props) {
   const hasMore = currentTab?.hasMore ?? true;
 
   return (
-    <section className="container-custom max-w-2xl my-6">
+    <section className="container-custom max-w-2xl my-6 md:my-8">
+      {/* Header */}
+      <div className="mb-3 flex items-end justify-between gap-3">
+        <div>
+          <h2 className="text-base font-bold text-slate-900">Your feed</h2>
+          <p className="text-xs text-slate-500">
+            What&apos;s moved across your shortlists, advisors and the market.
+          </p>
+        </div>
+        <Link
+          href="/feed"
+          className="shrink-0 text-xs font-semibold text-blue-600 hover:text-blue-700"
+        >
+          See all →
+        </Link>
+      </div>
+
       {/* Tab bar */}
-      <div className="flex gap-0.5 mb-0 bg-slate-100 rounded-xl p-1" role="tablist">
+      <div className="mb-3 flex gap-0.5 rounded-xl bg-slate-100 p-1" role="tablist">
         {TABS.map((tab) => (
           <button
             key={tab}
             role="tab"
             aria-selected={activeTab === tab}
             onClick={() => switchTab(tab)}
-            className={`flex-1 text-xs font-semibold py-1.5 rounded-lg transition-colors ${
+            className={`flex-1 rounded-lg py-1.5 text-xs font-semibold transition-colors ${
               activeTab === tab
                 ? "bg-white text-slate-900 shadow-sm"
                 : "text-slate-500 hover:text-slate-700"
@@ -203,37 +280,36 @@ export default function HomeFeedTabs({ initialEvents, initialCursor }: Props) {
         ))}
       </div>
 
-      {/* Feed events */}
-      <div
-        className="bg-white border border-slate-200 rounded-xl overflow-hidden mt-2 shadow-sm"
-        role="tabpanel"
-      >
+      {/* Events */}
+      <div role="tabpanel" className="space-y-2">
         {events.length === 0 && !loading ? (
-          <div className="px-4 py-8 text-center text-sm text-slate-500">
-            {currentTab?.loaded
-              ? "Nothing here yet — check back soon."
-              : "Loading…"}
-          </div>
+          currentTab?.loaded ? (
+            <div className="rounded-xl border border-dashed border-slate-200 bg-white px-4 py-10 text-center">
+              <div className="mx-auto mb-2 grid h-9 w-9 place-items-center rounded-full bg-slate-100 text-slate-400">
+                <Icon name="check-circle" size={18} />
+              </div>
+              <p className="text-sm font-medium text-slate-600">You&apos;re all caught up</p>
+              <p className="text-xs text-slate-400">New activity will land here.</p>
+            </div>
+          ) : (
+            <>
+              <CardSkeleton />
+              <CardSkeleton />
+              <CardSkeleton />
+            </>
+          )
         ) : (
           <>
-            {events.map((event) => (
-              <FeedEventCard key={event.id} event={event} />
+            {events.map((event, i) => (
+              <FeedEventCard key={event.id} event={event} index={i} />
             ))}
             {/* Infinite scroll sentinel */}
-            {hasMore && (
-              <div ref={sentinelRef} className="h-1" aria-hidden="true" />
+            {hasMore && <div ref={sentinelRef} className="h-1" aria-hidden="true" />}
+            {loading && <CardSkeleton />}
+            {!hasMore && events.length > 0 && (
+              <p className="py-2 text-center text-xs text-slate-400">You&apos;re all caught up.</p>
             )}
           </>
-        )}
-        {loading && (
-          <div className="px-4 py-3 text-xs text-slate-500 text-center border-t border-slate-100">
-            Loading…
-          </div>
-        )}
-        {!hasMore && events.length > 0 && (
-          <div className="px-4 py-3 text-xs text-slate-500 text-center border-t border-slate-100">
-            You&apos;re all caught up.
-          </div>
         )}
       </div>
     </section>

--- a/docs/plans/DECISION_COCKPIT.md
+++ b/docs/plans/DECISION_COCKPIT.md
@@ -1,0 +1,109 @@
+# Decision Cockpit — the logged-in home
+
+> The personalised surface a logged-in user sees directly under the hero.
+> Not a "social feed" — a money command-center whose only job is to **advance
+> the user's actual decision** and tell them **what changed since they last
+> looked**. Robinhood-grade craft, pointed at *research progress, not trades*
+> (per `RETAIL_UX_NORTHSTAR.md`: "celebrate readiness, not trades").
+
+Status: **Phase 0 shipped** (card system + motion + placement). Phases 1–3
+below are sequenced against two hard gates that are **founder-owned, not
+autonomous**: the compliance line and the cron switch.
+
+---
+
+## The reframe
+
+A comparison + marketplace + advisor platform under ASIC promotion rules is
+not a brokerage. So the world-class version of "the thing under the hero" is a
+**decision cockpit**, not a timeline. Anonymous visitors get the marketing
+hero; logged-in users get *"Welcome back — here's what moved."* That single
+swap is the highest-leverage retention change available, and it makes the
+north-star metric literal: **Weekly Decision-Ready Returners** (saved ≥1 +
+returned ≤7d).
+
+---
+
+## Hard gates (founder-owned — do not build/merge/enable autonomously)
+
+1. **Compliance (Tier E / `REGULATORY-AVOID-LIST`).** The *craft* and the
+   *factual* layers are lawful to ship. The **relevance/recommendation engine**
+   — anything that decides "*you personally* should look at X" — is
+   personal-advice-adjacent. It requires **founder + legal sign-off** before it
+   is built or merged. The lawful framing: surface **facts about things the
+   user explicitly chose** ("a listing matching *a search you saved* dropped
+   8%"; "fee changed on *a broker you compared*"), with a visible
+   "why you're seeing this" chip, and **never** "you should buy/switch."
+   Celebrate *research milestones*, never *returns*.
+2. **Cron (founder switch).** The live/notification phases ride on the cron
+   fleet, **dark since 2026-05-23**. Code can be built and merged; it stays
+   inert until `CRON_BRIDGE_ENABLED=true` is set in Netlify (+ `CRON_SECRET`).
+
+---
+
+## Phases
+
+### Phase 0 — craft + placement ✅ (shipped)
+- `HomeFeedTabs` / `FeedEventCard` rebuilt to the `UX_UI_FINTECH_ALIGNMENT.md`
+  standard: rounded cards, `hover:-translate-y-0.5`, house `Icon` (never
+  emoji), per-type colour accents, **actor avatars** (the `image_url` /
+  `actor_name` already stored and previously unused), an emerald **"live"
+  pulse** on <1h items, staggered `fadeInUp` entrance, skeleton loading.
+- Relocated **directly under the hero** for logged-in users, capped to 6.
+- No new ranking/recommendation logic — pure presentation. Compliance-safe.
+
+### Phase 1 — the delta engine (the "smart") · gate: **compliance**
+- Fuse the disconnected personal signals into one relevance pass: the
+  `SinceYouWereHere` fee-diff, saved searches / saved comparisons, Get-Matched
+  P8/P9 intent + outcome-learning, Country Mode corridor, follows.
+- The atomic card becomes **"what changed on something you chose,"** each with
+  a **reason chip** (transparency = trust + the compliance guardrail).
+- Negative signals (dismiss / "not relevant") shorten and sharpen the feed.
+- **Investor vs advisor split** (see below) — same card system, different
+  signal set.
+- ⚠️ Ships only behind the legal packet (Q1–Q3 below).
+
+### Phase 2 — alive (signal bus + realtime + notifications) · gate: **cron**
+- A unified event/signal bus: every surface (fee recheck, new listing, brief
+  status, advisor reply, rule alert) emits one typed event; `feed_events` is
+  the seed schema. The feed, the weekly digest, and push become **views of one
+  stream**.
+- Per-user ranked feed materialised server-side + edge-cached, recomputed on
+  new signals (not ranked client-side per load).
+- Supabase Realtime channel so a rate-change / availability flip animates
+  **while watched**. Notification spine (in-app + push + digest) — **cron-gated**.
+
+### Phase 3 — world-class · gate: **compliance + infra**
+- Learned ranking (Get-Matched already logs outcomes → close the loop).
+- Semantic matching (embed listings/articles against the user's stated thesis).
+- An LLM **"3 things worth your attention today"** concierge summary at the top
+  (in-session / Max-plan, no API bill — same lane as the AI journeys).
+
+---
+
+## Investor vs advisor — two cockpits, one engine
+
+The feed currently renders for **any** logged-in user with identical content
+(`HomeFeedSection`: `if (!user) return null`). World-class = audience-aware:
+- **Investor:** decision cockpit — what changed on the things you're deciding
+  between; next-best-step into compare / match.
+- **Advisor:** practice pulse — new leads, a teammate's referral, leaderboard
+  movement, a claimable brief, a review landed. (This is why the feed currently
+  feels random to a logged-in advisor — they're shown an investor feed.)
+
+---
+
+## North-star metric & instrumentation
+
+Instrument the only thing that matters: does a card lead to a
+compare / save / match / booking? Kill cards that don't move decisions. Target:
+**Weekly Decision-Ready Returners**.
+
+## Open legal questions (clear before Phase 1 ships)
+
+1. May we surface **factual changes on user-chosen items** (saved search, saved
+   comparison, followed advisor) with a "why" chip, framed as information only?
+2. Where is the line between a **factual "matches a search you saved"** chip and
+   a **recommendation**? Approved phrasings vs banned phrasings.
+3. Does an **LLM-generated factual summary** of already-published events need
+   additional disclosure / human-in-the-loop review?


### PR DESCRIPTION
Found while dogfooding the advisor portal + homepage as a logged-in advisor.

## 1. Advisor-portal dashboard 401 (the "Some data couldn't be loaded" banner)
`/api/advisor-dashboard` authenticated only via the legacy `advisor_session` cookie, so any advisor who logged in with the Supabase JWT flow (magic-link / password) got a `401` — blanking Profile Views / Enquiries / Booking Clicks and tripping the load-error banner. Now routed through the shared `requireAdvisorSession` resolver, which accepts **both** schemes. Closes the half-done auth migration for the ~177 advisors who can't currently use the dashboard.

## 2. Prod schema-drift queries (from the Postgres logs)
- `advisor/[slug]` selected `advisor_certifications.issued_year`; the real column is `issued_at` (render derives the year). Broke the certs block on public profiles.
- `article` / `glossary` / `how-to` used `.overlaps("tags", …)` on `articles.tags`, which is `jsonb` — PostgREST `&&` errors there. Tag overlap now filtered in JS. Broke "related articles".

Code-only — prod already has the correct columns; no migration / ledger change.

## 3. Decision Cockpit — Phase 0 (homepage feed)
The personalised feed rendered ~20 plain emoji rows in the homepage's #2 slot, burying the product. Rebuilt `HomeFeedTabs` / `FeedEventCard` to the `UX_UI_FINTECH_ALIGNMENT` standard — rounded hover-lift cards, house `Icon` (no emoji), per-type colour accents, **actor avatars** (stored but unused), an emerald **"live" pulse** on <1h items, staggered entrance + skeletons — and placed it **directly under the hero** for logged-in users (capped to 6).

Presentation only — **no ranking/recommendation logic**, so it stays clear of the personal-advice line. The smart-relevance, realtime and LLM-concierge phases are sequenced — with their **compliance + cron gates** (both founder-owned) — in `docs/plans/DECISION_COCKPIT.md`.

## Testing
- `tsc --noEmit` clean · ESLint clean
- `advisor-dashboard.test.ts` 12/12 · `feed-ranking` + `home-listing-curation` + `dynamic-route-404-guard` 35/35
- Phase 0 is presentation; not deployed (no live deploy until redeploy)

https://claude.ai/code/session_01TSAJcyWjpinP4CnjXWBgdA