### PR TITLE
fix(home): de-duplicate Country-Mode tailored strips vs the global teasers

### DIFF
--- a/__tests__/components/country-mode/HideWhenCountryStrip.test.tsx
+++ b/__tests__/components/country-mode/HideWhenCountryStrip.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, afterEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import HideWhenCountryStrip from "@/components/country-mode/HideWhenCountryStrip";
+
+function addStrip(kind: string) {
+  const el = document.createElement("section");
+  el.setAttribute("data-country-strip", kind);
+  document.body.appendChild(el);
+}
+
+describe("HideWhenCountryStrip", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("shows the global section when no country strip is present", async () => {
+    render(
+      <HideWhenCountryStrip strip="listings">
+        <div>global teaser</div>
+      </HideWhenCountryStrip>,
+    );
+    expect(await screen.findByText("global teaser")).toBeVisible();
+  });
+
+  it("collapses the global section once its matching country strip is on the page", async () => {
+    addStrip("listings");
+    render(
+      <HideWhenCountryStrip strip="listings">
+        <div>global teaser</div>
+      </HideWhenCountryStrip>,
+    );
+    const el = screen.getByText("global teaser");
+    await waitFor(() => expect(el).not.toBeVisible()); // wrapper flipped to display:none
+  });
+
+  it("keeps the global section when only a different strip is present (no false hide)", async () => {
+    addStrip("experts");
+    render(
+      <HideWhenCountryStrip strip="listings">
+        <div>global teaser</div>
+      </HideWhenCountryStrip>,
+    );
+    expect(await screen.findByText("global teaser")).toBeVisible();
+  });
+});

--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -16,6 +16,7 @@ import CountryListingsPreview from "@/components/country-mode/CountryListingsPre
 import CountryExpertsPreview from "@/components/country-mode/CountryExpertsPreview";
 import CountryComparePreview from "@/components/country-mode/CountryComparePreview";
 import CountryPopularLinks from "@/components/country-mode/CountryPopularLinks";
+import HideWhenCountryStrip from "@/components/country-mode/HideWhenCountryStrip";
 import ScrollFadeIn from "@/components/ScrollFadeIn";
 import HomepagePersonalisedStrip from "@/components/HomepagePersonalisedStrip";
 import HomeMarketToday from "@/components/HomeMarketToday";
@@ -265,7 +266,12 @@ export default async function HomePage() {
       <CountryListingsPreview />
 
       <ScrollFadeIn>
-        <HomeListingsTeaser listings={listingList} totalCount={totalListingCount} />
+        {/* Hidden client-side when CountryListingsPreview rendered its tailored
+            strip above, so foreign-investor mode shows one opportunities
+            section, not two (ISR of this teaser is unchanged). */}
+        <HideWhenCountryStrip strip="listings">
+          <HomeListingsTeaser listings={listingList} totalCount={totalListingCount} />
+        </HideWhenCountryStrip>
       </ScrollFadeIn>
 
       {/* Single consolidated get-matched band — the one catch-all funnel,
@@ -282,7 +288,11 @@ export default async function HomePage() {
           upcoming-events strip and post-a-request strip dock underneath
           as one visual unit. */}
       <ScrollFadeIn>
-        <HomeAdvisorsTeaser advisors={advisorList} totalCount={totalProfessionalCount} />
+        {/* Hidden client-side when CountryExpertsPreview rendered above (one
+            experts section in foreign-investor mode, not two). */}
+        <HideWhenCountryStrip strip="experts">
+          <HomeAdvisorsTeaser advisors={advisorList} totalCount={totalProfessionalCount} />
+        </HideWhenCountryStrip>
       </ScrollFadeIn>
 
       <HomeSquadOfTheMonth />

--- a/components/country-mode/CountryExpertsPreview.tsx
+++ b/components/country-mode/CountryExpertsPreview.tsx
@@ -65,6 +65,7 @@ export default async function CountryExpertsPreview() {
   return (
     <section
       aria-label={`Experts tailored for ${meta.label}`}
+      data-country-strip="experts"
       className="bg-white border-y border-amber-100"
     >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 py-6">

--- a/components/country-mode/CountryListingsPreview.tsx
+++ b/components/country-mode/CountryListingsPreview.tsx
@@ -72,6 +72,7 @@ export default async function CountryListingsPreview() {
   return (
     <section
       aria-label={`Listings tailored for ${meta.label}`}
+      data-country-strip="listings"
       className="bg-white border-y border-amber-100"
     >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 py-6">

--- a/components/country-mode/HideWhenCountryStrip.tsx
+++ b/components/country-mode/HideWhenCountryStrip.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect, useRef, type ReactNode } from "react";
+
+/**
+ * Homepage Country-Mode de-dupe.
+ *
+ * When a country-tailored strip (CountryListingsPreview / CountryExpertsPreview)
+ * actually renders, its global counterpart (HomeListingsTeaser /
+ * HomeAdvisorsTeaser) is redundant — a foreign-investor visitor was seeing two
+ * "opportunities" / two "experts" sections. This wrapper hides the global one
+ * when its matching strip is present on the page.
+ *
+ * Keyed off the *presence of the strip element* (`[data-country-strip]`), not
+ * the cookie — so a country whose supply is too low (its strip returns null)
+ * still shows the global teaser, with no empty gap. Purely client-side and via
+ * a direct style toggle (no setState → no cascading render): the server render
+ * and the homepage's ISR caching are unchanged; the global stays in the HTML
+ * and is only collapsed after hydration when the strip exists.
+ */
+export default function HideWhenCountryStrip({
+  strip,
+  children,
+}: {
+  strip: "listings" | "experts";
+  children: ReactNode;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (document.querySelector(`[data-country-strip="${strip}"]`)) {
+      ref.current?.style.setProperty("display", "none");
+    }
+  }, [strip]);
+
+  // display:contents → the wrapper itself adds no box, so the global section
+  // lays out exactly as before; flipping to display:none collapses it cleanly.
+  return (
+    <div ref={ref} style={{ display: "contents" }}>
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
Fixes the duplicated homepage sections you spotted (two "opportunities", two "experts") in foreign-investor mode.

## Cause
With `iv_intent_country` set, the homepage renders **both** the Country-tailored strips (`CountryListingsPreview` / `CountryExpertsPreview` — *"Investments often considered by investors from [country]"*) **and** the global teasers (`HomeListingsTeaser` / `HomeAdvisorsTeaser` — *"...shown clearly"* / *"Find the right expert"*). The strips were designed to sit **above** the globals but never suppressed them, so you saw each section twice. It's a deliberate ISR trade-off (cached globals + dynamic country strips), not a render loop.

## Fix
`HideWhenCountryStrip` — a tiny client wrapper around each global teaser that collapses it when its matching tailored strip is actually on the page (`[data-country-strip]`).
- **Keyed off the rendered strip, not the cookie** → a low-supply country whose strip falls back to `null` still shows the global teaser, so there's never an empty gap.
- **Purely client-side** (a `display` toggle via ref, no `setState`) → the server render and the homepage's **ISR caching are unchanged**; the global stays in the HTML and is only collapsed after hydration when the strip exists.

Net: foreign-investor mode now shows **one** opportunities + **one** experts section; everyone else is unaffected. +3 tests; tsc + lint clean.

> Only affects visitors with a country/foreign-investor cookie. Best verified on the mirror with that cookie set.

https://claude.ai/code/session_01KMTVeHKD2GpG1huECg5FRF

---
_Generated by [Claude Code](https://claude.ai/code/session_01KMTVeHKD2GpG1huECg5FRF)_