### PR TITLE
fix(advisor-portal): resilient dashboard route — stop the 500 that zeroed every KPI

### DIFF
--- a/__tests__/api/advisor-dashboard.test.ts
+++ b/__tests__/api/advisor-dashboard.test.ts
@@ -27,6 +27,7 @@ vi.mock("@/lib/require-advisor-session", () => ({
 
 import { GET } from "@/app/api/advisor-dashboard/route";
 import { requireAdvisorSession } from "@/lib/require-advisor-session";
+import { createAdminClient } from "@/lib/supabase/admin";
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -545,5 +546,72 @@ describe("GET /api/advisor-dashboard", () => {
     expect(data.stats.leads7d).toBe(2); // yesterday + 5 days ago both within 7d
     expect(data.stats.leadsThisMonth).toBe(expectedThisMonth);
     expect(data.stats.leadsLastMonth).toBeGreaterThanOrEqual(1); // prevMonthMid
+  });
+
+  // ── Resilience: a missing service-role key or one failed slice must NOT
+  //    500 the whole dashboard (the bug behind "Some data couldn't be loaded"). ──
+
+  it("degrades to 200 (not 500) when the service-role key is missing", async () => {
+    // createAdminClient() throws without SUPABASE_SERVICE_ROLE_KEY. Previously
+    // that throw — inline in Promise.all — rejected the entire route → 500 →
+    // every KPI 0 + the load-error banner. Now it degrades to bookings = 0.
+    vi.mocked(createAdminClient).mockImplementationOnce(() => {
+      throw new Error("Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY environment variable");
+    });
+    mockFrom.mockImplementation(
+      makeFromWithLeads([makeLead(new Date().toISOString(), "new", 80)]),
+    );
+
+    const res = await GET(makeGet(SESSION_TOKEN));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.stats.totalLeads).toBe(1); // leads still load via the user client
+    expect(data.stats.bookingClicks30d).toBe(0); // bookings degrade, not crash
+  });
+
+  it("degrades to 200 when one slice (leads) rejects", async () => {
+    mockFrom.mockImplementation((table: string) => {
+      if (table === "advisor_sessions") {
+        const b = createChainableBuilder("advisor_sessions");
+        b.single = vi.fn(() =>
+          Promise.resolve({
+            data: { professional_id: ADVISOR_ID, expires_at: new Date(Date.now() + 86400000).toISOString() },
+            error: null,
+          }),
+        );
+        return b;
+      }
+      if (table === "professionals") {
+        const b = createChainableBuilder("professionals");
+        b.single = vi.fn(() => Promise.resolve({ data: makeAdvisor(), error: null }));
+        return b;
+      }
+      if (table === "professional_leads") {
+        // Simulate an RLS denial / network reject for this slice only.
+        const b = createChainableBuilder("professional_leads");
+        b.then = vi.fn((_ok: unknown, rej?: (e: unknown) => void) => {
+          rej?.(new Error("RLS denied"));
+          return Promise.resolve();
+        });
+        return b;
+      }
+      if (table === "lead_pricing") {
+        const b = createChainableBuilder("lead_pricing");
+        b.single = vi.fn(() => Promise.resolve({ data: null, error: null }));
+        return b;
+      }
+      const b = createChainableBuilder(table);
+      b.then = vi.fn((cb: (v: { data: unknown[]; error: null }) => void) => {
+        cb({ data: [], error: null });
+        return Promise.resolve();
+      });
+      return b;
+    });
+
+    const res = await GET(makeGet(SESSION_TOKEN));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.stats.totalLeads).toBe(0); // the failed slice degrades to empty
+    expect(data.advisor.name).toBe("Jane Smith"); // the rest still loads
   });
 });

--- a/__tests__/lib/widget/advisor-embed-token.test.ts
+++ b/__tests__/lib/widget/advisor-embed-token.test.ts
@@ -73,7 +73,13 @@ describe("advisor-embed-token", () => {
     const parts = token.split(".");
     // Flip the last char of the HMAC segment.
     const sig = parts[2]!;
-    const flipped = sig.slice(0, -1) + (sig.endsWith("A") ? "B" : "A");
+    // Tamper the FIRST char of the HMAC segment, not the last: base64url's
+    // final char of a 32-byte HMAC carries only 4 significant bits (the low 2
+    // are padding), so an ±1 flip there can change only ignored bits — the
+    // decoded signature stays identical and the tamper goes undetected ~1 run
+    // in 16 (the source of this test's flakiness). The first char always
+    // carries significant bits, so this is a deterministic tamper.
+    const flipped = (sig[0] === "A" ? "B" : "A") + sig.slice(1);
     const tampered = `${parts[0]}.${parts[1]}.${flipped}`;
     const result = verifyAdvisorEmbedToken(tampered);
     expect(result.ok).toBe(false);

--- a/app/api/advisor-dashboard/route.ts
+++ b/app/api/advisor-dashboard/route.ts
@@ -19,14 +19,23 @@ export async function GET(request: NextRequest) {
   const now = new Date();
   const thirtyDaysAgo = new Date(now.getTime() - 30 * 86400000).toISOString();
 
-  const [
-    { data: advisor },
-    { data: leads },
-    { data: billing },
-    { data: views },
-    { data: reviews },
-    { data: bookings },
-  ] = await Promise.all([
+  // advisor_bookings is non-anon RLS, so it needs the service-role client.
+  // Guard its construction: in preview envs without SUPABASE_SERVICE_ROLE_KEY,
+  // createAdminClient() throws — and because it was called inline inside the
+  // Promise.all, that throw rejected the ENTIRE dashboard fetch (500 → every KPI
+  // 0 + the "couldn't be loaded" banner). Degrade to a null admin client so the
+  // rest of the dashboard still loads.
+  let admin: ReturnType<typeof createAdminClient> | null = null;
+  try {
+    admin = createAdminClient();
+  } catch {
+    admin = null;
+  }
+
+  // allSettled (not all): one failing slice degrades that one card rather than
+  // blanking the whole dashboard.
+  const [advisorR, leadsR, billingR, viewsR, reviewsR, bookingsR] =
+    await Promise.allSettled([
     // Advisor profile (for completeness check + billing)
     supabase
       .from("professionals")
@@ -67,14 +76,24 @@ export async function GET(request: NextRequest) {
       .eq("professional_id", advisorId)
       .eq("status", "approved")
       .order("created_at", { ascending: false }),
-    // Bookings count (for booking clicks stat) — service-role: non-anon table,
-    // scoped to the validated advisorId.
-    createAdminClient()
-      .from("advisor_bookings")
-      .select("id, created_at")
-      .eq("professional_id", advisorId)
-      .gte("created_at", thirtyDaysAgo),
+    // Bookings count (booking-clicks stat) — service-role, scoped to the
+    // validated advisorId; resolves to [] when no admin client is available.
+    admin
+      ? admin
+          .from("advisor_bookings")
+          .select("id, created_at")
+          .eq("professional_id", advisorId)
+          .gte("created_at", thirtyDaysAgo)
+      : Promise.resolve({ data: [] as { id: string; created_at: string }[] }),
   ]);
+
+  // Unwrap each settled slice → data (or null/[] on failure).
+  const advisor = advisorR.status === "fulfilled" ? advisorR.value.data : null;
+  const leads = leadsR.status === "fulfilled" ? leadsR.value.data : null;
+  const billing = billingR.status === "fulfilled" ? billingR.value.data : null;
+  const views = viewsR.status === "fulfilled" ? viewsR.value.data : null;
+  const reviews = reviewsR.status === "fulfilled" ? reviewsR.value.data : null;
+  const bookings = bookingsR.status === "fulfilled" ? bookingsR.value.data : null;
 
   // Fetch category pricing for this advisor's type
   let categoryPricing = null;

--- a/docs/plans/ADVISOR_PORTAL_REDESIGN.md
+++ b/docs/plans/ADVISOR_PORTAL_REDESIGN.md
@@ -1,0 +1,103 @@
+# Advisor Portal — redesign to smart-fintech grade
+
+Status: **in progress** (core-first sequencing, approved 2026-06-14).
+Owner: Fin. Tracking doc for the multi-PR advisor-portal uplift.
+
+## Goal
+
+Take `/advisor-portal` (~22 dashboard tabs + sub-pages) from "looks broken and
+unpolished" to a credible, smart-fintech product: real data on the dashboard, a
+discoverable way in/out, and a consistent design system — without a 22-tab
+big-bang. Each phase ships as its own screenshotted PR.
+
+## Diagnosis (verified against the live DB; advisor #273 = Kai/Nexus = `finnduns@gmail.com`)
+
+**Looks broken — it's a code bug, not missing data.** #273 actually has 9 leads,
+244 profile views, 5 bookings, 5 reviews live. They render as `0` because:
+
+1. **`/api/advisor-dashboard` 500s.** The route builds its `Promise.all` by
+   calling `createAdminClient()` **synchronously** for the `advisor_bookings`
+   read; `createAdminClient()` throws when `SUPABASE_SERVICE_ROLE_KEY` is absent
+   (likely on the preview/mirror env). That throw rejects the whole route → 500
+   → every KPI falls back to `|| 0` and the "Some data couldn't be loaded"
+   banner (`anyFetchFailed`) fires. (Rating 4.8 + Trust 60 survive because they
+   come from separate endpoints — `/api/advisor-auth/session` and
+   `/trust-score`.)
+2. **`professional_leads` is RLS-gated on `auth.uid()`.** The portal's custom
+   `advisor_session` cookie carries no Supabase JWT, so legacy-cookie sessions
+   read 0 leads even when the route works. (JWT/magic-link sessions — incl. the
+   founder — DO satisfy the policy.)
+3. **`Stats` API contract gap.** Analytics' "Engagement Breakdown" reads
+   `phoneClicks / websiteClicks / bookingClicks / articleViews /
+   searchImpressions / articles` — fields `/api/advisor-dashboard` never
+   returns. Declared on the `Stats` type so TS stays quiet → permanent `0`.
+
+**Looks unpolished ("not smart fintech"):** 8+ ad-hoc sub-`xs` font sizes
+(`text-[0.5rem]`…`text-[0.68rem]`); split colour system (violet/teal/emerald/
+slate, inconsistent primary button); hand-rolled charts (no axes/gridlines);
+widgets that vanish when empty (layout jumps); hardcoded growth claims stated as
+fact ("3× more leads") — also a compliance flag.
+
+**Navigation:** no link to `/advisor-portal` anywhere (header/footer/account
+menu). Advisors reach it only by URL or magic-link; no way back to the site.
+
+## Phases
+
+### Phase 1 — Make it REAL (data layer)  ← current
+- [ ] `/api/advisor-dashboard`: guard `createAdminClient()` (try/catch → null)
+      and use `Promise.allSettled` so one failed query degrades a single card
+      instead of 500-ing everything. Bookings read only when the admin client
+      is available, else `[]`.
+- [ ] Keep RLS-gated personal reads (leads/billing) working for JWT sessions;
+      note admin-scoped fallback for legacy-cookie sessions as a follow-up.
+- [ ] Fix the `Stats` contract when redesigning Analytics (Phase 4) — return the
+      engagement fields (source: `advisor_metrics_daily`) or remove dead tiles.
+- [ ] Diagnose the live 500 precisely. If it's a missing
+      `SUPABASE_SERVICE_ROLE_KEY` on the mirror, flag (Tier D) — don't touch prod.
+
+### Phase 2 — Navigation (in + out)
+- [ ] "Advisor portal" entry in the logged-in account menu, shown when the user
+      resolves to an advisor (reuse `enforcePortalKind`/session check).
+- [ ] Portal → "Back to site" + breadcrumbs; group the 22 tabs into sections
+      (Grow / Engage / Manage) so mobile "More…" isn't a flat 14-item scroll.
+
+### Phase 3 — Design system (the "smart fintech" layer)
+- [ ] One type scale (kills the bespoke sub-`xs` sizes); one accent + token set
+      (colour/spacing/radius/shadow); shared primitives: `StatCard`, `Chart`
+      (real axes/gridlines), `EmptyState` (no disappearing widgets),
+      `SectionHeader`, `Pill`.
+- [ ] Apply to the shell + **Dashboard** as the exemplar → founder sign-off on
+      the bar before rolling wider.
+
+### Phase 4 — Roll the system across tabs
+Priority: Dashboard → Leads → Analytics → Reviews → Profile → long tail
+(CPD, Feed, Case Studies, Events, Courses, Billing, Settings, Widgets, Embed
+Kit, Badges, Earn, Team). Extract the inline Articles tab into its own file.
+
+### Phase 5 — Honesty / compliance pass
+- [ ] Replace hardcoded "3×"-style claims with real computed deltas or neutral
+      copy. Route disclosure copy through `lib/compliance.ts`.
+
+### Phase 6 — Reproducible seed + bots
+- [ ] Idempotent seed migration keyed to slug `kai-tanaka-nexus` populating
+      every portal table: leads, profile views, bookings, reviews, billing,
+      leaderboard, feed posts, case studies, articles, CPD credits, a course, an
+      event, badges. Ships as a migration file — **human-triggered `db push`**.
+- [ ] Move the archive firm-member seed (Kai) into the active migration set so a
+      fresh DB rebuild creates the demo advisor.
+- [ ] Wire the portal's custom-cookie login into the screenshot `auto-login`;
+      sweep every tab (`npm run screenshots STATES=advisor MATCH=/advisor-portal`)
+      for before/after. Re-verify the public `/invest` + `/advisors` cards.
+
+## Guardrails
+- Migrations forward-only, idempotent, RLS-aware; **no autonomous `db push`**.
+- Service-role stays scoped to the validated `advisorId` (existing booking-read
+  precedent in the route); justify each use per CLAUDE.md.
+- Merge per `docs/audits/MERGE_AUTHORIZATION.md` — data/RLS/API = Tier B/C.
+- Each phase = its own PR, screenshotted.
+
+## Out of scope (separate tracks)
+- `/compare` `?category=` URL-flapping client bug.
+- Invest migration `db push` (biodiversity $25k→$50k data fix).
+- Schema drift on certifications/articles/expert-teams endpoints (logged by the
+  data deep-dive) — fold into Phase 4 when those tabs are touched.


### PR DESCRIPTION
**Phase 1 of the advisor-portal uplift** (tracked in `docs/plans/ADVISOR_PORTAL_REDESIGN.md`). Fixes the "Some data couldn't be loaded" banner + the all-zero KPIs on the dashboard.

## Root cause (verified against the live DB)
The advisor whose login this resolves to (#273) actually has 9 leads, 244 profile views, 5 bookings, 5 reviews. They rendered as `0` because `/api/advisor-dashboard` built its `Promise.all` by calling `createAdminClient()` **inline** for the `advisor_bookings` read. `createAdminClient()` **throws** when `SUPABASE_SERVICE_ROLE_KEY` is absent (very likely on the preview/mirror env) — and that synchronous throw rejected the *entire* `Promise.all` → the route 500'd → every KPI fell back to `|| 0` and the load-error banner (`anyFetchFailed`) fired. Rating (4.8) and Trust Score (60) survived only because they come from separate endpoints.

## Fix
- Guard the admin-client construction (`try/catch → null`); the bookings read resolves to `[]` when no admin client is available, instead of crashing the route.
- Switch the parallel fetch to **`Promise.allSettled`** so any single failing slice degrades that one card rather than blanking the whole dashboard.

Net effect: on an env without the service-role key the dashboard now loads leads/views/reviews (via the advisor's JWT) with booking-clicks at 0, and shows **no error banner** — instead of zeroing everything.

## Tests
+2 resilience tests (missing service-role key → 200; one rejected slice → 200). 14/14 pass, lint + type-check clean.

> Note: if the live mirror is missing `SUPABASE_SERVICE_ROLE_KEY`, that's the trigger — this PR makes the route robust to it; setting that env var (so booking-clicks populate too) is a separate, env-level decision.

https://claude.ai/code/session_01KMTVeHKD2GpG1huECg5FRF

---
_Generated by [Claude Code](https://claude.ai/code/session_01KMTVeHKD2GpG1huECg5FRF)_