### PR TITLE
feat(advisor-portal): redesign the dashboard on a slate+indigo design system

### DIFF
--- a/__tests__/components/advisor-portal/primitives.test.tsx
+++ b/__tests__/components/advisor-portal/primitives.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import {
+  StatCard,
+  MiniBarChart,
+  EmptyState,
+  StatusPill,
+  ProgressBar,
+  SectionCard,
+} from "@/app/advisor-portal/ui/primitives";
+
+describe("advisor-portal primitives", () => {
+  it("StatCard renders label, value and sub", () => {
+    render(<StatCard label="Profile views" value="244" sub="last 30 days" />);
+    expect(screen.getByText("Profile views")).toBeInTheDocument();
+    expect(screen.getByText("244")).toBeInTheDocument();
+    expect(screen.getByText("last 30 days")).toBeInTheDocument();
+  });
+
+  it("StatCard shows a positive delta in emerald and hides a zero delta", () => {
+    const { rerender } = render(<StatCard label="Enquiries" value="9" delta={3} />);
+    const delta = screen.getByText("+3");
+    expect(delta).toBeInTheDocument();
+    expect(delta.className).toContain("emerald");
+    rerender(<StatCard label="Enquiries" value="9" delta={0} />);
+    expect(screen.queryByText("+0")).toBeNull();
+  });
+
+  it("MiniBarChart renders an inline empty state (never disappears) when there's no data", () => {
+    render(<MiniBarChart data={[]} emptyLabel="No enquiries yet." />);
+    expect(screen.getByText("No enquiries yet.")).toBeInTheDocument();
+  });
+
+  it("MiniBarChart renders bars + values when data is present", () => {
+    render(
+      <MiniBarChart
+        data={[
+          { label: "1 Jun", value: 4 },
+          { label: "8 Jun", value: 7 },
+        ]}
+      />,
+    );
+    expect(screen.getByText("4")).toBeInTheDocument();
+    expect(screen.getByText("7")).toBeInTheDocument();
+    expect(screen.getByText("8 Jun")).toBeInTheDocument();
+  });
+
+  it("StatusPill renders the status label", () => {
+    render(<StatusPill status="converted" />);
+    expect(screen.getByText("converted")).toBeInTheDocument();
+  });
+
+  it("EmptyState renders title, body and a CTA link", () => {
+    render(
+      <EmptyState title="No reviews yet" cta={{ label: "Share link", href: "/advisor/x", external: true }}>
+        Ask happy clients to review you.
+      </EmptyState>,
+    );
+    expect(screen.getByText("No reviews yet")).toBeInTheDocument();
+    expect(screen.getByText("Ask happy clients to review you.")).toBeInTheDocument();
+    const link = screen.getByRole("link", { name: /share link/i });
+    expect(link).toHaveAttribute("href", "/advisor/x");
+  });
+
+  it("ProgressBar clamps the fill width to 0–100%", () => {
+    const { container, rerender } = render(<ProgressBar value={150} />);
+    expect((container.querySelector("[style*='width']") as HTMLElement)?.style.width).toBe("100%");
+    rerender(<ProgressBar value={-20} />);
+    expect((container.querySelector("[style*='width']") as HTMLElement)?.style.width).toBe("0%");
+  });
+
+  it("SectionCard renders its title, action and children", () => {
+    render(
+      <SectionCard title="Recent enquiries" action={<button>View all</button>}>
+        <p>body content</p>
+      </SectionCard>,
+    );
+    expect(screen.getByText("Recent enquiries")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "View all" })).toBeInTheDocument();
+    expect(screen.getByText("body content")).toBeInTheDocument();
+  });
+});

--- a/__tests__/lib/widget/advisor-embed-token.test.ts
+++ b/__tests__/lib/widget/advisor-embed-token.test.ts
@@ -73,7 +73,13 @@ describe("advisor-embed-token", () => {
     const parts = token.split(".");
     // Flip the last char of the HMAC segment.
     const sig = parts[2]!;
-    const flipped = sig.slice(0, -1) + (sig.endsWith("A") ? "B" : "A");
+    // Tamper the FIRST char of the HMAC segment, not the last: base64url's
+    // final char of a 32-byte HMAC carries only 4 significant bits (the low 2
+    // are padding), so an ±1 flip there can change only ignored bits — the
+    // decoded signature stays identical and the tamper goes undetected ~1 run
+    // in 16 (the source of this test's flakiness). The first char always
+    // carries significant bits, so this is a deterministic tamper.
+    const flipped = (sig[0] === "A" ? "B" : "A") + sig.slice(1);
     const tampered = `${parts[0]}.${parts[1]}.${flipped}`;
     const result = verifyAdvisorEmbedToken(tampered);
     expect(result.ok).toBe(false);

--- a/app/advisor-portal/DashboardTab.tsx
+++ b/app/advisor-portal/DashboardTab.tsx
@@ -14,13 +14,24 @@ import LeadCapBanner from "./LeadCapBanner";
 import AdvisorTrustScoreCard from "@/components/AdvisorTrustScoreCard";
 import OnboardingWizard from "./OnboardingWizard";
 import { deriveProfileCompleteness, type WizardStepId } from "@/lib/advisor-portal/profile-completeness";
+import {
+  SectionCard,
+  StatCard,
+  EmptyState,
+  ProgressBar,
+  StatusPill,
+  MiniBarChart,
+  SectionEyebrow,
+} from "./ui/primitives";
 
-type LeaderboardRank = {
-  rank: number;
-  score: number;
-  total: number;
-  percentile: number | null;
-} | { rank: null };
+type LeaderboardRank =
+  | {
+      rank: number;
+      score: number;
+      total: number;
+      percentile: number | null;
+    }
+  | { rank: null };
 
 function YourRankWidget() {
   const [data, setData] = useState<LeaderboardRank | null>(null);
@@ -28,57 +39,68 @@ function YourRankWidget() {
   useEffect(() => {
     fetch("/api/advisor-auth/leaderboard")
       .then((r) => (r.ok ? r.json() : null))
-      .then((d: LeaderboardRank | null) => { if (d) setData(d); })
-      .catch(() => { /* fail silently */ });
+      .then((d: LeaderboardRank | null) => {
+        if (d) setData(d);
+      })
+      .catch(() => {
+        /* fail silently */
+      });
   }, []);
 
   if (!data) return null;
 
   if (!data.rank) {
     return (
-      <div className="bg-white border border-slate-200 rounded-xl p-4 mb-6">
-        <div className="flex items-center gap-2 mb-2">
-          <div className="w-8 h-8 bg-slate-100 border border-slate-200 rounded-full flex items-center justify-center shrink-0">
-            <Icon name="award" size={15} className="text-slate-500" />
+      <div className="rounded-xl border border-slate-200 bg-white p-4">
+        <div className="flex items-center gap-2.5">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-slate-100">
+            <Icon name="award" size={16} className="text-slate-400" />
           </div>
-          <h3 className="text-sm font-semibold text-slate-600">Your Leaderboard Rank</h3>
+          <div>
+            <h3 className="text-sm font-semibold text-slate-900">Leaderboard rank</h3>
+            <p className="mt-0.5 text-xs text-slate-500">
+              Complete your profile and earn leads to appear on the{" "}
+              <Link href="/advisors/leaderboard" className="font-medium text-indigo-600 hover:underline">
+                monthly leaderboard
+              </Link>
+              .
+            </p>
+          </div>
         </div>
-        <p className="text-xs text-slate-500 leading-relaxed">
-          Complete your profile and earn leads to appear on the{" "}
-          <Link href="/advisors/leaderboard" className="text-teal-600 hover:underline font-medium">
-            monthly leaderboard
-          </Link>.
-        </p>
       </div>
     );
   }
 
   return (
-    <div className="bg-teal-50 border border-teal-200 rounded-xl p-4 mb-6 flex items-center justify-between gap-4">
+    <div className="flex items-center justify-between gap-4 rounded-xl border border-indigo-200 bg-indigo-50/60 p-4">
       <div className="flex items-center gap-3">
-        <div className="w-10 h-10 bg-teal-100 border border-teal-200 rounded-full flex items-center justify-center shrink-0">
-          <Icon name="award" size={18} className="text-teal-600" />
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-indigo-100">
+          <Icon name="award" size={18} className="text-indigo-600" />
         </div>
         <div>
-          <h3 className="text-sm font-bold text-slate-800">Your Leaderboard Rank</h3>
-          <p className="text-xs text-slate-500 mt-0.5">
-            {data.percentile != null ? `Top ${100 - data.percentile}% of advisors this month` : `Score: ${data.score}`}
+          <h3 className="text-sm font-semibold text-slate-900">Leaderboard rank</h3>
+          <p className="mt-0.5 text-xs text-slate-500">
+            {data.percentile != null
+              ? `Top ${100 - data.percentile}% of advisors this month`
+              : `Score: ${data.score}`}
           </p>
         </div>
       </div>
-      <div className="text-right shrink-0">
-        <div className="flex items-baseline gap-0.5 justify-end">
-          <span className="text-[0.65rem] font-semibold text-slate-500">#</span>
-          <span className="text-3xl font-extrabold text-teal-600">{data.rank}</span>
+      <div className="flex items-center gap-4">
+        <div className="text-right">
+          <div className="flex items-baseline justify-end gap-0.5">
+            <span className="text-xs font-semibold text-slate-400">#</span>
+            <span className="text-3xl font-bold tabular-nums tracking-tight text-indigo-600">{data.rank}</span>
+          </div>
+          <div className="text-xs text-slate-400">of {data.total}</div>
         </div>
-        <div className="text-[0.62rem] text-slate-500 font-medium">of {data.total}</div>
+        <Link
+          href="/advisors/leaderboard"
+          className="shrink-0 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 transition-colors hover:bg-slate-50"
+        >
+          View →
+        </Link>
       </div>
-      <Link
-        href="/advisors/leaderboard"
-        className="shrink-0 text-xs font-bold text-teal-600 hover:text-teal-800 border border-slate-200 rounded-lg px-3 py-1.5 bg-white hover:bg-slate-50 transition-colors"
-      >
-        View →
-      </Link>
     </div>
   );
 }
@@ -119,206 +141,231 @@ function useRelativeTime(date: Date | null | undefined): string {
 }
 
 export default function DashboardTab({
-  advisor, stats, leads, profileCompleteness, reviews,
-  viewsByDay, weeklyEnquiries, dismissedOnboarding, isPending,
-  onNavigate, onDismissOnboarding, billingSummary, dataLoadedAt, onRefresh,
+  advisor,
+  stats,
+  leads,
+  profileCompleteness,
+  reviews,
+  viewsByDay,
+  weeklyEnquiries,
+  dismissedOnboarding,
+  isPending,
+  onNavigate,
+  onDismissOnboarding,
+  billingSummary,
+  dataLoadedAt,
+  onRefresh,
   onAdvisorChange,
 }: Props) {
   const refreshLabel = useRelativeTime(dataLoadedAt);
   // Guided onboarding wizard — null = closed, otherwise the step to open at.
   const [wizardStep, setWizardStep] = useState<WizardStepId | null | "closed">("closed");
   const [expandedLeadId, setExpandedLeadId] = useState<number | null>(null);
-  const [respondedLeads, setRespondedLeads] = useState<Set<number>>(new Set());
-  const [leadNotes, setLeadNotes] = useState<Record<number, string>>({});
-  const [noteInput, setNoteInput] = useState<Record<number, string>>({});
 
   const toggleLead = useCallback((id: number) => {
     setExpandedLeadId((prev) => (prev === id ? null : id));
   }, []);
 
-  const markResponded = useCallback((id: number, e: React.MouseEvent) => {
-    e.stopPropagation();
-    setRespondedLeads((prev) => { const s = new Set(prev); s.add(id); return s; });
-  }, []);
+  const avgRatingDisplay =
+    stats?.avgRating || (advisor?.rating ? Number(advisor.rating).toFixed(1) : "—");
 
-  const saveNote = useCallback((id: number, e: React.MouseEvent) => {
-    e.stopPropagation();
-    const text = noteInput[id]?.trim();
-    if (!text) return;
-    setLeadNotes((prev) => ({ ...prev, [id]: text }));
-    setNoteInput((prev) => ({ ...prev, [id]: "" }));
-  }, [noteInput]);
   return (
     <>
-      <div className="flex items-center justify-between mb-1">
-        <h1 className="text-xl font-bold text-slate-900">Welcome{isPending ? "" : " back"}, {advisor?.name?.split(" ")[0]}</h1>
+      {/* Header */}
+      <div className="mb-1 flex items-center justify-between">
+        <h1 className="text-xl font-bold tracking-tight text-slate-900">
+          Welcome{isPending ? "" : " back"}, {advisor?.name?.split(" ")[0]}
+        </h1>
         {refreshLabel && onRefresh && (
           <div className="flex items-center gap-1.5">
-            <span className="text-[0.62rem] text-slate-500">Updated {refreshLabel}</span>
-            <button onClick={onRefresh} aria-label="Refresh data" className="text-slate-500 hover:text-slate-700 transition-colors">
+            <span className="text-xs text-slate-400">Updated {refreshLabel}</span>
+            <button
+              onClick={onRefresh}
+              aria-label="Refresh data"
+              className="text-slate-400 transition-colors hover:text-slate-600"
+            >
               <Icon name="refresh-cw" size={13} />
             </button>
           </div>
         )}
       </div>
-      <p className="text-sm text-slate-500 mb-4">{advisor?.firm_name || PROFESSIONAL_TYPE_LABELS[advisor?.type as keyof typeof PROFESSIONAL_TYPE_LABELS]}</p>
+      <p className="mb-5 text-sm text-slate-500">
+        {advisor?.firm_name ||
+          PROFESSIONAL_TYPE_LABELS[advisor?.type as keyof typeof PROFESSIONAL_TYPE_LABELS]}
+      </p>
 
       <AvailabilityWidget advisor={advisor} />
 
       {advisor?.profile_complete && !advisor?.booking_link && (
-        <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 mb-5 flex flex-col sm:flex-row items-start sm:items-center gap-3">
-          <Icon name="calendar" size={22} className="text-amber-600 shrink-0" />
+        <div className="mb-5 flex flex-col items-start gap-3 rounded-xl border border-amber-200 bg-amber-50 p-4 sm:flex-row sm:items-center">
+          <Icon name="calendar" size={20} className="shrink-0 text-amber-600" />
           <div className="flex-1">
-            <p className="font-bold text-sm text-amber-900">
-              Add a booking link — your profile is ready, investors can&rsquo;t schedule yet
+            <p className="text-sm font-semibold text-amber-900">
+              Add a booking link so investors can schedule with you
             </p>
-            <p className="text-xs text-amber-800 mt-0.5">
-              Calendly, SavvyCal or any scheduling URL. Advisors with a booking link convert 2-4x more enquiries.
+            <p className="mt-0.5 text-xs text-amber-800">
+              Your profile is ready, but there&rsquo;s no way to book yet. Paste a Calendly, SavvyCal
+              or any scheduling URL.
             </p>
           </div>
           <button
             onClick={() => onNavigate("profile")}
-            className="bg-amber-500 hover:bg-amber-600 text-slate-900 font-bold text-xs px-4 py-2 rounded-lg whitespace-nowrap"
+            className="whitespace-nowrap rounded-lg bg-amber-500 px-4 py-2 text-xs font-bold text-slate-900 transition-colors hover:bg-amber-600"
           >
             Add booking link
           </button>
         </div>
       )}
 
-      {/* Stats cards */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
-        {[
-          { label: "Profile Views", value: stats?.totalViews30d || 0, sub: "last 30 days", icon: "eye", color: "text-blue-600", bg: "bg-blue-50" },
-          { label: "Enquiries", value: stats?.leads30d || 0, sub: "last 30 days", icon: "inbox", color: "text-violet-600", bg: "bg-violet-50" },
-          { label: "Booking Clicks", value: stats?.bookingClicks30d || 0, sub: "last 30 days", icon: "calendar", color: "text-emerald-600", bg: "bg-emerald-50" },
-          { label: "Avg Rating", value: stats?.avgRating || (advisor?.rating ? Number(advisor.rating).toFixed(1) : "—"), sub: `${stats?.reviewCount || advisor?.review_count || 0} reviews`, icon: "star", color: "text-amber-600", bg: "bg-amber-50" },
-        ].map((kpi, i) => (
-          <div key={i} className="bg-white border border-slate-200 rounded-xl p-4 hover:shadow-sm transition-shadow">
-            <div className="flex items-center justify-between mb-2">
-              <div className="text-xs text-slate-500 font-medium">{kpi.label}</div>
-              <div className={`w-8 h-8 ${kpi.bg} rounded-lg flex items-center justify-center`}><Icon name={kpi.icon} size={16} className={kpi.color} /></div>
-            </div>
-            <div className="text-2xl font-extrabold text-slate-900">{typeof kpi.value === "number" ? kpi.value.toLocaleString() : kpi.value}</div>
-            <div className="text-[0.62rem] text-slate-500 mt-0.5">{kpi.sub}</div>
-          </div>
-        ))}
+      {/* KPI row */}
+      <SectionEyebrow>Last 30 days</SectionEyebrow>
+      <div className="mb-6 grid grid-cols-2 gap-3 md:grid-cols-4">
+        <StatCard label="Profile views" value={(stats?.totalViews30d ?? 0).toLocaleString()} icon="eye" sub="last 30 days" />
+        <StatCard label="Enquiries" value={(stats?.leads30d ?? 0).toLocaleString()} icon="inbox" sub="last 30 days" />
+        <StatCard label="Booking clicks" value={(stats?.bookingClicks30d ?? 0).toLocaleString()} icon="calendar" sub="last 30 days" />
+        <StatCard
+          label="Avg rating"
+          value={avgRatingDisplay}
+          icon="star"
+          sub={`${stats?.reviewCount || advisor?.review_count || 0} reviews`}
+        />
       </div>
 
-      <YourRankWidget />
+      <div className="mb-3">
+        <YourRankWidget />
+      </div>
       <div className="mb-6">
         <AdvisorTrustScoreCard />
       </div>
 
       {/* Free-leads notice (advisor still on the launch trial) */}
       {(advisor?.free_leads_used ?? 0) < 3 && (
-        <div className="bg-emerald-50 border border-emerald-200 rounded-xl p-4 mb-4 flex items-center justify-between gap-3">
+        <div className="mb-4 flex items-center justify-between gap-3 rounded-xl border border-emerald-200 bg-emerald-50 p-4">
           <div>
-            <p className="text-sm font-bold text-emerald-800">
+            <p className="text-sm font-semibold text-emerald-900">
               {3 - (advisor?.free_leads_used ?? 0)} free trial leads remaining
             </p>
-            <p className="text-xs text-emerald-700 mt-0.5">
-              Your first 3 leads are on us — convert one to unlock the discounted lead pricing.
+            <p className="mt-0.5 text-xs text-emerald-700">
+              Your first 3 leads are on us — convert one to unlock discounted lead pricing.
             </p>
           </div>
           <button
             onClick={() => onNavigate("billing")}
-            className="px-3 py-1.5 bg-emerald-600 text-white text-xs font-bold rounded-lg hover:bg-emerald-700 transition-colors shrink-0"
+            className="shrink-0 rounded-lg bg-emerald-600 px-3 py-1.5 text-xs font-bold text-white transition-colors hover:bg-emerald-700"
           >
             See pricing
           </button>
         </div>
       )}
 
-      {/* Monthly lead-cap upsell — factual usage vs tier allowance; CTA
-          reuses the existing /advisor-portal/upgrade Stripe flow. */}
+      {/* Monthly lead-cap upsell — factual usage vs tier allowance. */}
       <LeadCapBanner />
 
-      {/* Annual-billing nudge for paid-tier advisors — PR-X4 */}
+      {/* Annual-billing nudge for paid-tier advisors. */}
       <AnnualBillingPrompt advisorTier={advisor?.advisor_tier ?? null} />
 
-      {/* Unified billing widget — replaces the prior credit banner */}
-      {billingSummary
-        ? <PinnedBillingWidget summary={billingSummary} />
-        : (advisor?.credit_balance_cents ?? 0) > 0
-          ? (
-            <PinnedBillingWidget
-              summary={{
-                balance_cents: advisor?.credit_balance_cents ?? 0,
-                lifetime_credit_cents: advisor?.lifetime_credit_cents ?? 0,
-                lifetime_spend_cents: advisor?.lifetime_lead_spend_cents ?? 0,
-                expiring_soon_cents: 0,
-                free_leads_used: advisor?.free_leads_used ?? 0,
-                free_leads_remaining: Math.max(0, 3 - (advisor?.free_leads_used ?? 0)),
-                lead_price_cents: advisor?.lead_price_cents ?? 4900,
-                advisor_tier: "free",
-                pending_tier: null,
-                pending_tier_effective_at: null,
-                has_payment_method: false,
-                has_stripe_customer: false,
-                ledger_first_page: [],
-                ledger_total: 0,
-              }}
-            />
-          )
-          : null}
+      {/* Unified billing widget. */}
+      {billingSummary ? (
+        <PinnedBillingWidget summary={billingSummary} />
+      ) : (advisor?.credit_balance_cents ?? 0) > 0 ? (
+        <PinnedBillingWidget
+          summary={{
+            balance_cents: advisor?.credit_balance_cents ?? 0,
+            lifetime_credit_cents: advisor?.lifetime_credit_cents ?? 0,
+            lifetime_spend_cents: advisor?.lifetime_lead_spend_cents ?? 0,
+            expiring_soon_cents: 0,
+            free_leads_used: advisor?.free_leads_used ?? 0,
+            free_leads_remaining: Math.max(0, 3 - (advisor?.free_leads_used ?? 0)),
+            lead_price_cents: advisor?.lead_price_cents ?? 4900,
+            advisor_tier: "free",
+            pending_tier: null,
+            pending_tier_effective_at: null,
+            has_payment_method: false,
+            has_stripe_customer: false,
+            ledger_first_page: [],
+            ledger_total: 0,
+          }}
+        />
+      ) : null}
 
-      {/* Onboarding Checklist — driven by the shared completeness lib (same
-          fields/steps as the dashboard API + the guided wizard, so the three
-          can never disagree). Click a step → the wizard opens at that step. */}
-      {(!profileCompleteness || profileCompleteness.score < 80) && !dismissedOnboarding && (() => {
-        const local = deriveProfileCompleteness(advisor as unknown as Record<string, unknown> | null);
-        const steps = profileCompleteness?.steps ?? local.steps;
-        const score = profileCompleteness?.score ?? local.score;
-        const nextStep = steps.find((s) => !s.complete) ?? null;
-        return (
-        <div className="bg-gradient-to-br from-violet-50 to-white border border-violet-200 rounded-xl p-5 mb-6">
-          <div className="flex items-start justify-between mb-3">
-            <div>
-              <h3 className="text-sm font-bold text-violet-900">Get your profile ready</h3>
-              <p className="text-xs text-violet-600 mt-0.5">
-                {nextStep
-                  ? <>{score}% complete — next: <strong>{nextStep.title.toLowerCase()}</strong></>
-                  : "Complete these steps to start receiving leads"}
-              </p>
-            </div>
-            <button onClick={onDismissOnboarding} aria-label="Dismiss setup checklist" className="text-violet-400 hover:text-violet-600 text-xs min-h-11 min-w-11 -mt-2 -mr-2 flex items-center justify-center">✕</button>
-          </div>
-          <div className="space-y-2 mb-4">
-            {steps.map((step) => (
-              <button
-                key={step.id}
-                onClick={step.complete ? undefined : () => setWizardStep(step.id)}
-                disabled={step.complete}
-                className={`w-full text-left flex items-center gap-3 p-2.5 min-h-11 rounded-lg ${step.complete ? "opacity-50" : "cursor-pointer hover:bg-violet-50"}`}
-              >
-                <div className={`w-5 h-5 rounded-full flex items-center justify-center shrink-0 ${step.complete ? "bg-emerald-500" : "bg-white border-2 border-violet-300"}`} aria-hidden="true">
-                  {step.complete && <svg className="w-3 h-3 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" /></svg>}
+      {/* Onboarding checklist — driven by the shared completeness lib. */}
+      {(!profileCompleteness || profileCompleteness.score < 80) &&
+        !dismissedOnboarding &&
+        (() => {
+          const local = deriveProfileCompleteness(advisor as unknown as Record<string, unknown> | null);
+          const steps = profileCompleteness?.steps ?? local.steps;
+          const score = profileCompleteness?.score ?? local.score;
+          const nextStep = steps.find((s) => !s.complete) ?? null;
+          return (
+            <div className="mb-6 rounded-xl border border-indigo-200 bg-indigo-50/50 p-5">
+              <div className="mb-3 flex items-start justify-between">
+                <div>
+                  <h3 className="text-sm font-semibold text-slate-900">Get your profile ready</h3>
+                  <p className="mt-0.5 text-xs text-slate-500">
+                    {nextStep ? (
+                      <>
+                        {score}% complete — next: <strong className="text-slate-700">{nextStep.title.toLowerCase()}</strong>
+                      </>
+                    ) : (
+                      "Complete these steps to start receiving leads"
+                    )}
+                  </p>
                 </div>
-                <span className={`text-xs font-medium ${step.complete ? "line-through text-slate-500" : "text-slate-700"}`}>
-                  {step.title}
-                  {!step.complete && step.missing.length > 0 && (
-                    <span className="block text-[0.62rem] text-slate-500 font-normal mt-0.5">{step.missing.join(" · ")}</span>
-                  )}
-                </span>
-                {!step.complete && <svg className="w-3.5 h-3.5 text-violet-400 ml-auto shrink-0" aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" /></svg>}
-              </button>
-            ))}
-          </div>
-          <div className="flex items-center gap-3">
-            <div className="flex-1 h-2 bg-violet-100 rounded-full overflow-hidden">
-              <div className="h-full bg-violet-500 rounded-full transition-all duration-500" style={{ width: `${score}%` }} />
+                <button
+                  onClick={onDismissOnboarding}
+                  aria-label="Dismiss setup checklist"
+                  className="-mr-2 -mt-2 flex min-h-11 min-w-11 items-center justify-center text-slate-400 hover:text-slate-600"
+                >
+                  ✕
+                </button>
+              </div>
+              <div className="mb-4 space-y-1">
+                {steps.map((step) => (
+                  <button
+                    key={step.id}
+                    onClick={step.complete ? undefined : () => setWizardStep(step.id)}
+                    disabled={step.complete}
+                    className={`flex min-h-11 w-full items-center gap-3 rounded-lg p-2.5 text-left ${
+                      step.complete ? "opacity-60" : "cursor-pointer hover:bg-white"
+                    }`}
+                  >
+                    <div
+                      className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full ${
+                        step.complete ? "bg-emerald-500" : "border-2 border-indigo-300 bg-white"
+                      }`}
+                      aria-hidden="true"
+                    >
+                      {step.complete && (
+                        <svg className="h-3 w-3 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
+                        </svg>
+                      )}
+                    </div>
+                    <span className={`text-sm font-medium ${step.complete ? "text-slate-400 line-through" : "text-slate-700"}`}>
+                      {step.title}
+                      {!step.complete && step.missing.length > 0 && (
+                        <span className="mt-0.5 block text-xs font-normal text-slate-500">{step.missing.join(" · ")}</span>
+                      )}
+                    </span>
+                    {!step.complete && (
+                      <Icon name="chevron-right" size={15} className="ml-auto shrink-0 text-indigo-400" />
+                    )}
+                  </button>
+                ))}
+              </div>
+              <div className="flex items-center gap-3">
+                <ProgressBar value={score} className="flex-1" />
+                <span className="text-xs font-bold tabular-nums text-indigo-700">{score}%</span>
+                <button
+                  onClick={() => setWizardStep(nextStep?.id ?? null)}
+                  className="whitespace-nowrap rounded-lg bg-indigo-600 px-3 py-2 text-xs font-bold text-white hover:bg-indigo-700"
+                >
+                  Continue setup →
+                </button>
+              </div>
             </div>
-            <span className="text-xs font-bold text-violet-700">{score}%</span>
-            <button
-              onClick={() => setWizardStep(nextStep?.id ?? null)}
-              className="px-3 py-2 min-h-11 bg-violet-600 text-white text-xs font-bold rounded-lg hover:bg-violet-700 whitespace-nowrap"
-            >
-              Continue setup →
-            </button>
-          </div>
-        </div>
-        );
-      })()}
+          );
+        })()}
 
       {/* Guided onboarding wizard */}
       {wizardStep !== "closed" && advisor && (
@@ -328,219 +375,154 @@ export default function DashboardTab({
           onAdvisorChange={(a) => onAdvisorChange?.(a)}
           onClose={() => {
             setWizardStep("closed");
-            onRefresh?.(); // re-pull dashboard so completeness/score reflect saves
+            onRefresh?.();
           }}
         />
       )}
 
-      {/* Profile Completeness (compact) */}
-      {profileCompleteness && profileCompleteness.score < 100 && (profileCompleteness.score >= 80 || dismissedOnboarding) && (
-        <div className="bg-white border border-slate-200 rounded-xl p-4 mb-6">
-          <div className="flex items-center justify-between mb-2">
-            <h3 className="text-sm font-bold text-slate-900">Profile Completeness</h3>
-            <span className={`text-sm font-extrabold ${profileCompleteness.score >= 80 ? "text-emerald-600" : profileCompleteness.score >= 50 ? "text-amber-600" : "text-red-500"}`}>
-              {profileCompleteness.score}%
-            </span>
-          </div>
-          <div className="w-full h-2.5 bg-slate-100 rounded-full overflow-hidden mb-3">
-            <div
-              className={`h-full rounded-full transition-all duration-500 ${
-                profileCompleteness.score >= 80 ? "bg-emerald-500" : profileCompleteness.score >= 50 ? "bg-amber-500" : "bg-red-500"
-              }`}
-              style={{ width: `${profileCompleteness.score}%` }}
-            />
-          </div>
-          {profileCompleteness.missingFields.length > 0 && (
-            <div>
-              <span className="text-[0.62rem] text-slate-500 block mb-1.5">Missing:</span>
-              <div className="flex flex-col sm:flex-row sm:flex-wrap gap-2 sm:gap-1.5">
-                {profileCompleteness.missingFields.map((f) => (
-                  <button
-                    key={f}
-                    onClick={() => onNavigate("profile")}
-                    className="text-xs font-medium text-violet-600 bg-violet-50 border border-violet-200 rounded-lg sm:rounded-full hover:bg-violet-100 transition-colors flex items-center px-3 py-3 sm:py-1 sm:px-2.5 sm:text-[0.68rem] min-h-[44px] sm:min-h-0 w-full sm:w-auto"
-                  >
-                    {f}
-                  </button>
-                ))}
+      {/* Profile completeness (compact, post-onboarding) */}
+      {profileCompleteness &&
+        profileCompleteness.score < 100 &&
+        (profileCompleteness.score >= 80 || dismissedOnboarding) && (
+          <SectionCard
+            title="Profile completeness"
+            action={
+              <span
+                className={`text-sm font-bold tabular-nums ${
+                  profileCompleteness.score >= 80
+                    ? "text-emerald-600"
+                    : profileCompleteness.score >= 50
+                      ? "text-amber-600"
+                      : "text-red-500"
+                }`}
+              >
+                {profileCompleteness.score}%
+              </span>
+            }
+            className="mb-6"
+          >
+            <ProgressBar value={profileCompleteness.score} className="mb-3" />
+            {profileCompleteness.missingFields.length > 0 && (
+              <div>
+                <span className="mb-1.5 block text-xs text-slate-500">Missing</span>
+                <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:gap-1.5">
+                  {profileCompleteness.missingFields.map((f) => (
+                    <button
+                      key={f}
+                      onClick={() => onNavigate("profile")}
+                      className="flex min-h-11 w-full items-center rounded-lg border border-indigo-200 bg-indigo-50 px-3 text-xs font-medium text-indigo-700 transition-colors hover:bg-indigo-100 sm:min-h-0 sm:w-auto sm:rounded-full sm:px-2.5 sm:py-1"
+                    >
+                      {f}
+                    </button>
+                  ))}
+                </div>
               </div>
-            </div>
-          )}
-        </div>
-      )}
-
-      {/* Enquiries Per Week chart */}
-      <div className="bg-white border border-slate-200 rounded-xl p-4 mb-6">
-        <h3 className="text-sm font-bold text-slate-900 mb-1">Enquiries Per Week</h3>
-        <p className="text-[0.62rem] text-slate-500 mb-4">Last 8 weeks</p>
-        {weeklyEnquiries.length > 0 ? (
-          <div className="flex items-end gap-2 h-28">
-            {weeklyEnquiries.map((w, i) => {
-              const max = Math.max(...weeklyEnquiries.map(wk => wk.count), 1);
-              const pct = (w.count / max) * 100;
-              return (
-                <div key={i} className="flex-1 flex flex-col items-center justify-end gap-1">
-                  <span className="text-[0.56rem] font-bold text-slate-700">{w.count}</span>
-                  <div
-                    className="w-full bg-violet-500 rounded-t-md transition-all duration-300 hover:bg-violet-600"
-                    style={{ height: `${Math.max(pct, 4)}%`, minHeight: "3px" }}
-                    title={`${w.weekLabel}: ${w.count} enquiries`}
-                  />
-                  <span className="text-[0.5rem] text-slate-500 whitespace-nowrap">{w.weekLabel}</span>
-                </div>
-              );
-            })}
-          </div>
-        ) : (
-          <p className="text-xs text-slate-500 text-center py-6">
-            No enquiries yet — they&apos;ll appear here once investors reach out.
-          </p>
+            )}
+          </SectionCard>
         )}
-      </div>
 
-      {/* Profile Views chart */}
-      {viewsByDay.length > 0 && (
-        <div className="bg-white border border-slate-200 rounded-xl p-4 mb-6">
-          <h3 className="text-sm font-bold text-slate-900 mb-1">Profile Views</h3>
-          <p className="text-[0.62rem] text-slate-500 mb-3">Daily views over the last 30 days</p>
-          <div className="flex items-end gap-0.5 h-20">
-            {viewsByDay.map((d, i) => {
-              const max = Math.max(...viewsByDay.map(v => v.view_count), 1);
-              const pct = (d.view_count / max) * 100;
-              return (
-                <div key={i} className="flex-1 flex flex-col items-center justify-end" title={`${d.view_date}: ${d.view_count} views`}>
-                  <div className="w-full bg-blue-500 rounded-sm min-h-[2px] hover:bg-blue-600 transition-colors" style={{ height: `${Math.max(pct, 3)}%` }} />
-                </div>
-              );
-            })}
-          </div>
-        </div>
-      )}
+      <SectionEyebrow>Performance</SectionEyebrow>
 
-      {/* Recent Enquiries table */}
-      <div className="bg-white border border-slate-200 rounded-xl mb-6 overflow-hidden">
-        <div className="flex items-center justify-between px-4 py-3 border-b border-slate-100">
-          <h3 className="text-sm font-bold text-slate-900">Recent Enquiries</h3>
-          <button onClick={() => onNavigate("leads")} className="text-xs text-violet-600 hover:text-violet-700 font-semibold">View All &rarr;</button>
-        </div>
+      {/* Enquiries per week */}
+      <SectionCard title="Enquiries per week" className="mb-6">
+        <p className="mb-4 text-xs text-slate-400">Last 8 weeks</p>
+        <MiniBarChart
+          data={weeklyEnquiries.map((w) => ({ label: w.weekLabel, value: w.count }))}
+          emptyLabel="No enquiries yet — they'll appear here once investors reach out."
+        />
+      </SectionCard>
+
+      {/* Profile views */}
+      <SectionCard title="Profile views" className="mb-6">
+        <p className="mb-4 text-xs text-slate-400">Daily views over the last 30 days</p>
+        <MiniBarChart
+          data={viewsByDay.map((d) => ({ label: d.view_date, value: d.view_count }))}
+          height={80}
+          showValues={false}
+          showLabels={false}
+          emptyLabel="No profile views recorded yet."
+        />
+      </SectionCard>
+
+      {/* Recent enquiries */}
+      <SectionCard
+        title="Recent enquiries"
+        action={
+          <button onClick={() => onNavigate("leads")} className="text-xs font-semibold text-indigo-600 hover:text-indigo-700">
+            View all →
+          </button>
+        }
+        className="mb-6"
+        bodyClassName=""
+      >
         {leads.length === 0 ? (
-          <div className="px-4 py-8 text-center">
-            <Icon name="inbox" size={28} className="text-slate-300 mx-auto mb-2" />
-            <p className="text-sm text-slate-500">No enquiries yet. They&apos;ll appear here when investors contact you.</p>
-          </div>
+          <EmptyState icon="inbox" title="No enquiries yet">
+            They&apos;ll appear here when investors contact you.
+          </EmptyState>
         ) : (
           <div className="overflow-x-auto">
             <table className="w-full text-left">
-              <caption className="sr-only">Recent Enquiries</caption>
+              <caption className="sr-only">Recent enquiries</caption>
               <thead>
-                <tr className="bg-slate-50 text-[0.62rem] font-semibold text-slate-500 uppercase tracking-wider">
-                  <th scope="col" className="px-4 py-2">Name</th>
-                  <th scope="col" className="px-4 py-2">Date</th>
-                  <th scope="col" className="px-4 py-2 text-center">Quality</th>
-                  <th scope="col" className="px-4 py-2">Status</th>
-                  <th scope="col" className="px-4 py-2">Message</th>
-                  <th scope="col" className="px-3 py-2 w-8"><span className="sr-only">Expand</span></th>
+                <tr className="border-b border-slate-100 text-xs font-semibold uppercase tracking-wider text-slate-400">
+                  <th scope="col" className="px-5 py-2.5">Name</th>
+                  <th scope="col" className="px-3 py-2.5">Date</th>
+                  <th scope="col" className="px-3 py-2.5 text-center">Quality</th>
+                  <th scope="col" className="px-3 py-2.5">Status</th>
+                  <th scope="col" className="px-3 py-2.5">Message</th>
+                  <th scope="col" className="w-8 px-3 py-2.5"><span className="sr-only">Expand</span></th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-slate-100">
                 {leads.slice(0, 8).map((lead) => {
                   const isExpanded = expandedLeadId === lead.id;
-                  const isResponded = respondedLeads.has(lead.id);
-                  const savedNote = leadNotes[lead.id];
                   return (
                     <React.Fragment key={lead.id}>
                       <tr
                         onClick={() => toggleLead(lead.id)}
-                        className={`text-xs cursor-pointer select-none ${
-                          isExpanded
-                            ? "bg-violet-50 border-b-0"
-                            : lead.status === "new"
-                            ? "bg-violet-50/40 hover:bg-violet-50/80"
-                            : "hover:bg-slate-50"
-                        } transition-colors`}
+                        className={`cursor-pointer select-none text-sm transition-colors ${
+                          isExpanded ? "bg-indigo-50/60" : lead.status === "new" ? "bg-indigo-50/30 hover:bg-indigo-50/60" : "hover:bg-slate-50"
+                        }`}
                       >
-                        <td className="px-4 py-2.5">
+                        <td className="px-5 py-3">
                           <div className="font-semibold text-slate-900">{lead.user_name}</div>
-                          <div className="text-[0.58rem] text-slate-500">{lead.user_email}</div>
+                          <div className="text-xs text-slate-400">{lead.user_email}</div>
                         </td>
-                        <td className="px-4 py-2.5 text-slate-500 whitespace-nowrap">
+                        <td className="whitespace-nowrap px-3 py-3 text-xs text-slate-500">
                           {new Date(lead.created_at).toLocaleDateString("en-AU", { day: "numeric", month: "short" })}
                         </td>
-                        <td className="px-4 py-2.5 text-center">
+                        <td className="px-3 py-3 text-center">
                           {lead.quality_score != null ? (
                             <LeadScoreBadge score={lead.quality_score} signals={lead.quality_signals} tier={lead.lead_tier} compact />
                           ) : (
-                            <span className="text-slate-300">&mdash;</span>
+                            <span className="text-slate-300">—</span>
                           )}
                         </td>
-                        <td className="px-4 py-2.5">
-                          <span className={`text-[0.56rem] font-bold px-2 py-0.5 rounded-full ${
-                            isResponded || lead.status === "contacted" ? "bg-blue-100 text-blue-700" :
-                            lead.status === "new" ? "bg-violet-100 text-violet-700" :
-                            lead.status === "converted" ? "bg-emerald-100 text-emerald-700" :
-                            lead.status === "lost" ? "bg-red-100 text-red-600" :
-                            "bg-slate-100 text-slate-500"
-                          }`}>
-                            {isResponded && lead.status === "new" ? "contacted" : lead.status}
-                          </span>
+                        <td className="px-3 py-3">
+                          <StatusPill status={lead.status} />
                         </td>
-                        <td className="px-4 py-2.5 text-slate-500 max-w-[200px] truncate">
-                          {lead.message ? lead.message.slice(0, 80) + (lead.message.length > 80 ? "..." : "") : <span className="text-slate-300">&mdash;</span>}
+                        <td className="max-w-[200px] truncate px-3 py-3 text-xs text-slate-500">
+                          {lead.message ? lead.message.slice(0, 80) + (lead.message.length > 80 ? "…" : "") : <span className="text-slate-300">—</span>}
                         </td>
-                        <td className="px-3 py-2.5 text-slate-500 text-right">
-                          <Icon name={isExpanded ? "chevron-up" : "chevron-down"} size={13} />
+                        <td className="px-3 py-3 text-right text-slate-400">
+                          <Icon name={isExpanded ? "chevron-up" : "chevron-down"} size={14} />
                         </td>
                       </tr>
                       {isExpanded && (
-                        <tr key={`${lead.id}-expanded`} className="bg-violet-50/60 border-b border-violet-100">
-                          <td colSpan={6} className="px-4 pt-2 pb-4">
-                            <div className="flex flex-col sm:flex-row sm:items-start gap-3">
-                              {/* Quick actions */}
-                              <div className="flex flex-wrap gap-2">
-                                <button
-                                  onClick={() => onNavigate("leads")}
-                                  className="flex items-center gap-1.5 text-xs font-semibold text-violet-700 bg-white border border-violet-200 rounded-lg px-3 py-2 hover:bg-violet-50 transition-colors"
-                                >
-                                  <Icon name="external-link" size={12} />
-                                  View Full Lead
-                                </button>
-                                <button
-                                  onClick={(e) => markResponded(lead.id, e)}
-                                  disabled={isResponded || lead.status !== "new"}
-                                  className={`flex items-center gap-1.5 text-xs font-semibold rounded-lg px-3 py-2 transition-colors ${
-                                    isResponded || lead.status !== "new"
-                                      ? "text-slate-500 bg-white border border-slate-200 cursor-default"
-                                      : "text-emerald-700 bg-white border border-emerald-200 hover:bg-emerald-50"
-                                  }`}
-                                >
-                                  <Icon name="check" size={12} />
-                                  {isResponded ? "Marked Responded" : "Mark Responded"}
-                                </button>
-                              </div>
-                              {/* Note input */}
-                              <div className="flex-1 flex items-center gap-2 min-w-0">
-                                <input
-                                  type="text"
-                                  placeholder="Add a note…"
-                                  value={noteInput[lead.id] ?? ""}
-                                  onClick={(e) => e.stopPropagation()}
-                                  onChange={(e) => setNoteInput((prev) => ({ ...prev, [lead.id]: e.target.value }))}
-                                  onKeyDown={(e) => { if (e.key === "Enter") saveNote(lead.id, e as unknown as React.MouseEvent); }}
-                                  className="flex-1 min-w-0 text-xs border border-slate-200 rounded-lg px-3 py-2 bg-white focus:outline-none focus:ring-1 focus:ring-violet-300 focus:border-violet-300 placeholder:text-slate-500"
-                                />
-                                <button
-                                  onClick={(e) => saveNote(lead.id, e)}
-                                  className="text-xs font-semibold text-white bg-violet-600 border border-violet-600 rounded-lg px-3 py-2 hover:bg-violet-700 transition-colors shrink-0"
-                                >
-                                  Save
-                                </button>
-                              </div>
-                            </div>
-                            {savedNote && (
-                              <p className="mt-2 text-[0.68rem] text-slate-600 bg-white border border-slate-200 rounded-lg px-3 py-1.5">
-                                <span className="font-semibold text-slate-500">Note:</span> {savedNote}
+                        <tr key={`${lead.id}-expanded`} className="bg-indigo-50/40">
+                          <td colSpan={6} className="px-5 pb-4 pt-1">
+                            {lead.message && (
+                              <p className="mb-3 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm leading-relaxed text-slate-600">
+                                {lead.message}
                               </p>
                             )}
+                            <button
+                              onClick={() => onNavigate("leads")}
+                              className="inline-flex items-center gap-1.5 rounded-lg border border-indigo-200 bg-white px-3 py-2 text-xs font-semibold text-indigo-700 transition-colors hover:bg-indigo-50"
+                            >
+                              <Icon name="external-link" size={12} />
+                              Manage in Leads
+                            </button>
                           </td>
                         </tr>
                       )}
@@ -551,77 +533,97 @@ export default function DashboardTab({
             </table>
           </div>
         )}
-      </div>
+      </SectionCard>
 
-      {/* Latest Reviews */}
-      <div className="bg-white border border-slate-200 rounded-xl p-4 mb-6">
-        <div className="flex items-center justify-between mb-3">
-          <h3 className="text-sm font-bold text-slate-900">Latest Reviews</h3>
-          {reviews.length > 0 && (
+      {/* Latest reviews */}
+      <SectionCard
+        title="Latest reviews"
+        action={
+          reviews.length > 0 ? (
             <div className="flex items-center gap-1.5">
-              <span className="text-amber-400 text-sm">{"★".repeat(Math.round(Number(stats?.avgRating || advisor?.rating || 0)))}</span>
-              <span className="text-xs font-bold text-slate-700">{stats?.avgRating || (advisor?.rating ? Number(advisor.rating).toFixed(1) : "N/A")}</span>
-              <span className="text-[0.62rem] text-slate-500">({stats?.reviewCount || 0})</span>
+              <span className="text-sm text-amber-400">{"★".repeat(Math.round(Number(stats?.avgRating || advisor?.rating || 0)))}</span>
+              <span className="text-xs font-bold text-slate-700">{avgRatingDisplay}</span>
+              <span className="text-xs text-slate-400">({stats?.reviewCount || 0})</span>
             </div>
-          )}
-        </div>
+          ) : undefined
+        }
+        className="mb-6"
+      >
         {reviews.length === 0 ? (
-          <div className="py-6 text-center">
-            <Icon name="star" size={28} className="text-slate-300 mx-auto mb-2" />
-            <p className="text-sm text-slate-500">No reviews yet. Ask happy clients to leave a review on your profile.</p>
-            <Link href={`/advisor/${advisor?.slug}`} target="_blank" rel="noopener noreferrer" className="inline-block mt-2 text-xs font-semibold text-violet-600 hover:text-violet-700">Share review link &rarr;</Link>
-          </div>
+          <EmptyState
+            icon="star"
+            title="No reviews yet"
+            cta={{ label: "Share your review link", href: `/advisor/${advisor?.slug}`, external: true }}
+          >
+            Ask happy clients to leave a review on your profile.
+          </EmptyState>
         ) : (
           <div className="space-y-3">
             {reviews.slice(0, 4).map((r) => (
-              <div key={r.id} className="border border-slate-100 rounded-lg p-3 hover:bg-slate-50/50 transition-colors">
-                <div className="flex items-center justify-between mb-1.5">
+              <div key={r.id} className="rounded-lg border border-slate-100 p-3 transition-colors hover:bg-slate-50/60">
+                <div className="mb-1.5 flex items-center justify-between">
                   <div className="flex items-center gap-2">
-                    <div className="w-7 h-7 bg-violet-100 rounded-full flex items-center justify-center text-[0.56rem] font-bold text-violet-700">
+                    <div className="flex h-7 w-7 items-center justify-center rounded-full bg-indigo-100 text-xs font-bold text-indigo-700">
                       {r.reviewer_name.charAt(0).toUpperCase()}
                     </div>
                     <div>
                       <span className="text-sm font-semibold text-slate-900">{r.reviewer_name}</span>
-                      <div className="text-[0.56rem] text-slate-500">{new Date(r.created_at).toLocaleDateString("en-AU", { day: "numeric", month: "short", year: "numeric" })}</div>
+                      <div className="text-xs text-slate-400">
+                        {new Date(r.created_at).toLocaleDateString("en-AU", { day: "numeric", month: "short", year: "numeric" })}
+                      </div>
                     </div>
                   </div>
                   <div className="flex items-center gap-0.5">
-                    {[1,2,3,4,5].map(s => (
+                    {[1, 2, 3, 4, 5].map((s) => (
                       <span key={s} className={`text-sm ${s <= r.rating ? "text-amber-400" : "text-slate-200"}`}>★</span>
                     ))}
                   </div>
                 </div>
-                {r.title && <div className="text-xs font-semibold text-slate-800 mb-1">{r.title}</div>}
-                {r.body && <p className="text-xs text-slate-600 leading-relaxed">{r.body.slice(0, 200)}{r.body.length > 200 ? "..." : ""}</p>}
+                {r.title && <div className="mb-1 text-sm font-semibold text-slate-800">{r.title}</div>}
+                {r.body && <p className="text-xs leading-relaxed text-slate-600">{r.body.slice(0, 200)}{r.body.length > 200 ? "…" : ""}</p>}
                 {(r.communication_rating || r.expertise_rating || r.value_for_money_rating) && (
-                  <div className="flex gap-3 mt-2">
-                    {r.communication_rating && <span className="text-[0.56rem] text-slate-500">Communication: <strong className="text-slate-600">{r.communication_rating}/5</strong></span>}
-                    {r.expertise_rating && <span className="text-[0.56rem] text-slate-500">Expertise: <strong className="text-slate-600">{r.expertise_rating}/5</strong></span>}
-                    {r.value_for_money_rating && <span className="text-[0.56rem] text-slate-500">Value: <strong className="text-slate-600">{r.value_for_money_rating}/5</strong></span>}
+                  <div className="mt-2 flex gap-3">
+                    {r.communication_rating && <span className="text-xs text-slate-500">Communication <strong className="text-slate-600">{r.communication_rating}/5</strong></span>}
+                    {r.expertise_rating && <span className="text-xs text-slate-500">Expertise <strong className="text-slate-600">{r.expertise_rating}/5</strong></span>}
+                    {r.value_for_money_rating && <span className="text-xs text-slate-500">Value <strong className="text-slate-600">{r.value_for_money_rating}/5</strong></span>}
                   </div>
                 )}
               </div>
             ))}
           </div>
         )}
-      </div>
+      </SectionCard>
 
       {/* Quick actions */}
-      <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
-        <button onClick={() => onNavigate("profile")} className="bg-white border border-slate-200 rounded-xl p-4 text-left hover:bg-slate-50 hover:shadow-sm transition-all">
-          <Icon name="user" size={20} className="text-violet-600 mb-2" />
-          <div className="text-sm font-bold text-slate-900">Edit Profile</div>
+      <SectionEyebrow>Quick actions</SectionEyebrow>
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-3">
+        <button
+          onClick={() => onNavigate("profile")}
+          className="rounded-xl border border-slate-200 bg-white p-4 text-left transition-all hover:border-slate-300 hover:shadow-sm"
+        >
+          <Icon name="user" size={18} className="mb-2 text-indigo-600" />
+          <div className="text-sm font-semibold text-slate-900">Edit profile</div>
           <div className="text-xs text-slate-500">Update bio, fees, specialties</div>
         </button>
-        <Link href={`/advisor/${advisor?.slug}`} target="_blank" rel="noopener noreferrer" className="bg-white border border-slate-200 rounded-xl p-4 text-left hover:bg-slate-50 hover:shadow-sm transition-all">
-          <Icon name="external-link" size={20} className="text-blue-600 mb-2" />
-          <div className="text-sm font-bold text-slate-900">View Public Profile</div>
+        <Link
+          href={`/advisor/${advisor?.slug}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="rounded-xl border border-slate-200 bg-white p-4 text-left transition-all hover:border-slate-300 hover:shadow-sm"
+        >
+          <Icon name="external-link" size={18} className="mb-2 text-indigo-600" />
+          <div className="text-sm font-semibold text-slate-900">View public profile</div>
           <div className="text-xs text-slate-500">See how investors see you</div>
         </Link>
-        <button onClick={() => onNavigate("billing")} className="bg-white border border-slate-200 rounded-xl p-4 text-left hover:bg-slate-50 hover:shadow-sm transition-all">
-          <Icon name="credit-card" size={20} className="text-emerald-600 mb-2" />
-          <div className="text-sm font-bold text-slate-900">Billing</div>
-          <div className="text-xs text-slate-500">{stats?.pendingBilledCents ? `$${(stats.pendingBilledCents / 100).toFixed(0)} pending` : "No charges yet"}</div>
+        <button
+          onClick={() => onNavigate("billing")}
+          className="rounded-xl border border-slate-200 bg-white p-4 text-left transition-all hover:border-slate-300 hover:shadow-sm"
+        >
+          <Icon name="credit-card" size={18} className="mb-2 text-indigo-600" />
+          <div className="text-sm font-semibold text-slate-900">Billing</div>
+          <div className="text-xs text-slate-500">
+            {stats?.pendingBilledCents ? `$${(stats.pendingBilledCents / 100).toFixed(0)} pending` : "No charges yet"}
+          </div>
         </button>
       </div>
     </>

--- a/app/advisor-portal/ui/primitives.tsx
+++ b/app/advisor-portal/ui/primitives.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+/**
+ * Advisor-portal design-system primitives (slate + indigo).
+ *
+ * One accent (indigo-600), a neutral slate base, and a disciplined type scale:
+ * eyebrow/label = text-xs, body = text-sm, KPI = text-2xl/3xl — replacing the
+ * ad-hoc `text-[0.5rem]…[0.68rem]` soup that made the portal feel unpolished.
+ * Every portal surface should compose these instead of re-styling cards inline.
+ */
+
+import React from "react";
+import Link from "next/link";
+import Icon from "@/components/Icon";
+
+/** White surface card with an optional header (title + right-aligned action). */
+export function SectionCard({
+  title,
+  icon,
+  action,
+  children,
+  className = "",
+  bodyClassName = "p-5",
+}: {
+  title?: React.ReactNode;
+  icon?: string;
+  action?: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+  bodyClassName?: string;
+}) {
+  return (
+    <section className={`rounded-xl border border-slate-200 bg-white ${className}`}>
+      {(title || action) && (
+        <header className="flex items-center justify-between gap-3 px-5 py-3.5 border-b border-slate-100">
+          <div className="flex items-center gap-2 min-w-0">
+            {icon && <Icon name={icon} size={15} className="text-slate-400 shrink-0" />}
+            {title && <h3 className="text-sm font-semibold text-slate-900 truncate">{title}</h3>}
+          </div>
+          {action && <div className="shrink-0">{action}</div>}
+        </header>
+      )}
+      <div className={bodyClassName}>{children}</div>
+    </section>
+  );
+}
+
+/** A single KPI tile: muted label, big tabular number, optional sub + delta. */
+export function StatCard({
+  label,
+  value,
+  sub,
+  icon,
+  delta,
+}: {
+  label: string;
+  value: React.ReactNode;
+  sub?: string;
+  icon?: string;
+  /** Signed period delta, e.g. +3 / -1. Coloured emerald/red, omitted when 0/undefined. */
+  delta?: number | null;
+}) {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-4">
+      <div className="mb-3 flex items-center justify-between">
+        <span className="text-xs font-medium text-slate-500">{label}</span>
+        {icon && <Icon name={icon} size={15} className="text-slate-300" />}
+      </div>
+      <div className="flex items-baseline gap-2">
+        <span className="text-2xl font-bold tabular-nums tracking-tight text-slate-900">{value}</span>
+        {delta != null && delta !== 0 && (
+          <span
+            className={`text-xs font-semibold tabular-nums ${
+              delta > 0 ? "text-emerald-600" : "text-red-500"
+            }`}
+          >
+            {delta > 0 ? "+" : ""}
+            {delta}
+          </span>
+        )}
+      </div>
+      {sub && <div className="mt-1 text-xs text-slate-400">{sub}</div>}
+    </div>
+  );
+}
+
+/** Calm, consistent empty state — never let a widget silently disappear. */
+export function EmptyState({
+  icon = "inbox",
+  title,
+  children,
+  cta,
+}: {
+  icon?: string;
+  title: string;
+  children?: React.ReactNode;
+  cta?: { label: string; href?: string; onClick?: () => void; external?: boolean };
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center px-4 py-8 text-center">
+      <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-slate-100">
+        <Icon name={icon} size={18} className="text-slate-400" />
+      </div>
+      <p className="text-sm font-medium text-slate-700">{title}</p>
+      {children && <p className="mt-1 max-w-sm text-xs leading-relaxed text-slate-500">{children}</p>}
+      {cta &&
+        (cta.href ? (
+          <Link
+            href={cta.href}
+            target={cta.external ? "_blank" : undefined}
+            rel={cta.external ? "noopener noreferrer" : undefined}
+            className="mt-3 text-xs font-semibold text-indigo-600 hover:text-indigo-700"
+          >
+            {cta.label} →
+          </Link>
+        ) : (
+          <button
+            onClick={cta.onClick}
+            className="mt-3 text-xs font-semibold text-indigo-600 hover:text-indigo-700"
+          >
+            {cta.label} →
+          </button>
+        ))}
+    </div>
+  );
+}
+
+/** Indigo progress bar with a consistent track. */
+export function ProgressBar({ value, className = "" }: { value: number; className?: string }) {
+  const pct = Math.max(0, Math.min(100, value));
+  return (
+    <div className={`h-2 w-full overflow-hidden rounded-full bg-slate-100 ${className}`}>
+      <div
+        className="h-full rounded-full bg-indigo-500 transition-all duration-500"
+        style={{ width: `${pct}%` }}
+      />
+    </div>
+  );
+}
+
+const STATUS_STYLE: Record<string, string> = {
+  new: "bg-indigo-50 text-indigo-700 ring-indigo-200",
+  contacted: "bg-blue-50 text-blue-700 ring-blue-200",
+  converted: "bg-emerald-50 text-emerald-700 ring-emerald-200",
+  lost: "bg-red-50 text-red-600 ring-red-200",
+};
+
+/** Lead-status chip — semantic colour, consistent shape. */
+export function StatusPill({ status }: { status: string }) {
+  const cls = STATUS_STYLE[status] ?? "bg-slate-100 text-slate-600 ring-slate-200";
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold capitalize ring-1 ring-inset ${cls}`}
+    >
+      {status}
+    </span>
+  );
+}
+
+/**
+ * Minimal bar chart with a baseline axis + a faint max gridline — reads as a
+ * real chart, not a row of naked divs. Renders an inline empty state (a flat
+ * baseline + message) rather than vanishing when there's no data.
+ */
+export function MiniBarChart({
+  data,
+  height = 112,
+  emptyLabel = "No data yet",
+  showValues = true,
+  showLabels = true,
+}: {
+  data: { label: string; value: number }[];
+  height?: number;
+  emptyLabel?: string;
+  showValues?: boolean;
+  showLabels?: boolean;
+}) {
+  const max = Math.max(...data.map((d) => d.value), 1);
+  const hasData = data.some((d) => d.value > 0);
+
+  if (!hasData) {
+    return (
+      <div className="relative" style={{ height }}>
+        <div className="absolute inset-x-0 bottom-6 border-t border-dashed border-slate-200" />
+        <div className="absolute inset-0 flex items-center justify-center">
+          <span className="text-xs text-slate-400">{emptyLabel}</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="flex items-end gap-1.5" style={{ height }}>
+        {data.map((d, i) => {
+          const pct = (d.value / max) * 100;
+          return (
+            <div key={i} className="flex flex-1 flex-col items-center justify-end gap-1">
+              {showValues && (
+                <span className="text-xs font-semibold tabular-nums text-slate-600">{d.value}</span>
+              )}
+              <div
+                className="w-full rounded-t bg-indigo-500 transition-all duration-300 hover:bg-indigo-600"
+                style={{ height: `${Math.max(pct, 2)}%`, minHeight: 3 }}
+                title={`${d.label}: ${d.value}`}
+              />
+            </div>
+          );
+        })}
+      </div>
+      {showLabels && (
+        <div className="mt-1.5 flex gap-1.5 border-t border-slate-100 pt-1.5">
+          {data.map((d, i) => (
+            <span key={i} className="flex-1 truncate text-center text-[0.7rem] text-slate-400">
+              {d.label}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Section eyebrow used between stacked cards (e.g. "Performance"). */
+export function SectionEyebrow({ children }: { children: React.ReactNode }) {
+  return (
+    <h2 className="mb-3 mt-8 text-xs font-semibold uppercase tracking-wider text-slate-400 first:mt-0">
+      {children}
+    </h2>
+  );
+}


### PR DESCRIPTION
**Phase 3 of the advisor-portal uplift** (`docs/plans/ADVISOR_PORTAL_REDESIGN.md`) — the visual redesign that makes the portal read as "smart fintech". This is the **Dashboard exemplar** for the new design system; once the bar's approved it rolls across the remaining tabs (Phase 4).

## What it fixes
The old Dashboard mixed **8+ bespoke sub-`xs` font sizes** (`text-[0.5rem]`…`[0.68rem]`), a **split palette** (violet/teal/blue/emerald), **naked-`div` charts** with no baseline, widgets that **silently vanished** when empty (layout jumps), and **unsubstantiated growth claims** ("2-4× more enquiries") stated as fact.

## What it does
- **New primitives** — `app/advisor-portal/ui/primitives.tsx`: `SectionCard`, `StatCard`, `MiniBarChart` (real baseline + an inline empty state — never disappears), `EmptyState`, `ProgressBar`, `StatusPill`, `SectionEyebrow`. One **indigo** accent, one **type scale** (`text-xs` floor), neutral slate base.
- **DashboardTab rebuilt** on the primitives: consistent cards, legible type, calm empty states, the **slashed-zero-free** numbers from the earlier card work, and an **honest-copy pass** (drops the "2-4×" claim).
- **Recent-enquiries table → read-only.** The old inline "Mark Responded" + notes were `useState`-only and never persisted (an advisor would think a note saved, then lose it). Per-lead actions now route to the **Leads** tab where they actually persist.

## Scope / safety
Pure presentation — **identical data props and child widgets** (AvailabilityWidget, TrustScore, OnboardingWizard, billing widgets all unchanged). +8 primitive tests; tsc + lint clean. (Pairs with #1582 — the data-resilience fix — so the redesigned KPIs show real numbers, not zeros.)

Includes the `advisor-embed-token` deflake (cherry-picked) so CI is deterministic.

> Best reviewed on the deployed mirror (you're logged in as Kai) once this + #1582 land — the portal's custom-cookie auth makes a static preview hard. Accent is a single token, trivially swappable if you'd prefer emerald/amber.

https://claude.ai/code/session_01KMTVeHKD2GpG1huECg5FRF

---
_Generated by [Claude Code](https://claude.ai/code/session_01KMTVeHKD2GpG1huECg5FRF)_