### PR TITLE
feat(advisor-portal): give advisors a discoverable link into their portal

### DIFF
--- a/__tests__/components/WorkspaceSwitcher.test.tsx
+++ b/__tests__/components/WorkspaceSwitcher.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import WorkspaceSwitcher from "@/components/WorkspaceSwitcher";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+
+type Membership = { kind: string; kind_id: string; status: string; display_label: string };
+
+function stubActiveKind(memberships: Membership[], active: string | null = null) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({ ok: true, json: async () => ({ memberships, active }) })),
+  );
+}
+
+const m = (kind: string, display_label = kind): Membership => ({
+  kind,
+  kind_id: `${kind}-1`,
+  status: "active",
+  display_label,
+});
+
+describe("WorkspaceSwitcher", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("renders nothing for an unauthenticated user (no memberships)", async () => {
+    stubActiveKind([]);
+    const { container } = render(<WorkspaceSwitcher />);
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing for an investor-only user (investor has no portal)", async () => {
+    stubActiveKind([m("investor", "Investor")], "investor");
+    const { container } = render(<WorkspaceSwitcher />);
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
+  });
+
+  it("renders a direct portal link for a single advisor membership (the nav gap)", async () => {
+    stubActiveKind([m("advisor", "Kai / Nexus")], "advisor");
+    render(<WorkspaceSwitcher />);
+    const link = await screen.findByTestId("portal-link");
+    expect(link).toHaveAttribute("href", "/advisor-portal");
+    expect(link).toHaveTextContent(/advisor portal/i);
+  });
+
+  it("links a single broker_partner membership to the broker portal", async () => {
+    stubActiveKind([m("broker_partner")], "broker_partner");
+    render(<WorkspaceSwitcher />);
+    const link = await screen.findByTestId("portal-link");
+    expect(link).toHaveAttribute("href", "/broker-portal");
+  });
+
+  it("renders the switcher (not a single link) for 2+ memberships", async () => {
+    stubActiveKind([m("investor", "Investor"), m("advisor", "Advisor")], "investor");
+    render(<WorkspaceSwitcher />);
+    expect(await screen.findByTestId("workspace-switcher")).toBeInTheDocument();
+    expect(screen.queryByTestId("portal-link")).toBeNull();
+  });
+});

--- a/__tests__/lib/widget/advisor-embed-token.test.ts
+++ b/__tests__/lib/widget/advisor-embed-token.test.ts
@@ -73,7 +73,13 @@ describe("advisor-embed-token", () => {
     const parts = token.split(".");
     // Flip the last char of the HMAC segment.
     const sig = parts[2]!;
-    const flipped = sig.slice(0, -1) + (sig.endsWith("A") ? "B" : "A");
+    // Tamper the FIRST char of the HMAC segment, not the last: base64url's
+    // final char of a 32-byte HMAC carries only 4 significant bits (the low 2
+    // are padding), so an ±1 flip there can change only ignored bits — the
+    // decoded signature stays identical and the tamper goes undetected ~1 run
+    // in 16 (the source of this test's flakiness). The first char always
+    // carries significant bits, so this is a deterministic tamper.
+    const flipped = (sig[0] === "A" ? "B" : "A") + sig.slice(1);
     const tampered = `${parts[0]}.${parts[1]}.${flipped}`;
     const result = verifyAdvisorEmbedToken(tampered);
     expect(result.ok).toBe(false);

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -580,6 +580,7 @@ export default function Header() {
                 {SHOW_MATCH_LANGUAGE ? "Get Matched" : "Take the quiz"}
               </Link>
               <YourPlanChip variant="menu-row" />
+              <WorkspaceSwitcher />
               <div className="flex gap-2">
                 <Link
                   href="/advisors"

--- a/components/WorkspaceSwitcher.tsx
+++ b/components/WorkspaceSwitcher.tsx
@@ -36,6 +36,19 @@ const KIND_ICON: Record<string, string> = {
   listing_owner: "🏷️",
 };
 
+// Direct portal path per kind — mirrors lib/account-kinds.portalForKind, kept
+// client-side so this component doesn't pull the server-only account-kinds
+// module (it imports the service-role client) into the browser bundle. Investor
+// is intentionally absent: it has no portal, so investor-only users get nothing.
+const KIND_PORTAL: Record<string, string> = {
+  advisor: "/advisor-portal",
+  broker_partner: "/broker-portal",
+  business_owner: "/business-portal",
+  listing_owner: "/invest/my-listings",
+  startup: "/startup-portal",
+  org_admin: "/org-portal",
+};
+
 interface Membership {
   kind: string;
   kind_id: string;
@@ -83,7 +96,33 @@ export default function WorkspaceSwitcher() {
     return () => document.removeEventListener("mousedown", onDocClick);
   }, [open]);
 
-  if (!data || data.memberships.length < 2) return null;
+  if (!data) return null;
+
+  // Single workspace that's a portal kind → a direct link to that portal. The
+  // switcher proper only renders for 2+ memberships, so without this an advisor
+  // (commonly advisor-only) would have NO way to reach their portal from the
+  // site — the navigation gap this closes.
+  if (data.memberships.length === 1) {
+    const only = data.memberships[0];
+    const portal = only ? KIND_PORTAL[only.kind] : undefined;
+    if (only && portal) {
+      return (
+        <Link
+          href={portal}
+          data-testid="portal-link"
+          title={`Go to your ${KIND_LABEL[only.kind] ?? only.kind} portal`}
+          className="inline-flex items-center gap-1.5 px-3 py-1 text-xs font-semibold rounded-full bg-slate-900 text-white hover:bg-slate-800 transition-colors"
+        >
+          <span aria-hidden>{KIND_ICON[only.kind] ?? "•"}</span>
+          <span>{KIND_LABEL[only.kind] ?? only.kind} portal</span>
+          <span aria-hidden>→</span>
+        </Link>
+      );
+    }
+    return null;
+  }
+
+  if (data.memberships.length < 2) return null;
 
   const label = data.active ? KIND_LABEL[data.active] : "Choose workspace";
   const icon = data.active ? KIND_ICON[data.active] : "⇄";


### PR DESCRIPTION
**Phase 2 of the advisor-portal uplift** (`docs/plans/ADVISOR_PORTAL_REDESIGN.md`). Answers "how is a user meant to navigate to the advisor portal?" — currently: they can't.

## Problem
There is **no link to `/advisor-portal` anywhere** — header, footer, or account menu. The `WorkspaceSwitcher` (the one header component that knows the user's workspace memberships) returns `null` for anyone holding fewer than **2** workspaces. An advisor who holds only the `advisor` kind therefore sees nothing and can reach the portal only by typing the URL or following a magic-link email.

## Fix
- When a user holds a **single portal kind** (`advisor` / `broker_partner` / `business_owner` / `listing_owner` / `startup` / `org_admin`), render a direct **"Advisor portal →"** link (paths mirror `lib/account-kinds.portalForKind`, kept client-side so the server-only kinds module isn't pulled into the browser bundle).
- Surface the switcher in the **mobile menu** too — it was desktop-only.
- Multi-workspace users keep the existing switcher unchanged; investor-only users still get nothing (investor has no portal).

## Tests
New `WorkspaceSwitcher.test.tsx` (5 tests): no-membership → nothing; investor-only → nothing; single advisor/broker → direct portal link; 2+ → switcher. Lint + type-check clean.

https://claude.ai/code/session_01KMTVeHKD2GpG1huECg5FRF

---
_Generated by [Claude Code](https://claude.ai/code/session_01KMTVeHKD2GpG1huECg5FRF)_